### PR TITLE
fix: CIのe2eジョブをローカルSupabase起動方式に変更

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,13 +30,31 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # WHY: e2e/env-guard.ts のデフォルト許可ホストは127.0.0.1/localhostのみ。
+      #      本番Supabaseの接続情報がCIに一切渡らないよう、GitHub Secretsは使わず
+      #      ローカルSupabaseを起動してその場で発行される接続情報だけを使う。
+      - name: Start local Supabase
+        run: |
+          supabase start
+          supabase db reset
+
+      - name: Export local Supabase connection info
+        run: |
+          echo "SUPABASE_API_URL=$(supabase status -o json | jq -r '.API_URL')" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$(supabase status -o json | jq -r '.ANON_KEY')" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o json | jq -r '.SERVICE_ROLE_KEY')" >> "$GITHUB_ENV"
+
       - name: Run E2E smoke tests
         run: npm run test:e2e
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
-          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-          # テスト専用Supabaseのホストのみ許可（e2e/env-guard.ts が本番URLを即失敗させる）
-          E2E_ALLOWED_SUPABASE_HOSTS: ${{ secrets.E2E_ALLOWED_SUPABASE_HOSTS }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ env.SUPABASE_API_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ env.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ env.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+          # WHY: ダミーデータ規約（docs/agents/common.md）に合わせた固定のテスト用メール。
+          #      ローカルSupabaseは毎回まっさらな状態なので機密情報ではなくsecrets化不要
+          E2E_TEST_EMAIL: e2e-test-user@example.com


### PR DESCRIPTION
## Summary
- `.github/workflows/e2e.yml` がGitHub Secrets経由でSupabase本番環境（`dddwaoooqzrtlbtcnwso.supabase.co`、ダッシュボードで確認済みの本番プロジェクト）に接続する設定になっており、`e2e/env-guard.ts` のガードで全PR（#31・#33・#34）のCIが失敗していた
- `env-guard.ts` の本来の設計（デフォルト許可ホストは `127.0.0.1`/`localhost` のみ）に合わせ、`supabase/setup-cli` + `supabase start` + `supabase db reset` でCI内にローカルSupabaseを起動し、`supabase status -o json` から動的に取得した接続情報のみを使うよう変更
- 本番Supabaseのsecretsがe2eジョブに一切渡らなくなり、`E2E_ALLOWED_SUPABASE_HOSTS` へ本番ホストを登録するような危険な回避策も構造的に不要になった
- `E2E_TEST_EMAIL` は `docs/agents/common.md` のダミーデータ規約に合わせて固定値 `e2e-test-user@example.com` を直接指定（機密情報ではないためsecrets化不要）

## Test plan
- [x] Pythonでのyaml構文検証を実施済み
- [ ] このPR自体のCI（e2eジョブ）が実際に緑になることを確認 ← 本PRの主目的
- [ ] 緑になったら、同じ修正が他の開いているPR（#31・#33・#34）にも波及する（ベースがmainのため、これらのブランチも今後のCIで恩恵を受ける）
- [ ] 本番Supabaseの `NEXT_PUBLIC_SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` 等のGitHub Secretsが、他の用途（本番デプロイ等）で引き続き必要か別途確認（本PRのスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)