### PR TITLE
Phase1入口をaidd-phase1-router.jsに統一しTRI/RISK判定を自動化

### DIFF
--- a/.claude/workflows/aidd-phase1-router.js
+++ b/.claude/workflows/aidd-phase1-router.js
@@ -1,0 +1,57 @@
+export const meta = {
+  name: 'aidd-phase1-router',
+  description: 'taskDescriptionをTRI/RISK基準に照合し、aidd-phase1（軽量Sweep）とaidd-1-1-deep-task（深掘り）のどちらを起動するか自動判定する。',
+  whenToUse: 'Phase 1調査の入り口として使う。DBスキーマ変更・auth/facility/tenant/organization/inventory/RLS/policy等の高リスク判定を機械的に行い、手動判断を不要にする。',
+  phases: [
+    { title: 'Route', detail: 'TRI/RISKキーワード照合で軽量/深掘りを判定' },
+  ],
+}
+
+// args: { taskDescription?: string, maxRounds?: number }
+// 判定はtaskDescriptionのキーワードマッチのみ（変更ファイル・git diffは見ない）
+
+const RISK_KEYWORDS = [
+  // パス由来
+  'migrations', 'migration', 'マイグレーション', 'スキーマ',
+  'src/lib/supabase', 'middleware.ts', 'ミドルウェア',
+  // ドメイン由来（common.md TRI/RISK基準）
+  'auth', '認証', 'ログイン',
+  'facility', '施設',
+  'tenant', 'テナント',
+  'organization', '組織',
+  'inventory', '在庫',
+  'rls', 'policy', 'ポリシー',
+]
+
+// 意図的に安全側に倒す（common.md TRI/RISK原則: 迷ったら高リスク側）。
+// false positive（軽微なタスクが深掘りに回る＝時間コスト増）は許容し、
+// false negative（高リスク変更を軽量版で見逃す）は許容しない。
+
+// Workflowツール実行系のargsがverbatimでなく文字列化されて渡ってくる既知の不具合への回避策。
+// argsが文字列で届いた場合はJSONとしてパースしてから使う。
+const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
+
+const taskDescription = parsedArgs?.taskDescription ?? '現在のコードベース全体の調査'
+const maxRounds = parsedArgs?.maxRounds ?? 3
+
+phase('Route')
+
+const lowerTask = taskDescription.toLowerCase()
+const matched = RISK_KEYWORDS.filter(kw => lowerTask.includes(kw.toLowerCase()))
+const isHighRisk = matched.length > 0
+
+log(
+  isHighRisk
+    ? `TRI/RISK該当キーワード検出（${matched.join(', ')}）→ aidd-1-1-deep-task を起動`
+    : 'TRI/RISK該当なし → aidd-phase1（軽量Sweep）を起動'
+)
+
+const result = isHighRisk
+  ? await workflow('aidd-1-1-deep-task', { taskDescription, maxRounds })
+  : await workflow('aidd-phase1', { taskDescription })
+
+return {
+  route: isHighRisk ? 'aidd-1-1-deep-task' : 'aidd-phase1',
+  matchedKeywords: matched,
+  result,
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,17 @@ Phase 1 調査(並列) → Phase 2 仕様書 → [停止① 人間レビュー]
 
 | エージェント | モデル | 役割 | Phase |
 |---|---|---|---|
+| `sweep-ui` | haiku | src/app/・src/components/ を調査。コンポーネント・props・stateのバグ・型エラーを報告 | Phase 1 |
+| `sweep-data` | haiku | src/lib/supabase/ とAPIルートを調査。型エラー・セキュリティ問題・設計違反を報告 | Phase 1 |
+| `sweep-db` | haiku | Supabaseスキーマ・マイグレーション・RLSを調査。整合性・設計・セキュリティ問題を報告 | Phase 1 |
+| `sweep-types` | haiku | 型定義・mappers・DB列・UIプロップスを縦断調査。層をまたぐ型不一致・欠落を報告 | Phase 1 |
+| `completeness-critic` | sonnet | 未調査モダリティ・未検証クレーム・未読ソースを検出。網羅性チェック・終了判定 | Phase 1 / Phase 1深掘り |
+| `proposer` | sonnet | 設計アプローチを1案提案（スタンス指定で起動） | Phase 1深掘り |
+| `judge-panel` | sonnet | 複数の設計提案を評価・採点し、synthesis（統合提案）を作成。読み取り専用 | Phase 1深掘り |
+| `adversarial-verify` | opus | Sweep指摘に反論を試み、偽陽性を除去。読み取り専用 | Phase 1深掘り |
+| `contract-writer` | sonnet | src/types/ の型定義・APIインターフェース型を先行確定。implementerへの「契約」を書く | Phase 3 |
 | `implementer` | opus | TDD実装（RED→GREEN→REFACTOR）。テスト削除・期待値改ざん禁止 | Phase 3 |
+| `integrator` | sonnet | マイグレーション適用確認・共有ファイルの結線・npm test/lint確認 | Phase 4 |
 | `reviewer` | sonnet | TDD品質規約検証・4観点指摘（正しさ/仕様カバレッジ/重複/型安全）読み取り専用 | Phase 5 |
 
 ## プロジェクト固有スキル（`.claude/skills/`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Phase 5 検証(並列) →
 **SDD・AIDD・手動実装など、フロー種別を問わず**以下のタイミングで必ず Bash 実行する（Stop hook が自動でレポート生成）：
 
 ```bash
-# 1. AIDDフロー開始時（aidd-phase1.js を呼ぶ前）
+# 1. AIDDフロー開始時（aidd-phase1-router.js を呼ぶ前）
 echo '' | ~/write_aidd_stats.sh start "<feature>" "$(pwd)"
 
 # 2. phase1 開始直前

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -71,6 +71,22 @@ migrationファイルだけがスキーマの唯一のソースオブトゥル�
 直接実行を禁止し、既存の未記録スキーマ変更を見つけた場合は必ずキャッチアップmigrationとして
 記録するルールにした。
 
+## なぜaidd-phase1-router.jsでargsをJSON.parseする防御コードを入れたか
+
+`.claude/workflows/aidd-phase1-router.js` は、`typeof args === 'string'` の場合に
+`JSON.parse(args)` してから使う防御コードを持つ。これはスクリプト側のバグ対応ではなく、
+**Workflowツール自体の未解決の不具合への回避策**。
+
+実測では、Workflowツールに `args: {"taskDescription": "..."}` をオブジェクトとして渡しても、
+スクリプト内で受け取った `args` が `typeof args === 'string'` になる（JSON文字列化された状態で
+渡ってくる）ことを診断用スクリプトで確認した。ツールの仕様上は「argsをverbatim（そのまま）で
+渡す」とされているが、実際の挙動は仕様と食い違っている。
+
+ツール本体の不具合は自分たちの管理外のため直接修正できない。将来Workflowツール側の実装が
+修正された場合、この防御コードは不要になる可能性がある。ただし後方互換のため、修正確認が
+取れるまでは外さないこと（`typeof args === 'string'` のガードがあるため、objectで正しく届く
+ようになっても副作用なく動作し続ける）。
+
 ## なぜE2E/BSGはテスト専用Supabaseのみに接続する設計にしたか
 
 `NODE_ENV=test` では `.env.local`（本番接続情報）を読み込ませず、`e2e/env-guard.ts` で

--- a/docs/ai-config-map.md
+++ b/docs/ai-config-map.md
@@ -49,9 +49,10 @@ medical-inventory-vkumai/               ← このプロジェクト
     │   ├── structured-review/SKILL.md  ← 最終構造化レビュー（Phase 5後）
     │   └── e2e-runner/SKILL.md         ← E2Eテスト・スクリーンショット
     └── workflows/
-        ├── aidd-phase1.js              ← Phase 1 調査ワークフロー
+        ├── aidd-phase1-router.js       ← Phase 1 入口。TRI/RISKキーワードでaidd-phase1/aidd-1-1-deep-taskへ自動振り分け
+        ├── aidd-phase1.js              ← Phase 1 調査ワークフロー（軽量Sweep。routerから呼ばれる）
         ├── aidd-phase2.js              ← Phase 3-5 実装〜検証ワークフロー
-        ├── aidd-1-1-deep-task.js       ← 深掘り調査・仕様検証（オンデマンド）
+        ├── aidd-1-1-deep-task.js       ← 深掘り調査・仕様検証（routerから高リスク判定時に呼ばれる）
         └── aidd-session-report.js      ← セッションレポート生成
 ```
 
@@ -111,10 +112,22 @@ medical-inventory-vkumai/               ← このプロジェクト
 ## 開発フロー（Phase 1-5）とエージェントの対応
 
 ```
-Phase 1: 調査（並列 4軸 Sweep）  ← aidd-phase1.js
-  → sweep-ui / sweep-data / sweep-db / sweep-types を並列起動
+Phase 1: 調査  ← aidd-phase1-router.js（正式な入口）
+  → taskDescriptionをTRI/RISKキーワード（migrations/auth/facility/tenant/
+    organization/inventory/RLS/policy等）に照合し、機械的に自動振り分け
+  → 該当なし: aidd-phase1.js（軽量Sweep、4エージェント）
+     sweep-ui / sweep-data / sweep-db / sweep-types を並列起動
+  → 該当あり: aidd-1-1-deep-task.js（深掘り、adversarial-verify / judge-panel / proposer 等）
+     Sweep+Loop Until Dry→Draft Spec→Find→Adversarial Verify→Completeness Critic
+     →Judge Panel→Synthesizeの8フェーズをフル実行
   → completeness-critic で網羅性チェック・終了判定
-  ※ 深掘りが必要なら aidd-1-1-deep-task.js（adversarial-verify / judge-panel / proposer）
+
+  ⚠️ コスト差は一桁以上ある（実測値、2026-07-10検証）：
+     軽量版: 4エージェント / 数分
+     深掘り版: 75エージェント / 約27分 / 約217万トークン
+  false positive（軽微なタスクが深掘りに誤って回ること）は意図的に許容している
+  （common.md TRI/RISK原則「迷ったら高リスク側に倒す」）。false negative（高リスク
+  変更の見逃し）よりコスト増の方が安全という判断。理由は decisions.md 参照。
 
 Phase 2: 仕様書  [skill: feature-spec]
   → SPEC.md 生成（Part 1 を人間にレビューしてもらう）
@@ -153,7 +166,8 @@ Phase 5: 検証 [agent: reviewer × 並列 4観点]  ← aidd-phase2.js
 | `CLAUDE.md` | Phase 1-5 の詳細フロー定義・絶対ルール |
 | `AGENTS.md` | AIツール向けクイックリファレンス |
 | `.claude/settings.json` | Bash/MCP 権限リスト（Supabase・npm・git） |
-| `.claude/workflows/aidd-phase1.js` | Phase 1 ワークフロー実装（args・完了後手順） |
+| `.claude/workflows/aidd-phase1-router.js` | Phase 1 正式入口。TRI/RISK自動振り分け（argsのJSON.parse防御理由はdecisions.md参照） |
+| `.claude/workflows/aidd-phase1.js` | Phase 1 軽量Sweepワークフロー実装（routerから呼ばれる） |
 | `.claude/workflows/aidd-phase2.js` | Phase 3-5 ワークフロー実装（args・完了後手順） |
 | `.claude/workflows/aidd-1-1-deep-task.js` | 深掘り調査ワークフロー（オンデマンド） |
 | `docs/ai-config-map.md` | このファイル（全体マップ） |


### PR DESCRIPTION
## Summary
- taskDescriptionをTRI/RISKキーワード(migrations/auth/facility/tenant/organization/inventory/RLS/policy等)に照合し、軽量Sweep(aidd-phase1)と深掘り調査(aidd-1-1-deep-task)への振り分けを自動化した
- これまで「メインループがタスクを見て毎回どちらを呼ぶか判断する」手動運用だった箇所を機械判定に置き換えた
- Workflowツールのargsがverbatimで渡らず文字列化される既知の不具合を発見し、JSON.parseによる防御的パースで回避(理由はdecisions.mdに記録)
- CLAUDE.md / AGENTS.md / docs/ai-config-map.md / docs/agents/decisions.md を更新し、新しいPhase1入口・コスト差・Phase1系エージェント一覧を反映

## Test plan
- [x] router.jsの分岐ロジックをNode単体テストで検証(5パターン、キーワードマッチ/非マッチとも意図通り)
- [x] 実際にWorkflowツール経由で軽量版(aidd-phase1)を実行し、agent typeが正しく解決されることを確認
- [x] argsのJSON.parse回避策導入後、深掘り版(aidd-1-1-deep-task)をフル実行し完走を確認(75エージェント・約217万トークン・約27分)
- [x] `matchedKeywords: ["在庫"]` → `route: "aidd-1-1-deep-task"` を実行ログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)