### PR TITLE
docs: AIDD Run Manifestのスキーマを定義

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ e2e/.auth/user.json
 
 # Stop hookのセッション内重複提案抑止用の一時状態（ローカル専用）
 /.claude/.doc-suggest-state/
+
+# AIDD Run Manifest（フロー実行ごとに生成される一時状態。スキーマはdocs/agents/run-manifest.md参照）
+/.aidd/

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -61,3 +61,4 @@ any code. Heed deprecation notices.
 | `src/components/` | UI コンポーネント |
 | `src/lib/supabase/` | Supabase クライアント・データ取得層 |
 | `supabase/migrations/` | DBマイグレーション |
+| [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |

--- a/docs/agents/run-manifest.example.json
+++ b/docs/agents/run-manifest.example.json
@@ -1,0 +1,14 @@
+{
+  "specPath": "docs/superpowers/specs/2026-07-10-example-feature-design.md",
+  "specHash": "3b1c9d5f2a6e4d0c8b7a1f9e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6b7a8f9e0d1c",
+  "baseCommit": "d1a7dbdb1c4e2f6a9b0c3d4e5f6a7b8c9d0e1f2a",
+  "changedFiles": [
+    "src/app/example-feature/page.tsx",
+    "src/lib/supabase/example-feature.ts",
+    "supabase/migrations/20260710000000_example_feature.sql"
+  ],
+  "approval": {
+    "approvedBy": "huuriekaiseki@gmail.com",
+    "approvedAt": "2026-07-10T05:00:00+09:00"
+  }
+}

--- a/docs/agents/run-manifest.md
+++ b/docs/agents/run-manifest.md
@@ -1,0 +1,43 @@
+# Run Manifest
+
+AIDDフロー（Phase 1〜5）が1回の実行の中で「どの仕様書を」「どのコミットを起点に」
+「誰が承認したか」を機械的に突合できるようにするための記録。
+
+## 背景
+
+現状、specPath・specHash・baseCommit・changedFiles・承認記録がフェーズ間で分散しており、
+「レビュー時に見た仕様書」と「実装時に参照した仕様書」が一致している保証がない。
+Run ManifestはこのズレをPhase間で検出するための唯一の正とする。
+
+## 保存場所
+
+```
+.aidd/run-manifest.json
+```
+
+リポジトリ直下に生成する一時ファイル。フロー実行のたびに上書きされるため `.gitignore` 済み
+（コミット対象にしない）。サンプルは [`run-manifest.example.json`](./run-manifest.example.json) を参照。
+
+## スキーマ
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `specPath` | string | 対象SPEC.mdのリポジトリ相対パス |
+| `specHash` | string | `specPath` の内容から算出したsha256ハッシュ（承認時点） |
+| `baseCommit` | string | 実装の起点となったgitコミットSHA |
+| `changedFiles` | string[] | このAIDD実行で変更されたファイルの相対パス一覧 |
+| `approval.approvedBy` | string | 停止①（仕様レビュー）を承認した人物 |
+| `approval.approvedAt` | string (ISO 8601) | 承認日時 |
+
+## 書き出し・突合タイミング
+
+- **Phase 1完了時**: `specPath` を確定させ、`baseCommit`（現在のHEAD）を記録する。
+- **停止①（人間レビュー）承認時**: `specHash` を計算し、`approval` を記録する。
+- **Phase 2開始時**: `specPath` の現在のハッシュを再計算し、manifestの `specHash` と突合する。
+  一致しない場合はPhase 2を起動せずエラーにする（レビュー後にSPEC.mdが変更されたことを検出するため）。
+- **Phase 3〜4完了時**: `changedFiles` を実際の変更ファイル一覧で更新する。
+
+## 関連ファイル
+
+- [`common.md`](./common.md) — 全AIエージェント共通ルール
+- [`decisions.md`](./decisions.md) — 各ルールの設計理由


### PR DESCRIPTION
## Summary
- Phase間でspecHash/baseCommitを突合できず、レビュー後にSPEC.mdが変更されても検出できない問題に対処するため、Run Manifestのスキーマと保存場所(`.aidd/run-manifest.json`)を定義
- 保存場所は実行時生成物として`.gitignore`に追加
- サンプルファイルと`common.md`への参照を追加

## Test plan
- [ ] ドキュメントのみの変更のためテスト不要
- [ ] `docs/agents/run-manifest.md`の内容がスキーマ・保存場所・突合タイミングを網羅していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)