### PR TITLE
feat: aidd-phase1.jsがRun Manifest用のbaseCommitを収集する

### DIFF
--- a/.claude/workflows/aidd-phase1.js
+++ b/.claude/workflows/aidd-phase1.js
@@ -12,11 +12,20 @@ export const meta = {
 //
 // ── 完了後の手順（Claude が実行すること）──────────────────────────────
 // 1. 調査結果をもとに SPEC.md を生成する
-// 2. 【停止①】仕様書を人間に提示し、承認を得るまで Phase 3 に進まない
+// 2. runManifestSeed.baseCommit と、確定した SPEC.md のパスを使って
+//    .aidd/run-manifest.json を Write tool で書き出す
+//    （スキーマは docs/agents/run-manifest.md 参照。specHash・approval は
+//    停止①で人間が承認した時点で追記する）
+// 3. 【停止①】仕様書を人間に提示し、承認を得るまで Phase 3 に進まない
 //
 // ── 深掘り調査・仕様検証が必要な場合 ────────────────────────────────
 // `.claude/workflows/aidd-1-1-deep-task.js` を Read して実行する（オンデマンド）
 // ────────────────────────────────────────────────────────────────────
+//
+// 注記: このワークフロースクリプトはサンドボックス実行のためファイルシステムAPIを
+// 持たない。そのためRun Manifestの実ファイル書き出しはスクリプト内では行わず、
+// 書き出しに必要な値（baseCommit）だけをここで収集し、返却値経由でオーケストレーター
+// に渡す。
 
 const taskDescription = args?.taskDescription ?? '現在のコードベース全体の調査'
 
@@ -25,14 +34,20 @@ log('4軸並列Sweep 開始（1ラウンド）')
 
 const sweepPrompt = `タスク: ${taskDescription}`
 
-const [uiResult, dataResult, dbResult, typesResult] = await parallel([
+const [uiResult, dataResult, dbResult, typesResult, baseCommitRaw] = await parallel([
   () => agent(sweepPrompt, { label: 'sweep-ui',    agentType: 'sweep-ui',    phase: 'Sweep' }),
   () => agent(sweepPrompt, { label: 'sweep-data',  agentType: 'sweep-data',  phase: 'Sweep' }),
   () => agent(sweepPrompt, { label: 'sweep-db',    agentType: 'sweep-db',    phase: 'Sweep' }),
   () => agent(sweepPrompt, { label: 'sweep-types', agentType: 'sweep-types', phase: 'Sweep' }),
+  () => agent('Run `git rev-parse HEAD` in the repository root and return only the resulting commit SHA, with no other text.', { label: 'capture-base-commit', phase: 'Sweep', effort: 'low' }),
 ])
 
 log('Sweep 完了')
+
+const baseCommit = baseCommitRaw?.trim().match(/^[0-9a-f]{7,40}$/)?.[0] ?? null
+if (!baseCommit) {
+  log('警告: baseCommitの取得に失敗しました。Run Manifestのbase_commitは手動で埋めてください。')
+}
 
 return {
   findings: {
@@ -47,5 +62,9 @@ return {
     rounds: 1,
     findingCount: [uiResult, dataResult, dbResult, typesResult]
       .filter(r => r && r !== '指摘なし').length,
+  },
+  runManifestSeed: {
+    baseCommit,
+    changedFiles: [],
   },
 }


### PR DESCRIPTION
## Summary
- issue #4「各フェーズがRun Manifestを読み書きするよう配線する」の第一歩
- ワークフロースクリプトはサンドボックス実行のためファイルシステムAPIを持たないため、実ファイル書き出しはできない
- Phase1でbaseCommit（`git rev-parse HEAD`）を取得し、`runManifestSeed`として返却値に含める形に変更
- 実際の`.aidd/run-manifest.json`書き出しは、オーケストレーター（Claude本体）がSPEC.md確定後にWrite toolで行う手順として、ワークフロー冒頭のコメントに明記した

## 未着手（別issue）
- Phase2開始時にspecHashを再計算して突合し、不一致ならブロックする処理
- 実際の`.aidd/run-manifest.json`の書き出し・読み込みを試すE2E的な確認

## Test plan
- [ ] `aidd-phase1`ワークフローを実行し、`runManifestSeed.baseCommit`に正しいgitコミットSHAが入ることを確認
- [ ] gitコミットSHAの取得に失敗した場合、警告ログが出て`baseCommit: null`になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)