### PR TITLE
feat: AIDDワークフローのagent呼び出しにstatus(pass/fail/blocked)を導入

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -25,6 +25,39 @@ export const meta = {
 const taskDescription = args?.taskDescription ?? '現在のコードベース全体の調査'
 const maxRounds = args?.maxRounds ?? 3
 
+// docs/agents/agent-result-schema.md 参照
+const AGENT_RESULT_SCHEMA_PB = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['pass', 'blocked'] },
+    detail: { type: 'string' },
+  },
+  required: ['status', 'detail'],
+}
+
+const AGENT_RESULT_SCHEMA_PFB = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['pass', 'fail', 'blocked'] },
+    detail: { type: 'string' },
+  },
+  required: ['status', 'detail'],
+}
+
+const SWEEP_GUIDE = `
+
+## 出力形式
+status と detail を返すこと。
+- status: "pass"=調査を最後まで実行できた(指摘の有無は問わない) / "blocked"=権限不足・対象コード不在等で調査自体が実行できなかった
+- detail: 調査結果の本文(指摘が無ければ「指摘なし」と書く)`
+
+const CRITIC_GUIDE = `
+
+## 出力形式
+status と detail を返すこと。
+- status: "pass"=批評を完了した(追加調査の要否は問わない) / "blocked"=Sweep結果が空で批評に着手できなかった
+- detail: 批評の本文。追加調査が必要な場合は「追加調査対象:」に続けて記述すること`
+
 // ─── Phase 1-2: Sweep + Completeness Critic ──────────────────────────
 let round = 1
 let dryRounds = 0
@@ -35,46 +68,48 @@ while (dryRounds < 2 && round <= maxRounds) {
   log(`Sweepラウンド ${round}/${maxRounds} 開始`)
   phase('Sweep')
 
-  const sweepPrompt = additionalContext
+  const sweepPrompt = (additionalContext
     ? `タスク: ${taskDescription}\n\n前ラウンドのCritic追加指示:\n${additionalContext}`
-    : `タスク: ${taskDescription}`
+    : `タスク: ${taskDescription}`) + SWEEP_GUIDE
 
   const [uiResult, dataResult, dbResult, typesResult] = await parallel([
-    () => agent(sweepPrompt, { label: `sweep-ui:R${round}`,    agentType: 'sweep-ui',    phase: 'Sweep' }),
-    () => agent(sweepPrompt, { label: `sweep-data:R${round}`,  agentType: 'sweep-data',  phase: 'Sweep' }),
-    () => agent(sweepPrompt, { label: `sweep-db:R${round}`,    agentType: 'sweep-db',    phase: 'Sweep' }),
-    () => agent(sweepPrompt, { label: `sweep-types:R${round}`, agentType: 'sweep-types', phase: 'Sweep' }),
+    () => agent(sweepPrompt, { label: `sweep-ui:R${round}`,    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
+    () => agent(sweepPrompt, { label: `sweep-data:R${round}`,  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
+    () => agent(sweepPrompt, { label: `sweep-db:R${round}`,    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
+    () => agent(sweepPrompt, { label: `sweep-types:R${round}`, agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
   ])
 
-  const isNew = (r) => r && r.trim() !== '指摘なし'
-  if (isNew(uiResult))    allFindings.ui.push(`[R${round}]\n${uiResult}`)
-  if (isNew(dataResult))  allFindings.data.push(`[R${round}]\n${dataResult}`)
-  if (isNew(dbResult))    allFindings.db.push(`[R${round}]\n${dbResult}`)
-  if (isNew(typesResult)) allFindings.types.push(`[R${round}]\n${typesResult}`)
+  // isNew: 完遂できた(status==='pass')うえで、実際に新規の指摘がある(detail!=='指摘なし')場合のみ新規findingsとみなす(2軸判定)
+  const isNew = (r) => r?.status === 'pass' && r?.detail !== '指摘なし'
+  if (isNew(uiResult))    allFindings.ui.push(`[R${round}]\n${uiResult.detail}`)
+  if (isNew(dataResult))  allFindings.data.push(`[R${round}]\n${dataResult.detail}`)
+  if (isNew(dbResult))    allFindings.db.push(`[R${round}]\n${dbResult.detail}`)
+  if (isNew(typesResult)) allFindings.types.push(`[R${round}]\n${typesResult.detail}`)
 
   const hasNewFindings = isNew(uiResult) || isNew(dataResult) || isNew(dbResult) || isNew(typesResult)
 
   const roundSummary = [
-    `## UI層\n${uiResult ?? '指摘なし'}`,
-    `## データ取得層\n${dataResult ?? '指摘なし'}`,
-    `## DB層\n${dbResult ?? '指摘なし'}`,
-    `## 型整合性\n${typesResult ?? '指摘なし'}`,
+    `## UI層\n${uiResult?.detail ?? '指摘なし'}`,
+    `## データ取得層\n${dataResult?.detail ?? '指摘なし'}`,
+    `## DB層\n${dbResult?.detail ?? '指摘なし'}`,
+    `## 型整合性\n${typesResult?.detail ?? '指摘なし'}`,
   ].join('\n\n')
 
   phase('Completeness Critic')
   const criticResult = await agent(
-    `タスク: ${taskDescription}\n\n## 今ラウンドのSweep結果\n${roundSummary}\n\n## 累積発見\nUI: ${allFindings.ui.join('\n')}\nData: ${allFindings.data.join('\n')}\nDB: ${allFindings.db.join('\n')}\nTypes: ${allFindings.types.join('\n')}`,
-    { label: `critic:R${round}`, agentType: 'completeness-critic', phase: 'Completeness Critic' }
+    `タスク: ${taskDescription}\n\n## 今ラウンドのSweep結果\n${roundSummary}\n\n## 累積発見\nUI: ${allFindings.ui.join('\n')}\nData: ${allFindings.data.join('\n')}\nDB: ${allFindings.db.join('\n')}\nTypes: ${allFindings.types.join('\n')}${CRITIC_GUIDE}`,
+    { label: `critic:R${round}`, agentType: 'completeness-critic', phase: 'Completeness Critic', schema: AGENT_RESULT_SCHEMA_PB }
   )
 
-  const hasNewCriticFindings = criticResult != null && criticResult.includes('追加調査対象:')
+  // hasNewCriticFindings: 完遂できた(status==='pass')うえで、detail内に「追加調査対象:」の記述がある場合のみ継続トリガーとする(2軸判定)
+  const hasNewCriticFindings = criticResult?.status === 'pass' && criticResult.detail?.includes('追加調査対象:')
 
   if (!hasNewFindings && !hasNewCriticFindings) {
     dryRounds++
     log(`Dry ラウンド ${dryRounds}/2`)
   } else {
     dryRounds = 0
-    additionalContext = hasNewCriticFindings ? criticResult : ''
+    additionalContext = hasNewCriticFindings ? criticResult.detail : ''
   }
   round++
 }
@@ -92,8 +127,14 @@ log(`Sweep完了: ${round - 1}ラウンド`)
 phase('Draft Spec')
 
 const draftSpec = await agent(
-  `以下の調査結果をもとに、機能仕様書ドラフトを生成してください。\n\nタスク: ${taskDescription}\n\n## 調査結果\n${sweepSummary}\n\n## 出力形式\n### Part 1 — 仕様（人間レビュー用）\n- 何ができるようになるか（利用者目線）\n- 操作の流れ・受け入れ条件（チェックリスト）\n\n### Part 2 — 実装計画（AI用）\n- 実装セット一覧（依存順）\n- 各セットのテスト観点・型・データアクセス層の方針\n- 並列グループ宣言（触るファイルを明記）`,
-  { label: 'draft-spec', phase: 'Draft Spec', model: 'claude-sonnet-4-6', effort: 'medium' }
+  `以下の調査結果をもとに、機能仕様書ドラフトを生成してください。\n\nタスク: ${taskDescription}\n\n## 調査結果\n${sweepSummary}\n\n## 出力形式\n### Part 1 — 仕様（人間レビュー用）\n- 何ができるようになるか（利用者目線）\n- 操作の流れ・受け入れ条件（チェックリスト）\n\n### Part 2 — 実装計画（AI用）\n- 実装セット一覧（依存順）\n- 各セットのテスト観点・型・データアクセス層の方針\n- 並列グループ宣言（触るファイルを明記）${''}
+
+## status/detail
+上記の仕様書ドラフト本文は detail に格納し、status も返すこと。
+- pass: 仕様書ドラフトを生成できた
+- fail: 生成されたが調査結果を反映していない等明らかに不完全
+- blocked: Sweep結果が空でドラフト生成に着手できなかった`,
+  { label: 'draft-spec', phase: 'Draft Spec', model: 'claude-sonnet-4-6', effort: 'medium', schema: AGENT_RESULT_SCHEMA_PFB }
 )
 
 log('仕様書ドラフト生成完了。Deep Spec 検証を開始します。')
@@ -131,7 +172,7 @@ const FINDERS = [
 
 const findResults = await parallel(
   FINDERS.map(f => () => agent(
-    `${f.prompt}、以下の仕様書ドラフトの問題点を列挙せよ。\n\n${draftSpec}`,
+    `${f.prompt}、以下の仕様書ドラフトの問題点を列挙せよ。\n\n${draftSpec?.detail}`,
     { label: `find:${f.lens}`, phase: 'Find', schema: FINDING_SCHEMA, model: 'claude-haiku-4-5-20251001', effort: 'low' }
   ))
 )
@@ -160,7 +201,7 @@ const VERDICT_SCHEMA = {
 
 const verdicts = await parallel(
   dedupedFindings.map((f, i) => () => agent(
-    `次の仕様指摘を反証しようとせよ。仕様書のどこかで既に対処されているか、問題が成立しない理由があれば refuted=true にせよ。不確かなら refuted=false にせよ（疑わしいものは生存させる）。\n\nタイトル: ${f.title}\n説明: ${f.description}\n\n仕様書ドラフト:\n${draftSpec}`,
+    `次の仕様指摘を反証しようとせよ。仕様書のどこかで既に対処されているか、問題が成立しない理由があれば refuted=true にせよ。不確かなら refuted=false にせよ（疑わしいものは生存させる）。\n\nタイトル: ${f.title}\n説明: ${f.description}\n\n仕様書ドラフト:\n${draftSpec?.detail}`,
     { label: `verify:${i}`, phase: 'Adversarial Verify', schema: VERDICT_SCHEMA, model: 'claude-sonnet-4-6', effort: 'medium' }
   ))
 )
@@ -191,7 +232,7 @@ const CRITIC_SCHEMA = {
 }
 
 const criticResult2 = await agent(
-  `以下の仕様書ドラフトと生存した指摘リストを見て、まだ検証されていない領域・抜け漏れ・未回答の設計判断を指摘せよ。\n\n## 仕様書ドラフト\n${draftSpec}\n\n## 生存した指摘\n${survived.map(f => `- [${f.severity}] ${f.title}: ${f.description}`).join('\n')}`,
+  `以下の仕様書ドラフトと生存した指摘リストを見て、まだ検証されていない領域・抜け漏れ・未回答の設計判断を指摘せよ。\n\n## 仕様書ドラフト\n${draftSpec?.detail}\n\n## 生存した指摘\n${survived.map(f => `- [${f.severity}] ${f.title}: ${f.description}`).join('\n')}`,
   { label: 'completeness-critic-2', phase: 'Completeness Critic', schema: CRITIC_SCHEMA, model: 'claude-sonnet-4-6', effort: 'medium' }
 )
 
@@ -233,7 +274,7 @@ const PROPOSERS = [
 
 const proposals = await parallel(
   PROPOSERS.map(p => () => agent(
-    `${p.prompt}\n\n## 仕様書ドラフト\n${draftSpec}\n\n## 生存した問題点\n${survived.map(f => `- [${f.severity}] ${f.title}`).join('\n')}\n\n## ギャップ\n${gaps.map(g => `- ${g.area}: ${g.description}`).join('\n')}`,
+    `${p.prompt}\n\n## 仕様書ドラフト\n${draftSpec?.detail}\n\n## 生存した問題点\n${survived.map(f => `- [${f.severity}] ${f.title}`).join('\n')}\n\n## ギャップ\n${gaps.map(g => `- ${g.area}: ${g.description}`).join('\n')}`,
     { label: `propose:${p.stance}`, phase: 'Judge Panel', schema: PROPOSAL_SCHEMA, model: 'claude-sonnet-4-6', effort: 'medium' }
   ))
 )
@@ -264,8 +305,8 @@ log(`Judge Panel完了: 最高スコア案 "${winner?.proposal?.name}" (${Math.r
 phase('Synthesize')
 
 const synthesis = await agent(
-  `以下の全検証結果を統合して、仕様書ドラフトへの具体的な修正提案を出力せよ。\n\n## 元の仕様書ドラフト\n${draftSpec}\n\n## 生存した問題点 (${survived.length}件)\n${survived.map(f => `- [${f.severity}][${f.category}] ${f.title}: ${f.description}`).join('\n')}\n\n## ギャップ (${gaps.length}件)\n${gaps.map(g => `- [${g.area}] ${g.description} → 提案: ${g.suggestion}`).join('\n')}\n\n## Judge Panel結果\n### 採用推奨案: ${winner?.proposal?.name} (スコア: ${Math.round(winner?.avgScore ?? 0)})\n${winner?.proposal?.description}\n主要判断: ${winner?.proposal?.keyDecisions?.join(' / ')}\n\n### 他案のグラフト候補\n${runnerUps.map(r => `- ${r.proposal?.name}: ${r.proposal?.keyDecisions?.join(' / ')}`).join('\n')}\n\n## 出力形式\n1. **必須修正** (critical/important の問題点)\n2. **推奨修正** (minor・ギャップ)\n3. **設計判断** (採用推奨アプローチとその理由)\n4. **未解決事項** (人間が判断すべきポイント)`,
-  { label: 'synthesize', phase: 'Synthesize', model: 'claude-opus-4-8', effort: 'high' }
+  `以下の全検証結果を統合して、仕様書ドラフトへの具体的な修正提案を出力せよ。\n\n## 元の仕様書ドラフト\n${draftSpec?.detail}\n\n## 生存した問題点 (${survived.length}件)\n${survived.map(f => `- [${f.severity}][${f.category}] ${f.title}: ${f.description}`).join('\n')}\n\n## ギャップ (${gaps.length}件)\n${gaps.map(g => `- [${g.area}] ${g.description} → 提案: ${g.suggestion}`).join('\n')}\n\n## Judge Panel結果\n### 採用推奨案: ${winner?.proposal?.name} (スコア: ${Math.round(winner?.avgScore ?? 0)})\n${winner?.proposal?.description}\n主要判断: ${winner?.proposal?.keyDecisions?.join(' / ')}\n\n### 他案のグラフト候補\n${runnerUps.map(r => `- ${r.proposal?.name}: ${r.proposal?.keyDecisions?.join(' / ')}`).join('\n')}\n\n## 出力形式\n1. **必須修正** (critical/important の問題点)\n2. **推奨修正** (minor・ギャップ)\n3. **設計判断** (採用推奨アプローチとその理由)\n4. **未解決事項** (人間が判断すべきポイント)\n\n## status/detail\n上記の統合提案本文は detail に格納し、status も返すこと。\n- pass: 統合提案を生成できた\n- fail: 生成されたが必須修正等のセクションが欠落するなど明らかに不完全\n- blocked: survived/gaps/winnerのいずれかが揃わず統合に着手できなかった`,
+  { label: 'synthesize', phase: 'Synthesize', model: 'claude-opus-4-8', effort: 'high', schema: AGENT_RESULT_SCHEMA_PFB }
 )
 
 return {

--- a/.claude/workflows/aidd-phase1.js
+++ b/.claude/workflows/aidd-phase1.js
@@ -20,32 +20,52 @@ export const meta = {
 
 const taskDescription = args?.taskDescription ?? '現在のコードベース全体の調査'
 
+// docs/agents/agent-result-schema.md 参照。調査系エージェントに「失敗」概念は無いため pass/blocked の2値
+const AGENT_RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['pass', 'blocked'] },
+    detail: { type: 'string' },
+  },
+  required: ['status', 'detail'],
+}
+
+const STATUS_GUIDE = `
+
+## 出力形式
+status と detail を返すこと。
+- status: "pass"=調査を最後まで実行できた(指摘の有無は問わない) / "blocked"=権限不足・対象コード不在等で調査自体が実行できなかった
+- detail: 調査結果の本文(指摘が無ければ「指摘なし」と書く)`
+
 phase('Sweep')
 log('4軸並列Sweep 開始（1ラウンド）')
 
-const sweepPrompt = `タスク: ${taskDescription}`
+const sweepPrompt = `タスク: ${taskDescription}${STATUS_GUIDE}`
 
 const [uiResult, dataResult, dbResult, typesResult] = await parallel([
-  () => agent(sweepPrompt, { label: 'sweep-ui',    agentType: 'sweep-ui',    phase: 'Sweep' }),
-  () => agent(sweepPrompt, { label: 'sweep-data',  agentType: 'sweep-data',  phase: 'Sweep' }),
-  () => agent(sweepPrompt, { label: 'sweep-db',    agentType: 'sweep-db',    phase: 'Sweep' }),
-  () => agent(sweepPrompt, { label: 'sweep-types', agentType: 'sweep-types', phase: 'Sweep' }),
+  () => agent(sweepPrompt, { label: 'sweep-ui',    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
+  () => agent(sweepPrompt, { label: 'sweep-data',  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
+  () => agent(sweepPrompt, { label: 'sweep-db',    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
+  () => agent(sweepPrompt, { label: 'sweep-types', agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
 ])
 
 log('Sweep 完了')
 
+const results = [uiResult, dataResult, dbResult, typesResult]
+
 return {
   findings: {
-    ui:    uiResult    ?? '指摘なし',
-    data:  dataResult  ?? '指摘なし',
-    db:    dbResult    ?? '指摘なし',
-    types: typesResult ?? '指摘なし',
+    ui:    uiResult?.detail    ?? '指摘なし',
+    data:  dataResult?.detail  ?? '指摘なし',
+    db:    dbResult?.detail    ?? '指摘なし',
+    types: typesResult?.detail ?? '指摘なし',
   },
   stats: {
     phase: 'phase1',
     agents: 4,
     rounds: 1,
-    findingCount: [uiResult, dataResult, dbResult, typesResult]
-      .filter(r => r && r !== '指摘なし').length,
+    // findingCount: 完遂できた調査のうち、実際に指摘が見つかった本数(status/detailの2軸判定。docs/agents/agent-result-schema.md参照)
+    findingCount: results.filter(r => r?.status === 'pass' && r?.detail !== '指摘なし').length,
+    blockedCount: results.filter(r => r?.status === 'blocked').length,
   },
 }

--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -27,6 +27,24 @@ export const meta = {
 
 const specPath = args?.specPath ?? 'SPEC.md'
 
+// docs/agents/agent-result-schema.md 参照。実装/統合/レビュー系はpass/fail/blockedの3値
+const AGENT_RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['pass', 'fail', 'blocked'] },
+    detail: { type: 'string' },
+  },
+  required: ['status', 'detail'],
+}
+
+const guide = (pass, fail, blocked) => `
+
+## 出力形式
+status と detail を返すこと。
+- pass: ${pass}
+- fail: ${fail}
+- blocked: ${blocked}`
+
 // ─── Phase A: Contract Write + DB（並列）─────────────────────────────
 // contract-writer: src/types/ の型定義を確定（implementerの「契約」）
 // db-impl: supabase/migrations/ を実装（SPEC.mdから直接、contract-writerと並行）
@@ -34,12 +52,20 @@ phase('Contract + DB')
 
 const [contractResult, dbResult] = await parallel([
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに src/types/ の型定義・APIインターフェース型を確定させてください。`,
-    { label: 'contract-writer', phase: 'Contract + DB', agentType: 'contract-writer' }
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに src/types/ の型定義・APIインターフェース型を確定させてください。${guide(
+      '型定義・APIインターフェース型を確定できた',
+      '型定義を試みたが不完全・矛盾がある',
+      'SPEC.mdが存在しない/読めない'
+    )}`,
+    { label: 'contract-writer', phase: 'Contract + DB', agentType: 'contract-writer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。`,
-    { label: 'db-impl', phase: 'Contract + DB', agentType: 'implementer' }
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。${guide(
+      'マイグレーション実装が完了した',
+      'マイグレーションを試みたがエラー・矛盾がある',
+      'SPEC.mdが存在しない、またはPart2にマイグレーション情報が無く着手不能'
+    )}`,
+    { label: 'db-impl', phase: 'Contract + DB', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
 ])
 
@@ -51,18 +77,24 @@ log('Contract + DB完了')
 // db-impl の完了報告も渡す（スキーマ変更があった場合に追従できるよう）
 phase('Implement')
 
+const implGuide = guide(
+  '担当範囲の実装を完了できた',
+  '実装したが明らかに不完全、またはcontract-writer/db-implの結果と矛盾する',
+  'SPEC.mdが見つからない、またはcontract-writer/db-implの完了報告が空で着手できなかった'
+)
+
 const [dataResult, apiResult, uiResult] = await parallel([
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/lib/supabase/ のデータアクセス関数を実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/lib/supabase/ と src/lib/*/repository.ts。\n\n## contract-writer完了報告\n${contractResult}\n\n## db-impl完了報告\n${dbResult}`,
-    { label: 'data-impl', phase: 'Implement', agentType: 'implementer' }
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/lib/supabase/ のデータアクセス関数を実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/lib/supabase/ と src/lib/*/repository.ts。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`,
+    { label: 'data-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/**/route.ts（/api配下に限らない）を実装してください。\n型定義（src/types/）は確定済みです。\nPart 2 に記載の関数シグネチャに従って src/lib/ の関数を呼ぶこと（実装がまだでも名前・型が確定していれば前進可）。\n触ってよいファイル: src/app/**/route.ts のみ。\n\n## contract-writer完了報告\n${contractResult}\n\n## db-impl完了報告\n${dbResult}`,
-    { label: 'api-impl', phase: 'Implement', agentType: 'implementer' }
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/**/route.ts（/api配下に限らない）を実装してください。\n型定義（src/types/）は確定済みです。\nPart 2 に記載の関数シグネチャに従って src/lib/ の関数を呼ぶこと（実装がまだでも名前・型が確定していれば前進可）。\n触ってよいファイル: src/app/**/route.ts のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`,
+    { label: 'api-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/(pages)/ と src/components/ のUIを実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/app/(pages)/ と src/components/ のみ。\n\n## contract-writer完了報告\n${contractResult}`,
-    { label: 'ui-impl', phase: 'Implement', agentType: 'implementer' }
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/(pages)/ と src/components/ のUIを実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/app/(pages)/ と src/components/ のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}${implGuide}`,
+    { label: 'ui-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
 ])
 
@@ -72,8 +104,12 @@ log('Implement完了')
 phase('Integrate')
 
 const integrationResult = await agent(
-  `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. 全テスト・lint緑を確認して報告\n\n## 各完了報告\n### contract-writer\n${contractResult}\n### db-impl\n${dbResult}\n### data-impl\n${dataResult}\n### api-impl\n${apiResult}\n### ui-impl\n${uiResult}`,
-  { label: 'integrator', phase: 'Integrate', agentType: 'integrator' }
+  `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. 全テスト・lint緑を確認して報告\n\n## 各完了報告\n### contract-writer\n${contractResult?.detail}\n### db-impl\n${dbResult?.detail}\n### data-impl\n${dataResult?.detail}\n### api-impl\n${apiResult?.detail}\n### ui-impl\n${uiResult?.detail}${guide(
+    'npm test・npm run lintが最終的に緑で統合完了',
+    '3回の修正試行後もtest/lintが赤のまま',
+    'SPEC.mdが見つからない、またはいずれかのimplエージェントの完了報告に「仕様書が見つからない」「作業を開始できない」旨の記述がある'
+  )}`,
+  { label: 'integrator', phase: 'Integrate', agentType: 'integrator', schema: AGENT_RESULT_SCHEMA }
 )
 
 log('統合完了')
@@ -88,14 +124,22 @@ const REVIEW_DIMENSIONS = [
   { key: 'type-safety', label: '型安全・データ層の整合' },
 ]
 
+const reviewGuide = guide(
+  'レビューを完了し指摘なし',
+  'レビューを完了し1件以上の指摘がある',
+  'レビュー対象のコード・SPEC.mdが見つからずレビュー自体ができなかった'
+)
+
 const reviewResults = await parallel(
   REVIEW_DIMENSIONS.map(dim => () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。`,
-    { label: `review:${dim.key}`, agentType: 'reviewer', phase: 'Review' }
+    `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。${reviewGuide}`,
+    { label: `review:${dim.key}`, agentType: 'reviewer', phase: 'Review', schema: AGENT_RESULT_SCHEMA }
   ))
 )
 
 log('検証完了。/structured-review でレビュー結果を確認してください。')
+
+const implResults = [contractResult, dbResult, dataResult, apiResult, uiResult]
 
 return {
   contractResult,
@@ -106,13 +150,14 @@ return {
   integration:  integrationResult,
   reviewFindings: REVIEW_DIMENSIONS.map((dim, i) => ({
     dimension: dim.label,
-    findings:  reviewResults[i] ?? '指摘なし',
+    findings:  reviewResults[i]?.detail ?? '指摘なし',
   })),
   stats: {
     phase: 'phase2',
     implAgents: 5,
     reviewAgents: REVIEW_DIMENSIONS.length,
     totalAgents: 5 + 1 + REVIEW_DIMENSIONS.length,
-    implSuccessCount: [contractResult, dbResult, dataResult, apiResult, uiResult].filter(Boolean).length,
+    implSuccessCount: implResults.filter(r => r?.status === 'pass').length,
+    implBlockedCount: implResults.filter(r => r?.status === 'blocked').length,
   },
 }

--- a/.claude/workflows/aidd-session-report.js
+++ b/.claude/workflows/aidd-session-report.js
@@ -51,6 +51,7 @@ ${notes || '（なし）'}
 ### Phase 1 調査
 - Sweeper: ${phase1Stats?.agents ?? '?'}台 × ${phase1Stats?.rounds ?? '?'}ラウンド
 - 指摘あり軸数: ${phase1Stats?.findingCount ?? '?'} / 4
+- 調査不能(blocked)軸数: ${phase1Stats?.blockedCount ?? '?'} / 4
 
 ### Phase 2〜5 実装・検証
 - implementer: ${phase2Stats?.implAgents ?? '?'}台（並列）
@@ -58,6 +59,7 @@ ${notes || '（なし）'}
 - reviewer: ${phase2Stats?.reviewAgents ?? '?'}台（並列）
 - 合計エージェント数: ${phase2Stats?.totalAgents ?? '?'}台
 - 実装成功グループ数: ${phase2Stats?.implSuccessCount ?? '?'} / ${phase2Stats?.implAgents ?? '?'}
+- 着手不能(blocked)グループ数: ${phase2Stats?.implBlockedCount ?? '?'} / ${phase2Stats?.implAgents ?? '?'}
 
 ## 結果サマリー
 - うまくいったこと: （生成時に記入）

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,85 +1,85 @@
-# SPEC: /hospital-prices に施設セレクタUIを追加（Issue #29）
+# SPEC: AIDDフェーズの返却値をpass/fail/blockedに統一する型を定義する
 
----
+対応issue: #41
 
-## Part 1 — 仕様（★人間がレビューする部分）
+## 背景（Phase 1調査結果）
 
-### 何ができるようになるか
+現状、`.claude/workflows/` 配下のAIDDワークフロースクリプトは、`agent()`呼び出しの成否を機械的に判定していない。
 
-- 複数の施設に所属しているユーザー、および管理者(admin)が、「施設別価格管理」画面(`/hospital-prices`)で見たい施設を切り替えられるようになります。
-- これまでは常に「先頭の施設」の価格しか表示されませんでしたが、画面上部に施設を選ぶプルダウンが追加され、選んだ施設の価格一覧に切り替わります。
-- 管理者も含めて、必ずどれか1つの施設を選んだ状態で価格一覧を見る、という単純な仕組みに統一します（「全施設まとめて表示」という特別モードは今回は作りません。将来的に必要になれば別issueで検討します）。**[人間承認済み: 施設選択必須のみ]**
-- 施設を切り替えた状態はURLに記録されるため、リロードしたり、URLをブックマーク・共有したりしても選択していた施設が保持されます。**[人間承認済み: URLクエリパラメータで保持]**
+- `aidd-phase1.js`（sweep-db/data/ui/types L28-33）: `agent()`の返却値をそのまま`?? '指摘なし'`で受け取るだけ。`findingCount`は`r !== '指摘なし'`という**固定文字列一致**で判定している（L48-49）
+- `aidd-phase2.js`（contract-writer/db-impl L36-43, data-impl/api-impl/ui-impl L54-67, integrator L74-77, reviewer L91-96）: `implSuccessCount`は`filter(Boolean).length`という**truthy判定のみ**（L116）。エージェントが失敗を報告する文章を返しても、文字列が空でなければ成功としてカウントされてしまう
+- `aidd-1-1-deep-task.js`: `isNew()`(L49)や`criticResult.includes('追加調査対象:')`(L70)など、**キーワード文字列一致による分岐**が2箇所あり、いずれもSweepループの継続/終了という制御フローに直結している
+- `aidd-phase1-router.js`: `workflow()`の結果をそのまま返すだけで、自身は成否判定をしていない（下流workflowの結果を素通しするため、本issueの型導入により自動的に恩恵を受ける想定。本issueの直接対象外）
+- `aidd-session-report.js`: `phase1Stats`/`phase2Stats`から`agents`/`rounds`/`findingCount`/`implSuccessCount`等の**件数集計のみ**を読んでおり、個々のagentが「なぜ失敗したか」「ブロックされたか」を区別できない
 
-### 画面イメージ / 操作の流れ
+## やること（Part 1: 型定義）
 
-1. `/hospital-prices` を開く（例: `/hospital-prices?facilityId=<施設名昇順の先頭施設ID>`）
-2. 画面上部（見出し「施設別価格管理」の下）に施設選択プルダウンが表示される 📸
-3. 初期状態では、URLに`facilityId`が無ければ自分が所属する施設のうち施設名の昇順で一番先頭の施設が選ばれており、その施設の価格一覧が表示されている（`listFacilities()`は`name`昇順ソートのため順序は安定している）
-4. プルダウンから別の施設を選ぶと、その施設の価格一覧に切り替わり、URLの`facilityId`クエリパラメータも更新される 📸
-5. その状態でリロード、または他ページから戻ってくると、URLの`facilityId`で指定した施設が選択されたまま表示される
-6. 1施設にしか所属していないユーザーの場合、プルダウンは1件だけの選択肢になる（切り替え自体は可能）
+### 1-1. 共通型
 
-### 受け入れ条件（チェックリスト）
+`docs/agents/agent-result-schema.md`に以下を新設する。
 
-- [ ] `/hospital-prices` 画面上部に施設選択プルダウンが表示される
-- [ ] 初期表示時、URLに`facilityId`クエリパラメータが無ければ、自分が所属する施設一覧を施設名の昇順で並べた先頭施設が選択され、その施設の価格が表示される（既存動作を維持）
-- [ ] URLに`facilityId`クエリパラメータがある場合は、それに対応する施設が初期選択される（自分がアクセス権を持つ施設に限る。不正・アクセス不可なfacilityIdの場合は先頭施設にフォールバックする）
-- [ ] プルダウンで別の施設を選ぶと、選択した施設の価格一覧に切り替わり（`/api/hospital-prices?facilityId=...` を選択施設IDで再取得）、URLの`facilityId`クエリパラメータも更新される
-- [ ] admin（全施設が選択肢に並ぶ）も同じプルダウンUIで施設を切り替えられる。「全件表示」オプションは設けない
-- [ ] 所属施設が0件の場合、プルダウンは空表示となり、価格一覧も空のまま（エラーにはしない。既存の「先頭施設なし→空配列」の挙動を踏襲）
-- [ ] 既存の新規登録・編集・削除の導線（各行のボタン、`+ 新規価格を登録`）は施設切り替え後も同様に動作する
-- [ ] `requireFacilityAccess` / RLS（`facility_member_or_admin`）による施設ごとのアクセス制御は変更しない（プルダウンの選択肢は `/api/facilities` が返す＝アクセス可能な施設のみになる）
+```
+AgentResult = {
+  status: 'pass' | 'fail' | 'blocked',
+  detail: string        // 人間可読の要約(現状の自由記述文字列をそのまま格納)
+}
+```
 
----
+### 1-2. status追加対象と判定基準（agent呼び出しごとに1行）
 
-## Part 2 — 実装計画（AI用・レビュー不要）
+**`aidd-phase1.js`**
 
-### 実装セット一覧（依存順）
+| 呼び出し (L28-33) | pass | fail | blocked |
+|---|---|---|---|
+| sweep-ui / sweep-data / sweep-db / sweep-types（4本） | 調査を最後まで実行できた（指摘の有無は問わない。指摘内容はstatusではなくdetailで表現） | 該当なし（調査系エージェントに「失敗」概念は無く、常にpass/blockedいずれかを返す） | 権限不足・対象コード不在等で調査そのものが実行できなかった |
 
-**Set A: 施設セレクタ状態管理とURL連動・データ取得の分離**
-- `src/app/hospital-prices/page.tsx` を改修
-  - 現状: 1つの `useEffect` で facilities・prices（先頭施設固定）・distributorProducts をまとめて取得
-  - 変更後:
-    - `useSearchParams()`（next/navigation）でURLの `facilityId` クエリパラメータを読む
-    - 初回ロード用 `useEffect`（`refreshKey` 依存）: facilities・distributorProducts を取得。取得後、選択施設IDを次の優先順で決定する
-      1. URLの `facilityId` が取得済み facilities に含まれていればそれを採用
-      2. 含まれていない（未指定・不正・アクセス不可）場合は施設名昇順の先頭施設を採用
-      3. facilities が空なら `null`
-      決定した施設IDが現在のURLの`facilityId`と異なる場合は `router.replace()` でURLを同期する（履歴を汚さないため push ではなく replace）
-    - `selectedFacilityId` state はURLの `facilityId` を信頼できる情報源(source of truth)とし、上記で決定した値で初期化・更新する
-    - 施設セレクタの `onChange` では `router.replace(`/hospital-prices?facilityId=${newId}`)` のように URLを更新する。URL変更 → `useSearchParams()` の再評価 → `selectedFacilityId` 反映という流れにする
-    - 価格取得用 `useEffect`（`selectedFacilityId` 依存）: `selectedFacilityId` が truthy なら `/api/hospital-prices?facilityId=...` を取得、falsy（施設0件）なら `prices` を空配列にする
-  - `<select>` 要素を見出し行の下に追加。`value={selectedFacilityId ?? ''}`
-  - 削除後の `refresh()` は現在の `selectedFacilityId` を維持したまま価格のみ再取得されればよい（`refreshKey` は初回ロード用 useEffect のみに紐付け、価格再取得用 useEffect の依存に `refreshKey` は含めない。削除操作は同一施設内の話なので、削除後の再取得は価格取得用 useEffect の依存に `refreshKey` も追加して対応する）
+**`aidd-phase2.js`**
 
-**Set B: テスト追加**
-- `src/app/hospital-prices/__tests__/page.test.tsx` に以下を追加
-  - 複数施設が返る場合、プルダウンに全施設が選択肢として表示されること
-  - URLに`facilityId`が無い場合、施設名昇順の先頭施設が初期選択されること
-  - URLに有効な`facilityId`がある場合、その施設が初期選択されること
-  - URLに不正・アクセス不可な`facilityId`がある場合、先頭施設にフォールバックすること
-  - プルダウンで施設を切り替えると `/api/hospital-prices?facilityId=<選択したID>` が呼ばれ、表示される価格一覧が切り替わること、かつURLの`facilityId`が更新されること（`useRouter`のモックで`replace`呼び出しを検証）
-  - 施設が0件の場合、プルダウンが空・価格一覧も空で表示されること（エラーにならない）
+| 呼び出し | pass | fail | blocked |
+|---|---|---|---|
+| contract-writer (L36-39) | 型定義・APIインターフェース型を確定できた | 型定義を試みたが不完全・矛盾がある | SPEC.mdが存在しない/読めない |
+| db-impl (L40-43) | マイグレーション実装が完了した | マイグレーションを試みたがエラー・矛盾がある | SPEC.mdが存在しない、またはPart2にマイグレーション情報が無く着手不能 |
+| data-impl (L55-58) / api-impl (L59-62) / ui-impl (L63-66) | 担当範囲の実装を完了できた | 実装したが明らかに不完全、またはcontract-writer/db-implの結果と矛盾する | SPEC.mdが見つからない、またはcontract-writer/db-implの完了報告が空で着手できなかった |
+| integrator (L74-77) | npm test・npm run lintが最終的に緑で統合完了 | 3回の修正試行後もtest/lintが赤のまま | SPEC.mdが見つからない、またはいずれかのimplエージェントの完了報告に「仕様書が見つからない」「作業を開始できない」旨の記述がある（現行プロンプトL75の異常検知指示に対応） |
+| review:correctness / coverage / redundancy / type-safety（4本, L91-96） | レビューを完了し指摘なし | レビューを完了し1件以上の指摘がある（重大度による絞り込みは#42のスコープとし、ここではpass/failの二値のみ） | レビュー対象のコード・SPEC.mdが見つからずレビュー自体ができなかった |
 
-### 並列グループ宣言
+**`aidd-1-1-deep-task.js`**：Part 1-3で表として詳細化する。
 
-- Set A（`src/app/hospital-prices/page.tsx`）と Set B（`src/app/hospital-prices/__tests__/page.test.tsx`）は別ファイルだが、Bのテストは Aの実装（stateの持ち方・selectのDOM構造）に依存するため、同一の波では実装せず **Set A → Set B の順で直列実装**する（TDDなので実際は「Bのテストを先に書いて赤にし、Aを実装して緑にする」進め方でも良い。ファイルは別だが内容的に密結合なため統合ゲート不要・1セット扱いとする）
+## やること（Part 1-3: `aidd-1-1-deep-task.js`のstatus対象／対象外 一覧）
 
-### テスト観点
+このファイルはagent呼び出しが9系統ある。呼び出し元（本ファイル自身）が使う判定方法ごとに、status追加の要否を以下の表で確定する。
 
-- 初期表示（URLパラメータなし）: facilities配列を名前昇順で並べた先頭が選択され、対応するfacilityIdでprices取得APIが呼ばれる
-- 初期表示（URLパラメータあり・有効）: URLのfacilityIdが選択され、それでprices取得APIが呼ばれる
-- 初期表示（URLパラメータあり・不正/アクセス不可）: 先頭施設にフォールバックし、URLも先頭施設のfacilityIdに補正される
-- 切り替え: select の onChange 発火で正しいfacilityIdを指定して再フェッチされ、URLの`facilityId`も更新される（`router.replace`が呼ばれる）
-- 空施設: facilities が空配列のとき、fetchが `facilityId` なしで呼ばれない（またはスキップされる）こと、エラー表示にならないこと
-- 既存の削除・編集導線が回帰しないこと（既存テストのまま通ること）
+| # | 呼び出し（行番号） | 現状の判定方法 | status追加 | 理由 |
+|---|---|---|---|---|
+| 1 | sweep-ui/data/db/types（L43-46, 4本） | `isNew()`＝`r.trim() !== '指摘なし'` という文字列一致で**ループ継続判定**に使用 | **対象** | 制御フロー（Loop Until Dry の継続要否）が文字列一致に依存しており、本issueが解消すべき典型例。基準: pass=調査完了(指摘有無問わず)/blocked=調査不能/fail=該当なし |
+| 2 | completeness-critic 1周目（L65-68） | `criticResult.includes('追加調査対象:')` という文字列一致で**ループ継続判定**に使用 | **対象** | 同上。基準: pass=批評を完了した(追加調査の要否は問わない)/blocked=Sweep結果が空で批評に着手できなかった/fail=該当なし |
+| 3 | draft-spec（L94-97） | 判定なし。生成結果をそのまま次フェーズに渡すのみ | **対象** | 現状schemaなしの自由記述で、生成失敗（空・調査結果を反映できない内容）を呼び出し元が検知できない。基準: pass=仕様書ドラフトを生成できた/fail=生成されたが調査結果を反映していない等明らかに不完全/blocked=Sweep結果が空でドラフト生成に着手できなかった |
+| 4 | find（L133-136, lens×5） | 既存の`FINDING_SCHEMA`（severity等）で完結。呼び出し元はfindings配列のseverityを直接参照 | **対象外** | 汎用statusを読む消費先が本ファイル内に存在しない（ドメインschemaで完結済み） |
+| 5 | verify（Adversarial Verify, L162-166） | 既存の`VERDICT_SCHEMA`（refuted/reason）で完結 | **対象外** | 同上 |
+| 6 | completeness-critic 2周目（L193-196） | 既存の`CRITIC_SCHEMA`（gaps）で完結。1周目(#2)と異なり制御フロー分岐には使われない | **対象外** | 同上 |
+| 7 | propose（Judge Panel, L235-239, stance×3） | 既存の`PROPOSAL_SCHEMA`で完結 | **対象外** | 同上 |
+| 8 | score（Judge Panel, L246-249, lens×3×proposal数） | 既存の`SCORE_SCHEMA`で完結。avgScore集計に使用 | **対象外** | 同上 |
+| 9 | synthesize（L266-269） | 判定なし。最終成果物として`return`されるのみ | **対象** | 自由記述かつワークフローの最終出力。生成失敗（必須セクション欠落等）を呼び出し元が検知できない。基準: pass=統合提案を生成できた/fail=生成されたが必須修正等のセクションが欠落するなど明らかに不完全/blocked=survived/gaps/winnerのいずれかが揃わず統合に着手できなかった |
 
-### 型・データアクセス層の方針
+**まとめ**: 9系統中、status追加対象は **#1・#2・#3・#9（4系統）**。#4-8（find/verify/critic-2周目/propose/score）はドメイン固有schemaで完結しており対象外。
 
-- API層（`src/app/api/hospital-prices/route.ts`）・データアクセス層（`src/lib/hospital-prices/repository.ts`）・RLSは変更しない（Phase1調査で確認済み: `facilityId` によるクエリ絞り込みは既に実装済み）
-- `Facility` 型（`src/types/facility.ts`）も変更なし。既存の `facilities` state をそのままプルダウンの選択肢に使う
+## やること（Part 2: 集計ロジックの置き換え）
 
-### 実装上の注意
+1. `aidd-phase1.js`の`findingCount`（L48-49）は、**statusとは別軸**として維持する。sweep系は「fail」を返さない設計（Part 1-2参照）のため、`status`だけでは「指摘が見つかった本数」を表現できない。よって以下の2つを両方stats（L44-50）に持たせる
+   - `findingCount`（従来通り、意味は変えない）: `[uiResult, dataResult, dbResult, typesResult].filter(r => r.status === 'pass' && r.detail !== '指摘なし').length`（＝完遂できた調査のうち、実際に指摘が見つかった本数。`status === 'pass'`の条件を加えるのは、blocked時の`detail`（エラーメッセージ等）がたまたま`'指摘なし'`と一致しない場合に誤って「指摘あり」として数えてしまう既存の潜在バグを防ぐため）
+   - `blockedCount`（新規追加）: `[uiResult, dataResult, dbResult, typesResult].filter(r => r.status === 'blocked').length`（Part 2-4でaidd-session-report.jsに表示するblocked件数の集計元）
+2. `aidd-phase2.js`の`implSuccessCount`（L116）を、`filter(Boolean).length`から`filter(r => r.status === 'pass').length`に置き換える
+3. `aidd-1-1-deep-task.js`の`isNew()`（L49）・`hasNewCriticFindings`（L70）を、上記表#1・#2のstatusベース判定に置き換える（ループ継続条件: 新規findingsまたはcriticのstatusがpass以外だった場合、等に再設計）
+4. `aidd-session-report.js`のテンプレートに、pass/fail/blocked件数の内訳表示を追加する（既存の「実装成功: X/Yグループ」表示に加えて、blocked件数を明示）
 
-- `useSearchParams()` を使うクライアントコンポーネントはNext.jsの推奨に従い `<Suspense>` で囲む（Phase1調査で `src/app/login/page.tsx:111` に同種の指摘があった＝Suspense fallback未設定のパターンを繰り返さないこと）
+## スコープ外（別issue）
+
+- `aidd-phase2.js`にstatusベースの品質ゲート（fail時に後続フェーズをブロックする）を実装するのは **issue #42** の範囲。本issueでは型定義とAgentResultの集計置き換えまでとし、ゲート制御ロジック自体は追加しない
+- reviewerの指摘に重大度(critical/important/minor)を持たせてfail判定を絞り込むのも**issue #42**の範囲とする
+
+## 完了条件
+
+- 上表で「対象」とした呼び出し（`aidd-phase1.js`全4本、`aidd-phase2.js`全10本、`aidd-1-1-deep-task.js`の4系統）が`status`フィールドを持つ構造化オブジェクトを返すようになっている
+- `findingCount`（status+detailの組み合わせ）・`implSuccessCount`（status参照）・Loop Until Dryの継続判定が、文字列一致・truthy判定から置き換わっている
+- 既存のnpm testが引き続きグリーンである
+- `docs/agents/agent-result-schema.md`に型定義と、各agent呼び出しの判定基準（本SPECの表の内容）が記載されている

--- a/docs/agents/agent-result-schema.md
+++ b/docs/agents/agent-result-schema.md
@@ -1,0 +1,60 @@
+# AgentResult 共通スキーマ
+
+AIDDワークフロー（`.claude/workflows/`）の`agent()`呼び出しが、成否を機械判定できるようにするための共通スキーマ。対応issue: #41
+
+## 型定義
+
+```
+AgentResult = {
+  status: 'pass' | 'fail' | 'blocked',
+  detail: string   // 人間可読の要約(自由記述文字列)
+}
+```
+
+- `pass`: 完遂できた（内容の良し悪しは`detail`で表現する）
+- `fail`: 完遂を試みたが、成果物が要件を満たさない
+- `blocked`: 前提条件が欠けており着手・完遂できなかった
+- 呼び出し種別によっては`fail`が存在しない設計のものがある（下記参照）
+
+## 判定基準（agent呼び出しごと）
+
+### `aidd-phase1.js`
+
+| 呼び出し (L28-33) | pass | fail | blocked |
+|---|---|---|---|
+| sweep-ui / sweep-data / sweep-db / sweep-types | 調査を最後まで実行できた（指摘の有無は問わない） | 該当なし（調査系エージェントに「失敗」概念は無い） | 権限不足・対象コード不在等で調査そのものが実行できなかった |
+
+### `aidd-phase2.js`
+
+| 呼び出し | pass | fail | blocked |
+|---|---|---|---|
+| contract-writer | 型定義・APIインターフェース型を確定できた | 型定義を試みたが不完全・矛盾がある | SPEC.mdが存在しない/読めない |
+| db-impl | マイグレーション実装が完了した | マイグレーションを試みたがエラー・矛盾がある | SPEC.mdが存在しない、またはPart2にマイグレーション情報が無く着手不能 |
+| data-impl / api-impl / ui-impl | 担当範囲の実装を完了できた | 実装したが明らかに不完全、またはcontract-writer/db-implの結果と矛盾する | SPEC.mdが見つからない、またはcontract-writer/db-implの完了報告が空で着手できなかった |
+| integrator | npm test・npm run lintが最終的に緑で統合完了 | 3回の修正試行後もtest/lintが赤のまま | SPEC.mdが見つからない、またはいずれかのimplエージェントの完了報告に「仕様書が見つからない」「作業を開始できない」旨の記述がある |
+| review:correctness / coverage / redundancy / type-safety | レビューを完了し指摘なし | レビューを完了し1件以上の指摘がある | レビュー対象のコード・SPEC.mdが見つからずレビュー自体ができなかった |
+
+### `aidd-1-1-deep-task.js`
+
+9系統のagent呼び出しのうち、status追加対象は4系統のみ。残り5系統は既存のドメイン固有schema（severity/refuted/gaps/score等）で完結しており、汎用statusを読む消費先が本ファイル内に存在しないため対象外とする。
+
+| # | 呼び出し | status追加 | pass | fail | blocked |
+|---|---|---|---|---|---|
+| 1 | sweep-ui/data/db/types（4本） | 対象 | 調査完了(指摘有無問わず) | 該当なし | 調査不能 |
+| 2 | completeness-critic 1周目 | 対象 | 批評を完了した(追加調査の要否は問わない) | 該当なし | Sweep結果が空で批評に着手できなかった |
+| 3 | draft-spec | 対象 | 仕様書ドラフトを生成できた | 生成されたが調査結果を反映していない等明らかに不完全 | Sweep結果が空でドラフト生成に着手できなかった |
+| 4 | find（lens×5） | 対象外 | — | — | — |
+| 5 | verify (Adversarial Verify) | 対象外 | — | — | — |
+| 6 | completeness-critic 2周目 | 対象外 | — | — | — |
+| 7 | propose（stance×3） | 対象外 | — | — | — |
+| 8 | score（lens×3×proposal数） | 対象外 | — | — | — |
+| 9 | synthesize | 対象 | 統合提案を生成できた | 必須修正等のセクションが欠落するなど明らかに不完全 | survived/gaps/winnerのいずれかが揃わず統合に着手できなかった |
+
+## 集計ロジックの原則（2軸分離）
+
+`status`は「エージェントが完遂できたか」を表す軸であり、「指摘・findingsの有無」を表す軸とは別である。この2つを混同すると、たとえば調査系（sweep/critic）のように`fail`を返さない設計のエージェントでは、`status`だけを見てもfindings件数を正しく数えられない。
+
+- 完遂したかどうか（ゲート・observability用）→ `status`
+- 何を見つけたか（セッションレポートの件数指標用）→ `detail`の内容（例: `status === 'pass' && detail !== '指摘なし'`）
+
+両者を必要に応じて組み合わせて使う（例: `aidd-phase1.js`の`findingCount`は両方を参照する）。


### PR DESCRIPTION
## Summary
- aidd-phase1.js/aidd-phase2.js/aidd-1-1-deep-task.jsのagent呼び出しに共通型AgentResult(status: pass/fail/blocked, detail: string)を導入
- 文字列一致(r !== '指摘なし')・truthy判定(filter(Boolean))に依存していた成否判定を、statusベースの判定に置き換え
- findingCountはstatus/detailの2軸判定を維持し、既存の意味（指摘が見つかった本数）を変えないよう設計
- blockedCount/implBlockedCountを新規追加し、aidd-session-report.jsのテンプレートに表示
- aidd-1-1-deep-task.jsは9系統のagent呼び出しのうち4系統（sweep×4/critic1周目/draft-spec/synthesize）のみstatus追加。既存のドメイン固有schema(find/verify/critic2周目/propose/score)は対象外
- 判定基準はdocs/agents/agent-result-schema.mdに一覧化

## Test plan
- [x] node --check で4ファイルとも構文エラーなし
- [x] npm test 83ファイル・482テスト全てグリーン
- [x] npm run lint エラー0（既存の警告2件は今回の変更対象外ファイル）

Closes #41