### PR TITLE
feat: aidd-phase2.jsにstatusベースの品質ゲートを実装する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -71,6 +71,20 @@ const [contractResult, dbResult] = await parallel([
 
 log('Contract + DB完了')
 
+// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
+// （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
+// blockedもfail同様に後続へ進めない（着手不能な前提のまま実装を続けさせない）
+if ([contractResult, dbResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+  log('品質ゲート: Contract + DBでfail/blockedを検知したため中断（Implement以降へは進みません）')
+  return {
+    contractResult,
+    dbResult,
+    blocked: true,
+    blockedAt: 'Contract + DB',
+    stats: { phase: 'phase2', blocked: true, blockedAt: 'Contract + DB' },
+  }
+}
+
 // ─── Phase B: data / api / ui（並列）─────────────────────────────────
 // 3グループは contract-writer の出力（src/types/）を契約として参照する
 // api-impl は SPEC.md Part 2 記載の関数シグネチャに従って呼び出すだけ（data-impl の完了を待たない）
@@ -100,6 +114,21 @@ const [dataResult, apiResult, uiResult] = await parallel([
 
 log('Implement完了')
 
+// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
+if ([dataResult, apiResult, uiResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+  log('品質ゲート: Implementでfail/blockedを検知したため中断（統合ゲートへは進みません）')
+  return {
+    contractResult,
+    dbResult,
+    dataResult,
+    apiResult,
+    uiResult,
+    blocked: true,
+    blockedAt: 'Implement',
+    stats: { phase: 'phase2', blocked: true, blockedAt: 'Implement' },
+  }
+}
+
 // ─── Phase C: 統合ゲート ──────────────────────────────────────────────
 phase('Integrate')
 
@@ -113,6 +142,22 @@ const integrationResult = await agent(
 )
 
 log('統合完了')
+
+// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
+if ([integrationResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+  log('品質ゲート: Integrateでfail/blockedを検知したため中断（Reviewへは進みません）')
+  return {
+    contractResult,
+    dbResult,
+    dataResult,
+    apiResult,
+    uiResult,
+    integration: integrationResult,
+    blocked: true,
+    blockedAt: 'Integrate',
+    stats: { phase: 'phase2', blocked: true, blockedAt: 'Integrate' },
+  }
+}
 
 // ─── Phase D: 4観点並列レビュー ───────────────────────────────────────
 phase('Review')

--- a/.claude/workflows/lib/__tests__/quality-gate.test.js
+++ b/.claude/workflows/lib/__tests__/quality-gate.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { shouldBlock } from '../quality-gate.js'
+
+describe('shouldBlock', () => {
+  it('全結果がpassならfalse', () => {
+    expect(shouldBlock([{ status: 'pass' }, { status: 'pass' }])).toBe(false)
+  })
+
+  it('1件でもfailがあればtrue', () => {
+    expect(shouldBlock([{ status: 'pass' }, { status: 'fail' }])).toBe(true)
+  })
+
+  it('1件でもblockedがあればtrue（着手不能はfailと同様に止める）', () => {
+    expect(shouldBlock([{ status: 'pass' }, { status: 'blocked' }])).toBe(true)
+  })
+
+  it('nullish要素があってもエラーにならない', () => {
+    expect(shouldBlock([null, undefined, { status: 'pass' }])).toBe(false)
+  })
+
+  it('空配列ならfalse', () => {
+    expect(shouldBlock([])).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/quality-gate.js
+++ b/.claude/workflows/lib/quality-gate.js
@@ -1,0 +1,9 @@
+// AgentResult（docs/agents/agent-result-schema.md）のstatus='fail'|'blocked'を検知する品質ゲート判定。
+// blockedはfailより情報量が少ない「そもそも着手不能」な状態のため、failと同様に後続フェーズへ
+// 進めてはならない（進めると存在しない前提を元にした無駄な実装・レビューが走る）。
+// aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+export function shouldBlock(results) {
+  return results.some(r => r?.status === 'fail' || r?.status === 'blocked')
+}

--- a/docs/agents/agent-result-schema.md
+++ b/docs/agents/agent-result-schema.md
@@ -58,3 +58,16 @@ AgentResult = {
 - 何を見つけたか（セッションレポートの件数指標用）→ `detail`の内容（例: `status === 'pass' && detail !== '指摘なし'`）
 
 両者を必要に応じて組み合わせて使う（例: `aidd-phase1.js`の`findingCount`は両方を参照する）。
+
+## 品質ゲート（`aidd-phase2.js`）
+
+対応issue: #42
+
+`aidd-phase2.js`は各フェーズ完了直後に、そのフェーズのエージェント結果に`status === 'fail'`または`status === 'blocked'`が1件でもあれば後続フェーズへ進まず中断する。
+`blocked`は「試みたが不完全」な`fail`よりも情報量が少なく、そもそも着手できていない状態のため、`fail`と同様に後続へは進めない（進めると存在しない前提のまま無駄な実装・レビューが走る）。
+中断時は`{ blocked: true, blockedAt: '<フェーズ名>', ... }`を返し、`stats.blocked`で観測できる。
+
+判定ロジック（`results.some(r => r?.status === 'fail' || r?.status === 'blocked')`）の正本は [`.claude/workflows/lib/quality-gate.js`](../../.claude/workflows/lib/quality-gate.js)（`shouldBlock`）にあり、vitestで単体テストする。
+`aidd-phase2.js`はWorkflow DSLのためrequireできず、同一ロジックをインラインで複製している（3箇所: Contract + DB後・Implement後・Integrate後）。
+
+`implSuccessCount`は`status === 'pass'`の件数、`implBlockedCount`は`status === 'blocked'`の件数を集計する。


### PR DESCRIPTION
## Summary
- Reviewer/Implementerの結果statusが`fail`または`blocked`の場合、後続フェーズへ進めずPhase2を中断する品質ゲートを実装
- 判定ロジック(`shouldBlock`)を `.claude/workflows/lib/quality-gate.js` に純粋関数として抽出し、vitestで単体テスト可能にした（Workflow DSLはrequire不可のため、`aidd-phase2.js`側は同一ロジックをインライン複製）
- `blocked`もゲート対象に含める（着手不能な前提のまま無駄な実装・レビューが走るのを防ぐ）
- `implSuccessCount`のstatus==='pass'集計は#41で対応済み

Closes #42

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/quality-gate.test.js` — 5件全パス
- [x] `npm run lint` — エラーなし（既存の無関係な警告2件のみ）
- [x] aidd-phase2.jsの3フェーズ（Contract+DB / Implement / Integrate）それぞれでfail/blocked検知時に中断・`blocked: true`を返すことをコードレベルで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)