### PR TITLE
fix: 発注作成RPC3種のp_itemsをJSON.stringifyせず配列のまま渡す

### DIFF
--- a/src/lib/case-orders/__tests__/repository.test.ts
+++ b/src/lib/case-orders/__tests__/repository.test.ts
@@ -64,9 +64,8 @@ describe('createCaseOrder', () => {
       p_procedure_name: 'TAVI',
     }))
     const args = rpc.mock.calls[0][1] as Record<string, unknown>
-    // items は JSON 文字列で渡す
-    expect(typeof args.p_items).toBe('string')
-    expect(JSON.parse(args.p_items as string)).toEqual([
+    // p_items はJSONB引数のため配列のまま渡す（JSON.stringifyしない。issue #287）
+    expect(args.p_items).toEqual([
       { jan: '4901234567890', lot: 'L001', ubd: '2027-01', quantity: 2 },
     ])
   })

--- a/src/lib/case-orders/repository.ts
+++ b/src/lib/case-orders/repository.ts
@@ -77,14 +77,12 @@ export async function createCaseOrder(db: SupabaseClient, facilityId: string, in
     p_patient_initials: input.patientInitials,
     p_gender: input.gender,
     p_doctor_name: input.doctorName,
-    p_items: JSON.stringify(
-      input.items.map(item => ({
-        jan: item.jan,
-        lot: item.lot ?? null,
-        ubd: item.ubd ?? null,
-        quantity: item.quantity,
-      }))
-    ),
+    p_items: input.items.map(item => ({
+      jan: item.jan,
+      lot: item.lot ?? null,
+      ubd: item.ubd ?? null,
+      quantity: item.quantity,
+    })),
   })
   if (error) throw new Error(error.message)
 

--- a/src/lib/consumable-orders/__tests__/repository.test.ts
+++ b/src/lib/consumable-orders/__tests__/repository.test.ts
@@ -36,8 +36,8 @@ describe('createConsumableOrder', () => {
       p_facility_id: 'f-1',
     }))
     const args = rpc.mock.calls[0][1] as Record<string, unknown>
-    expect(typeof args.p_items).toBe('string')
-    expect(JSON.parse(args.p_items as string)).toEqual([
+    // p_items はJSONB引数のため配列のまま渡す（JSON.stringifyしない。issue #287）
+    expect(args.p_items).toEqual([
       { consumable_id: 'c-1', quantity: 3 },
     ])
   })

--- a/src/lib/consumable-orders/repository.ts
+++ b/src/lib/consumable-orders/repository.ts
@@ -55,12 +55,10 @@ export async function createConsumableOrder(db: SupabaseClient, facilityId: stri
   // 単一トランザクションで完結させるため RPC を呼ぶ（ヘッダー+明細を原子的に INSERT）
   const { data, error } = await db.rpc('create_consumable_order_atomic', {
     p_facility_id: facilityId,
-    p_items: JSON.stringify(
-      input.items.map(item => ({
-        consumable_id: item.consumableId,
-        quantity: item.quantity,
-      }))
-    ),
+    p_items: input.items.map(item => ({
+      consumable_id: item.consumableId,
+      quantity: item.quantity,
+    })),
   })
   if (error) throw new Error(error.message)
 

--- a/src/lib/loan-orders/__tests__/repository.test.ts
+++ b/src/lib/loan-orders/__tests__/repository.test.ts
@@ -44,8 +44,8 @@ describe('createLoanOrder', () => {
       p_maker: 'メドトロニック',
     }))
     const args = rpc.mock.calls[0][1] as Record<string, unknown>
-    expect(typeof args.p_items).toBe('string')
-    expect(JSON.parse(args.p_items as string)).toEqual([
+    // p_items はJSONB引数のため配列のまま渡す（JSON.stringifyしない。issue #287）
+    expect(args.p_items).toEqual([
       { jan: '490001', name: 'カテーテルA', quantity: 1 },
     ])
   })

--- a/src/lib/loan-orders/repository.ts
+++ b/src/lib/loan-orders/repository.ts
@@ -63,13 +63,11 @@ export async function createLoanOrder(db: SupabaseClient, facilityId: string, in
     p_facility_id: facilityId,
     p_procedure_name: input.procedureName,
     p_maker: input.maker,
-    p_items: JSON.stringify(
-      input.items.map(item => ({
-        jan: item.jan ?? null,
-        name: item.name,
-        quantity: item.quantity,
-      }))
-    ),
+    p_items: input.items.map(item => ({
+      jan: item.jan ?? null,
+      name: item.name,
+      quantity: item.quantity,
+    })),
   })
   if (error) throw new Error(error.message)
 

--- a/supabase/__tests__/integration/order-repositories.integration.test.ts
+++ b/supabase/__tests__/integration/order-repositories.integration.test.ts
@@ -1,0 +1,146 @@
+// supabase/__tests__/integration/order-repositories.integration.test.ts
+// WHY: issue #287で発覚した「p_items(JSONB)にJSON.stringify済み文字列を渡すと
+//      本物のPostgREST/PostgreSQLでは 'cannot extract elements from a scalar' で
+//      失敗する」バグは、db.rpcをモックする既存のリポジトリテストでは検知できない。
+//      本物のローカルSupabaseに接続してリポジトリ関数（createLoanOrder等）を直接
+//      呼び出すことで、シリアライズ不整合の再発を防ぐ。
+
+import { randomUUID } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+import { createLoanOrder } from '@/lib/loan-orders/repository'
+import { createCaseOrder } from '@/lib/case-orders/repository'
+import { createConsumableOrder } from '@/lib/consumable-orders/repository'
+
+const TEST_USER_PASSWORD = 'order-repo-integration-test-0000'
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[order-repositories] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+describe('発注作成RPC 3種 (issue #287: p_itemsはJSON.stringifyせず配列のまま渡す)', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+
+  let facilityId: string
+  let userId: string
+  let userClient: SupabaseClient
+  let productJan: string
+  let consumableId: string
+
+  beforeAll(async () => {
+    const { data: facility, error: facilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-発注RPC-${runId}` })
+      .select('id')
+      .single()
+    if (facilityError || !facility) {
+      throw new Error(`施設作成失敗: ${facilityError?.message}`)
+    }
+    facilityId = facility.id as string
+
+    const email = `order-repo-test-${runId}@example.test`
+    const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+      email,
+      password: TEST_USER_PASSWORD,
+      email_confirm: true,
+    })
+    if (userError || !userData.user) {
+      throw new Error(`ユーザー作成失敗: ${userError?.message}`)
+    }
+    userId = userData.user.id
+
+    const { error: linkError } = await serviceClient
+      .from('user_facilities')
+      .insert({ user_id: userId, facility_id: facilityId, role: 'staff' })
+    if (linkError) {
+      throw new Error(`user_facilities作成失敗: ${linkError.message}`)
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    userClient = createClient(supabaseUrl, anonKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+    const { error: signInError } = await userClient.auth.signInWithPassword({
+      email,
+      password: TEST_USER_PASSWORD,
+    })
+    if (signInError) {
+      throw new Error(`サインイン失敗: ${signInError.message}`)
+    }
+
+    productJan = `9999999${runId.slice(0, 6)}`
+    const { error: productError } = await serviceClient
+      .from('products')
+      .insert({ jan: productJan, ref: `REF-${runId}` })
+    if (productError) {
+      throw new Error(`products作成失敗: ${productError.message}`)
+    }
+
+    const { data: consumable, error: consumableError } = await serviceClient
+      .from('consumables')
+      .insert({ facility_id: facilityId, name: `テスト消耗品-${runId}`, purpose: 'テスト用途' })
+      .select('id')
+      .single()
+    if (consumableError || !consumable) {
+      throw new Error(`consumables作成失敗: ${consumableError?.message}`)
+    }
+    consumableId = consumable.id as string
+  }, 60_000)
+
+  afterAll(async () => {
+    await serviceClient.auth.admin.deleteUser(userId)
+    await serviceClient.from('facilities').delete().eq('id', facilityId)
+    await serviceClient.from('products').delete().eq('jan', productJan)
+  })
+
+  it('createLoanOrder: 実DBに対して短貸発注を作成できる', async () => {
+    const order = await createLoanOrder(userClient, facilityId, {
+      procedureName: '統合テスト術式',
+      maker: '統合テストメーカー',
+      items: [{ name: '統合テスト器材', quantity: 2 }],
+    })
+
+    expect(order.facilityId).toBe(facilityId)
+    expect(order.items).toHaveLength(1)
+    expect(order.items[0].quantity).toBe(2)
+  })
+
+  it('createCaseOrder: 実DBに対して症例発注を作成できる', async () => {
+    const order = await createCaseOrder(userClient, facilityId, {
+      caseDatetime: new Date().toISOString(),
+      procedureName: '統合テスト症例術式',
+      patientId: 'PT-0001',
+      patientInitials: 'T.T.',
+      gender: 'other',
+      doctorName: '統合テスト医師',
+      items: [{ jan: productJan, quantity: 3 }],
+    })
+
+    expect(order.facilityId).toBe(facilityId)
+    expect(order.items).toHaveLength(1)
+    expect(order.items[0].quantity).toBe(3)
+  })
+
+  it('createConsumableOrder: 実DBに対して消耗品発注を作成できる', async () => {
+    const order = await createConsumableOrder(userClient, facilityId, {
+      items: [{ consumableId, quantity: 5 }],
+    })
+
+    expect(order.facilityId).toBe(facilityId)
+    expect(order.items).toHaveLength(1)
+    expect(order.items[0].quantity).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- issue #287の修正。`loan-orders`/`case-orders`/`consumable-orders`の`createXxxOrder`が`p_items`(JSONB引数)に`JSON.stringify(...)`済み文字列を渡していたため、本物のPostgREST/PostgreSQLでは `cannot extract elements from a scalar` で発注作成が失敗していた（既存のモックテストはdb.rpc自体をモックしていたため検知できなかった）
- 3箇所とも`JSON.stringify`を除去し、配列をそのまま`.rpc()`に渡すよう修正
- 既存のモックテスト3件は「p_itemsは文字列である」という誤った前提を検証していたため、配列のまま渡される前提に修正
- 実DBに接続する新規統合テスト(`supabase/__tests__/integration/order-repositories.integration.test.ts`)を追加し、3つのリポジトリ関数を直接呼び出して回帰を検知できるようにした

## Test plan
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `npm test` (490 tests pass)
- [x] `npm run test:integration` の新規テストを、修正前(JSON.stringifyあり)で実行し `cannot extract elements from a scalar` で失敗することを確認
- [x] 修正後の同テストが3件とも成功することを確認

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)