### PR TITLE
fix: AIDD品質ゲートをfail-openからdeny-by-defaultに変更する

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -62,6 +62,11 @@ status と detail を返すこと。
 let round = 1
 let dryRounds = 0
 const allFindings = { ui: [], data: [], db: [], types: [] }
+// 軸ごとに既出の指摘文言(先頭80文字)を記録し、ラウンドをまたいだ同一指摘の再掲を
+// 「新規」として扱わないようにする（issue #293: 再掲が永遠に新規扱いされ収束しない問題）
+const seenFindingKeys = { ui: new Set(), data: new Set(), db: new Set(), types: new Set() }
+// 直近ラウンドでblocked/未応答（deny-by-default）だった軸。エスカレーション報告に使う
+let lastRoundBlockedAxes = []
 let additionalContext = ''
 
 while (dryRounds < 2 && round <= maxRounds) {
@@ -78,15 +83,34 @@ while (dryRounds < 2 && round <= maxRounds) {
     () => agent(sweepPrompt, { label: `sweep-db:R${round}`,    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
     () => agent(sweepPrompt, { label: `sweep-types:R${round}`, agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
   ])
+  const axisResults = { ui: uiResult, data: dataResult, db: dbResult, types: typesResult }
 
-  // isNew: 完遂できた(status==='pass')うえで、実際に新規の指摘がある(detail!=='指摘なし')場合のみ新規findingsとみなす(2軸判定)
-  const isNew = (r) => r?.status === 'pass' && r?.detail !== '指摘なし'
-  if (isNew(uiResult))    allFindings.ui.push(`[R${round}]\n${uiResult.detail}`)
-  if (isNew(dataResult))  allFindings.data.push(`[R${round}]\n${dataResult.detail}`)
-  if (isNew(dbResult))    allFindings.db.push(`[R${round}]\n${dbResult.detail}`)
-  if (isNew(typesResult)) allFindings.types.push(`[R${round}]\n${typesResult.detail}`)
+  // deny-by-default: status==='pass'と確認できない軸（blocked・null・未知の値）はすべてblocked扱いにしてエスカレーションする
+  lastRoundBlockedAxes = Object.entries(axisResults)
+    .filter(([, r]) => r?.status !== 'pass')
+    .map(([axis, r]) => `${axis}(status=${r?.status ?? 'なし'})`)
+  if (lastRoundBlockedAxes.length > 0) {
+    log(`Sweep警告: ラウンド${round}でblocked/未応答の軸を検知 → ${lastRoundBlockedAxes.join(', ')}`)
+  }
 
-  const hasNewFindings = isNew(uiResult) || isNew(dataResult) || isNew(dbResult) || isNew(typesResult)
+  // isNew: 完遂できた(status==='pass')・指摘ありに加え、同一文言を過去ラウンドで既に記録していないことを条件にする(3軸判定)
+  const isNew = (axis, r) => {
+    if (r?.status !== 'pass' || r?.detail === '指摘なし') return false
+    const key = r.detail.trim().slice(0, 80)
+    if (seenFindingKeys[axis].has(key)) return false
+    seenFindingKeys[axis].add(key)
+    return true
+  }
+  const isNewUi    = isNew('ui', uiResult)
+  const isNewData  = isNew('data', dataResult)
+  const isNewDb    = isNew('db', dbResult)
+  const isNewTypes = isNew('types', typesResult)
+  if (isNewUi)    allFindings.ui.push(`[R${round}]\n${uiResult.detail}`)
+  if (isNewData)  allFindings.data.push(`[R${round}]\n${dataResult.detail}`)
+  if (isNewDb)    allFindings.db.push(`[R${round}]\n${dbResult.detail}`)
+  if (isNewTypes) allFindings.types.push(`[R${round}]\n${typesResult.detail}`)
+
+  const hasNewFindings = isNewUi || isNewData || isNewDb || isNewTypes
 
   const roundSummary = [
     `## UI層\n${uiResult?.detail ?? '指摘なし'}`,
@@ -121,7 +145,17 @@ const sweepSummary = [
   `## 型整合性\n${allFindings.types.join('\n') || '指摘なし'}`,
 ].join('\n\n')
 
-log(`Sweep完了: ${round - 1}ラウンド`)
+// converged: dryRounds到達（新規指摘が尽きた）による正常終了。falseならラウンド上限到達による打ち切りで、
+// 未解決の指摘が残っている可能性がある（issue #293: 上限到達時も常に「Sweep完了」と報告していた問題）
+const sweepConverged = dryRounds >= 2
+if (sweepConverged) {
+  log(`Sweep完了（収束）: ${round - 1}ラウンド`)
+} else {
+  log(`Sweep未完了: ラウンド上限(${maxRounds})に到達したため打ち切り。未解決の指摘が残っている可能性があります`)
+}
+if (lastRoundBlockedAxes.length > 0) {
+  log(`Sweep: 最終ラウンドでblocked/未応答だった軸 → ${lastRoundBlockedAxes.join(', ')}（調査が完遂していない可能性）`)
+}
 
 // ─── Phase 3: 仕様書ドラフト生成 ──────────────────────────────────────
 phase('Draft Spec')
@@ -136,6 +170,21 @@ const draftSpec = await agent(
 - blocked: Sweep結果が空でドラフト生成に着手できなかった`,
   { label: 'draft-spec', phase: 'Draft Spec', model: 'claude-sonnet-4-6', effort: 'medium', schema: AGENT_RESULT_SCHEMA_PFB }
 )
+
+// 品質ゲート: deny-by-default（.claude/workflows/lib/quality-gate.js shouldBlockと同一発想）。
+// これまでdraftSpecのstatusを一切見ずFind以降へ進んでいたため、fail/blockedでも
+// 空・矛盾したドラフトを元に後続の調査が無駄に走っていた（issue #293）
+if (draftSpec?.status !== 'pass') {
+  log(`品質ゲート: Draft Specがstatus="${draftSpec?.status ?? 'なし'}"のため中断（Find以降へは進みません）`)
+  return {
+    sweepFindings: allFindings,
+    sweepConverged,
+    sweepBlockedAxes: lastRoundBlockedAxes,
+    draftSpec,
+    blocked: true,
+    blockedAt: 'Draft Spec',
+  }
+}
 
 log('仕様書ドラフト生成完了。Deep Spec 検証を開始します。')
 
@@ -333,6 +382,8 @@ const synthesis = await agent(
 
 return {
   sweepFindings: allFindings,
+  sweepConverged,
+  sweepBlockedAxes: lastRoundBlockedAxes,
   draftSpec,
   survived,
   gaps,

--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -73,8 +73,8 @@ log('Contract + DB完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
 // （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
-// blockedもfail同様に後続へ進めない（着手不能な前提のまま実装を続けさせない）
-if ([contractResult, dbResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+// deny-by-default: 全員がpassでない限り止める（fail/blockedはもちろんnull・未知の値も止める。issue #289）
+if (![contractResult, dbResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Contract + DBでfail/blockedを検知したため中断（Implement以降へは進みません）')
   return {
     contractResult,
@@ -114,8 +114,8 @@ const [dataResult, apiResult, uiResult] = await parallel([
 
 log('Implement完了')
 
-// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
-if ([dataResult, apiResult, uiResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
+if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Implementでfail/blockedを検知したため中断（統合ゲートへは進みません）')
   return {
     contractResult,
@@ -143,8 +143,8 @@ const integrationResult = await agent(
 
 log('統合完了')
 
-// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
-if ([integrationResult].some(r => r?.status === 'fail' || r?.status === 'blocked')) {
+// 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
+if (![integrationResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Integrateでfail/blockedを検知したため中断（Reviewへは進みません）')
   return {
     contractResult,

--- a/.claude/workflows/lib/__tests__/quality-gate.test.js
+++ b/.claude/workflows/lib/__tests__/quality-gate.test.js
@@ -14,11 +14,19 @@ describe('shouldBlock', () => {
     expect(shouldBlock([{ status: 'pass' }, { status: 'blocked' }])).toBe(true)
   })
 
-  it('nullish要素があってもエラーにならない', () => {
-    expect(shouldBlock([null, undefined, { status: 'pass' }])).toBe(false)
+  it('nullish要素があればtrue（deny-by-default: passと確認できないものは止める）', () => {
+    expect(shouldBlock([null, undefined, { status: 'pass' }])).toBe(true)
   })
 
-  it('空配列ならfalse', () => {
+  it('未知のstatus値があればtrue（deny-by-default）', () => {
+    expect(shouldBlock([{ status: 'weird' }, { status: 'pass' }])).toBe(true)
+  })
+
+  it('全結果がpassの場合のみfalse', () => {
+    expect(shouldBlock([{ status: 'pass' }, { status: 'pass' }])).toBe(false)
+  })
+
+  it('空配列ならfalse（判定対象自体が無い）', () => {
     expect(shouldBlock([])).toBe(false)
   })
 })

--- a/.claude/workflows/lib/quality-gate.js
+++ b/.claude/workflows/lib/quality-gate.js
@@ -1,9 +1,12 @@
-// AgentResult（docs/agents/agent-result-schema.md）のstatus='fail'|'blocked'を検知する品質ゲート判定。
-// blockedはfailより情報量が少ない「そもそも着手不能」な状態のため、failと同様に後続フェーズへ
-// 進めてはならない（進めると存在しない前提を元にした無駄な実装・レビューが走る）。
+// AgentResult（docs/agents/agent-result-schema.md）の品質ゲート判定。
+// deny-by-default: 全員がstatus==='pass'でない限り止める（fail/blockedはもちろん、
+// null・未返却（エージェントが致命的エラーで死んだ場合）・未知のstatus値も含めて
+// 「passと確認できないものは全て止める」。fail-open（failを探す方式）だと、
+// 想定外の値がすべて素通りしてしまう（issue #289）。
 // aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
 // このファイルはvitestでの単体テスト用の正本。
 
 export function shouldBlock(results) {
-  return results.some(r => r?.status === 'fail' || r?.status === 'blocked')
+  if (results.length === 0) return false
+  return !results.every(r => r?.status === 'pass')
 }


### PR DESCRIPTION
## Summary
- issue #289: `.claude/workflows/lib/quality-gate.js`の`shouldBlock`が「fail/blockedを探す」fail-open方式になっており、status不明・null・未返却（エージェントが致命的エラーで死んだ場合）・未知の値がすべて後続フェーズへ素通りしていた。「全員がstatus==='pass'でなければ止める」deny-by-default方式に変更。`aidd-phase2.js`の3箇所のインラインコピー（Contract+DB / Implement / Integrate）も同様に修正
- issue #293: 同じfail-openパターンが`aidd-1-1-deep-task.js`にもあったため横展開
  - Draft Specの`status`を一切チェックせずFind以降へ進んでいた箇所にゲートを追加（fail/blockedなら中断）
  - Sweep各軸がblocked/未応答(deny-by-default)の場合にログでエスカレーションし、最終ラウンドの状態を戻り値に含める
  - ラウンドをまたいだ同一指摘の再掲を「新規」として扱わないよう、軸ごとに既出の指摘文言を記録して重複判定
  - ラウンド上限到達時は「Sweep完了」ではなく「未完了（ラウンド上限到達）」と明示的にログ・戻り値で報告する

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/quality-gate.test.js` (7 tests pass、null/undefined/未知のstatus値でtrueになることを確認)
- [x] `npm test` (492 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `node --check` で`aidd-phase2.js`・`aidd-1-1-deep-task.js`の構文確認

Closes #289
Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)