### PR TITLE
fix: Judge Panelの分岐判定をkeyDecisions完全一致からbigram類似度に変更する

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -338,11 +338,41 @@ const proposals = await parallel(
 const validProposals = proposals.filter(Boolean)
 
 // 設計判断が実質同じ提案しかない場合は採点パネル（3案 x 3観点 = 9エージェント）を省略する。
-// 正規化したkeyDecisionsの重複率が高い（=判断が割れていない）ほど採点の価値が低いため。
-const normalizeDecision = (d) => d.trim().toLowerCase()
-const allDecisions = validProposals.flatMap(p => p.keyDecisions.map(normalizeDecision))
-const uniqueDecisions = new Set(allDecisions)
-const divergenceRatio = allDecisions.length > 0 ? uniqueDecisions.size / allDecisions.length : 0
+// 品質ゲート: .claude/workflows/lib/judge-panel.js の computeDivergence と同一ロジック
+// （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
+// 旧実装は正規化文字列の完全一致でしか重複を判定できず、別々のLLM提案が表現違いなだけでも
+// 常に「分岐あり」と判定され、不要な採点パネルが起動していた（issue #295）。
+// 文字bigramのJaccard類似度に基づくクラスタリングに変更する。
+function toBigrams(text) {
+  const cleaned = String(text).replace(/\s+/g, '')
+  const grams = new Set()
+  if (cleaned.length < 2) {
+    if (cleaned.length > 0) grams.add(cleaned)
+    return grams
+  }
+  for (let i = 0; i <= cleaned.length - 2; i++) {
+    grams.add(cleaned.slice(i, i + 2))
+  }
+  return grams
+}
+function decisionSimilarity(a, b) {
+  const setA = toBigrams(a)
+  const setB = toBigrams(b)
+  if (setA.size === 0 && setB.size === 0) return 1
+  let intersection = 0
+  for (const gram of setA) {
+    if (setB.has(gram)) intersection++
+  }
+  const union = setA.size + setB.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+const allDecisions = validProposals.flatMap(p => p.keyDecisions)
+const clusterRepresentatives = []
+for (const decision of allDecisions) {
+  const isDuplicate = clusterRepresentatives.some(rep => decisionSimilarity(rep, decision) >= 0.5)
+  if (!isDuplicate) clusterRepresentatives.push(decision)
+}
+const divergenceRatio = allDecisions.length > 0 ? clusterRepresentatives.length / allDecisions.length : 0
 const hasDivergence = validProposals.length > 1 && divergenceRatio >= 0.5
 
 let validScored

--- a/.claude/workflows/lib/__tests__/judge-panel.test.js
+++ b/.claude/workflows/lib/__tests__/judge-panel.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { computeDivergence } from '../judge-panel.js'
+
+describe('computeDivergence', () => {
+  it('提案が1件のみならhasDivergenceはfalse', () => {
+    const result = computeDivergence([
+      { keyDecisions: ['在庫データをリアルタイムで同期する'] },
+    ])
+    expect(result.hasDivergence).toBe(false)
+  })
+
+  it('keyDecisionsが空ならdivergenceRatioは0でhasDivergenceはfalse', () => {
+    const result = computeDivergence([{ keyDecisions: [] }, { keyDecisions: [] }])
+    expect(result.divergenceRatio).toBe(0)
+    expect(result.hasDivergence).toBe(false)
+  })
+
+  it('語尾・助詞が違うだけの言い換えは重複とみなしhasDivergenceはfalse（issue #295: 完全一致判定だと常にtrueになっていた、3提案が実運用のPROPOSERS数）', () => {
+    const result = computeDivergence([
+      { keyDecisions: ['在庫データをリアルタイムで同期する', '施設ごとにテーブルを分離する'] },
+      { keyDecisions: ['在庫データをリアルタイムに同期させる', '施設ごとにテーブルを分ける'] },
+      { keyDecisions: ['在庫データをリアルタイムに同期する', '施設ごとにテーブルを分離しておく'] },
+    ])
+    expect(result.hasDivergence).toBe(false)
+  })
+
+  it('明らかに異なる設計判断が多い場合はhasDivergenceがtrue', () => {
+    const result = computeDivergence([
+      { keyDecisions: ['在庫データをリアルタイムで同期する', '施設ごとにテーブルを分離する'] },
+      { keyDecisions: ['夜間バッチでまとめて在庫を更新する', '全施設共通の単一テーブルをRLSで分離する'] },
+      { keyDecisions: ['外部倉庫システムに在庫管理ごと委託する', '施設概念を廃止して単一在庫プールにする'] },
+    ])
+    expect(result.hasDivergence).toBe(true)
+  })
+
+  it('完全一致の文字列は同一クラスタとして扱われる', () => {
+    const result = computeDivergence([
+      { keyDecisions: ['同じ判断', '同じ判断'] },
+      { keyDecisions: ['同じ判断'] },
+    ])
+    expect(result.divergenceRatio).toBeCloseTo(1 / 3)
+    expect(result.hasDivergence).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/judge-panel.js
+++ b/.claude/workflows/lib/judge-panel.js
@@ -1,0 +1,59 @@
+// Judge Panel（aidd-1-1-deep-task.js）の分岐判定ロジック。
+// 旧実装は正規化した文字列の「完全一致」でkeyDecisionsの重複を判定していたが、
+// 別々のLLM提案は意味が同じでも表現が異なることがほとんどのため、常に「分岐あり」
+// と判定され、不要な採点パネル（3案×3観点=9エージェント）が起動されていた（issue #295）。
+// LLM呼び出し無しで決定的にテストできるよう、文字bigram（2文字の並び）のJaccard類似度で
+// 判定する。日本語は単語間にスペースが無いため、単語分割ではなく文字n-gramを使う。
+// 制約: 語尾・助詞レベルの言い換え（表記ゆれ）は捉えられるが、「データ」↔「情報」のような
+// 真の同義語言い換えまでは検出できない（それには埋め込み/LLM判定が必要でコスト増になるため
+// 意図的にスコープ外とした。issue #295の「キーワード抽出＋部分一致等」の対応方針を採用）。
+// aidd-1-1-deep-task.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+const DEFAULT_SIMILARITY_THRESHOLD = 0.5
+
+function toBigrams(text) {
+  const cleaned = String(text).replace(/\s+/g, '')
+  const grams = new Set()
+  if (cleaned.length < 2) {
+    if (cleaned.length > 0) grams.add(cleaned)
+    return grams
+  }
+  for (let i = 0; i <= cleaned.length - 2; i++) {
+    grams.add(cleaned.slice(i, i + 2))
+  }
+  return grams
+}
+
+function jaccardSimilarity(a, b) {
+  const setA = toBigrams(a)
+  const setB = toBigrams(b)
+  if (setA.size === 0 && setB.size === 0) return 1
+  let intersection = 0
+  for (const gram of setA) {
+    if (setB.has(gram)) intersection++
+  }
+  const union = setA.size + setB.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+// validProposals: [{ keyDecisions: string[], ... }, ...]
+// 戻り値: { divergenceRatio, hasDivergence }
+// divergenceRatio: 全keyDecisionsのうち、既存クラスタと非類似（新規判断）だった割合
+// hasDivergence: 採点パネルを起動するかどうか（提案が2件以上かつdivergenceRatio >= threshold）
+export function computeDivergence(validProposals, threshold = DEFAULT_SIMILARITY_THRESHOLD) {
+  const allDecisions = validProposals.flatMap(p => p.keyDecisions)
+  if (allDecisions.length === 0) {
+    return { divergenceRatio: 0, hasDivergence: false }
+  }
+
+  const clusterRepresentatives = []
+  for (const decision of allDecisions) {
+    const isDuplicate = clusterRepresentatives.some(rep => jaccardSimilarity(rep, decision) >= threshold)
+    if (!isDuplicate) clusterRepresentatives.push(decision)
+  }
+
+  const divergenceRatio = clusterRepresentatives.length / allDecisions.length
+  const hasDivergence = validProposals.length > 1 && divergenceRatio >= 0.5
+  return { divergenceRatio, hasDivergence }
+}


### PR DESCRIPTION
## Summary
- issue #295: `aidd-1-1-deep-task.js`のJudge Panelで、提案間の分岐率をkeyDecisionsの正規化文字列「完全一致」で判定していたため、別々のLLM提案が意味は同じでも表現が異なるだけで常に「分岐あり」と判定され、不要な採点パネル（3案×3観点=9エージェント）が起動していた
- 文字bigram（2文字の並び）のJaccard類似度に基づくクラスタリングに変更（閾値0.5以上を同一クラスタとみなす）
- LLM呼び出し無しで決定的にテストできるよう`.claude/workflows/lib/judge-panel.js`にロジックを切り出し、`aidd-1-1-deep-task.js`（Workflow DSL、require不可）には同一ロジックをインライン複製
- 制約として、語尾・助詞レベルの言い換えは検出できるが、「データ」↔「情報」のような真の同義語言い換えまでは検出できない旨をコードにコメントで明記（それには埋め込み/LLM判定が必要でコスト増になるため意図的にスコープ外とした）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/judge-panel.test.js` (5 tests pass: 提案1件、keyDecisions空、語尾言い換えの重複判定、明確な分岐、完全一致の重複)
- [x] `npm test` (497 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `node --check` で`aidd-1-1-deep-task.js`の構文確認

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)