### PR TITLE
feat: Review指摘をImplementerへ差し戻す修正ループ(最大3回)を実装する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -159,7 +159,13 @@ if (![integrationResult].every(r => r?.status === 'pass')) {
   }
 }
 
-// ─── Phase D: 4観点並列レビュー ───────────────────────────────────────
+// ─── Phase D: 4観点並列レビュー（fail時はImplementerへ差し戻す修正ループ、最大3回）──
+// issue #45/#292: 従来はReviewのstatus(fail)を一切見ずdetailのみ使い、指摘があっても
+// 後続に何も反映されず「検証完了」として終わっていた。fail検出時はImplementerへ
+// 差し戻して再修正させ、再度4観点レビューし直す。最大3回再試行し、それでもfailが
+// 残る場合はblockedとして人間（停止②の構造化レビュー）に引き渡す。
+// 判定ロジック: .claude/workflows/lib/review-retry.js の classifyReviewRound と同一
+// （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
 phase('Review')
 
 const REVIEW_DIMENSIONS = [
@@ -175,12 +181,78 @@ const reviewGuide = guide(
   'レビュー対象のコード・SPEC.mdが見つからずレビュー自体ができなかった'
 )
 
-const reviewResults = await parallel(
-  REVIEW_DIMENSIONS.map(dim => () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。${reviewGuide}`,
-    { label: `review:${dim.key}`, agentType: 'reviewer', phase: 'Review', schema: AGENT_RESULT_SCHEMA }
-  ))
-)
+function classifyReviewRound(results, dimensions, attempt, maxRetries) {
+  const failingDimensions = dimensions
+    .map((dim, i) => ({ dim, result: results[i] }))
+    .filter(({ result }) => result?.status === 'fail')
+  if (failingDimensions.length === 0) return { done: true, blocked: false, failingDimensions: [] }
+  if (attempt > maxRetries) return { done: true, blocked: true, failingDimensions }
+  return { done: false, blocked: false, failingDimensions }
+}
+
+const MAX_REVIEW_RETRIES = 3
+let reviewResults
+let reviewAttempt = 0
+let reviewRetryAgentCount = 0
+
+while (true) {
+  reviewAttempt++
+  log(`Reviewラウンド ${reviewAttempt}/${MAX_REVIEW_RETRIES + 1} 開始`)
+
+  reviewResults = await parallel(
+    REVIEW_DIMENSIONS.map(dim => () => agent(
+      `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。${reviewGuide}`,
+      { label: `review:${dim.key}:R${reviewAttempt}`, agentType: 'reviewer', phase: 'Review', schema: AGENT_RESULT_SCHEMA }
+    ))
+  )
+
+  const { done, blocked, failingDimensions } = classifyReviewRound(reviewResults, REVIEW_DIMENSIONS, reviewAttempt, MAX_REVIEW_RETRIES)
+
+  if (done && !blocked) {
+    log(`Review完了: ラウンド${reviewAttempt}で全観点pass（指摘なし、またはblockedのみ）`)
+    break
+  }
+
+  if (blocked) {
+    log(`品質ゲート: Reviewで${MAX_REVIEW_RETRIES}回の差し戻し後もfailが残るため中断（blockedとして人間に引き渡します）`)
+    return {
+      contractResult,
+      dbResult,
+      dataResult,
+      apiResult,
+      uiResult,
+      integration: integrationResult,
+      reviewFindings: REVIEW_DIMENSIONS.map((dim, i) => ({
+        dimension: dim.label,
+        findings:  reviewResults[i]?.detail ?? '指摘なし',
+      })),
+      blocked: true,
+      blockedAt: 'Review',
+      stats: {
+        phase: 'phase2',
+        blocked: true,
+        blockedAt: 'Review',
+        reviewRetries: reviewRetryAgentCount,
+      },
+    }
+  }
+
+  log(`Review: ${failingDimensions.length}件の観点でfailを検知（試行${reviewAttempt}/${MAX_REVIEW_RETRIES + 1}）→ Implementerへ差し戻します`)
+
+  const retryFindings = failingDimensions
+    .map(({ dim, result }) => `## ${dim.label}\n${result.detail}`)
+    .join('\n\n')
+
+  await agent(
+    `まず ${specPath} を Read ツールで読んでください。\n以下はコードレビューで検出された指摘です。該当箇所を修正してください（修正のみ、レビューはしない）。\n\n${retryFindings}${guide(
+      '指摘箇所をすべて修正できた',
+      '修正を試みたが解決できない指摘が残る',
+      '指摘内容から修正対象・該当ファイルが特定できない'
+    )}`,
+    { label: `implementer-retry:R${reviewAttempt}`, phase: 'Review', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
+  )
+  reviewRetryAgentCount++
+}
 
 log('検証完了。/structured-review でレビュー結果を確認してください。')
 
@@ -201,7 +273,8 @@ return {
     phase: 'phase2',
     implAgents: 5,
     reviewAgents: REVIEW_DIMENSIONS.length,
-    totalAgents: 5 + 1 + REVIEW_DIMENSIONS.length,
+    reviewRetries: reviewRetryAgentCount,
+    totalAgents: 5 + 1 + REVIEW_DIMENSIONS.length + reviewRetryAgentCount,
     implSuccessCount: implResults.filter(r => r?.status === 'pass').length,
     implBlockedCount: implResults.filter(r => r?.status === 'blocked').length,
   },

--- a/.claude/workflows/lib/__tests__/review-retry.test.js
+++ b/.claude/workflows/lib/__tests__/review-retry.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { classifyReviewRound } from '../review-retry.js'
+
+const DIMENSIONS = [
+  { key: 'correctness', label: '正しさ' },
+  { key: 'coverage',    label: 'カバレッジ' },
+]
+
+describe('classifyReviewRound', () => {
+  it('全観点passならdone=true, blocked=false', () => {
+    const result = classifyReviewRound(
+      [{ status: 'pass', detail: '指摘なし' }, { status: 'pass', detail: '指摘なし' }],
+      DIMENSIONS, 1, 3
+    )
+    expect(result).toEqual({ done: true, blocked: false, failingDimensions: [] })
+  })
+
+  it('blockedのみ(fail無し)ならdone=true, blocked=false（レビュー自体ができなかっただけで差し戻し対象ではない）', () => {
+    const result = classifyReviewRound(
+      [{ status: 'blocked', detail: '対象が見つからない' }, { status: 'pass', detail: '指摘なし' }],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(true)
+    expect(result.blocked).toBe(false)
+  })
+
+  it('failが1件でもあり、上限内ならdone=falseで差し戻し対象を返す', () => {
+    const result = classifyReviewRound(
+      [{ status: 'fail', detail: 'バグあり' }, { status: 'pass', detail: '指摘なし' }],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(false)
+    expect(result.blocked).toBe(false)
+    expect(result.failingDimensions).toHaveLength(1)
+    expect(result.failingDimensions[0].dim.key).toBe('correctness')
+  })
+
+  it('わざと毎回failするダミーレビューは、maxRetries回の差し戻し後(attempt=maxRetries+1)にblockedで停止する', () => {
+    const maxRetries = 3
+    const dummyFailResults = [{ status: 'fail', detail: '直らない指摘' }, { status: 'pass', detail: '指摘なし' }]
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const result = classifyReviewRound(dummyFailResults, DIMENSIONS, attempt, maxRetries)
+      expect(result.done).toBe(false)
+      expect(result.blocked).toBe(false)
+    }
+
+    const finalResult = classifyReviewRound(dummyFailResults, DIMENSIONS, maxRetries + 1, maxRetries)
+    expect(finalResult.done).toBe(true)
+    expect(finalResult.blocked).toBe(true)
+    expect(finalResult.failingDimensions).toHaveLength(1)
+  })
+})

--- a/.claude/workflows/lib/review-retry.js
+++ b/.claude/workflows/lib/review-retry.js
@@ -1,0 +1,31 @@
+// aidd-phase2.js のReviewフェーズ（issue #45/#292）の判定ロジック。
+// 従来はReviewのstatus(fail)を一切見ずdetailのみ使っていたため、指摘があっても
+// 後続に何も反映されず「検証完了」として終わっていた。1ラウンド分の結果を見て、
+// 「Implementerへ差し戻して再試行すべきか」「これ以上は打ち切ってblockedにすべきか」
+// を判定する。エージェント呼び出しを含まない純粋関数のため、LLM呼び出し無しで
+// 決定的にテストできる（最大リトライ到達→blockedになる完了条件を含む）。
+// aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+// reviewResults: dimensionsと同じ並びのAgentResult(status/detail)配列
+// dimensions: [{ key, label }, ...]
+// attempt: 今回が何回目のReviewラウンドか（1始まり）
+// maxRetries: Implementerへの差し戻し許容回数（打ち切りはattempt > maxRetries + 1ラウンド目で発生）
+//
+// 戻り値:
+// - done: true ならReviewループを終了する（pass確定 or 打ち切り）
+// - blocked: true なら打ち切り（人間に引き渡す）。doneがfalseの場合は常にfalse
+// - failingDimensions: status==='fail'だった観点（{ dim, result }[]）。差し戻しプロンプトに使う
+export function classifyReviewRound(reviewResults, dimensions, attempt, maxRetries) {
+  const failingDimensions = dimensions
+    .map((dim, i) => ({ dim, result: reviewResults[i] }))
+    .filter(({ result }) => result?.status === 'fail')
+
+  if (failingDimensions.length === 0) {
+    return { done: true, blocked: false, failingDimensions: [] }
+  }
+  if (attempt > maxRetries) {
+    return { done: true, blocked: true, failingDimensions }
+  }
+  return { done: false, blocked: false, failingDimensions }
+}


### PR DESCRIPTION
## Summary
- issue #45/#292: `aidd-phase2.js`のReviewフェーズは各観点のstatus(pass/fail/blocked)を取得していたが、返却処理ではdetailのみを使用しており、statusがfailでも後続の制御に一切反映されず「検証完了」として終わっていた
- fail検出時はImplementerへ指摘内容を差し戻して再修正させ、再度4観点レビューをやり直すループを実装
- 最大3回まで再試行し、それでもfailが残る場合はblockedとして中断し、停止②（構造化レビュー）で人間に明示的に引き渡す
- 判定ロジック（差し戻すか・打ち切るか）は`.claude/workflows/lib/review-retry.js`に切り出し、LLM呼び出し無しで決定的にテストできるようにした（`aidd-phase2.js`はWorkflow DSLでrequire不可のためインライン複製、正本・テストはlib側）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/review-retry.test.js` (4 tests pass: 全pass、blockedのみ、fail1件で差し戻し対象、ダミーレビューが3回差し戻し後にblockedで停止)
- [x] `npm test` (496 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `node --check` で`aidd-phase2.js`の構文確認

Closes #45
Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)