### PR TITLE
fix: aidd-phase1-router.jsの判定を実際の変更ファイル(diff)ベースにする

### DIFF
--- a/.claude/workflows/aidd-phase1-router.js
+++ b/.claude/workflows/aidd-phase1-router.js
@@ -1,14 +1,24 @@
 export const meta = {
   name: 'aidd-phase1-router',
-  description: 'taskDescriptionをTRI/RISK基準に照合し、aidd-phase1（軽量Sweep）とaidd-1-1-deep-task（深掘り）のどちらを起動するか自動判定する。',
-  whenToUse: 'Phase 1調査の入り口として使う。DBスキーマ変更・auth/facility/tenant/organization/inventory/RLS/policy等の高リスク判定を機械的に行い、手動判断を不要にする。',
+  description: 'taskDescriptionとchangedFiles(変更ファイル一覧)をTRI/RISK基準に照合し、aidd-phase1（軽量Sweep）とaidd-1-1-deep-task（深掘り）のどちらを起動するか自動判定する。',
+  whenToUse: 'Phase 1調査の入り口として使う。DBスキーマ変更・auth/facility/tenant/organization/inventory/RLS/policy等の高リスク判定を機械的に行い、手動判断を不要にする。呼び出し側は事前に `git diff --name-only` 等で変更（予定）ファイル一覧を取得し、changedFilesとして渡すこと。',
   phases: [
-    { title: 'Route', detail: 'TRI/RISKキーワード照合で軽量/深掘りを判定' },
+    { title: 'Route', detail: 'ファイルパス（優先）とtaskDescriptionキーワード（補助）でTRI/RISK判定' },
   ],
 }
 
-// args: { taskDescription?: string, maxRounds?: number }
-// 判定はtaskDescriptionのキーワードマッチのみ（変更ファイル・git diffは見ない）
+// args: { taskDescription?: string, maxRounds?: number, changedFiles?: string[] }
+// changedFiles: 変更対象ファイルパスの配列。Workflowスクリプト自体はgit diffを実行できない
+//   （filesystem/Node.js APIアクセス無し）ため、呼び出し側（Claude Code）が
+//   `git diff --name-only` や変更予定ファイルリストから取得して渡すこと。
+// 判定優先順位: changedFilesのパス一致（common.md TRI/RISK基準）を優先し、
+//   taskDescriptionのキーワード一致は補助判定として残す（どちらか一方でも該当すれば深掘りへ。issue #286）
+
+// common.md記載のパスベース基準: supabase/migrations/ 配下、src/lib/supabase/ 配下
+const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
+
+// common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
+const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
 
 const RISK_KEYWORDS = [
   // パス由来
@@ -27,22 +37,32 @@ const RISK_KEYWORDS = [
 // false positive（軽微なタスクが深掘りに回る＝時間コスト増）は許容し、
 // false negative（高リスク変更を軽量版で見逃す）は許容しない。
 
+function isHighRiskPath(filePath) {
+  const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
+  if (RISK_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))) return true
+  // middleware.ts はプロジェクト内のすべてのmiddlewareが対象（common.md）
+  if (normalized === 'middleware.ts' || normalized.endsWith('/middleware.ts')) return true
+  return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
+}
+
 // Workflowツール実行系のargsがverbatimでなく文字列化されて渡ってくる既知の不具合への回避策。
 // argsが文字列で届いた場合はJSONとしてパースしてから使う。
 const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
 
 const taskDescription = parsedArgs?.taskDescription ?? '現在のコードベース全体の調査'
 const maxRounds = parsedArgs?.maxRounds ?? 3
+const changedFiles = parsedArgs?.changedFiles ?? []
 
 phase('Route')
 
 const lowerTask = taskDescription.toLowerCase()
-const matched = RISK_KEYWORDS.filter(kw => lowerTask.includes(kw.toLowerCase()))
-const isHighRisk = matched.length > 0
+const matchedKeywords = RISK_KEYWORDS.filter(kw => lowerTask.includes(kw.toLowerCase()))
+const matchedPaths = changedFiles.filter(isHighRiskPath)
+const isHighRisk = matchedKeywords.length > 0 || matchedPaths.length > 0
 
 log(
   isHighRisk
-    ? `TRI/RISK該当キーワード検出（${matched.join(', ')}）→ aidd-1-1-deep-task を起動`
+    ? `TRI/RISK該当（キーワード: ${matchedKeywords.join(', ') || 'なし'} / 変更ファイル: ${matchedPaths.join(', ') || 'なし'}）→ aidd-1-1-deep-task を起動`
     : 'TRI/RISK該当なし → aidd-phase1（軽量Sweep）を起動'
 )
 
@@ -52,6 +72,7 @@ const result = isHighRisk
 
 return {
   route: isHighRisk ? 'aidd-1-1-deep-task' : 'aidd-phase1',
-  matchedKeywords: matched,
+  matchedKeywords,
+  matchedPaths,
   result,
 }

--- a/.claude/workflows/lib/__tests__/router-risk.test.js
+++ b/.claude/workflows/lib/__tests__/router-risk.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { classifyRisk } from '../router-risk.js'
+
+describe('classifyRisk', () => {
+  it('taskDescriptionにキーワードがあれば高リスク（後方互換）', () => {
+    const result = classifyRisk('facility周りのバグ修正', [])
+    expect(result.isHighRisk).toBe(true)
+    expect(result.matchedKeywords).toContain('facility')
+  })
+
+  it('taskDescriptionにキーワードが無くchangedFilesも空なら高リスクではない', () => {
+    const result = classifyRisk('ボタンの色を変える', [])
+    expect(result.isHighRisk).toBe(false)
+  })
+
+  it('taskDescriptionにキーワードが無くてもsupabase/migrations/配下の変更があれば高リスク', () => {
+    const result = classifyRisk('ちょっとしたリファクタ', ['supabase/migrations/20260711000000_add_index.sql'])
+    expect(result.isHighRisk).toBe(true)
+    expect(result.matchedPaths).toEqual(['supabase/migrations/20260711000000_add_index.sql'])
+  })
+
+  it('taskDescriptionにキーワードが無くてもsrc/lib/supabase/配下の変更があれば高リスク', () => {
+    const result = classifyRisk('リファクタ', ['src/lib/supabase/orders.ts'])
+    expect(result.isHighRisk).toBe(true)
+  })
+
+  it('taskDescriptionにキーワードが無くてもmiddleware.tsの変更があれば高リスク', () => {
+    const result = classifyRisk('リファクタ', ['middleware.ts'])
+    expect(result.isHighRisk).toBe(true)
+  })
+
+  it('taskDescriptionにキーワードが無くてもドメインキーワードを含むパスの変更があれば高リスク（issue #286の完了条件）', () => {
+    const result = classifyRisk('画面のちょっとした調整', ['src/app/(pages)/facility/settings/page.tsx'])
+    expect(result.isHighRisk).toBe(true)
+    expect(result.matchedPaths.length).toBe(1)
+  })
+
+  it('リスクに無関係なファイルのみの変更なら高リスクではない', () => {
+    const result = classifyRisk('ボタンの色を変える', ['src/components/Button.tsx', 'src/app/page.tsx'])
+    expect(result.isHighRisk).toBe(false)
+    expect(result.matchedPaths).toEqual([])
+  })
+
+  it('taskDescriptionとchangedFilesの両方が該当しても問題なく高リスクと判定する', () => {
+    const result = classifyRisk('RLSポリシーの見直し', ['supabase/migrations/20260711000000_rls.sql'])
+    expect(result.isHighRisk).toBe(true)
+    expect(result.matchedKeywords.length).toBeGreaterThan(0)
+    expect(result.matchedPaths.length).toBeGreaterThan(0)
+  })
+
+  it('changedFiles未指定でもエラーにならない（デフォルト空配列）', () => {
+    const result = classifyRisk('ボタンの色を変える')
+    expect(result.isHighRisk).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/router-risk.js
+++ b/.claude/workflows/lib/router-risk.js
@@ -1,0 +1,56 @@
+// aidd-phase1-router.js のTRI/RISK判定ロジック。
+// 旧実装はtaskDescription（人間が書いた説明文）のキーワード一致のみで判定しており、
+// 実際の変更ファイル・diffを見ていなかった。docs/agents/common.mdのTRI/RISK機械判定基準は
+// 「ファイルパス・変更内容」を基準にしているため、実装と基準が一致していなかった（issue #286）。
+// 説明文にキーワードが無くても、変更ファイルパスがRLS/auth/facility等のドメインに
+// 触れる場合は深掘りパスに振り分ける（ファイルパス一致を優先、キーワード一致は補助判定として残す）。
+// aidd-phase1-router.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+// 意図的に安全側に倒す（common.md TRI/RISK原則: 迷ったら高リスク側）。
+// false positive（軽微なタスクが深掘りに回る＝時間コスト増）は許容し、
+// false negative（高リスク変更を軽量版で見逃す）は許容しない。
+
+const RISK_KEYWORDS = [
+  // パス由来
+  'migrations', 'migration', 'マイグレーション', 'スキーマ',
+  'src/lib/supabase', 'middleware.ts', 'ミドルウェア',
+  // ドメイン由来（common.md TRI/RISK基準）
+  'auth', '認証', 'ログイン',
+  'facility', '施設',
+  'tenant', 'テナント',
+  'organization', '組織',
+  'inventory', '在庫',
+  'rls', 'policy', 'ポリシー',
+]
+
+// common.md記載のパスベース基準: supabase/migrations/ 配下、src/lib/supabase/ 配下
+const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
+
+// common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
+const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
+
+function isHighRiskPath(filePath) {
+  const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
+  if (RISK_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))) return true
+  // middleware.ts はプロジェクト内のすべてのmiddlewareが対象（common.md）
+  if (normalized === 'middleware.ts' || normalized.endsWith('/middleware.ts')) return true
+  return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
+}
+
+function matchTaskKeywords(taskDescription) {
+  const lower = String(taskDescription ?? '').toLowerCase()
+  return RISK_KEYWORDS.filter(kw => lower.includes(kw.toLowerCase()))
+}
+
+// taskDescription: 人間が書いた説明文（補助判定、後方互換のため残す）
+// changedFiles: 変更対象ファイルパスの配列（優先判定。Workflowスクリプト自体はgit diffを
+//               実行できない[filesystem/Node.js API access無し]ため、呼び出し側がgit diff等で
+//               取得して渡す）
+// 戻り値: { isHighRisk, matchedKeywords, matchedPaths }
+export function classifyRisk(taskDescription, changedFiles = []) {
+  const matchedKeywords = matchTaskKeywords(taskDescription)
+  const matchedPaths = (changedFiles ?? []).filter(isHighRiskPath)
+  const isHighRisk = matchedKeywords.length > 0 || matchedPaths.length > 0
+  return { isHighRisk, matchedKeywords, matchedPaths }
+}


### PR DESCRIPTION
## Summary
- issue #286: `aidd-phase1-router.js`はtaskDescription（人間が書いた説明文）中のキーワード一致だけでTRI/RISK判定を行っており、実際の変更ファイル・diffを見ていなかった。説明文にキーワードが含まれない場合、実際にはRLS/facility等を触る変更でも軽量パス（aidd-phase1.js）に誤って振り分けられ、深い検証（RLS/IDOR観点を含むSweep等）がスキップされていた
- Router呼び出し時に`changedFiles`（変更ファイルパスの配列）を渡せるようにした。Workflowスクリプト自体はfilesystem/Node.js APIアクセスが無くgit diffを実行できないため、呼び出し側（Claude Code）が`git diff --name-only`等で取得して渡す設計
- `docs/agents/common.md`のTRI/RISK機械判定基準（`supabase/migrations/`配下、`src/lib/supabase/`配下、`middleware.ts`、auth/facility/tenant/organization/inventory/RLS/policyドメインキーワード）をパスベースで機械的に照合
- ファイルパス一致を優先し、taskDescriptionのキーワード一致は補助判定として後方互換性を保持（どちらか一方でも該当すれば深掘りパスへ）
- 判定ロジックは`.claude/workflows/lib/router-risk.js`に切り出し、LLM呼び出し無しで決定的にテストできるようにした（`aidd-phase1-router.js`はWorkflow DSLでrequire不可のためインライン複製、正本・テストはlib側）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/router-risk.test.js` (9 tests pass: taskDescriptionキーワードのみ／changedFilesのみ／両方／該当なしの各パターン、migrations・src/lib/supabase・middleware.ts・ドメインキーワードパスの検知を確認)
- [x] `npm test` (506 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `node --check` で`aidd-phase1-router.js`の構文確認

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)