### PR TITLE
feat: newsフィードに管理者の「全施設」閲覧モードを実装する

### DIFF
--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { listFacilities, createFacility } from '@/lib/facilities/repository'
 import { apiError } from '@/lib/api-error'
 import type { FacilityInput } from '@/types/facility'
@@ -8,9 +9,14 @@ import type { FacilityInput } from '@/types/facility'
 export async function GET() {
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
     const facilities = await listFacilities(db)
-    return NextResponse.json({ facilities })
+    // WHY: フロントエンドが「全施設」表示オプションを出すかどうかの判定に使う。
+    // require-facility-access.ts の resolveIsAdmin と同じ判定にすることで、
+    // UIが「全施設」を選べるのにAPIがfacilityId必須で弾く、という不整合を防ぐ（issue #40）
+    const isAdmin = await resolveIsAdmin(db, user)
+    return NextResponse.json({ facilities, isAdmin })
   } catch (error) {
     return apiError(error instanceof Error ? error.message : '施設の取得に失敗しました')
   }

--- a/src/app/api/news/__tests__/route.test.ts
+++ b/src/app/api/news/__tests__/route.test.ts
@@ -125,4 +125,19 @@ describe('GET /api/news', () => {
     expect(res.status).toBe(200)
     expect(mockListNewsFeed).toHaveBeenCalledWith(expect.anything(), { facilityId: 'f1', limit: 100, offset: 0 })
   })
+
+  it('admin・facilityId省略時は全施設データが返る（issue #40）', async () => {
+    authenticated()
+    mockRequireFacilityAccess.mockResolvedValue({ facilityId: null })
+    mockListNewsFeed.mockResolvedValue([
+      { id: 'n1', eventType: 'new_product', facilityName: '施設A' },
+      { id: 'n2', eventType: 'new_product', facilityName: '施設B' },
+    ])
+
+    const res = await GET(new NextRequest('http://localhost/api/news'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toHaveLength(2)
+    expect(mockListNewsFeed).toHaveBeenCalledWith(expect.anything(), { facilityId: null, limit: 20, offset: 0 })
+  })
 })

--- a/src/app/news/__tests__/page.test.tsx
+++ b/src/app/news/__tests__/page.test.tsx
@@ -128,6 +128,70 @@ describe('NewsPage', () => {
     expect(screen.queryByRole('button', { name: 'もっと見る' })).not.toBeInTheDocument()
   })
 
+  it('管理者はfacilityId未指定時「全施設」がデフォルトで選択され、facilityId無しでニュースを取得する（issue #40）', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities, isAdmin: true }))
+      if (url === '/api/news?limit=20&offset=0') {
+        return Promise.resolve(
+          jsonResponse({ items: [makeItem('1', '2026-07-08T00:00:00Z'), makeItem('2', '2026-07-08T00:00:00Z')] })
+        )
+      }
+      return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewsPage />)
+
+    expect(await screen.findByText('商品1', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('商品2', { exact: false })).toBeInTheDocument()
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    expect(select.value).toBe('')
+    expect(screen.getByRole('option', { name: '全施設' })).toBeInTheDocument()
+
+    // 管理者の「全施設」モードではURLにfacilityIdクエリを付与しない
+    expect(replace).not.toHaveBeenCalledWith(expect.stringContaining('facilityId='))
+  })
+
+  it('管理者が「全施設」から特定施設に切り替えるとfacilityId付きで再取得しURLも更新される（issue #40）', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities, isAdmin: true }))
+      if (url === '/api/news?limit=20&offset=0') return Promise.resolve(jsonResponse({ items: [] }))
+      if (url.startsWith('/api/news?facilityId=f1')) {
+        return Promise.resolve(jsonResponse({ items: [makeItem('1', '2026-07-08T00:00:00Z')] }))
+      }
+      return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+
+    render(<NewsPage />)
+    const select = await screen.findByRole('combobox') as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe(''))
+
+    await user.selectOptions(select, 'f1')
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/news?facilityId=f1')
+    })
+    expect(await screen.findByText('商品1', { exact: false })).toBeInTheDocument()
+  })
+
+  it('非adminには「全施設」の選択肢が表示されない', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities, isAdmin: false }))
+      if (url.startsWith('/api/news?facilityId=f1')) {
+        return Promise.resolve(jsonResponse({ items: [makeItem('1', '2026-07-08T00:00:00Z')] }))
+      }
+      return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewsPage />)
+    await screen.findByText('商品1', { exact: false })
+    expect(screen.queryByRole('option', { name: '全施設' })).not.toBeInTheDocument()
+  })
+
   it('施設が0件の場合、お知らせはありませんと表示される', async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [] }))

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -14,6 +14,8 @@ function NewsPageInner() {
   const urlFacilityId = searchParams.get('facilityId')
 
   const [facilities, setFacilities] = useState<Facility[]>([])
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [initialized, setInitialized] = useState(false)
   const [selectedFacilityId, setSelectedFacilityId] = useState<string | null>(null)
   const [items, setItems] = useState<NewsFeedItem[]>([])
   const [offset, setOffset] = useState(0)
@@ -21,6 +23,7 @@ function NewsPageInner() {
   const [error, setError] = useState<string | null>(null)
 
   // 初回ロード用: facilities を取得し、選択施設IDを決定する
+  // 管理者はURLで施設が指定されていなければ「全施設」（selectedFacilityId=null）をデフォルトにする（issue #40）
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -29,17 +32,22 @@ function NewsPageInner() {
         if (!res.ok) throw new Error()
         const data = await res.json()
         const loadedFacilities = data.facilities as Facility[]
+        const admin = Boolean(data.isAdmin)
         if (cancelled) return
 
         setFacilities(loadedFacilities)
+        setIsAdmin(admin)
 
         const isValidUrlFacility =
           urlFacilityId !== null && loadedFacilities.some((f) => f.id === urlFacilityId)
         const resolvedFacilityId = isValidUrlFacility
           ? urlFacilityId
-          : (loadedFacilities[0]?.id ?? null)
+          : admin
+            ? null
+            : (loadedFacilities[0]?.id ?? null)
 
         setSelectedFacilityId(resolvedFacilityId)
+        setInitialized(true)
 
         if (resolvedFacilityId !== urlFacilityId && resolvedFacilityId) {
           router.replace(`/news?facilityId=${encodeURIComponent(resolvedFacilityId)}`)
@@ -56,18 +64,21 @@ function NewsPageInner() {
   }, [])
 
   // フィード取得用: selectedFacilityId が変わるたびに1ページ目から取得する
+  // 管理者がselectedFacilityId=null（全施設）の場合はfacilityIdを付与せず取得する
   useEffect(() => {
     let cancelled = false
     async function loadFeed() {
-      if (!selectedFacilityId) {
+      if (!initialized) return
+      if (!selectedFacilityId && !isAdmin) {
         setItems([])
         setHasMore(false)
         return
       }
       try {
-        const res = await fetch(
-          `/api/news?facilityId=${encodeURIComponent(selectedFacilityId)}&limit=${PAGE_SIZE}&offset=0`
-        )
+        const query = selectedFacilityId
+          ? `facilityId=${encodeURIComponent(selectedFacilityId)}&limit=${PAGE_SIZE}&offset=0`
+          : `limit=${PAGE_SIZE}&offset=0`
+        const res = await fetch(`/api/news?${query}`)
         if (!res.ok) throw new Error()
         const data = await res.json()
         if (cancelled) return
@@ -82,14 +93,15 @@ function NewsPageInner() {
     return () => {
       cancelled = true
     }
-  }, [selectedFacilityId])
+  }, [selectedFacilityId, isAdmin, initialized])
 
   async function handleLoadMore() {
-    if (!selectedFacilityId) return
+    if (!selectedFacilityId && !isAdmin) return
     try {
-      const res = await fetch(
-        `/api/news?facilityId=${encodeURIComponent(selectedFacilityId)}&limit=${PAGE_SIZE}&offset=${offset}`
-      )
+      const query = selectedFacilityId
+        ? `facilityId=${encodeURIComponent(selectedFacilityId)}&limit=${PAGE_SIZE}&offset=${offset}`
+        : `limit=${PAGE_SIZE}&offset=${offset}`
+      const res = await fetch(`/api/news?${query}`)
       if (!res.ok) throw new Error()
       const data = await res.json()
       setItems((prev) => [...prev, ...data.items])
@@ -101,8 +113,14 @@ function NewsPageInner() {
   }
 
   function handleFacilityChange(newId: string) {
-    setSelectedFacilityId(newId)
-    router.replace(`/news?facilityId=${encodeURIComponent(newId)}`)
+    // 空文字は「全施設」選択（管理者のみ選択肢として表示）を表す
+    const resolved = newId === '' ? null : newId
+    setSelectedFacilityId(resolved)
+    if (resolved) {
+      router.replace(`/news?facilityId=${encodeURIComponent(resolved)}`)
+    } else {
+      router.replace('/news')
+    }
   }
 
   return (
@@ -133,6 +151,7 @@ function NewsPageInner() {
             className="rounded border px-3 py-2 text-sm"
             style={{ borderColor: '#072C2C33', color: '#072C2C' }}
           >
+            {isAdmin && <option value="">全施設</option>}
             {facilities.map((facility) => (
               <option key={facility.id} value={facility.id}>
                 {facility.name}


### PR DESCRIPTION
## Summary
- issue #40: 設計書（`docs/superpowers/specs/2026-07-08-news-feed-design.md:179`）には「管理者は全施設相当の未選択状態も許可」と明記され、API層（`require-facility-access.ts`）は対応済みだったが、フロントエンド（`news/page.tsx`）にadmin/非admin判定が一切無く、常に先頭施設が強制選択されるためUIから「全施設」パスに到達する手段が無かった
- `/api/facilities`のレスポンスに`isAdmin`を追加（`require-facility-access.ts`と同じ`resolveIsAdmin`判定を使用し、UIとAPIの認可判定を一致させる）
- `news/page.tsx`: 管理者かつURLに`facilityId`未指定の場合は「全施設」（`selectedFacilityId=null`）をデフォルトにし、施設セレクタに管理者のみ「全施設」オプションを追加。選択時は`facilityId`クエリを付与せず取得する
- `src/app/api/news/__tests__/route.test.ts`に「admin・facilityId省略時は全施設データが返る」ケースを追加（issueで明示的に要求されていたテスト）
- `news/__tests__/page.test.tsx`にも、管理者のデフォルト全施設表示・施設切り替え・非adminには選択肢が出ないことを確認するテストを追加

## Test plan
- [x] `npx vitest run src/app/news/__tests__/page.test.tsx src/app/api/news/__tests__/route.test.ts` (22 tests pass)
- [x] `npm test` (514 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)