### PR TITLE
feat: 修正ループの終了条件をDONE基準に接続する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -78,10 +78,11 @@ log(`Manifest Check完了: status=${manifestCheck?.status ?? 'なし'}`)
 if (manifestCheck?.status !== 'pass') {
   log(`品質ゲート: Run Manifestのspec Hash突合に失敗したため中断（${manifestCheck?.detail ?? '詳細不明'}）`)
   return {
+    done: false,
     manifestCheck,
     blocked: true,
     blockedAt: 'Manifest Check',
-    stats: { phase: 'phase2', blocked: true, blockedAt: 'Manifest Check' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Manifest Check' },
   }
 }
 
@@ -117,11 +118,12 @@ log('Contract + DB完了')
 if (![contractResult, dbResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Contract + DBでfail/blockedを検知したため中断（Implement以降へは進みません）')
   return {
+    done: false,
     contractResult,
     dbResult,
     blocked: true,
     blockedAt: 'Contract + DB',
-    stats: { phase: 'phase2', blocked: true, blockedAt: 'Contract + DB' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Contract + DB' },
   }
 }
 
@@ -158,6 +160,7 @@ log('Implement完了')
 if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Implementでfail/blockedを検知したため中断（統合ゲートへは進みません）')
   return {
+    done: false,
     contractResult,
     dbResult,
     dataResult,
@@ -165,7 +168,7 @@ if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
     uiResult,
     blocked: true,
     blockedAt: 'Implement',
-    stats: { phase: 'phase2', blocked: true, blockedAt: 'Implement' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Implement' },
   }
 }
 
@@ -173,9 +176,9 @@ if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
 phase('Integrate')
 
 const integrationResult = await agent(
-  `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. 全テスト・lint緑を確認して報告\n6. .aidd/run-manifest.json をReadツールで読み、manifest.baseCommitを取得する（無ければこのステップはスキップしてよい）。取得できた場合、Bashツールで \`git diff --name-only \${baseCommit}\`（baseCommitはmanifestの値に置き換える）を実行し、変更されたファイル一覧を取得する。取得できたら .aidd/run-manifest.json の changedFiles フィールドをその一覧で上書きし、Writeツールで保存する（docs/agents/run-manifest.md 参照。他フィールドは変更しないこと）。\n\n## 各完了報告\n### contract-writer\n${contractResult?.detail}\n### db-impl\n${dbResult?.detail}\n### data-impl\n${dataResult?.detail}\n### api-impl\n${apiResult?.detail}\n### ui-impl\n${uiResult?.detail}${guide(
-    'npm test・npm run lintが最終的に緑で統合完了',
-    '3回の修正試行後もtest/lintが赤のまま',
+  `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. npx tsc --noEmit を実行 → 型エラーがあれば修正（3回まで。issue #46のDONE基準に型検査を含める）\n6. 全テスト・lint・tsc緑を確認して報告\n7. .aidd/run-manifest.json をReadツールで読み、manifest.baseCommitを取得する（無ければこのステップはスキップしてよい）。取得できた場合、Bashツールで \`git diff --name-only \${baseCommit}\`（baseCommitはmanifestの値に置き換える）を実行し、変更されたファイル一覧を取得する。取得できたら .aidd/run-manifest.json の changedFiles フィールドをその一覧で上書きし、Writeツールで保存する（docs/agents/run-manifest.md 参照。他フィールドは変更しないこと）。\n\n## 各完了報告\n### contract-writer\n${contractResult?.detail}\n### db-impl\n${dbResult?.detail}\n### data-impl\n${dataResult?.detail}\n### api-impl\n${apiResult?.detail}\n### ui-impl\n${uiResult?.detail}${guide(
+    'npm test・npm run lint・npx tsc --noEmitが最終的に全て緑で統合完了',
+    '3回の修正試行後もtest/lint/tscのいずれかが赤のまま',
     'SPEC.mdが見つからない、またはいずれかのimplエージェントの完了報告に「仕様書が見つからない」「作業を開始できない」旨の記述がある'
   )}`,
   { label: 'integrator', phase: 'Integrate', agentType: 'integrator', schema: AGENT_RESULT_SCHEMA }
@@ -187,6 +190,7 @@ log('統合完了')
 if (![integrationResult].every(r => r?.status === 'pass')) {
   log('品質ゲート: Integrateでfail/blockedを検知したため中断（Reviewへは進みません）')
   return {
+    done: false,
     contractResult,
     dbResult,
     dataResult,
@@ -195,7 +199,7 @@ if (![integrationResult].every(r => r?.status === 'pass')) {
     integration: integrationResult,
     blocked: true,
     blockedAt: 'Integrate',
-    stats: { phase: 'phase2', blocked: true, blockedAt: 'Integrate' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Integrate' },
   }
 }
 
@@ -256,6 +260,7 @@ while (true) {
   if (blocked) {
     log(`品質ゲート: Reviewで${MAX_REVIEW_RETRIES}回の差し戻し後もfailが残るため中断（blockedとして人間に引き渡します）`)
     return {
+      done: false,
       contractResult,
       dbResult,
       dataResult,
@@ -270,6 +275,7 @@ while (true) {
       blockedAt: 'Review',
       stats: {
         phase: 'phase2',
+        done: false,
         blocked: true,
         blockedAt: 'Review',
         reviewRetries: reviewRetryAgentCount,
@@ -294,11 +300,27 @@ while (true) {
   reviewRetryAgentCount++
 }
 
-log('検証完了。/structured-review でレビュー結果を確認してください。')
-
 const implResults = [contractResult, dbResult, dataResult, apiResult, uiResult]
 
+// DONE判定: .claude/workflows/lib/phase2-done.js の computeDone と同一ロジック
+// （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
+// issue #46: 修正ループ（Review差し戻し等）を実装しても、最終的な完了条件(DONE)が
+// 明示されていないと「いつ止まっていいか」が曖昧になる。DONE = 全実装がpass AND
+// 統合ゲート(test/lint/tsc)がpass AND 全観点Reviewがpass AND specHashが一致、の
+// すべてを満たした場合のみtrueにする。
+function allPass(results) {
+  return results.length > 0 && results.every(r => r?.status === 'pass')
+}
+const done =
+  allPass(implResults) &&
+  integrationResult?.status === 'pass' &&
+  allPass(reviewResults) &&
+  manifestCheck?.status === 'pass'
+
+log(`検証完了（DONE=${done}）。/structured-review でレビュー結果を確認してください。`)
+
 return {
+  done,
   manifestCheck,
   contractResult,
   dbResult,
@@ -312,6 +334,7 @@ return {
   })),
   stats: {
     phase: 'phase2',
+    done,
     implAgents: 5,
     reviewAgents: REVIEW_DIMENSIONS.length,
     reviewRetries: reviewRetryAgentCount,

--- a/.claude/workflows/lib/__tests__/phase2-done.test.js
+++ b/.claude/workflows/lib/__tests__/phase2-done.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { computeDone } from '../phase2-done.js'
+
+const pass = { status: 'pass', detail: 'ok' }
+const fail = { status: 'fail', detail: 'ng' }
+const blocked = { status: 'blocked', detail: 'blocked' }
+
+const implAllPass = [pass, pass, pass, pass, pass]
+
+describe('computeDone', () => {
+  it('全条件がpassならtrue', () => {
+    expect(computeDone(implAllPass, pass, [pass, pass, pass, pass], pass)).toBe(true)
+  })
+
+  it('implResultsに1件でもfailがあればfalse', () => {
+    const implWithFail = [pass, pass, fail, pass, pass]
+    expect(computeDone(implWithFail, pass, [pass, pass, pass, pass], pass)).toBe(false)
+  })
+
+  it('implResultsに1件でもblockedがあればfalse', () => {
+    const implWithBlocked = [pass, blocked, pass, pass, pass]
+    expect(computeDone(implWithBlocked, pass, [pass, pass, pass, pass], pass)).toBe(false)
+  })
+
+  it('integrationResult(test/lint/tsc)がpassでなければfalse', () => {
+    expect(computeDone(implAllPass, fail, [pass, pass, pass, pass], pass)).toBe(false)
+  })
+
+  it('reviewResultsに1件でもfail(critical/high相当)があればfalse', () => {
+    expect(computeDone(implAllPass, pass, [pass, fail, pass, pass], pass)).toBe(false)
+  })
+
+  it('manifestCheck(specHash突合)がpassでなければfalse', () => {
+    expect(computeDone(implAllPass, pass, [pass, pass, pass, pass], blocked)).toBe(false)
+  })
+
+  it('manifestCheckが未指定(null/undefined)でもエラーにならずfalse', () => {
+    expect(computeDone(implAllPass, pass, [pass, pass, pass, pass], null)).toBe(false)
+  })
+
+  it('implResults/reviewResultsが空配列ならfalse（判定対象が無いのに完了扱いしない）', () => {
+    expect(computeDone([], pass, [pass], pass)).toBe(false)
+    expect(computeDone(implAllPass, pass, [], pass)).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/phase2-done.js
+++ b/.claude/workflows/lib/phase2-done.js
@@ -1,0 +1,26 @@
+// aidd-phase2.js の最終的な「完了(DONE)」判定ロジック（issue #46）。
+// 各フェーズのゲート（Manifest Check・Contract+DB・Implement・Integrate・Review）は
+// 個別にdeny-by-defaultで中断するが、それらを組み合わせた「全条件を満たしたときだけ
+// DONEを返す」という完了条件自体は明示的に定義・テストされていなかった。
+// DONE = 全実装ブランチがpass AND 統合ゲート(test/lint/tsc)がpass
+//        AND 全観点のReviewがpass(critical/high相当のfailが0) AND Run ManifestのspecHashが一致
+// エージェント呼び出しを含まない純粋関数のため、LLM呼び出し無しで決定的にテストできる。
+// aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+function allPass(results) {
+  return results.length > 0 && results.every(r => r?.status === 'pass')
+}
+
+// implResults: [contractResult, dbResult, dataResult, apiResult, uiResult]
+// integrationResult: integratorのAgentResult（test/lint/tsc全て緑であることを含む）
+// reviewResults: 4観点reviewerのAgentResult配列
+// manifestCheck: Run ManifestのspecHash突合結果のAgentResult
+export function computeDone(implResults, integrationResult, reviewResults, manifestCheck) {
+  return (
+    allPass(implResults) &&
+    integrationResult?.status === 'pass' &&
+    allPass(reviewResults) &&
+    manifestCheck?.status === 'pass'
+  )
+}


### PR DESCRIPTION
## Summary
- issue #46: `aidd-phase2.js`の各ゲート（Manifest Check・Contract+DB・Implement・Integrate・Review差し戻しループ）は個別にdeny-by-defaultで中断するが、それらを組み合わせた最終的な「完了(DONE)」条件自体は明示されていなかった
- DONE = 全実装がpass AND 統合ゲート(test/lint/tsc)がpass AND 全観点Reviewがpass（critical/high相当のfailが0）AND Run ManifestのspecHashが一致、として明示的に判定する処理を追加
- 成功時のみ`done: true`を返し、各中断パス（Manifest Check/Contract+DB/Implement/Integrate/Review）は`done: false`を明示する
- 判定ロジックは`.claude/workflows/lib/phase2-done.js`に切り出し、LLM呼び出し無しで決定的にテストできるようにした
- 統合ゲート(integrator)の指示に`npx tsc --noEmit`の実行を追加し、DONE基準に型検査を含めた
- E2E・専用セキュリティスキャンは、ローカルSupabase起動が前提の重いテストであり毎回のAIDD実行に含めると環境依存の失敗リスクが増すため、今回は含めずCI（`.github/workflows/e2e.yml`）側の責務とした（ユーザーとの合意事項）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/phase2-done.test.js` (8 tests pass: 全条件pass／implResults中のfail・blocked／integrationResultがpassでない／reviewResults中のfail／manifestCheckがpassでない／manifestCheck未指定／空配列の各パターン)
- [x] `npm test` (522 tests pass)
- [x] `npm run lint` (既存の無関係な警告2件のみ、エラーなし)
- [x] `node --check` で`aidd-phase2.js`の構文確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)