### PR TITLE
feat: AIDD品質ゲート(Implement/Integrate/Review)に重大度分類を導入する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -28,14 +28,48 @@ export const meta = {
 
 const specPath = args?.specPath ?? 'SPEC.md'
 
-// docs/agents/agent-result-schema.md 参照。実装/統合/レビュー系はpass/fail/blockedの3値
+// docs/agents/agent-result-schema.md 参照。実装/統合/レビュー系はpass/fail/blockedの3値。
+// findingsはfail時の重大度分類（severity.js参照）。Sweep/Draft/Adversarial Verify
+// （aidd-1-1-deep-task.js FINDING_SCHEMA）と同じcritical/important/minorを使い、
+// 実装後ゲート（Contract+DB/Implement/Integrate/Review）にも重大度の概念を展開する。
 const AGENT_RESULT_SCHEMA = {
   type: 'object',
   properties: {
     status: { type: 'string', enum: ['pass', 'fail', 'blocked'] },
     detail: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['critical', 'important', 'minor'] },
+          description: { type: 'string' },
+        },
+        required: ['severity', 'description'],
+      },
+    },
   },
   required: ['status', 'detail'],
+}
+
+// 重大度判定（.claude/workflows/lib/severity.js の isMinorOnlyFailure と同一発想）。
+// Workflow DSLはrequire不可のためインライン複製している。ロジックの正本・テストはlib側。
+function isMinorOnlyFailure(result) {
+  if (result?.status !== 'fail') return false
+  if (!Array.isArray(result.findings) || result.findings.length === 0) return false
+  return result.findings.every(f => f?.severity === 'minor')
+}
+
+function shouldBlock(results) {
+  if (results.length === 0) return false
+  return !results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
+}
+
+function logMinorOnlyPassThrough(label, results) {
+  const minorOnly = results.filter(isMinorOnlyFailure)
+  if (minorOnly.length > 0) {
+    log(`品質ゲート: ${label}でminor指摘のみのfailが${minorOnly.length}件あったが通過扱い（critical/important指摘なし）`)
+  }
 }
 
 const guide = (pass, fail, blocked) => `
@@ -44,7 +78,12 @@ const guide = (pass, fail, blocked) => `
 status と detail を返すこと。
 - pass: ${pass}
 - fail: ${fail}
-- blocked: ${blocked}`
+- blocked: ${blocked}
+
+failの場合はfindings配列（{ severity: critical/important/minor, description }）で指摘ごとに
+重大度を明記すること。findings全件がminorならこのゲートは通過扱いになる。
+findingsを省略した場合、またはcritical/important指摘が1件でもあれば差し戻し対象になる
+（severity不明・欠損はcritical扱い。fail-open防止）。`
 
 // ─── Phase 0: Manifest Check ─────────────────────────────────────────
 // issue #44/#294: docs/agents/run-manifest.md にPhase 2開始時のspecHash突合が
@@ -114,8 +153,9 @@ log('Contract + DB完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
 // （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
-// deny-by-default: 全員がpassでない限り止める（fail/blockedはもちろんnull・未知の値も止める。issue #289）
-if (![contractResult, dbResult].every(r => r?.status === 'pass')) {
+// deny-by-default: 全員がpass（またはfindings全件minorのfail）でない限り止める
+// （fail/blockedはもちろんnull・未知の値も止める。issue #289）
+if (shouldBlock([contractResult, dbResult])) {
   log('品質ゲート: Contract + DBでfail/blockedを検知したため中断（Implement以降へは進みません）')
   return {
     done: false,
@@ -126,6 +166,7 @@ if (![contractResult, dbResult].every(r => r?.status === 'pass')) {
     stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Contract + DB' },
   }
 }
+logMinorOnlyPassThrough('Contract + DB', [contractResult, dbResult])
 
 // ─── Phase B: data / api / ui（並列）─────────────────────────────────
 // 3グループは contract-writer の出力（src/types/）を契約として参照する
@@ -157,7 +198,7 @@ const [dataResult, apiResult, uiResult] = await parallel([
 log('Implement完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
-if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
+if (shouldBlock([dataResult, apiResult, uiResult])) {
   log('品質ゲート: Implementでfail/blockedを検知したため中断（統合ゲートへは進みません）')
   return {
     done: false,
@@ -171,6 +212,7 @@ if (![dataResult, apiResult, uiResult].every(r => r?.status === 'pass')) {
     stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Implement' },
   }
 }
+logMinorOnlyPassThrough('Implement', [dataResult, apiResult, uiResult])
 
 // ─── Phase C: 統合ゲート ──────────────────────────────────────────────
 phase('Integrate')
@@ -187,7 +229,7 @@ const integrationResult = await agent(
 log('統合完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
-if (![integrationResult].every(r => r?.status === 'pass')) {
+if (shouldBlock([integrationResult])) {
   log('品質ゲート: Integrateでfail/blockedを検知したため中断（Reviewへは進みません）')
   return {
     done: false,
@@ -202,6 +244,7 @@ if (![integrationResult].every(r => r?.status === 'pass')) {
     stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Integrate' },
   }
 }
+logMinorOnlyPassThrough('Integrate', [integrationResult])
 
 // ─── Phase D: 4観点並列レビュー（fail時はImplementerへ差し戻す修正ループ、最大3回）──
 // issue #45/#292: 従来はReviewのstatus(fail)を一切見ずdetailのみ使い、指摘があっても
@@ -210,6 +253,8 @@ if (![integrationResult].every(r => r?.status === 'pass')) {
 // 残る場合はblockedとして人間（停止②の構造化レビュー）に引き渡す。
 // 判定ロジック: .claude/workflows/lib/review-retry.js の classifyReviewRound と同一
 // （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
+// 重大度分類: findings全件がminorの指摘だけでは差し戻さない（UIの軽微な指摘で修正ループを
+// 回さない。DB/ロジックのcritical/important指摘は従来通り差し戻し対象）
 phase('Review')
 
 const REVIEW_DIMENSIONS = [
@@ -228,7 +273,7 @@ const reviewGuide = guide(
 function classifyReviewRound(results, dimensions, attempt, maxRetries) {
   const failingDimensions = dimensions
     .map((dim, i) => ({ dim, result: results[i] }))
-    .filter(({ result }) => result?.status === 'fail')
+    .filter(({ result }) => result?.status === 'fail' && !isMinorOnlyFailure(result))
   if (failingDimensions.length === 0) return { done: true, blocked: false, failingDimensions: [] }
   if (attempt > maxRetries) return { done: true, blocked: true, failingDimensions }
   return { done: false, blocked: false, failingDimensions }
@@ -254,6 +299,7 @@ while (true) {
 
   if (done && !blocked) {
     log(`Review完了: ラウンド${reviewAttempt}で全観点pass（指摘なし、またはblockedのみ）`)
+    logMinorOnlyPassThrough('Review', reviewResults)
     break
   }
 
@@ -305,11 +351,11 @@ const implResults = [contractResult, dbResult, dataResult, apiResult, uiResult]
 // DONE判定: .claude/workflows/lib/phase2-done.js の computeDone と同一ロジック
 // （Workflow DSLはrequire不可のためインライン複製。ロジックの正本・テストはlib側）
 // issue #46: 修正ループ（Review差し戻し等）を実装しても、最終的な完了条件(DONE)が
-// 明示されていないと「いつ止まっていいか」が曖昧になる。DONE = 全実装がpass AND
-// 統合ゲート(test/lint/tsc)がpass AND 全観点Reviewがpass AND specHashが一致、の
-// すべてを満たした場合のみtrueにする。
+// 明示されていないと「いつ止まっていいか」が曖昧になる。DONE = 全実装がpass（またはfindings
+// 全件minorのfail） AND 統合ゲート(test/lint/tsc)がpass AND 全観点Reviewがpass AND
+// specHashが一致、のすべてを満たした場合のみtrueにする。
 function allPass(results) {
-  return results.length > 0 && results.every(r => r?.status === 'pass')
+  return results.length > 0 && results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
 }
 const done =
   allPass(implResults) &&

--- a/.claude/workflows/lib/__tests__/phase2-done.test.js
+++ b/.claude/workflows/lib/__tests__/phase2-done.test.js
@@ -42,4 +42,21 @@ describe('computeDone', () => {
     expect(computeDone([], pass, [pass], pass)).toBe(false)
     expect(computeDone(implAllPass, pass, [], pass)).toBe(false)
   })
+
+  it('implResultsにfindings全件minorのfailが混ざっていてもtrue（軽微な指摘のみは完了扱い）', () => {
+    const minorOnlyFail = { status: 'fail', findings: [{ severity: 'minor', description: '軽微' }] }
+    const implWithMinorFail = [pass, minorOnlyFail, pass, pass, pass]
+    expect(computeDone(implWithMinorFail, pass, [pass, pass, pass, pass], pass)).toBe(true)
+  })
+
+  it('reviewResultsにfindings全件minorのfailが混ざっていてもtrue（軽微な指摘のみは完了扱い）', () => {
+    const minorOnlyFail = { status: 'fail', findings: [{ severity: 'minor', description: '軽微' }] }
+    expect(computeDone(implAllPass, pass, [pass, minorOnlyFail, pass, pass], pass)).toBe(true)
+  })
+
+  it('implResultsにfindingsでimportantが混ざるfailがあればfalse（従来通りブロック）', () => {
+    const importantFail = { status: 'fail', findings: [{ severity: 'important', description: '重要' }] }
+    const implWithImportantFail = [pass, importantFail, pass, pass, pass]
+    expect(computeDone(implWithImportantFail, pass, [pass, pass, pass, pass], pass)).toBe(false)
+  })
 })

--- a/.claude/workflows/lib/__tests__/quality-gate.test.js
+++ b/.claude/workflows/lib/__tests__/quality-gate.test.js
@@ -29,4 +29,27 @@ describe('shouldBlock', () => {
   it('空配列ならfalse（判定対象自体が無い）', () => {
     expect(shouldBlock([])).toBe(false)
   })
+
+  it('failだがfindings全件がminorならfalse（軽微な指摘のみでは差し戻さない）', () => {
+    expect(shouldBlock([
+      { status: 'pass' },
+      { status: 'fail', findings: [{ severity: 'minor', description: 'UIの些細な指摘' }] },
+    ])).toBe(false)
+  })
+
+  it('failでfindingsにimportantが混ざればtrue（従来通りブロック）', () => {
+    expect(shouldBlock([
+      { status: 'fail', findings: [{ severity: 'minor', description: 'a' }, { severity: 'important', description: 'b' }] },
+    ])).toBe(true)
+  })
+
+  it('failでfindingsにcriticalが混ざればtrue（従来通りブロック）', () => {
+    expect(shouldBlock([
+      { status: 'fail', findings: [{ severity: 'critical', description: 'DBスキーマ不整合' }] },
+    ])).toBe(true)
+  })
+
+  it('failでfindingsを省略した場合はtrue（deny-by-default: 重大度不明はブロック側）', () => {
+    expect(shouldBlock([{ status: 'fail', detail: 'findings無し' }])).toBe(true)
+  })
 })

--- a/.claude/workflows/lib/__tests__/review-retry.test.js
+++ b/.claude/workflows/lib/__tests__/review-retry.test.js
@@ -50,4 +50,38 @@ describe('classifyReviewRound', () => {
     expect(finalResult.blocked).toBe(true)
     expect(finalResult.failingDimensions).toHaveLength(1)
   })
+
+  it('failだがfindings全件がminorなら差し戻し対象外でdone=true, blocked=false（UIの軽微な指摘だけで修正ループを回さない）', () => {
+    const result = classifyReviewRound(
+      [
+        { status: 'fail', findings: [{ severity: 'minor', description: 'ボタンの余白が気になる' }] },
+        { status: 'pass', detail: '指摘なし' },
+      ],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(true)
+    expect(result.blocked).toBe(false)
+    expect(result.failingDimensions).toHaveLength(0)
+  })
+
+  it('failでfindingsにimportant/criticalが混ざれば従来通り差し戻し対象になる', () => {
+    const result = classifyReviewRound(
+      [
+        { status: 'fail', findings: [{ severity: 'critical', description: 'RLSポリシー漏れ' }] },
+        { status: 'pass', detail: '指摘なし' },
+      ],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(false)
+    expect(result.failingDimensions).toHaveLength(1)
+  })
+
+  it('failでfindingsを省略した場合は従来通り差し戻し対象になる（deny-by-default）', () => {
+    const result = classifyReviewRound(
+      [{ status: 'fail', detail: '指摘あり（findings無し）' }, { status: 'pass', detail: '指摘なし' }],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(false)
+    expect(result.failingDimensions).toHaveLength(1)
+  })
 })

--- a/.claude/workflows/lib/__tests__/severity.test.js
+++ b/.claude/workflows/lib/__tests__/severity.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { isMinorOnlyFailure } from '../severity.js'
+
+describe('isMinorOnlyFailure', () => {
+  it('statusがpassならfalse（findingsの有無に関わらずminor-only判定の対象外）', () => {
+    expect(isMinorOnlyFailure({ status: 'pass', findings: [{ severity: 'critical', description: 'x' }] })).toBe(false)
+  })
+
+  it('statusがblockedならfalse', () => {
+    expect(isMinorOnlyFailure({ status: 'blocked', findings: [{ severity: 'minor', description: 'x' }] })).toBe(false)
+  })
+
+  it('statusがfailでfindings未指定ならfalse（deny-by-default: 重大度不明はブロック側）', () => {
+    expect(isMinorOnlyFailure({ status: 'fail', detail: 'ng' })).toBe(false)
+  })
+
+  it('statusがfailでfindingsが空配列ならfalse', () => {
+    expect(isMinorOnlyFailure({ status: 'fail', findings: [] })).toBe(false)
+  })
+
+  it('statusがfailでfindings全件minorならtrue', () => {
+    expect(isMinorOnlyFailure({
+      status: 'fail',
+      findings: [{ severity: 'minor', description: 'a' }, { severity: 'minor', description: 'b' }],
+    })).toBe(true)
+  })
+
+  it('statusがfailでfindingsにimportantが1件でも混ざればfalse', () => {
+    expect(isMinorOnlyFailure({
+      status: 'fail',
+      findings: [{ severity: 'minor', description: 'a' }, { severity: 'important', description: 'b' }],
+    })).toBe(false)
+  })
+
+  it('statusがfailでfindingsにcriticalが1件でも混ざればfalse', () => {
+    expect(isMinorOnlyFailure({
+      status: 'fail',
+      findings: [{ severity: 'critical', description: 'a' }],
+    })).toBe(false)
+  })
+
+  it('severityが不正・欠損な指摘が1件でもあればfalse（severity不明はcritical扱い）', () => {
+    expect(isMinorOnlyFailure({
+      status: 'fail',
+      findings: [{ severity: 'minor', description: 'a' }, { description: 'severity無し' }],
+    })).toBe(false)
+  })
+
+  it('resultがnull/undefinedならfalse', () => {
+    expect(isMinorOnlyFailure(null)).toBe(false)
+    expect(isMinorOnlyFailure(undefined)).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/phase2-done.js
+++ b/.claude/workflows/lib/phase2-done.js
@@ -2,14 +2,16 @@
 // 各フェーズのゲート（Manifest Check・Contract+DB・Implement・Integrate・Review）は
 // 個別にdeny-by-defaultで中断するが、それらを組み合わせた「全条件を満たしたときだけ
 // DONEを返す」という完了条件自体は明示的に定義・テストされていなかった。
-// DONE = 全実装ブランチがpass AND 統合ゲート(test/lint/tsc)がpass
-//        AND 全観点のReviewがpass(critical/high相当のfailが0) AND Run ManifestのspecHashが一致
+// DONE = 全実装ブランチがpass（またはfindings全件minorのfail） AND 統合ゲート(test/lint/tsc)がpass
+//        AND 全観点のReviewがpass(critical/important相当のfailが0) AND Run ManifestのspecHashが一致
 // エージェント呼び出しを含まない純粋関数のため、LLM呼び出し無しで決定的にテストできる。
 // aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
 // このファイルはvitestでの単体テスト用の正本。
 
+import { isMinorOnlyFailure } from './severity.js'
+
 function allPass(results) {
-  return results.length > 0 && results.every(r => r?.status === 'pass')
+  return results.length > 0 && results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
 }
 
 // implResults: [contractResult, dbResult, dataResult, apiResult, uiResult]

--- a/.claude/workflows/lib/quality-gate.js
+++ b/.claude/workflows/lib/quality-gate.js
@@ -1,12 +1,14 @@
 // AgentResult（docs/agents/agent-result-schema.md）の品質ゲート判定。
-// deny-by-default: 全員がstatus==='pass'でない限り止める（fail/blockedはもちろん、
-// null・未返却（エージェントが致命的エラーで死んだ場合）・未知のstatus値も含めて
-// 「passと確認できないものは全て止める」。fail-open（failを探す方式）だと、
-// 想定外の値がすべて素通りしてしまう（issue #289）。
+// deny-by-default: 全員がstatus==='pass'（またはfindings全件がminorのfail。severity.js参照）
+// でない限り止める（fail/blockedはもちろん、null・未返却（エージェントが致命的エラーで死んだ
+// 場合）・未知のstatus値も含めて「passと確認できないものは全て止める」。fail-open（failを
+// 探す方式）だと、想定外の値がすべて素通りしてしまう（issue #289）。
 // aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
 // このファイルはvitestでの単体テスト用の正本。
 
+import { isMinorOnlyFailure } from './severity.js'
+
 export function shouldBlock(results) {
   if (results.length === 0) return false
-  return !results.every(r => r?.status === 'pass')
+  return !results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
 }

--- a/.claude/workflows/lib/review-retry.js
+++ b/.claude/workflows/lib/review-retry.js
@@ -6,8 +6,13 @@
 // 決定的にテストできる（最大リトライ到達→blockedになる完了条件を含む）。
 // aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
 // このファイルはvitestでの単体テスト用の正本。
+//
+// 重大度分類（severity.js）: findings全件がminorのfailは差し戻し対象にしない
+// （UIの軽微な指摘だけで修正ループを回さない。DB/ロジックのcritical/important指摘は従来通り差し戻す）。
 
-// reviewResults: dimensionsと同じ並びのAgentResult(status/detail)配列
+import { isMinorOnlyFailure } from './severity.js'
+
+// reviewResults: dimensionsと同じ並びのAgentResult(status/detail/findings)配列
 // dimensions: [{ key, label }, ...]
 // attempt: 今回が何回目のReviewラウンドか（1始まり）
 // maxRetries: Implementerへの差し戻し許容回数（打ち切りはattempt > maxRetries + 1ラウンド目で発生）
@@ -15,11 +20,12 @@
 // 戻り値:
 // - done: true ならReviewループを終了する（pass確定 or 打ち切り）
 // - blocked: true なら打ち切り（人間に引き渡す）。doneがfalseの場合は常にfalse
-// - failingDimensions: status==='fail'だった観点（{ dim, result }[]）。差し戻しプロンプトに使う
+// - failingDimensions: 差し戻し対象の観点（{ dim, result }[]）。status==='fail'かつ
+//   findings全件minorではないもの（findings省略時はcritical相当として差し戻し対象）
 export function classifyReviewRound(reviewResults, dimensions, attempt, maxRetries) {
   const failingDimensions = dimensions
     .map((dim, i) => ({ dim, result: reviewResults[i] }))
-    .filter(({ result }) => result?.status === 'fail')
+    .filter(({ result }) => result?.status === 'fail' && !isMinorOnlyFailure(result))
 
   if (failingDimensions.length === 0) {
     return { done: true, blocked: false, failingDimensions: [] }

--- a/.claude/workflows/lib/severity.js
+++ b/.claude/workflows/lib/severity.js
@@ -1,0 +1,14 @@
+// Implement/Integrate/Reviewの各ゲートに共通する重大度判定ロジック。
+// Sweep/Draft/Adversarial Verify（aidd-1-1-deep-task.js）が既に採用しているseverity
+// (critical/important/minor)を実装後ゲートにも展開する（issue: AIDD品質ゲートへの重大度分類導入）。
+//
+// deny-by-default原則は維持する: statusがfailでもfindingsが無ければ「重大度不明」として
+// 従来通りブロックする。findingsが明記され、かつ全件がminorの場合のみ通過させる。
+// severityが省略・不正な値の指摘が1件でもあればcritical相当としてブロックする
+// （fail-open防止。issue #289/#291と同じ考え方）。
+
+export function isMinorOnlyFailure(result) {
+  if (result?.status !== 'fail') return false
+  if (!Array.isArray(result.findings) || result.findings.length === 0) return false
+  return result.findings.every(f => f?.severity === 'minor')
+}

--- a/docs/agents/agent-result-schema.md
+++ b/docs/agents/agent-result-schema.md
@@ -8,6 +8,10 @@ AIDDワークフロー（`.claude/workflows/`）の`agent()`呼び出しが、�
 AgentResult = {
   status: 'pass' | 'fail' | 'blocked',
   detail: string   // 人間可読の要約(自由記述文字列)
+  findings?: Array<{             // status==='fail'時の重大度分類（任意）
+    severity: 'critical' | 'important' | 'minor',
+    description: string,
+  }>
 }
 ```
 
@@ -15,6 +19,9 @@ AgentResult = {
 - `fail`: 完遂を試みたが、成果物が要件を満たさない
 - `blocked`: 前提条件が欠けており着手・完遂できなかった
 - 呼び出し種別によっては`fail`が存在しない設計のものがある（下記参照）
+- `findings`: `status === 'fail'`のときに指摘ごとの重大度を明記する（`aidd-phase2.js`のAGENT_RESULT_SCHEMA対象呼び出しのみ）。
+  Sweep/Draft/Adversarial Verify（`aidd-1-1-deep-task.js`のFINDING_SCHEMA）と同じ`critical`/`important`/`minor`を使う。
+  省略した場合、または`severity`が不正・欠損の指摘が1件でもある場合はcritical相当としてブロック側に倒す（deny-by-default、下記参照）。
 
 ## 判定基準（agent呼び出しごと）
 
@@ -61,13 +68,15 @@ AgentResult = {
 
 ## 品質ゲート（`aidd-phase2.js`）
 
-対応issue: #42
+対応issue: #42（deny-by-default化）、AIDD品質ゲートへの重大度分類導入（本セクション）
 
-`aidd-phase2.js`は各フェーズ完了直後に、そのフェーズのエージェント結果に`status === 'fail'`または`status === 'blocked'`が1件でもあれば後続フェーズへ進まず中断する。
-`blocked`は「試みたが不完全」な`fail`よりも情報量が少なく、そもそも着手できていない状態のため、`fail`と同様に後続へは進めない（進めると存在しない前提のまま無駄な実装・レビューが走る）。
-中断時は`{ blocked: true, blockedAt: '<フェーズ名>', ... }`を返し、`stats.blocked`で観測できる。
+`aidd-phase2.js`は各フェーズ完了直後に、そのフェーズのエージェント結果を品質ゲートで判定する。
+`status === 'blocked'`、または`status`がnull/未返却/未知の値は、情報量が無い・着手すらできていない状態のため常にブロックする。
+`status === 'fail'`は、`findings`が省略されている場合、または`findings`に`critical`/`important`の指摘が1件でもある場合はブロックする。
+`findings`が明記されていて全件`minor`の場合のみブロックせず後続へ進む（DB/ロジックのクリティカルな問題は厳しく止め、UIの軽微な指摘だけで差し戻しループを回さないための線引き）。
+中断時は`{ blocked: true, blockedAt: '<フェーズ名>', ... }`を返し、`stats.blocked`で観測できる。minor指摘のみで通過した場合はログに記録される（`logMinorOnlyPassThrough`）。
 
-判定ロジック（`results.some(r => r?.status === 'fail' || r?.status === 'blocked')`）の正本は [`.claude/workflows/lib/quality-gate.js`](../../.claude/workflows/lib/quality-gate.js)（`shouldBlock`）にあり、vitestで単体テストする。
-`aidd-phase2.js`はWorkflow DSLのためrequireできず、同一ロジックをインラインで複製している（3箇所: Contract + DB後・Implement後・Integrate後）。
+判定ロジックの正本は [`.claude/workflows/lib/severity.js`](../../.claude/workflows/lib/severity.js)（`isMinorOnlyFailure`）と、それを使う [`quality-gate.js`](../../.claude/workflows/lib/quality-gate.js)（`shouldBlock`、Contract + DB / Implement / Integrateゲート）・[`review-retry.js`](../../.claude/workflows/lib/review-retry.js)（`classifyReviewRound`、Reviewフェーズの差し戻し判定）・[`phase2-done.js`](../../.claude/workflows/lib/phase2-done.js)（`computeDone`、最終DONE判定）にあり、vitestで単体テストする。
+`aidd-phase2.js`はWorkflow DSLのためrequireできず、同一ロジックをインラインで複製している（`shouldBlock`呼び出し3箇所: Contract + DB後・Implement後・Integrate後、`classifyReviewRound`・`computeDone`相当の`allPass`は各1箇所）。
 
-`implSuccessCount`は`status === 'pass'`の件数、`implBlockedCount`は`status === 'blocked'`の件数を集計する。
+`implSuccessCount`は`status === 'pass'`の件数、`implBlockedCount`は`status === 'blocked'`の件数を集計する（`findings`全件minorの`fail`は現状この2カウントに含まれない）。


### PR DESCRIPTION
## Summary
- Sweep/Draft/Adversarial Verifyには既存のcritical/important/minor重大度分類があるが、実装後のquality gate(Implement/Integrate/Review)には重大度概念が無く「1件でも指摘があれば一律差し戻し」の二値判定だった
- `severity.js`(`isMinorOnlyFailure`)を新設し、`fail`時の`findings`配列(severity: critical/important/minor)が全件minorの場合のみゲート通過とする。findings省略・severity不明はcritical扱いでブロックし、deny-by-default(issue #289/#291)を維持
- `quality-gate.js`(Contract+DB/Implement/Integrateゲート)・`review-retry.js`(Reviewフェーズ差し戻し)・`phase2-done.js`(最終DONE判定)の3ファイルを更新し、`aidd-phase2.js`(Workflow DSL)には既存パターンに倣いインライン複製
- `docs/agents/agent-result-schema.md`を更新

Closes #307

## Test plan
- [x] `.claude/workflows/lib/__tests__/` 配下52テスト全パス(severity.test.js新規追加分含む)
- [x] eslintクリーン
- [ ] 実際のaidd-phase2.js実行での動作確認(次回AIDDフロー実行時に観測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)