### PR TITLE
docs: GitHub Free Planの制約によりrequired checkを見送り検知運用にする決定を追記

### DIFF
--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -105,10 +105,23 @@ E2Eテストやシード投入は本番相当の操作（データ作成・削�
 矛盾する。
 
 Supabase公式のGitHub Integration（Dashboard側でOAuth認可するだけで、GitHub Secretsへの
-手動登録が不要）を先に有効化する方針にした。これはPR/ブランチトリガーで動く「required
-check」であり、migrationとリモートDBの差分チェックをシークレット管理ゼロで機械的に担保できる。
+手動登録が不要）を先に有効化する方針にした。「Deploy to production」（mainマージで本番DBへ
+自動でmigrationを適用する機能）はOFFのままにしている。issue #30の目的は検知であって
+デプロイ自動化ではなく、AIDD品質ゲート（重大度分類のImplement/Integrateゲート組み込み）が
+未実装の段階で、最もクリティカルな変更であるDBスキーマ変更を自動デプロイの対象にするのは
+時期尚早と判断した。調査の結果、これまでも本番へのmigration適用はCIではなくローカルCLIでの
+手動 `supabase link` → `supabase db push`（都度確認付き）で行われており、Integrationを
+ONにすることは既存フローの自動化ではなく新規のリスクを追加することになる、という点も判断
+材料にした。
 
-ただし弱点として、PRを介さない変更（SQL Editor等での直接操作、rls_auto_enableの実際の事故
+GitHub側で「required status check」によるマージブロックも検討したが、このリポジトリは
+private repoでGitHub Free（Org）プランのため、classic branch protectionもRulesets（新機能）も
+「強制」が有効にならないことが判明した（プライベートリポジトリでの強制にはGitHub Team以上の
+プランが必要）。有償プランへのアップグレードは費用判断のため今回は見送り、Supabaseの
+ステータスチェックがPR画面に表示される「検知のみ」の状態を許容する方針にした。マージの
+可否は引き続き人間のレビューに委ねる。
+
+弱点として、PRを介さない変更（SQL Editor等での直接操作、rls_auto_enableの実際の事故
 パターン）はPRが発生するまで検知が遅延する。この「PRの外側の変更」をどう定期検知するかは
 未解決のまま残しており、シークレットをGitHub側に置かない代替案（Supabase Edge Functionの
-スケジュール実行など）を含めて別issueで検討する前提にしている。
+スケジュール実行など）を含めて別issue（#305）で検討する前提にしている。


### PR DESCRIPTION
## Summary
- issue #30 の実装を完了させるにあたり判明した追加事実を `docs/agents/decisions.md` に追記
- private repo + GitHub Free(Org)プランでは classic branch protection / Rulesets ともマージブロックが強制されないため、required check設定は見送り、Supabaseステータスチェック表示による人間レビュー運用に決定
- 「Deploy to production」をOFFにした理由（本番migrationは従来ローカルCLI手動pushだったという調査結果を含む）も記録

## Test plan
- ドキュメントのみの変更のためテスト対象なし