### PR TITLE
feat: AIDDワークフロー完了時にloop-observabilityログの記録漏れを検知する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -65,6 +65,17 @@ function shouldBlock(results) {
   return !results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
 }
 
+// ログ記録漏れ検知（.claude/workflows/lib/loop-observability-expectation.js の
+// isLoggableAgentType と同一ロジック。Workflow DSLはrequire不可のためインライン複製）。
+// reviewer/implementer/judge-panelのみ scripts/log-loop-observability.sh 呼び出し指示を
+// システムプロンプトに持つ（.claude/agents/*.md参照）。この件数を「期待される記録件数」として
+// 返し、フロー完了後に scripts/check-loop-observability-gap.sh で実際のログ行数と突き合わせる。
+const LOGGABLE_AGENT_TYPES = new Set(['reviewer', 'implementer', 'judge-panel'])
+let loggableAgentCount = 0
+function countLoggable(agentType) {
+  if (LOGGABLE_AGENT_TYPES.has(agentType)) loggableAgentCount++
+}
+
 function logMinorOnlyPassThrough(label, results) {
   const minorOnly = results.filter(isMinorOnlyFailure)
   if (minorOnly.length > 0) {
@@ -111,6 +122,7 @@ const manifestCheck = await agent(
   { label: 'manifest-check', phase: 'Manifest Check', agentType: 'reviewer', schema: MANIFEST_CHECK_SCHEMA }
 )
 
+countLoggable('reviewer')
 log(`Manifest Check完了: status=${manifestCheck?.status ?? 'なし'}`)
 
 // 品質ゲート: deny-by-default（.claude/workflows/lib/quality-gate.js shouldBlockと同一発想）
@@ -121,7 +133,7 @@ if (manifestCheck?.status !== 'pass') {
     manifestCheck,
     blocked: true,
     blockedAt: 'Manifest Check',
-    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Manifest Check' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Manifest Check', expectedLoopObservabilityRecords: loggableAgentCount },
   }
 }
 
@@ -149,6 +161,8 @@ const [contractResult, dbResult] = await parallel([
   ),
 ])
 
+countLoggable('contract-writer')
+countLoggable('implementer')
 log('Contract + DB完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック
@@ -163,7 +177,7 @@ if (shouldBlock([contractResult, dbResult])) {
     dbResult,
     blocked: true,
     blockedAt: 'Contract + DB',
-    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Contract + DB' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Contract + DB', expectedLoopObservabilityRecords: loggableAgentCount },
   }
 }
 logMinorOnlyPassThrough('Contract + DB', [contractResult, dbResult])
@@ -195,6 +209,9 @@ const [dataResult, apiResult, uiResult] = await parallel([
   ),
 ])
 
+countLoggable('implementer')
+countLoggable('implementer')
+countLoggable('implementer')
 log('Implement完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
@@ -209,7 +226,7 @@ if (shouldBlock([dataResult, apiResult, uiResult])) {
     uiResult,
     blocked: true,
     blockedAt: 'Implement',
-    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Implement' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Implement', expectedLoopObservabilityRecords: loggableAgentCount },
   }
 }
 logMinorOnlyPassThrough('Implement', [dataResult, apiResult, uiResult])
@@ -226,6 +243,7 @@ const integrationResult = await agent(
   { label: 'integrator', phase: 'Integrate', agentType: 'integrator', schema: AGENT_RESULT_SCHEMA }
 )
 
+countLoggable('integrator')
 log('統合完了')
 
 // 品質ゲート: .claude/workflows/lib/quality-gate.js の shouldBlock と同一ロジック（deny-by-default）
@@ -241,7 +259,7 @@ if (shouldBlock([integrationResult])) {
     integration: integrationResult,
     blocked: true,
     blockedAt: 'Integrate',
-    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Integrate' },
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Integrate', expectedLoopObservabilityRecords: loggableAgentCount },
   }
 }
 logMinorOnlyPassThrough('Integrate', [integrationResult])
@@ -295,6 +313,8 @@ while (true) {
     ))
   )
 
+  REVIEW_DIMENSIONS.forEach(() => countLoggable('reviewer'))
+
   const { done, blocked, failingDimensions } = classifyReviewRound(reviewResults, REVIEW_DIMENSIONS, reviewAttempt, MAX_REVIEW_RETRIES)
 
   if (done && !blocked) {
@@ -325,6 +345,7 @@ while (true) {
         blocked: true,
         blockedAt: 'Review',
         reviewRetries: reviewRetryAgentCount,
+        expectedLoopObservabilityRecords: loggableAgentCount,
       },
     }
   }
@@ -343,6 +364,7 @@ while (true) {
     )}`,
     { label: `implementer-retry:R${reviewAttempt}`, phase: 'Review', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   )
+  countLoggable('implementer')
   reviewRetryAgentCount++
 }
 
@@ -387,5 +409,6 @@ return {
     totalAgents: 1 + 5 + 1 + REVIEW_DIMENSIONS.length + reviewRetryAgentCount,
     implSuccessCount: implResults.filter(r => r?.status === 'pass').length,
     implBlockedCount: implResults.filter(r => r?.status === 'blocked').length,
+    expectedLoopObservabilityRecords: loggableAgentCount,
   },
 }

--- a/.claude/workflows/lib/__tests__/loop-observability-expectation.test.js
+++ b/.claude/workflows/lib/__tests__/loop-observability-expectation.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { isLoggableAgentType } from '../loop-observability-expectation.js'
+
+describe('isLoggableAgentType', () => {
+  it('reviewerはtrue（.claude/agents/reviewer.mdにログ記録指示がある）', () => {
+    expect(isLoggableAgentType('reviewer')).toBe(true)
+  })
+
+  it('implementerはtrue（.claude/agents/implementer.mdにログ記録指示がある）', () => {
+    expect(isLoggableAgentType('implementer')).toBe(true)
+  })
+
+  it('judge-panelはtrue（.claude/agents/judge-panel.mdにログ記録指示がある）', () => {
+    expect(isLoggableAgentType('judge-panel')).toBe(true)
+  })
+
+  it('sweep-uiはfalse（ログ記録指示を持たないagentType）', () => {
+    expect(isLoggableAgentType('sweep-ui')).toBe(false)
+  })
+
+  it('contract-writerはfalse（ログ記録指示を持たないagentType）', () => {
+    expect(isLoggableAgentType('contract-writer')).toBe(false)
+  })
+
+  it('integratorはfalse（ログ記録指示を持たないagentType）', () => {
+    expect(isLoggableAgentType('integrator')).toBe(false)
+  })
+
+  it('未知のagentTypeはfalse', () => {
+    expect(isLoggableAgentType('unknown-agent')).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/__tests__/loop-observability-gap.test.js
+++ b/.claude/workflows/lib/__tests__/loop-observability-gap.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { computeGap } from '../loop-observability-gap.js'
+
+describe('computeGap', () => {
+  it('実際の記録件数が期待件数と一致すればhasGap: false', () => {
+    expect(computeGap({ actualCount: 5, expectedCount: 5 })).toEqual({
+      actualCount: 5,
+      expectedCount: 5,
+      hasGap: false,
+    })
+  })
+
+  it('実際の記録件数が期待件数より少なければhasGap: true（記録漏れ）', () => {
+    expect(computeGap({ actualCount: 3, expectedCount: 5 })).toEqual({
+      actualCount: 3,
+      expectedCount: 5,
+      hasGap: true,
+    })
+  })
+
+  it('実際の記録件数が期待件数より多くてもhasGap: true（重複記録等の異常もズレとして扱う）', () => {
+    expect(computeGap({ actualCount: 7, expectedCount: 5 })).toEqual({
+      actualCount: 7,
+      expectedCount: 5,
+      hasGap: true,
+    })
+  })
+
+  it('期待件数が0で実際も0ならhasGap: false（ログ対象agentTypeを1つも呼ばなかったフロー）', () => {
+    expect(computeGap({ actualCount: 0, expectedCount: 0 })).toEqual({
+      actualCount: 0,
+      expectedCount: 0,
+      hasGap: false,
+    })
+  })
+})

--- a/.claude/workflows/lib/loop-observability-expectation.js
+++ b/.claude/workflows/lib/loop-observability-expectation.js
@@ -1,0 +1,8 @@
+// scripts/log-loop-observability.sh の呼び出し指示を持つagentType（issue: loop-observabilityログの記録漏れ検知）。
+// .claude/agents/{reviewer,implementer,judge-panel}.md にのみ「## レビュー結果のログ記録」等の指示があり、
+// sweep-*/contract-writer/integrator等の他agentTypeにはそもそも指示自体が存在しない。
+const LOGGABLE_AGENT_TYPES = new Set(['reviewer', 'implementer', 'judge-panel'])
+
+export function isLoggableAgentType(agentType) {
+  return LOGGABLE_AGENT_TYPES.has(agentType)
+}

--- a/.claude/workflows/lib/loop-observability-gap.js
+++ b/.claude/workflows/lib/loop-observability-gap.js
@@ -1,0 +1,34 @@
+export function computeGap({ actualCount, expectedCount }) {
+  return { actualCount, expectedCount, hasGap: actualCount !== expectedCount }
+}
+
+function parseArgs(argv) {
+  const args = {}
+  for (let i = 0; i < argv.length; i += 2) {
+    args[argv[i].replace(/^--/, '')] = argv[i + 1]
+  }
+  return args
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const actualCount = Number(args.actual)
+  const expectedCount = Number(args.expected)
+  if (!Number.isInteger(actualCount) || !Number.isInteger(expectedCount)) {
+    console.error('Usage: loop-observability-gap.js --actual N --expected M')
+    process.exit(1)
+  }
+
+  const result = computeGap({ actualCount, expectedCount })
+  console.log(JSON.stringify(result))
+  if (result.hasGap) {
+    console.error(
+      `WARNING: loop-observability記録漏れ（またはズレ）の可能性 (actual=${result.actualCount}, expected=${result.expectedCount})`,
+    )
+    process.exit(1)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -52,6 +52,21 @@ any code. Heed deprecation notices.
   なっていた場合は、着手前に `git checkout -b <new-branch> main` で新しいブランチを切ってから進める。
   1つのPRに無関係なissueのコミットが混ざると、レビュアーが混乱し、片方だけ却下・差し戻しになった際に切り分けられなくなる
 
+## loop-observabilityログの記録漏れ検知
+
+- AIDDフロー（`aidd-phase2.js` 等）は reviewer/implementer/judge-panel を呼ぶたびに
+  `scripts/log-loop-observability.sh` を呼び出す想定だが、これはエージェントへの自然言語指示に
+  依存しており強制力がない（Workflow DSL自体がfilesystem API不可のため、ワークフロー本体側から
+  機械的にログを書き込むことはできない）。2026-07-07以降、実際に記録が5日分丸ごと欠落していた
+  事例がある。理由は [`decisions.md`](./decisions.md) 参照。
+- **AIDDフロー（Phase 2以降）を実行する前後で、必ず以下を行うこと。**
+  1. 実行前に `wc -l logs/loop-observability.jsonl` で行数を記録する（ファイルが無ければ0）
+  2. フロー完了後、戻り値の `stats.expectedLoopObservabilityRecords` を確認する
+  3. `scripts/check-loop-observability-gap.sh --before <1の値> --expected <2の値>` を実行する
+  4. `hasGap: true`（exit 1）になった場合、記録漏れとして扱い、issue化するか原因を調査する
+- これは「記録漏れを機械的に検知する」ものであり、記録そのものを保証する仕組みではない
+  （エージェント任せの記録に依存する構造自体の解消は別途検討中）。
+
 ## 重要ファイルへのパス
 
 | ファイル | 目的 |

--- a/scripts/check-loop-observability-gap.sh
+++ b/scripts/check-loop-observability-gap.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="logs/loop-observability.jsonl"
+BEFORE_COUNT=""
+EXPECTED_COUNT=""
+
+usage() {
+  echo "Usage: $0 --before N --expected M [--log-file PATH]" >&2
+  echo "  --before N    フロー実行前に計測した logs/loop-observability.jsonl の行数" >&2
+  echo "  --expected M  ワークフローの戻り値 expectedLoopObservabilityRecords" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --before) BEFORE_COUNT="$2"; shift 2 ;;
+    --expected) EXPECTED_COUNT="$2"; shift 2 ;;
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$BEFORE_COUNT" || -z "$EXPECTED_COUNT" ]]; then
+  usage
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  AFTER_COUNT=0
+else
+  AFTER_COUNT="$(wc -l < "$LOG_FILE" | tr -d ' ')"
+fi
+
+ACTUAL_COUNT=$(( AFTER_COUNT - BEFORE_COUNT ))
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+npx -y tsx "$SCRIPT_DIR/../.claude/workflows/lib/loop-observability-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"


### PR DESCRIPTION
## Summary
- logs/loop-observability.jsonl が2026-07-07T23:45:41Z以降5日分丸ごと欠落していた事故を受け、記録漏れを機械的に検知する仕組みを追加
- 記録そのものの保証（エージェント任せで強制力がない）は別issueとして切り出し、まず「漏れたこと」を検知する軽量な対策を先行実装

## 背景
ログ記録は `.claude/agents/{reviewer,implementer,judge-panel}.md` 内の自然言語指示のみに依存しており、Workflow DSL自体がfilesystem API不可のためワークフロー本体側から機械的に書き込むことはできない。この構造上の弱さが実際に事故として顕在化していた。

## 変更内容
- `.claude/workflows/lib/loop-observability-expectation.js` — `isLoggableAgentType(agentType)`: ログ記録指示を持つagentType(reviewer/implementer/judge-panel)かどうかを判定する純粋関数
- `.claude/workflows/lib/loop-observability-gap.js` — `computeGap()`: 期待件数と実際件数のズレを判定する純粋関数 + CLIエントリポイント
- `scripts/check-loop-observability-gap.sh` — 実行前後のログ行数差分と期待件数を比較するCLIラッパー
- `.claude/workflows/aidd-phase2.js` — reviewer/implementer/judge-panel呼び出し回数をカウントし、全return箇所(正常完了・各フェーズのblocked中断、6箇所)に `stats.expectedLoopObservabilityRecords` を追加
- `docs/agents/common.md` — フロー実行前後にgapチェックを回す運用ルールを明記

## 検証
- 単体テスト63件（`.claude/workflows/lib/`配下）全てpass
- lint: 新規エラーなし（既存warning2件のみ、無関係）
- 静的確認: aidd-phase2.js内の6箇所のreturn文すべてに `expectedLoopObservabilityRecords` が漏れなく埋め込まれていることを目視確認
- **e2e検証**: 実際に `reviewer` agentTypeを1回呼び出したところ、指摘は返したが `scripts/log-loop-observability.sh` は呼ばれず、ログ行数は不変（78→78）だった。これは今回の事故の根本原因（自然言語指示だけでは記録が保証されない）を実際の実行で直接裏付ける結果になった。続けて `scripts/check-loop-observability-gap.sh --before 78 --expected 1` を実行し、`{"actualCount":0,"expectedCount":1,"hasGap":true}` で正しく記録漏れを検知（exit 1）することを確認した

## Test plan
- [x] `npx vitest run .claude/workflows/lib/` — 63件pass
- [x] `npm run lint` — 新規エラーなし
- [x] aidd-phase2.js内の全return箇所への配線を目視確認
- [x] reviewer agentType実呼び出し + gap検知スクリプトのe2e確認

## 補足
本PRは「記録漏れの検知」のみに限定したスコープ。記録そのものをtranscriptから機械的に再構築する完全な解決策は別issueとして切り出し済み（後続PRで対応予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)