### PR TITLE
feat: transcriptからloop-observabilityログを再構築するスクリプトを追加

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -66,6 +66,11 @@ any code. Heed deprecation notices.
   4. `hasGap: true`（exit 1）になった場合、記録漏れとして扱い、issue化するか原因を調査する
 - これは「記録漏れを機械的に検知する」ものであり、記録そのものを保証する仕組みではない
   （エージェント任せの記録に依存する構造自体の解消は別途検討中）。
+- 記録漏れが発生した過去分は、`scripts/lib/reconstruct-loop-observability.ts` で
+  `~/.claude/projects/**/subagents/workflows/wf_*/agent-<id>.jsonl` + `.meta.json` から
+  timestamp・model・tokens/costUsd・result(status/detail)を再構築できる（issue #312）。
+  ただし`feature`は呼び出し時に手動指定が必要、`intent`はプロンプト冒頭1文の抜粋、
+  `scenario`は復元不能である旨の固定文言になる（自己申告時点の情報粒度には及ばない）。
 
 ## 重要ファイルへのパス
 

--- a/docs/sessions/2026-07-13-loop-observability-transcript-reconstruc.md
+++ b/docs/sessions/2026-07-13-loop-observability-transcript-reconstruc.md
@@ -1,0 +1,43 @@
+# 2026-07-13 loop-observability-transcript-reconstruc
+
+AIDDのマルチエージェントフロー（Workflow/aidd-phase1/aidd-phase2）は使わず、issue #312に対して
+Claude本体が単独で調査・設計・実装した（手動実装）。
+
+## フロー実行時間
+- Phase 1（調査）:    —（AIDDフロー不使用）
+- Phase 2〜5（実装）: —（AIDDフロー不使用）
+- AI稼働合計:         —
+- セッション総時間:   —（人間レビュー待ち含む）
+
+## フロー実行統計
+
+### 調査
+journal.jsonl・agent-*.jsonl・.meta.jsonの実データをサンプリングして、
+timestamp/model/tokens/costUsd/result(status/detail)の復元精度を手動検証した
+（ユーザー指示で1件の親ログ突き合わせを先に実施）。
+
+### 実装（単独・TDD）
+- 実装エージェント: 1（Claude本体、並列化なし）
+- 成果物: `scripts/lib/model-pricing.ts`, `scripts/lib/reconstruct-loop-observability.ts`
+  とそれぞれのテスト
+- テスト結果: 新規20件 pass、既存含む全572件（94ファイル）pass、lint 0 error
+
+## 結果
+- うまくいったこと:
+  - journal.jsonl単体では timestamp/model/feature等が欠落していたが、
+    `subagents/workflows/wf_*/agent-<id>.jsonl` + `.meta.json` という別のデータソースに
+    ms単位のtimestamp・正確なmodel名・usageが残っていることを実データで確認できた
+  - 実際のissue #165実装時のワークフロー実行ディレクトリに対してスクリプトを走らせ、
+    pass/blockedの判定が正しく復元されることを確認した
+- 問題・気になった点:
+  - `feature`名はtranscriptから自動導出できず、CLI引数で手動指定する必要がある
+    （docs/sessions/配下のファイル名パターンからの自動導出は今回は見送り、将来の改善候補）
+  - `intent`はプロンプト冒頭1文の抜粋、`scenario`は固定の「復元不能」文言であり、
+    自己申告時点の情報粒度には及ばない
+  - `attempt`番号は同一ディレクトリ内の同一agentTypeをstartTimestamp昇順で採番しているだけなので、
+    並列実行された同じagentType（例: 並列implementer）がある場合は「再試行」ではなく
+    「並列実行の順序」を採番してしまう点に注意が必要
+- 次の課題:
+  - feature名の自動導出（docs/sessions/ファイル名との相関）
+  - 過去の全wf_*ディレクトリを一括スキャンするバッチ実行の追加
+  - 実際に本番のlogs/loop-observability.jsonlへ追記する運用（今回はライブラリ実装のみ）

--- a/scripts/lib/model-pricing.test.ts
+++ b/scripts/lib/model-pricing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getPricing } from './model-pricing'
+
+describe('getPricing', () => {
+  it('known model名に対して単価を返す', () => {
+    const pricing = getPricing('claude-opus-4-8')
+    expect(pricing).not.toBeNull()
+    expect(pricing?.inputPerMTok).toBeGreaterThan(0)
+    expect(pricing?.outputPerMTok).toBeGreaterThan(pricing?.inputPerMTok ?? 0)
+  })
+
+  it('未知のモデル名にはnullを返す（fallbackで誤ったコストを計算しない）', () => {
+    expect(getPricing('unknown-model-xyz')).toBeNull()
+  })
+
+  it('sonnet-5は2026-08-31以前のtimestampでは導入価格を返す', () => {
+    const pricing = getPricing('claude-sonnet-5', '2026-07-08T00:00:00.000Z')
+    expect(pricing).toEqual({ inputPerMTok: 2, outputPerMTok: 10, cacheWritePerMTok: 2.5, cacheReadPerMTok: 0.2 })
+  })
+
+  it('sonnet-5は2026-09-01以降のtimestampでは標準価格を返す', () => {
+    const pricing = getPricing('claude-sonnet-5', '2026-09-02T00:00:00.000Z')
+    expect(pricing).toEqual({ inputPerMTok: 3, outputPerMTok: 15, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.3 })
+  })
+
+  it('sonnet-5でtimestamp省略時は標準価格（保守的フォールバック）を返す', () => {
+    const pricing = getPricing('claude-sonnet-5')
+    expect(pricing?.inputPerMTok).toBe(3)
+  })
+})

--- a/scripts/lib/model-pricing.ts
+++ b/scripts/lib/model-pricing.ts
@@ -1,0 +1,28 @@
+export interface ModelPricing {
+  inputPerMTok: number
+  outputPerMTok: number
+  cacheWritePerMTok: number
+  cacheReadPerMTok: number
+}
+
+// 単価は100万トークンあたりのUSD。出典: https://platform.claude.com/docs/en/about-claude/pricing（2026-07-09取得）
+const SONNET_5_INTRO_CUTOFF = '2026-09-01T00:00:00Z'
+const SONNET_5_INTRO: ModelPricing = { inputPerMTok: 2, outputPerMTok: 10, cacheWritePerMTok: 2.5, cacheReadPerMTok: 0.2 }
+const SONNET_5_STANDARD: ModelPricing = { inputPerMTok: 3, outputPerMTok: 15, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.3 }
+
+const STATIC_PRICING_TABLE: Record<string, ModelPricing> = {
+  'claude-opus-4-8': { inputPerMTok: 5, outputPerMTok: 25, cacheWritePerMTok: 6.25, cacheReadPerMTok: 0.5 },
+  'claude-opus-4-6': { inputPerMTok: 5, outputPerMTok: 25, cacheWritePerMTok: 6.25, cacheReadPerMTok: 0.5 },
+  'claude-fable-5': { inputPerMTok: 10, outputPerMTok: 50, cacheWritePerMTok: 12.5, cacheReadPerMTok: 1 },
+  'claude-sonnet-4-6': { inputPerMTok: 3, outputPerMTok: 15, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.3 },
+  'claude-haiku-4-5-20251001': { inputPerMTok: 1, outputPerMTok: 5, cacheWritePerMTok: 1.25, cacheReadPerMTok: 0.1 },
+}
+
+export function getPricing(model: string, atISOTimestamp?: string): ModelPricing | null {
+  if (model === 'claude-sonnet-5') {
+    // timestamp省略時は標準価格（高い方）を返し、コストを過小評価しない
+    const at = atISOTimestamp ?? SONNET_5_INTRO_CUTOFF
+    return at < SONNET_5_INTRO_CUTOFF ? SONNET_5_INTRO : SONNET_5_STANDARD
+  }
+  return STATIC_PRICING_TABLE[model] ?? null
+}

--- a/scripts/lib/reconstruct-loop-observability.test.ts
+++ b/scripts/lib/reconstruct-loop-observability.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assignAttempts,
+  buildLoopObservabilityEntry,
+  deriveIntent,
+  mapAgentTypeToLoop,
+  pairAgentFiles,
+  parseAgentTranscriptLines,
+} from './reconstruct-loop-observability'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+describe('parseAgentTranscriptLines', () => {
+  it('最初のuserメッセージをpromptTextとstartTimestampとして抽出する', () => {
+    const lines = [
+      line({
+        type: 'user',
+        message: { role: 'user', content: 'SPEC.mdを読んで実装してください。' },
+        timestamp: '2026-07-11T03:37:47.236Z',
+      }),
+    ]
+    const summary = parseAgentTranscriptLines(lines)
+    expect(summary.promptText).toBe('SPEC.mdを読んで実装してください。')
+    expect(summary.startTimestamp).toBe('2026-07-11T03:37:47.236Z')
+  })
+
+  it('assistantメッセージのmodelとusageを集計する（tokensはinput+outputのみ）', () => {
+    const lines = [
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
+      line({
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 10, cache_read_input_tokens: 5 },
+        },
+        timestamp: '2026-07-11T03:00:01.000Z',
+      }),
+      line({
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          content: [{ type: 'text', text: 'ok2' }],
+          usage: { input_tokens: 20, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+        timestamp: '2026-07-11T03:00:02.000Z',
+      }),
+    ]
+    const summary = parseAgentTranscriptLines(lines)
+    expect(summary.model).toBe('claude-sonnet-5')
+    expect(summary.tokens).toBe(180) // (100+50) + (20+10)
+    expect(summary.costUsd).not.toBeNull()
+  })
+
+  it('末尾のStructuredOutput tool_useからstatus/detailとendTimestampを抽出する', () => {
+    const lines = [
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
+      line({
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          content: [
+            {
+              type: 'tool_use',
+              name: 'StructuredOutput',
+              input: { status: 'pass', detail: '実装完了' },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+        timestamp: '2026-07-11T03:39:23.648Z',
+      }),
+    ]
+    const summary = parseAgentTranscriptLines(lines)
+    expect(summary.status).toBe('pass')
+    expect(summary.detail).toBe('実装完了')
+    expect(summary.endTimestamp).toBe('2026-07-11T03:39:23.648Z')
+  })
+
+  it('StructuredOutputが無い場合はstatus/detailがnullで最後の行のtimestampをendTimestampにする', () => {
+    const lines = [
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
+      line({
+        type: 'assistant',
+        message: { model: 'claude-sonnet-5', content: [{ type: 'text', text: '途中' }] },
+        timestamp: '2026-07-11T03:00:05.000Z',
+      }),
+    ]
+    const summary = parseAgentTranscriptLines(lines)
+    expect(summary.status).toBeNull()
+    expect(summary.detail).toBeNull()
+    expect(summary.endTimestamp).toBe('2026-07-11T03:00:05.000Z')
+  })
+
+  it('JSONとしてパースできない行は無視する', () => {
+    const lines = ['not json', line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' })]
+    expect(() => parseAgentTranscriptLines(lines)).not.toThrow()
+  })
+
+  it('未知モデルが混在する場合、costUsdはnullを返す（誤ったコストを出さない）', () => {
+    const lines = [
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
+      line({
+        type: 'assistant',
+        message: {
+          model: 'unknown-model-xyz',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+        timestamp: '2026-07-11T03:00:01.000Z',
+      }),
+    ]
+    const summary = parseAgentTranscriptLines(lines)
+    expect(summary.costUsd).toBeNull()
+  })
+})
+
+describe('mapAgentTypeToLoop', () => {
+  it('reviewerとjudge-panelはdeveloperループにマッピングする（明示的に--loop developerを使っているため）', () => {
+    expect(mapAgentTypeToLoop('reviewer')).toBe('developer')
+    expect(mapAgentTypeToLoop('judge-panel')).toBe('developer')
+  })
+
+  it('implementerを含むそれ以外はagenticループにマッピングする（スクリプトのデフォルト値のため）', () => {
+    expect(mapAgentTypeToLoop('implementer')).toBe('agentic')
+    expect(mapAgentTypeToLoop('contract-writer')).toBe('agentic')
+  })
+})
+
+describe('assignAttempts', () => {
+  it('同じagentTypeのレコードをstartTimestamp昇順で1から採番する', () => {
+    const records = [
+      { agentType: 'implementer', startTimestamp: '2026-07-11T03:10:00.000Z' },
+      { agentType: 'implementer', startTimestamp: '2026-07-11T03:00:00.000Z' },
+      { agentType: 'reviewer', startTimestamp: '2026-07-11T03:05:00.000Z' },
+    ]
+    const result = assignAttempts(records)
+    const implementerAttempts = result.filter((r) => r.agentType === 'implementer').map((r) => r.attempt)
+    expect(implementerAttempts.sort()).toEqual([1, 2])
+    expect(result.find((r) => r.agentType === 'reviewer')?.attempt).toBe(1)
+  })
+})
+
+describe('deriveIntent', () => {
+  it('プロンプト冒頭の1文をintentとして抽出する', () => {
+    expect(deriveIntent('まず SPEC.md を Read ツールで読んでください。\nPart 2をもとに実装してください。')).toBe(
+      'まず SPEC.md を Read ツールで読んでください。',
+    )
+  })
+
+  it('promptTextがnullの場合は固定文言を返す', () => {
+    expect(deriveIntent(null)).toBe('(transcriptから復元: プロンプト不明)')
+  })
+})
+
+describe('pairAgentFiles', () => {
+  it('agent-<id>.jsonlとagent-<id>.meta.jsonをペアリングする', () => {
+    const filenames = [
+      'agent-a06545410e11c3354.jsonl',
+      'agent-a06545410e11c3354.meta.json',
+      'agent-af6b5162be4fe41d2.jsonl',
+      'agent-af6b5162be4fe41d2.meta.json',
+      'journal.jsonl',
+    ]
+    const pairs = pairAgentFiles(filenames)
+    expect(pairs).toHaveLength(2)
+    expect(pairs.map((p) => p.agentId).sort()).toEqual(['a06545410e11c3354', 'af6b5162be4fe41d2'])
+  })
+
+  it('meta.jsonが無いjsonlは無視する（journal.jsonl等）', () => {
+    const pairs = pairAgentFiles(['journal.jsonl', 'agent-a1.jsonl'])
+    expect(pairs).toHaveLength(0)
+  })
+})
+
+describe('buildLoopObservabilityEntry', () => {
+  it('スキーマに沿ったレコードを組み立て、reconstructed:trueを付与する', () => {
+    const entry = buildLoopObservabilityEntry({
+      agentType: 'implementer',
+      feature: 'unknown',
+      attempt: 1,
+      summary: {
+        model: 'claude-sonnet-5',
+        startTimestamp: '2026-07-11T03:37:47.236Z',
+        endTimestamp: '2026-07-11T03:39:23.648Z',
+        tokens: 1234,
+        costUsd: 0.05,
+        status: 'pass',
+        detail: '実装完了',
+        findings: null,
+        promptText: 'SPEC.mdを読んで実装してください。',
+      },
+    })
+    expect(entry).toMatchObject({
+      timestamp: '2026-07-11T03:39:23.648Z',
+      loop: 'agentic',
+      agent: 'implementer',
+      feature: 'unknown',
+      attempt: 1,
+      model: 'claude-sonnet-5',
+      tokens: 1234,
+      costUsd: 0.05,
+      result: 'pass',
+      reason: '実装完了',
+      intent: 'SPEC.mdを読んで実装してください。',
+      reconstructed: true,
+    })
+  })
+
+  it('endTimestampが無い場合はstartTimestampをtimestampとして使う', () => {
+    const entry = buildLoopObservabilityEntry({
+      agentType: 'reviewer',
+      feature: 'unknown',
+      attempt: 1,
+      summary: {
+        model: null,
+        startTimestamp: '2026-07-11T03:00:00.000Z',
+        endTimestamp: null,
+        tokens: 0,
+        costUsd: null,
+        status: null,
+        detail: null,
+        findings: null,
+        promptText: null,
+      },
+    })
+    expect(entry.timestamp).toBe('2026-07-11T03:00:00.000Z')
+    expect(entry.result).toBe('unknown')
+  })
+})

--- a/scripts/lib/reconstruct-loop-observability.ts
+++ b/scripts/lib/reconstruct-loop-observability.ts
@@ -1,0 +1,271 @@
+import { readdirSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { getPricing } from './model-pricing'
+
+// WHY: reviewer/judge-panelはscripts/log-loop-observability.shを`--loop developer`明示で呼ぶ設計、
+//      implementer等それ以外はスクリプトのデフォルト値`agentic`に依存する設計だった（docs/agents/*.md参照）。
+//      transcriptには元の--loop引数値自体は残らないため、agentTypeからこの既存の呼び分けを再現する。
+const DEVELOPER_LOOP_AGENT_TYPES = new Set(['reviewer', 'judge-panel'])
+
+export function mapAgentTypeToLoop(agentType: string): 'agentic' | 'developer' {
+  return DEVELOPER_LOOP_AGENT_TYPES.has(agentType) ? 'developer' : 'agentic'
+}
+
+export interface Finding {
+  severity: string
+  description: string
+}
+
+export interface AgentTranscriptSummary {
+  model: string | null
+  startTimestamp: string | null
+  endTimestamp: string | null
+  tokens: number
+  costUsd: number | null
+  status: 'pass' | 'fail' | 'blocked' | null
+  detail: string | null
+  findings: Finding[] | null
+  promptText: string | null
+}
+
+interface RawUsage {
+  input_tokens?: number
+  output_tokens?: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+}
+
+interface RawContentBlock {
+  type?: string
+  name?: string
+  text?: string
+  input?: { status?: string; detail?: string; findings?: Finding[] }
+}
+
+interface RawLine {
+  type?: string
+  timestamp?: string
+  message?: {
+    role?: string
+    model?: string
+    content?: string | RawContentBlock[]
+    usage?: RawUsage
+  }
+}
+
+function parseLine(line: string): RawLine | null {
+  try {
+    return JSON.parse(line) as RawLine
+  } catch {
+    return null
+  }
+}
+
+export function parseAgentTranscriptLines(lines: string[]): AgentTranscriptSummary {
+  let promptText: string | null = null
+  let startTimestamp: string | null = null
+  let endTimestamp: string | null = null
+  let model: string | null = null
+  let tokens = 0
+  let costUsd = 0
+  let costUnknown = false
+  let status: AgentTranscriptSummary['status'] = null
+  let detail: string | null = null
+  let findings: Finding[] | null = null
+  let lastTimestamp: string | null = null
+
+  for (const raw of lines) {
+    const parsed = parseLine(raw)
+    if (!parsed) continue
+    if (parsed.timestamp) lastTimestamp = parsed.timestamp
+
+    if (promptText === null && parsed.type === 'user' && typeof parsed.message?.content === 'string') {
+      promptText = parsed.message.content
+      startTimestamp = parsed.timestamp ?? null
+    }
+
+    if (parsed.type === 'assistant' && parsed.message) {
+      if (parsed.message.model) model = parsed.message.model
+
+      const usage = parsed.message.usage
+      if (usage) {
+        tokens += (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0)
+        if (!costUnknown) {
+          const pricing = getPricing(parsed.message.model ?? '', parsed.timestamp)
+          if (!pricing) {
+            costUnknown = true
+          } else {
+            costUsd +=
+              ((usage.input_tokens ?? 0) / 1_000_000) * pricing.inputPerMTok +
+              ((usage.output_tokens ?? 0) / 1_000_000) * pricing.outputPerMTok +
+              ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * pricing.cacheWritePerMTok +
+              ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cacheReadPerMTok
+          }
+        }
+      }
+
+      const blocks = Array.isArray(parsed.message.content) ? parsed.message.content : []
+      const structuredOutput = blocks.find((b) => b.type === 'tool_use' && b.name === 'StructuredOutput')
+      if (structuredOutput?.input) {
+        status = (structuredOutput.input.status as AgentTranscriptSummary['status']) ?? null
+        detail = structuredOutput.input.detail ?? null
+        findings = structuredOutput.input.findings ?? null
+        endTimestamp = parsed.timestamp ?? endTimestamp
+      }
+    }
+  }
+
+  if (endTimestamp === null) endTimestamp = lastTimestamp
+
+  return {
+    model,
+    startTimestamp,
+    endTimestamp,
+    tokens,
+    costUsd: costUnknown ? null : costUsd,
+    status,
+    detail,
+    findings,
+    promptText,
+  }
+}
+
+export function assignAttempts<T extends { agentType: string; startTimestamp: string | null }>(
+  records: T[],
+): (T & { attempt: number })[] {
+  const byType = new Map<string, T[]>()
+  for (const record of records) {
+    const bucket = byType.get(record.agentType) ?? []
+    bucket.push(record)
+    byType.set(record.agentType, bucket)
+  }
+
+  const attemptByRecord = new Map<T, number>()
+  for (const bucket of byType.values()) {
+    const sorted = [...bucket].sort((a, b) => (a.startTimestamp ?? '').localeCompare(b.startTimestamp ?? ''))
+    sorted.forEach((record, index) => attemptByRecord.set(record, index + 1))
+  }
+
+  return records.map((record) => ({ ...record, attempt: attemptByRecord.get(record) ?? 1 }))
+}
+
+const INTENT_UNKNOWN = '(transcriptから復元: プロンプト不明)'
+
+export function deriveIntent(promptText: string | null): string {
+  if (promptText === null) return INTENT_UNKNOWN
+  const firstLine = promptText.split('\n')[0]?.trim() ?? ''
+  return firstLine.length > 0 ? firstLine : INTENT_UNKNOWN
+}
+
+const SCENARIO_UNKNOWN = '(transcriptから復元: scenario情報は失われている)'
+const MAX_REASON_LENGTH = 300
+
+export function pairAgentFiles(filenames: string[]): { agentId: string; jsonlFile: string; metaFile: string }[] {
+  const jsonlFiles = new Set(filenames.filter((f) => /^agent-.+\.jsonl$/.test(f)))
+  const metaFiles = new Set(filenames.filter((f) => /^agent-.+\.meta\.json$/.test(f)))
+
+  const pairs: { agentId: string; jsonlFile: string; metaFile: string }[] = []
+  for (const jsonlFile of jsonlFiles) {
+    const agentId = jsonlFile.replace(/^agent-/, '').replace(/\.jsonl$/, '')
+    const metaFile = `agent-${agentId}.meta.json`
+    if (metaFiles.has(metaFile)) {
+      pairs.push({ agentId, jsonlFile, metaFile })
+    }
+  }
+  return pairs
+}
+
+export interface LoopObservabilityEntry {
+  timestamp: string
+  loop: string
+  agent: string
+  feature: string
+  attempt: number
+  model: string | null
+  tokens: number
+  costUsd: number | null
+  intent: string
+  scenario: string
+  result: string
+  reason: string
+  reconstructed: true
+}
+
+export function buildLoopObservabilityEntry(params: {
+  agentType: string
+  feature: string
+  attempt: number
+  summary: AgentTranscriptSummary
+}): LoopObservabilityEntry {
+  const { agentType, feature, attempt, summary } = params
+  const timestamp = summary.endTimestamp ?? summary.startTimestamp ?? ''
+  const reason = summary.detail
+    ? summary.detail.length > MAX_REASON_LENGTH
+      ? `${summary.detail.slice(0, MAX_REASON_LENGTH)}…`
+      : summary.detail
+    : '(transcriptから復元: detail不明)'
+
+  return {
+    timestamp,
+    loop: mapAgentTypeToLoop(agentType),
+    agent: agentType,
+    feature,
+    attempt,
+    model: summary.model,
+    tokens: summary.tokens,
+    costUsd: summary.costUsd,
+    intent: deriveIntent(summary.promptText),
+    scenario: SCENARIO_UNKNOWN,
+    result: summary.status ?? 'unknown',
+    reason,
+    reconstructed: true,
+  }
+}
+
+interface WorkflowAgentMeta {
+  agentType?: string
+}
+
+export function reconstructWorkflowDir(wfDirPath: string, feature: string): LoopObservabilityEntry[] {
+  const filenames = readdirSync(wfDirPath)
+  const pairs = pairAgentFiles(filenames)
+
+  const parsed = pairs.map(({ agentId, jsonlFile, metaFile }) => {
+    const meta = JSON.parse(readFileSync(join(wfDirPath, metaFile), 'utf-8')) as WorkflowAgentMeta
+    const lines = readFileSync(join(wfDirPath, jsonlFile), 'utf-8').split('\n').filter(Boolean)
+    const summary = parseAgentTranscriptLines(lines)
+    return { agentId, agentType: meta.agentType ?? 'unknown', startTimestamp: summary.startTimestamp, summary }
+  })
+
+  const withAttempts = assignAttempts(parsed)
+
+  return withAttempts.map((record) =>
+    buildLoopObservabilityEntry({
+      agentType: record.agentType,
+      feature,
+      attempt: record.attempt,
+      summary: record.summary,
+    }),
+  )
+}
+
+function main() {
+  const wfDirPath = process.argv[2]
+  const feature = process.argv[3] ?? 'unknown'
+  const logFilePath = process.argv[4] ?? 'logs/loop-observability.jsonl'
+
+  if (!wfDirPath) {
+    console.error('Usage: reconstruct-loop-observability.ts <wfDirPath> [feature] [logFilePath]')
+    process.exit(1)
+  }
+
+  const entries = reconstructWorkflowDir(wfDirPath, feature)
+  mkdirSync(join(logFilePath, '..'), { recursive: true })
+  const content = entries.map((entry) => JSON.stringify(entry)).join('\n') + (entries.length > 0 ? '\n' : '')
+  appendFileSync(logFilePath, content, 'utf-8')
+  console.log(`${entries.length}件のレコードを${logFilePath}に再構築しました`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Summary
- loop-observabilityログの記録漏れ（#311）の根本対応として、`subagents/workflows/wf_*/agent-<id>.jsonl` + `.meta.json` から過去のAIDDワークフロー実行のログレコードを再構築する `scripts/lib/reconstruct-loop-observability.ts` を追加
- journal.jsonl単体はtimestamp/model/feature等が欠落しており再構築の情報源として不十分だったが、サブエージェント自身の生transcript（`agent-<id>.jsonl`）にはms単位のtimestamp・正確なmodel名・usageが残っていることを実データ（issue #165実装時の実行結果）で確認し、これを情報源として採用
- `reviewer`/`judge-panel`は`--loop developer`明示、それ以外（`implementer`等）はスクリプトのデフォルト値`agentic`という既存の呼び分け（docs/agents/*.md参照）をagentTypeから再現するマッピングを実装

## 既知の制約（docs/agents/common.mdに追記済み）
- `feature`名はtranscriptから自動導出できず、CLI引数で手動指定が必要
- `intent`はプロンプト冒頭1文の抜粋、`scenario`は復元不能である旨の固定文言（自己申告時点の情報粒度には及ばない）
- `attempt`番号は同一wfディレクトリ内の同一agentTypeをstartTimestamp昇順で採番しているだけなので、並列実行された同じagentTypeがある場合は「再試行」ではなく「並列実行順」を採番してしまう

Closes #312

## Test plan
- [x] `npx vitest run scripts/lib/reconstruct-loop-observability.test.ts scripts/lib/model-pricing.test.ts` — 新規20件 pass
- [x] `npx vitest run` — 既存含む全572件（94ファイル）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）
- [x] 実データ（issue #165実装時のワークフロー実行ディレクトリ）に対して実行し、implementer 4回分（pass/blocked含む）・contract-writer 1回分が正しく再構築されることを手動確認