### PR TITLE
feat: reviewer系エージェント起動前にSPEC.md存在チェックを追加する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -3,6 +3,7 @@ export const meta = {
   description: 'Phase 3-5: contract-first並列実装 → 統合ゲート → 4観点並列検証。仕様書承認後（停止①の後）に実行。',
   whenToUse: '人間が仕様書（SPEC.md）を承認した後、Phase 3 実装に入るときに使う。aidd-1-1-deep-task.jsの後続として使う。',
   phases: [
+    { title: 'Spec Check',     detail: 'SPEC.md存在チェック（欠如時は後続の全エージェントを起動せず中断）' },
     { title: 'Manifest Check', detail: 'Run Manifestのspecハッシュ突合（レビュー後のSPEC.md改変を検知）' },
     { title: 'Contract + DB', detail: 'contract-writer（型定義）とdb-impl（migrations）を並列実行' },
     { title: 'Implement',     detail: 'data-impl / api-impl / ui-impl を並列実行' },
@@ -95,6 +96,48 @@ failの場合はfindings配列（{ severity: critical/important/minor, descripti
 重大度を明記すること。findings全件がminorならこのゲートは通過扱いになる。
 findingsを省略した場合、またはcritical/important指摘が1件でもあれば差し戻し対象になる
 （severity不明・欠損はcritical扱い。fail-open防止）。`
+
+// ─── Phase -1: Spec Check ────────────────────────────────────────────
+// issue #313: 2026-07-10時点の分析で「20回のreviewer呼び出しのうち9回はSPECファイル欠如で
+// 失敗し、145万トークン・$81.25を浪費した」ことが判明していた。その後の品質ゲート強化で
+// SPEC欠如時はblocked判定されるようになったが、それは「まず各エージェントを起動し、
+// エージェント自身がSPECファイルを読めずに気づいてblockedを自己申告する」方式のままだった。
+// Workflow DSLはfilesystem APIを持たないため fs.existsSync 等は使えず、Manifest Checkと
+// 同じパターン（軽量な単一エージェントによるReadツール確認）で最初にSPEC.mdの存在だけを
+// 確認し、無ければ後続の全エージェント（Manifest Check以降）を一切起動せず即座に返す。
+phase('Spec Check')
+
+const SPEC_CHECK_SCHEMA = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['pass', 'blocked'] },
+    detail: { type: 'string' },
+  },
+  required: ['status', 'detail'],
+}
+
+const specCheck = await agent(
+  `Readツールで ${specPath} が存在し読み込めるか確認してください。それ以外は何もしないでください。${guide(
+    `${specPath}が存在し読み込めた`,
+    '（未使用: このエージェントはpass/blockedの2値のみ返す）',
+    `${specPath}が存在しない、または読み込めない`
+  )}`,
+  { label: 'spec-check', phase: 'Spec Check', agentType: 'reviewer', schema: SPEC_CHECK_SCHEMA }
+)
+
+countLoggable('reviewer')
+log(`Spec Check完了: status=${specCheck?.status ?? 'なし'}`)
+
+if (shouldBlock([specCheck])) {
+  log(`品質ゲート: ${specPath}が存在しないため中断（Manifest Check以降のエージェントは起動しません）`)
+  return {
+    done: false,
+    specCheck,
+    blocked: true,
+    blockedAt: 'Spec Check',
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Spec Check', expectedLoopObservabilityRecords: loggableAgentCount },
+  }
+}
 
 // ─── Phase 0: Manifest Check ─────────────────────────────────────────
 // issue #44/#294: docs/agents/run-manifest.md にPhase 2開始時のspecHash突合が

--- a/.claude/workflows/lib/__tests__/quality-gate.test.js
+++ b/.claude/workflows/lib/__tests__/quality-gate.test.js
@@ -52,4 +52,12 @@ describe('shouldBlock', () => {
   it('failでfindingsを省略した場合はtrue（deny-by-default: 重大度不明はブロック側）', () => {
     expect(shouldBlock([{ status: 'fail', detail: 'findings無し' }])).toBe(true)
   })
+
+  it('issue #313: SPEC.md欠如でspec-checkがblockedを返した場合はtrue（後続の全エージェントを起動せず中断する）', () => {
+    expect(shouldBlock([{ status: 'blocked', detail: 'SPEC.mdが存在しない' }])).toBe(true)
+  })
+
+  it('issue #313: SPEC.mdが存在しspec-checkがpassを返した場合はfalse（後続フェーズへ進む）', () => {
+    expect(shouldBlock([{ status: 'pass', detail: 'SPEC.mdが存在し読み込めた' }])).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- `aidd-phase2.js`に新しい「Spec Check」フェーズを追加し、全フェーズ（Manifest Check/Contract+DB/Implement/Integrate/Review）の実行前にSPEC.mdの存在を確認するようにした
- SPEC.mdが存在しない場合、後続の全エージェントを一切起動せず即座に`blocked`で返す
- Workflow DSLはfilesystem/Node.js APIを持たない（`fs.existsSync`等が使えない）ため、issue本文が想定していた「Node側での事前チェック」は文字通りには実現できなかった。代わりに既存の`Manifest Check`フェーズと同じパターン（軽量な単一エージェントによるReadツール確認）を採用した

## 既存の関連実装との関係
- `Manifest Check`フェーズは`.aidd/run-manifest.json`の存在・承認記録・specHash突合を確認するが、SPEC.md自体の存在を直接・明示的にはチェックしていなかった
- 今回追加した`Spec Check`はManifest Checkよりも前段に置き、SPEC.mdが無い場合はManifest Check含む後続の全エージェントの起動を防ぐ

## Test plan
- [x] `node --check .claude/workflows/aidd-phase2.js` — 構文エラーなし
- [x] `npx vitest run .claude/workflows/lib/__tests__/quality-gate.test.js` — 新規2件含む13件 pass
      （`shouldBlock`はaidd-phase2.js内で使うロジックの正本。Spec CheckのSPEC欠如時パターンをケース追加した）
- [x] `npx vitest run` — 既存含む全574件（94ファイル）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）

Closes #313

## 既知の制約
- Workflow DSLの制約上、Spec Check自体もagent()呼び出し（reviewerエージェント1体）を要するため、issueが想定した「エージェント起動ゼロでの検知」ではなく「軽量な1エージェントでの早期検知」に留まる。ただし後続の4並列reviewer + contract-writer + db-impl + 3並列implementer + integratorの起動は防げるため、コスト削減効果自体は大きい