### PR TITLE
fix: Reviewループでblocked観点を即座に打ち切り対象にする

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -288,13 +288,21 @@ const reviewGuide = guide(
   'レビュー対象のコード・SPEC.mdが見つからずレビュー自体ができなかった'
 )
 
+// issue #314: blockedの観点はImplementerへの差し戻しでは解決しない（レビュー対象自体が
+// 見つからない等）ため、fail判定より先に見て即座に打ち切る。従来はblockedのみの回を
+// done=true,blocked=falseとして素通りしており、最終returnにblockedAtが付かず追跡できなかった。
 function classifyReviewRound(results, dimensions, attempt, maxRetries) {
+  const blockedDimensions = dimensions
+    .map((dim, i) => ({ dim, result: results[i] }))
+    .filter(({ result }) => result?.status === 'blocked')
+  if (blockedDimensions.length > 0) return { done: true, blocked: true, failingDimensions: [], blockedDimensions }
+
   const failingDimensions = dimensions
     .map((dim, i) => ({ dim, result: results[i] }))
     .filter(({ result }) => result?.status === 'fail' && !isMinorOnlyFailure(result))
-  if (failingDimensions.length === 0) return { done: true, blocked: false, failingDimensions: [] }
-  if (attempt > maxRetries) return { done: true, blocked: true, failingDimensions }
-  return { done: false, blocked: false, failingDimensions }
+  if (failingDimensions.length === 0) return { done: true, blocked: false, failingDimensions: [], blockedDimensions: [] }
+  if (attempt > maxRetries) return { done: true, blocked: true, failingDimensions, blockedDimensions: [] }
+  return { done: false, blocked: false, failingDimensions, blockedDimensions: [] }
 }
 
 const MAX_REVIEW_RETRIES = 3
@@ -315,16 +323,19 @@ while (true) {
 
   REVIEW_DIMENSIONS.forEach(() => countLoggable('reviewer'))
 
-  const { done, blocked, failingDimensions } = classifyReviewRound(reviewResults, REVIEW_DIMENSIONS, reviewAttempt, MAX_REVIEW_RETRIES)
+  const { done, blocked, failingDimensions, blockedDimensions } = classifyReviewRound(reviewResults, REVIEW_DIMENSIONS, reviewAttempt, MAX_REVIEW_RETRIES)
 
   if (done && !blocked) {
-    log(`Review完了: ラウンド${reviewAttempt}で全観点pass（指摘なし、またはblockedのみ）`)
+    log(`Review完了: ラウンド${reviewAttempt}で全観点pass（指摘なし）`)
     logMinorOnlyPassThrough('Review', reviewResults)
     break
   }
 
   if (blocked) {
-    log(`品質ゲート: Reviewで${MAX_REVIEW_RETRIES}回の差し戻し後もfailが残るため中断（blockedとして人間に引き渡します）`)
+    const reason = blockedDimensions.length > 0
+      ? `${blockedDimensions.length}件の観点でレビュー自体が実行できなかった（blocked）ため`
+      : `${MAX_REVIEW_RETRIES}回の差し戻し後もfailが残るため`
+    log(`品質ゲート: Reviewで${reason}中断（blockedとして人間に引き渡します）`)
     return {
       done: false,
       contractResult,
@@ -344,6 +355,7 @@ while (true) {
         done: false,
         blocked: true,
         blockedAt: 'Review',
+        reviewBlockedDimensions: blockedDimensions.length,
         reviewRetries: reviewRetryAgentCount,
         expectedLoopObservabilityRecords: loggableAgentCount,
       },

--- a/.claude/workflows/lib/__tests__/review-retry.test.js
+++ b/.claude/workflows/lib/__tests__/review-retry.test.js
@@ -12,16 +12,29 @@ describe('classifyReviewRound', () => {
       [{ status: 'pass', detail: '指摘なし' }, { status: 'pass', detail: '指摘なし' }],
       DIMENSIONS, 1, 3
     )
-    expect(result).toEqual({ done: true, blocked: false, failingDimensions: [] })
+    expect(result).toEqual({ done: true, blocked: false, failingDimensions: [], blockedDimensions: [] })
   })
 
-  it('blockedのみ(fail無し)ならdone=true, blocked=false（レビュー自体ができなかっただけで差し戻し対象ではない）', () => {
+  it('issue #314: blockedのみ(fail無し)でもdone=true, blocked=trueで即座に打ち切る（Implementerへの差し戻しでは解決しないため）', () => {
     const result = classifyReviewRound(
       [{ status: 'blocked', detail: '対象が見つからない' }, { status: 'pass', detail: '指摘なし' }],
       DIMENSIONS, 1, 3
     )
     expect(result.done).toBe(true)
-    expect(result.blocked).toBe(false)
+    expect(result.blocked).toBe(true)
+    expect(result.blockedDimensions).toHaveLength(1)
+    expect(result.blockedDimensions[0].dim.key).toBe('correctness')
+  })
+
+  it('issue #314: blockedとfailが同じラウンドに混在してもblockedを優先し即座に打ち切る（1回目の試行でも）', () => {
+    const result = classifyReviewRound(
+      [{ status: 'blocked', detail: '対象が見つからない' }, { status: 'fail', detail: 'バグあり' }],
+      DIMENSIONS, 1, 3
+    )
+    expect(result.done).toBe(true)
+    expect(result.blocked).toBe(true)
+    expect(result.blockedDimensions).toHaveLength(1)
+    expect(result.failingDimensions).toHaveLength(0)
   })
 
   it('failが1件でもあり、上限内ならdone=falseで差し戻し対象を返す', () => {

--- a/.claude/workflows/lib/review-retry.js
+++ b/.claude/workflows/lib/review-retry.js
@@ -22,16 +22,28 @@ import { isMinorOnlyFailure } from './severity.js'
 // - blocked: true なら打ち切り（人間に引き渡す）。doneがfalseの場合は常にfalse
 // - failingDimensions: 差し戻し対象の観点（{ dim, result }[]）。status==='fail'かつ
 //   findings全件minorではないもの（findings省略時はcritical相当として差し戻し対象）
+// - blockedDimensions: status==='blocked'の観点（{ dim, result }[]）。レビュー対象自体が
+//   見つからない等、Implementerへの差し戻しでは解決しない状態のため常に即座に打ち切る
+//   （issue #314: 従来はblockedのみの回をdone=true,blocked=falseとして素通りしており、
+//   最終returnにblockedAtが付かず「なぜ止まったか」が追跡できなかった）
 export function classifyReviewRound(reviewResults, dimensions, attempt, maxRetries) {
+  const blockedDimensions = dimensions
+    .map((dim, i) => ({ dim, result: reviewResults[i] }))
+    .filter(({ result }) => result?.status === 'blocked')
+
+  if (blockedDimensions.length > 0) {
+    return { done: true, blocked: true, failingDimensions: [], blockedDimensions }
+  }
+
   const failingDimensions = dimensions
     .map((dim, i) => ({ dim, result: reviewResults[i] }))
     .filter(({ result }) => result?.status === 'fail' && !isMinorOnlyFailure(result))
 
   if (failingDimensions.length === 0) {
-    return { done: true, blocked: false, failingDimensions: [] }
+    return { done: true, blocked: false, failingDimensions: [], blockedDimensions: [] }
   }
   if (attempt > maxRetries) {
-    return { done: true, blocked: true, failingDimensions }
+    return { done: true, blocked: true, failingDimensions, blockedDimensions: [] }
   }
-  return { done: false, blocked: false, failingDimensions }
+  return { done: false, blocked: false, failingDimensions, blockedDimensions: [] }
 }


### PR DESCRIPTION
## Summary
- `classifyReviewRound`（`.claude/workflows/lib/review-retry.js` およびaidd-phase2.jsのインライン複製）は`status:'fail'`の観点のみを差し戻し対象としてフィルタしており、全観点が`blocked`の回は「差し戻し対象なし=`done:true, blocked:false`」として素通りしていた
- `blocked`はレビュー対象自体が見つからない等の状態で、Implementerへの差し戻しでは解決しないため、`fail`判定より先に見て即座に`blocked:true`で打ち切るようにした
- 結果として、Reviewフェーズがblocked観点で停止した場合も、他フェーズ（Manifest Check/Contract+DB/Implement/Integrate）と同様に最終returnへ`blockedAt: 'Review'`が一貫して付与されるようになった（既存の差し戻し打ち切り時の`blocked:true`ハンドリングをそのまま再利用できたため、aidd-phase2.js側の変更は最小限で済んだ）
- 追加情報として`blockedDimensions`（どの観点がblockedだったか）を返り値・statsに含め、ログメッセージも「差し戻し上限到達」と「blocked即時打ち切り」を区別するようにした

## Test plan
- [x] `node --check .claude/workflows/aidd-phase2.js` — 構文エラーなし
- [x] `npx vitest run .claude/workflows/lib/__tests__/review-retry.test.js` — 新規2件・既存修正1件含む8件 pass
- [x] `npx vitest run` — 既存含む全573件（94ファイル）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）

Closes #314