### PR TITLE
test: Run Manifestのspecハッシュ突合・changedFiles更新ロジックをユニットテスト可能な形で文書化する

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -102,6 +102,11 @@ findingsを省略した場合、またはcritical/important指摘が1件でも�
 // 改変されるケースを検知できないまま実装が進んでしまう。
 // Workflow DSL自体はfilesystem/Node.js APIアクセスが無いため、Read/Bashツールを持つ
 // エージェントにマニフェスト読み込み・ハッシュ再計算・突合を行わせる。
+// issue #316: 下記プロンプトの1〜4の判定テーブルは .claude/workflows/lib/manifest-check.js の
+// classifyManifestCheck にテスト可能な形で文書化している。ただし実行パス自体はプロンプト依存の
+// ままであり（Workflow DSLの制約上、実際のmanifest読込・ハッシュ計算はエージェントに委譲する
+// 必要がある）、このプロンプト文言を変更した場合はmanifest-check.js側も手動で追従させること
+// （自動では同期されない）。
 phase('Manifest Check')
 
 const MANIFEST_CHECK_SCHEMA = {
@@ -232,6 +237,9 @@ if (shouldBlock([dataResult, apiResult, uiResult])) {
 logMinorOnlyPassThrough('Implement', [dataResult, apiResult, uiResult])
 
 // ─── Phase C: 統合ゲート ──────────────────────────────────────────────
+// issue #316: 手順7のchangedFiles上書き（「他フィールドは変更しないこと」）は
+// .claude/workflows/lib/manifest-check.js の applyChangedFiles にテスト可能な形で
+// 文書化している。こちらもプロンプト依存の実行パス自体は変わらない（上記Manifest Check参照）。
 phase('Integrate')
 
 const integrationResult = await agent(

--- a/.claude/workflows/lib/__tests__/manifest-check.test.js
+++ b/.claude/workflows/lib/__tests__/manifest-check.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { classifyManifestCheck, applyChangedFiles } from '../manifest-check.js'
+
+describe('classifyManifestCheck', () => {
+  it('manifestがnull（.aidd/run-manifest.jsonが存在しない）ならblocked', () => {
+    const result = classifyManifestCheck(null, 'abc123')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('Run Manifestが存在しません')
+  })
+
+  it('approval.approvedByが無ければblocked', () => {
+    const manifest = { specHash: 'abc123', approval: { approvedAt: '2026-07-10T05:00:00+09:00' } }
+    const result = classifyManifestCheck(manifest, 'abc123')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('承認が記録されていません')
+  })
+
+  it('approval.approvedAtが無ければblocked', () => {
+    const manifest = { specHash: 'abc123', approval: { approvedBy: 'huuriekaiseki@gmail.com' } }
+    const result = classifyManifestCheck(manifest, 'abc123')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('承認が記録されていません')
+  })
+
+  it('approval自体が無ければblocked', () => {
+    const manifest = { specHash: 'abc123' }
+    const result = classifyManifestCheck(manifest, 'abc123')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('承認が記録されていません')
+  })
+
+  it('specHashが無ければblocked', () => {
+    const manifest = { approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' } }
+    const result = classifyManifestCheck(manifest, 'abc123')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('specHashが記録されていません')
+  })
+
+  it('manifest.specHashとactualSpecHashが一致すればpass', () => {
+    const manifest = {
+      specHash: 'abc123',
+      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+    }
+    const result = classifyManifestCheck(manifest, 'abc123')
+    expect(result.status).toBe('pass')
+    expect(result.detail).toContain('specHash一致')
+  })
+
+  it('manifest.specHashとactualSpecHashが不一致ならblocked（レビュー承認後にSPEC.mdが変更された）', () => {
+    const manifest = {
+      specHash: 'abc123',
+      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+    }
+    const result = classifyManifestCheck(manifest, 'xyz789')
+    expect(result.status).toBe('blocked')
+    expect(result.detail).toContain('specHash不一致')
+    expect(result.detail).toContain('abc123')
+    expect(result.detail).toContain('xyz789')
+  })
+})
+
+describe('applyChangedFiles', () => {
+  it('changedFilesフィールドのみを上書きし、他フィールドは変更しない', () => {
+    const manifest = {
+      specPath: 'SPEC.md',
+      specHash: 'abc123',
+      baseCommit: 'd1a7dbd',
+      changedFiles: [],
+      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+    }
+    const updated = applyChangedFiles(manifest, ['src/app/page.tsx', 'src/lib/foo.ts'])
+    expect(updated.changedFiles).toEqual(['src/app/page.tsx', 'src/lib/foo.ts'])
+    expect(updated.specPath).toBe('SPEC.md')
+    expect(updated.specHash).toBe('abc123')
+    expect(updated.baseCommit).toBe('d1a7dbd')
+    expect(updated.approval).toEqual(manifest.approval)
+  })
+
+  it('元のmanifestオブジェクトを変更しない（イミュータブル）', () => {
+    const manifest = { changedFiles: ['old.ts'] }
+    applyChangedFiles(manifest, ['new.ts'])
+    expect(manifest.changedFiles).toEqual(['old.ts'])
+  })
+
+  it('changedFilesが空配列でも上書きできる', () => {
+    const manifest = { changedFiles: ['old.ts'] }
+    const updated = applyChangedFiles(manifest, [])
+    expect(updated.changedFiles).toEqual([])
+  })
+})

--- a/.claude/workflows/lib/manifest-check.js
+++ b/.claude/workflows/lib/manifest-check.js
@@ -1,0 +1,38 @@
+// aidd-phase2.js の Manifest Check フェーズ・integrator の changedFiles 更新指示（docs/agents/run-manifest.md）
+// が実際に行っている判定・更新ロジックを、可能な範囲でNode側の純粋関数として切り出したもの（issue #316）。
+//
+// 注意（構造的な制約）: Workflow DSL（aidd-phase2.js）自体はfilesystem/Node.js APIアクセスが無いため、
+// manifest.jsonの読み込み・specHashの再計算（shasum）・実際のpass/blocked判定は、この関数を呼ぶのではなく
+// 現在もエージェントへの自然言語プロンプト指示（Read/Bashツール）として実行されている。
+// このファイルはaidd-phase2.jsの実行パスには配線されておらず、プロンプトが表現しようとしている
+// 判定テーブル・更新ロジックを「文書化かつテスト可能な形」で保持するためのものである。
+// プロンプト文言（aidd-phase2.js内の該当箇所）を変更した場合、このファイルとテストも
+// 手動で追従させる必要がある（自動では同期されない）。
+
+// manifest: .aidd/run-manifest.json の内容（存在しなければnull）
+// actualSpecHash: 現在のSPEC.md内容から再計算したsha256ハッシュ
+export function classifyManifestCheck(manifest, actualSpecHash) {
+  if (!manifest) {
+    return { status: 'blocked', detail: 'Run Manifestが存在しません' }
+  }
+  if (!manifest.approval?.approvedBy || !manifest.approval?.approvedAt) {
+    return { status: 'blocked', detail: '停止①の承認が記録されていません' }
+  }
+  if (!manifest.specHash) {
+    return { status: 'blocked', detail: 'specHashが記録されていません' }
+  }
+  if (manifest.specHash !== actualSpecHash) {
+    return {
+      status: 'blocked',
+      detail: `specHash不一致: レビュー承認後にSPEC.mdが変更された可能性があります（manifest=${manifest.specHash}, actual=${actualSpecHash}）`,
+    }
+  }
+  return { status: 'pass', detail: 'specHash一致（承認後にSPEC.mdの変更なし）' }
+}
+
+// manifest: 更新対象のmanifestオブジェクト（変更しない）
+// changedFiles: 今回のAIDD実行で変更されたファイルの相対パス一覧
+// 戻り値: changedFilesのみを上書きした新しいmanifestオブジェクト（他フィールドは維持）
+export function applyChangedFiles(manifest, changedFiles) {
+  return { ...manifest, changedFiles: [...changedFiles] }
+}

--- a/docs/agents/run-manifest.md
+++ b/docs/agents/run-manifest.md
@@ -37,6 +37,15 @@ Run ManifestはこのズレをPhase間で検出するための唯一の正とす
   一致しない場合はPhase 2を起動せずエラーにする（レビュー後にSPEC.mdが変更されたことを検出するため）。
 - **Phase 3〜4完了時**: `changedFiles` を実際の変更ファイル一覧で更新する。
 
+## 突合・更新ロジックのテスト（issue #316）
+
+specHash突合（Phase 2開始時）・changedFiles更新（Phase 3〜4完了時）の判定・更新ロジックは、
+`.claude/workflows/lib/manifest-check.js`（`classifyManifestCheck`/`applyChangedFiles`）に
+テスト可能な形で文書化している。ただしWorkflow DSL（`aidd-phase2.js`）自体はfilesystem/Node.js
+APIアクセスが無いため、実際のmanifest読込・ハッシュ再計算・ファイル書き込みは今もエージェントへの
+自然言語プロンプト指示として実行される。`aidd-phase2.js`内のプロンプト文言を変更した場合、
+`manifest-check.js`とそのテストは自動では追従しないため、手動で同期させること。
+
 ## 関連ファイル
 
 - [`common.md`](./common.md) — 全AIエージェント共通ルール


### PR DESCRIPTION
## Summary
- `.claude/workflows/lib/manifest-check.js` に `classifyManifestCheck`（specHash突合の判定テーブル）と `applyChangedFiles`（changedFiles更新ロジック）を追加し、テストを書いた
- これらは `aidd-phase2.js` のManifest Check/Integrateフェーズのプロンプト文言（1〜4の判定手順、手順7のchangedFiles上書き）を、テスト可能な純粋関数として文書化したもの

## 重要な制約（着手前にユーザーへ共有し、合意の上で実施）
このissueが本来懸念していた「プロンプトの微修正やエージェントの解釈揺れで壊れても気づきにくい」というリスクは、**このPRだけでは解消されません**。

理由: Workflow DSL（`aidd-phase2.js`）自体はfilesystem/Node.js APIアクセスを持たないため、実際のmanifest読み込み・sha256ハッシュ再計算・JSON書き込みは今も100%エージェントへの自然言語プロンプト指示（Read/Bash/Writeツール）に依存しており、`shouldBlock`/`classifyReviewRound`のような「同一ロジックのインライン複製」が実行パスとして存在しません。

今回追加した`classifyManifestCheck`/`applyChangedFiles`は、プロンプトが表現しようとしている判定テーブル・更新ロジックを**文書化かつテスト可能な形で保持する**ものであり、`aidd-phase2.js`の実行パスには配線されていません。プロンプト文言を変更した場合、このファイルとテストは自動では追従せず、手動での同期が必要です（コメントとdocs/agents/run-manifest.mdに明記）。

この制約を解消する（実際の判定をJS側に委譲し、エージェントの役割を「生データ取得」のみに縮小する）には、MANIFEST_CHECK_SCHEMAの変更を含むより大きなリファクタが必要になるため、今回のスコープには含めていません。

## Test plan
- [x] `node --check .claude/workflows/aidd-phase2.js` — 構文エラーなし
- [x] `npx vitest run .claude/workflows/lib/__tests__/manifest-check.test.js` — 新規10件 pass
- [x] `npx vitest run` — 既存含む全582件（95ファイル）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）

Closes #316