### PR TITLE
test: RLS/IDOR統合テストをcase_orders/consumable_ordersに横展開する

### DIFF
--- a/supabase/__tests__/integration/case-orders-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/case-orders-rls-idor.integration.test.ts
@@ -1,0 +1,80 @@
+// supabase/__tests__/integration/case-orders-rls-idor.integration.test.ts
+// WHY: loan-orders-rls-idor.integration.test.ts（issue #165）と同じ手法で、
+//      case_orders でも「施設Bのユーザーが施設Aの症例発注にアクセスできない」ことを
+//      本物のローカルSupabaseへの接続を伴って確認する（issue #315: 他テーブルへの横展開）。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupCaseOrdersRlsIdorFixtures,
+  seedCaseOrdersRlsIdorFixtures,
+  type SeedCaseOrdersRlsIdorFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('case_orders RLS/IDOR (issue #315)', () => {
+  let fixtures: SeedCaseOrdersRlsIdorFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedCaseOrdersRlsIdorFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupCaseOrdersRlsIdorFixtures(fixtures)
+    }
+  })
+
+  it('ユーザーBは施設Aのcase_ordersを1件も取得できない', async () => {
+    const { data, error } = await fixtures.userB.client
+      .from('case_orders')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).toEqual([])
+  })
+
+  it('ユーザーBは施設Aに対してcreate_case_order_atomicを呼ぶと拒否される', async () => {
+    const { data, error } = await fixtures.userB.client.rpc('create_case_order_atomic', {
+      p_facility_id: fixtures.facilityA.id,
+      p_case_datetime: new Date().toISOString(),
+      p_procedure_name: 'IDORテスト術式',
+      p_patient_id: 'IDOR-TEST-PATIENT-0001',
+      p_patient_initials: 'IDORテスト患者',
+      p_gender: 'other',
+      p_doctor_name: 'IDORテスト医師',
+      p_items: [],
+    })
+
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+  })
+
+  it('ユーザーAは自分の施設Aのcase_ordersを取得でき、シード済みの1件が含まれる', async () => {
+    const { data, error } = await fixtures.userA.client
+      .from('case_orders')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data!.length).toBeGreaterThanOrEqual(1)
+    expect(data!.some((row) => row.id === fixtures.caseOrderA.id)).toBe(true)
+  })
+
+  it('ユーザーAは自分の施設Aに対してcreate_case_order_atomicを呼ぶと成功する', async () => {
+    const { data, error } = await fixtures.userA.client.rpc('create_case_order_atomic', {
+      p_facility_id: fixtures.facilityA.id,
+      p_case_datetime: new Date().toISOString(),
+      p_procedure_name: '正常系テスト術式',
+      p_patient_id: 'NORMAL-TEST-PATIENT-0001',
+      p_patient_initials: '正常系テスト患者',
+      p_gender: 'other',
+      p_doctor_name: '正常系テスト医師',
+      p_items: [],
+    })
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect((data as { facility_id?: string })?.facility_id).toBe(fixtures.facilityA.id)
+  })
+})

--- a/supabase/__tests__/integration/consumable-orders-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/consumable-orders-rls-idor.integration.test.ts
@@ -1,0 +1,68 @@
+// supabase/__tests__/integration/consumable-orders-rls-idor.integration.test.ts
+// WHY: loan-orders-rls-idor.integration.test.ts（issue #165）と同じ手法で、
+//      consumable_orders でも「施設Bのユーザーが施設Aの消耗品発注にアクセスできない」ことを
+//      本物のローカルSupabaseへの接続を伴って確認する（issue #315: 他テーブルへの横展開）。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupConsumableOrdersRlsIdorFixtures,
+  seedConsumableOrdersRlsIdorFixtures,
+  type SeedConsumableOrdersRlsIdorFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('consumable_orders RLS/IDOR (issue #315)', () => {
+  let fixtures: SeedConsumableOrdersRlsIdorFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedConsumableOrdersRlsIdorFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupConsumableOrdersRlsIdorFixtures(fixtures)
+    }
+  })
+
+  it('ユーザーBは施設Aのconsumable_ordersを1件も取得できない', async () => {
+    const { data, error } = await fixtures.userB.client
+      .from('consumable_orders')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).toEqual([])
+  })
+
+  it('ユーザーBは施設Aに対してcreate_consumable_order_atomicを呼ぶと拒否される', async () => {
+    const { data, error } = await fixtures.userB.client.rpc('create_consumable_order_atomic', {
+      p_facility_id: fixtures.facilityA.id,
+      p_items: [],
+    })
+
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+  })
+
+  it('ユーザーAは自分の施設Aのconsumable_ordersを取得でき、シード済みの1件が含まれる', async () => {
+    const { data, error } = await fixtures.userA.client
+      .from('consumable_orders')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data!.length).toBeGreaterThanOrEqual(1)
+    expect(data!.some((row) => row.id === fixtures.consumableOrderA.id)).toBe(true)
+  })
+
+  it('ユーザーAは自分の施設Aに対してcreate_consumable_order_atomicを呼ぶと成功する', async () => {
+    const { data, error } = await fixtures.userA.client.rpc('create_consumable_order_atomic', {
+      p_facility_id: fixtures.facilityA.id,
+      p_items: [],
+    })
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect((data as { facility_id?: string })?.facility_id).toBe(fixtures.facilityA.id)
+  })
+})

--- a/supabase/__tests__/integration/helpers/seed-rls-idor.ts
+++ b/supabase/__tests__/integration/helpers/seed-rls-idor.ts
@@ -28,7 +28,7 @@ export interface SeedRlsIdorFixtures {
 // テスト用パスワード。ローカル/テスト専用DBでのみ使う使い捨て値のため機密情報ではない。
 const TEST_USER_PASSWORD = 'rls-idor-test-password-0000'
 
-function createServiceRoleClient(): SupabaseClient {
+export function createServiceRoleClient(): SupabaseClient {
   // 本番Supabaseへの誤接続を防ぐ多層防御（globalSetupとの二重チェック）
   assertTestSupabaseEnv()
 
@@ -70,7 +70,7 @@ async function createSignedInClient(
   return client
 }
 
-async function createFacility(serviceClient: SupabaseClient, dummyName: string) {
+export async function createFacility(serviceClient: SupabaseClient, dummyName: string) {
   const { data, error } = await serviceClient
     .from('facilities')
     .insert({ name: dummyName })
@@ -82,7 +82,7 @@ async function createFacility(serviceClient: SupabaseClient, dummyName: string) 
   return { id: data.id as string, name: data.name as string }
 }
 
-async function createSeededUser(
+export async function createSeededUser(
   serviceClient: SupabaseClient,
   emailPrefix: string,
   facilityId: string
@@ -148,14 +148,124 @@ export async function seedRlsIdorFixtures(): Promise<SeedRlsIdorFixtures> {
   }
 }
 
-/** シードしたユーザー・施設を後始末する（service role clientで直接削除） */
-export async function cleanupRlsIdorFixtures(fixtures: SeedRlsIdorFixtures): Promise<void> {
+/**
+ * ユーザーA・B、施設A・Bを後始末する共通処理（issue #315: loan_orders専用だった
+ * cleanupRlsIdorFixturesから、case_orders/consumable_orders版でも再利用できるよう切り出した）。
+ * auth.usersの削除はON DELETE CASCADEでuser_facilitiesも連動して消える。
+ * facilitiesの削除はloan_orders/case_orders/consumable_orders等を
+ * ON DELETE CASCADEで連動して消す。
+ */
+export async function cleanupFacilitiesAndUsers(
+  userA: SeededUser,
+  userB: SeededUser,
+  facilityA: { id: string },
+  facilityB: { id: string }
+): Promise<void> {
   const serviceClient = createServiceRoleClient()
 
-  // auth.users の削除は ON DELETE CASCADE で user_facilities も連動して消える。
-  // facilities の削除は loan_orders 等を ON DELETE CASCADE で連動して消す。
-  await serviceClient.auth.admin.deleteUser(fixtures.userA.id)
-  await serviceClient.auth.admin.deleteUser(fixtures.userB.id)
-  await serviceClient.from('facilities').delete().eq('id', fixtures.facilityA.id)
-  await serviceClient.from('facilities').delete().eq('id', fixtures.facilityB.id)
+  await serviceClient.auth.admin.deleteUser(userA.id)
+  await serviceClient.auth.admin.deleteUser(userB.id)
+  await serviceClient.from('facilities').delete().eq('id', facilityA.id)
+  await serviceClient.from('facilities').delete().eq('id', facilityB.id)
+}
+
+/** シードしたユーザー・施設を後始末する（service role clientで直接削除） */
+export async function cleanupRlsIdorFixtures(fixtures: SeedRlsIdorFixtures): Promise<void> {
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
+}
+
+export interface SeedCaseOrdersRlsIdorFixtures {
+  facilityA: { id: string; name: string }
+  facilityB: { id: string; name: string }
+  userA: SeededUser
+  userB: SeededUser
+  caseOrderA: { id: string }
+}
+
+/**
+ * 施設A・施設B、ユーザーA（施設Aのみ）・ユーザーB（施設Bのみ）、
+ * 施設Aに紐づく case_orders 1件を作成する（issue #315: loan_ordersと同様の横展開）。
+ */
+export async function seedCaseOrdersRlsIdorFixtures(): Promise<SeedCaseOrdersRlsIdorFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facilityA = await createFacility(serviceClient, `テスト施設A-${runId}`)
+  const facilityB = await createFacility(serviceClient, `テスト施設B-${runId}`)
+
+  const userA = await createSeededUser(serviceClient, 'rls-idor-case-user-a', facilityA.id)
+  const userB = await createSeededUser(serviceClient, 'rls-idor-case-user-b', facilityB.id)
+
+  const { data: caseOrder, error: caseOrderError } = await serviceClient
+    .from('case_orders')
+    .insert({
+      facility_id: facilityA.id,
+      case_datetime: new Date().toISOString(),
+      procedure_name: 'シード用術式',
+      patient_id: 'IDOR-TEST-PATIENT-0000',
+      patient_initials: 'IDORテスト患者',
+      gender: 'other',
+      doctor_name: 'IDORテスト医師',
+    })
+    .select('id')
+    .single()
+  if (caseOrderError || !caseOrder) {
+    throw new Error(`[seed-rls-idor] case_orders シード作成失敗: ${caseOrderError?.message}`)
+  }
+
+  return {
+    facilityA,
+    facilityB,
+    userA,
+    userB,
+    caseOrderA: { id: caseOrder.id as string },
+  }
+}
+
+export async function cleanupCaseOrdersRlsIdorFixtures(fixtures: SeedCaseOrdersRlsIdorFixtures): Promise<void> {
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
+}
+
+export interface SeedConsumableOrdersRlsIdorFixtures {
+  facilityA: { id: string; name: string }
+  facilityB: { id: string; name: string }
+  userA: SeededUser
+  userB: SeededUser
+  consumableOrderA: { id: string }
+}
+
+/**
+ * 施設A・施設B、ユーザーA（施設Aのみ）・ユーザーB（施設Bのみ）、
+ * 施設Aに紐づく consumable_orders 1件を作成する（issue #315: loan_ordersと同様の横展開）。
+ */
+export async function seedConsumableOrdersRlsIdorFixtures(): Promise<SeedConsumableOrdersRlsIdorFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facilityA = await createFacility(serviceClient, `テスト施設A-${runId}`)
+  const facilityB = await createFacility(serviceClient, `テスト施設B-${runId}`)
+
+  const userA = await createSeededUser(serviceClient, 'rls-idor-consumable-user-a', facilityA.id)
+  const userB = await createSeededUser(serviceClient, 'rls-idor-consumable-user-b', facilityB.id)
+
+  const { data: consumableOrder, error: consumableOrderError } = await serviceClient
+    .from('consumable_orders')
+    .insert({ facility_id: facilityA.id })
+    .select('id')
+    .single()
+  if (consumableOrderError || !consumableOrder) {
+    throw new Error(`[seed-rls-idor] consumable_orders シード作成失敗: ${consumableOrderError?.message}`)
+  }
+
+  return {
+    facilityA,
+    facilityB,
+    userA,
+    userB,
+    consumableOrderA: { id: consumableOrder.id as string },
+  }
+}
+
+export async function cleanupConsumableOrdersRlsIdorFixtures(fixtures: SeedConsumableOrdersRlsIdorFixtures): Promise<void> {
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
 }


### PR DESCRIPTION
## Summary
- `loan_orders`専用だったシードヘルパー（`supabase/__tests__/integration/helpers/seed-rls-idor.ts`）から施設・ユーザー作成の共通処理（`createServiceRoleClient`/`createFacility`/`createSeededUser`/`cleanupFacilitiesAndUsers`）を切り出しexportした
- `case_orders`・`consumable_orders`向けのシード関数（`seedCaseOrdersRlsIdorFixtures`/`seedConsumableOrdersRlsIdorFixtures`とそれぞれのcleanup）を追加した
- 既存の`loan-orders-rls-idor.integration.test.ts`と同じ手法（2ユーザー×2施設、実RPC/PostgREST呼び出し）で `case-orders-rls-idor.integration.test.ts` / `consumable-orders-rls-idor.integration.test.ts` を追加した

## スコープを分離した部分（issue #321として切り出し）
issue #315にはe2e/smoke.spec.tsへのUIレベルクロス施設境界テスト追加も含まれていたが、調査の結果:
- 実際のページは静的な`/loan-orders`ではなく`/facilities/[id]/loan-orders`という動的ルートだった（issue本文の想定と食い違い）
- 現状のe2e基盤（`e2e/generate-auth-state.ts`）は単一の固定テストユーザー1人分のstorageStateしか生成せず、複数ユーザー・複数施設の認証済み状態を扱う仕組みが存在しない

この部分は新しいテストインフラの構築が必要な別スコープと判断し、[#321](https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/issues/321)として切り出した（ユーザーと合意の上で対応）。

## 既知の制約
- この開発環境（sandbox）には`.env.test`が設定されておらず、**既存の`loan-orders-rls-idor.integration.test.ts`も含めて実際にテスト用Supabaseへ接続して実行することができていない**。今回追加した2ファイルも同様に、コード・型としては妥当だが実行結果の確認はできていない
- `case_orders`のRPC呼び出しでは`p_items: []`（空配列）を渡している。既存のloan_ordersテストと同じ理由（jan等のFK制約に依存しないため）

## Test plan
- [x] `npx tsc --noEmit -p .` — 型エラーなし
- [x] `npx vitest run` — 既存含む全585件（95ファイル、`.integration.test.ts`は対象外）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）
- [ ] `npm run test:integration` の実行確認 — **環境に`.env.test`が無いため未実施**（既存のloan_ordersテストも同様に未実施であることを確認済み）

Closes #315