### PR TITLE
feat: e2eで複数ユーザー・複数施設のクロス施設UI境界テストを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ yarn-error.log*
 next-env.d.ts
 
 # playwright
-e2e/.auth/user.json
+e2e/.auth/*.json
 
 # loop observability
 /logs/

--- a/e2e/cross-facility-boundary.spec.ts
+++ b/e2e/cross-facility-boundary.spec.ts
@@ -1,0 +1,44 @@
+// e2e/cross-facility-boundary.spec.ts
+// WHY: issue #321（issue #315の後半として切り出し）。RLS/IDOR統合テスト（supabase/__tests__/integration/）
+//      はAPI/RPCレベルでのクロス施設境界を検証済みだが、UIレベル（実際のページ描画）での
+//      境界検証が存在しなかった。施設Bのユーザーが施設Aのloan-orders一覧を開いても、
+//      シードされた発注が見えないこと（アクセス権限エラーになること）をブラウザ越しに確認する。
+
+import { test, expect } from '@playwright/test'
+import {
+  readCrossFacilityFixtures,
+  CROSS_FACILITY_USER_A_AUTH_PATH,
+  CROSS_FACILITY_USER_B_AUTH_PATH,
+} from './generate-cross-facility-auth-state'
+
+const fixtures = readCrossFacilityFixtures()
+
+test.describe('施設間クロスアクセス境界（issue #321）', () => {
+  test.skip(!fixtures, 'cross-facilityフィクスチャが生成されていない（SUPABASE_SERVICE_ROLE_KEY等が未設定）')
+
+  test('ユーザーAは自分の施設Aのloan-orders一覧で、シードした発注を閲覧できる', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: CROSS_FACILITY_USER_A_AUTH_PATH })
+    const page = await context.newPage()
+    await page.goto(`/facilities/${fixtures!.facilityAId}/loan-orders`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText(fixtures!.loanOrderProcedureName)).toBeVisible()
+
+    await context.close()
+  })
+
+  test('ユーザーBが施設Aのloan-orders一覧を開くと、アクセス権限エラーになりシード済み発注は見えない', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: CROSS_FACILITY_USER_B_AUTH_PATH })
+    const page = await context.newPage()
+    await page.goto(`/facilities/${fixtures!.facilityAId}/loan-orders`)
+    await page.waitForLoadState('networkidle')
+
+    // src/app/api/loan-orders/route.ts の requireFacilityAccess が403を返し、
+    // src/app/facilities/[id]/loan-orders/page.tsx が「一覧の取得に失敗しました」を表示する
+    // （空の一覧として素通りするのではなく、明示的なエラーとして現れる）
+    await expect(page.getByText('一覧の取得に失敗しました')).toBeVisible()
+    await expect(page.getByText(fixtures!.loanOrderProcedureName)).not.toBeVisible()
+
+    await context.close()
+  })
+})

--- a/e2e/generate-auth-state.ts
+++ b/e2e/generate-auth-state.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { chromium } from '@playwright/test'
 import { loadEnvConfig } from '@next/env'
 import * as fs from 'fs'
@@ -13,6 +13,73 @@ loadEnvConfig(process.cwd())
 
 // 万一 .env.test やCI secretsに本番URLが設定されていても、ここで即失敗させる
 assertTestSupabaseEnv()
+
+/**
+ * 既存ユーザー（email_confirm済み）に対してマジックリンクでサインインし、
+ * 認証済みのPlaywright storageStateを authFilePath に書き出す。
+ * issue #321: 複数ユーザー分のstorageStateを生成する必要があるため、
+ * generateAuthState（単一の固定テストユーザー用）から共通処理として切り出した。
+ */
+export async function signInAndSaveStorageState(
+  supabase: SupabaseClient,
+  email: string,
+  authFilePath: string
+): Promise<void> {
+  fs.mkdirSync(path.dirname(authFilePath), { recursive: true })
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  const siteOrigin = new URL(siteUrl).origin
+
+  // Admin API でマジックリンクを直接生成（メール送信不要）。
+  // redirectToを明示しないとSupabase側のsite_url設定に依存し、127.0.0.1へ飛んで
+  // Cookieドメインがずれる事故が起きるため、必ずテストのbaseURLと同じオリジンを指定する
+  const { data, error } = await supabase.auth.admin.generateLink({
+    type: 'magiclink',
+    email,
+    options: { redirectTo: `${siteUrl}/` },
+  })
+
+  if (error || !data.properties?.action_link) {
+    throw new Error(`テストセッション生成失敗 (${email}): ${error?.message}`)
+  }
+
+  // ブラウザでリンクを開いてセッションCookieを取得。
+  // 環境変数が揃っているのに認証に失敗した場合は空のstorageStateで誤魔化さず即失敗させる
+  // （空stateだと後続テストが未認証のまま走り、原因が分かりにくいリダイレクト失敗として現れるため）
+  const browser = await chromium.launch()
+  try {
+    const page = await browser.newPage()
+    await page.goto(data.properties.action_link)
+
+    // マジックリンク検証後は /#access_token=... や /login#access_token=... など
+    // hash付きURLに着地するため、完全一致ではなくオリジン到達で判定する
+    await page.waitForURL((url) => url.origin === siteOrigin, { timeout: 30_000 })
+
+    // 認証完了はURLではなくSupabaseのauth Cookie（sb-*-auth-token）の出現で判定する
+    // （login/page.tsx のuseEffectがhashからsetSessionし終わるまで非同期のため）
+    const deadline = Date.now() + 30_000
+    let authenticated = false
+    while (Date.now() < deadline) {
+      const cookies = await page.context().cookies()
+      if (cookies.some((c) => /^sb-.+-auth-token/.test(c.name))) {
+        authenticated = true
+        break
+      }
+      await page.waitForTimeout(500)
+    }
+    if (!authenticated) {
+      throw new Error(
+        `[E2E auth] 認証Cookie（sb-*-auth-token）が30秒以内に設定されませんでした (${email})。` +
+          'マジックリンクのリダイレクト先とログインフロー（/login のhash処理）を確認してください。'
+      )
+    }
+
+    await page.context().storageState({ path: authFilePath })
+    console.log(`[E2E auth] 認証済みstorageStateを書き出しました: ${authFilePath}`)
+  } finally {
+    await browser.close()
+  }
+}
 
 export async function generateAuthState() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -72,58 +139,7 @@ export async function generateAuthState() {
     throw new Error(`E2Eテストユーザーへのadmin権限付与失敗: ${membershipError.message}`)
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
-  const siteOrigin = new URL(siteUrl).origin
-
-  // Admin API でマジックリンクを直接生成（メール送信不要）。
-  // redirectToを明示しないとSupabase側のsite_url設定に依存し、127.0.0.1へ飛んで
-  // Cookieドメインがずれる事故が起きるため、必ずテストのbaseURLと同じオリジンを指定する
-  const { data, error } = await supabase.auth.admin.generateLink({
-    type: 'magiclink',
-    email: testEmail,
-    options: { redirectTo: `${siteUrl}/` },
-  })
-
-  if (error || !data.properties?.action_link) {
-    throw new Error(`テストセッション生成失敗: ${error?.message}`)
-  }
-
-  // ブラウザでリンクを開いてセッションCookieを取得。
-  // 環境変数が揃っているのに認証に失敗した場合は空のstorageStateで誤魔化さず即失敗させる
-  // （空stateだと後続テストが未認証のまま走り、原因が分かりにくいリダイレクト失敗として現れるため）
-  const browser = await chromium.launch()
-  try {
-    const page = await browser.newPage()
-    await page.goto(data.properties.action_link)
-
-    // マジックリンク検証後は /#access_token=... や /login#access_token=... など
-    // hash付きURLに着地するため、完全一致ではなくオリジン到達で判定する
-    await page.waitForURL((url) => url.origin === siteOrigin, { timeout: 30_000 })
-
-    // 認証完了はURLではなくSupabaseのauth Cookie（sb-*-auth-token）の出現で判定する
-    // （login/page.tsx のuseEffectがhashからsetSessionし終わるまで非同期のため）
-    const deadline = Date.now() + 30_000
-    let authenticated = false
-    while (Date.now() < deadline) {
-      const cookies = await page.context().cookies()
-      if (cookies.some((c) => /^sb-.+-auth-token/.test(c.name))) {
-        authenticated = true
-        break
-      }
-      await page.waitForTimeout(500)
-    }
-    if (!authenticated) {
-      throw new Error(
-        '[E2E auth] 認証Cookie（sb-*-auth-token）が30秒以内に設定されませんでした。' +
-          'マジックリンクのリダイレクト先とログインフロー（/login のhash処理）を確認してください。'
-      )
-    }
-
-    await page.context().storageState({ path: authFilePath })
-    console.log(`[E2E auth] 認証済みstorageStateを書き出しました: ${authFilePath}`)
-  } finally {
-    await browser.close()
-  }
+  await signInAndSaveStorageState(supabase, testEmail, authFilePath)
 }
 
 // CLIから直接実行された場合（npm run e2e:auth 等）にも動くようにする。

--- a/e2e/generate-cross-facility-auth-state.ts
+++ b/e2e/generate-cross-facility-auth-state.ts
@@ -1,0 +1,137 @@
+// e2e/generate-cross-facility-auth-state.ts
+// WHY: issue #321（issue #315の後半として切り出し）。
+//      施設Bのユーザーが施設Aの発注データをUI上で閲覧できないことを検証するには、
+//      2ユーザー×2施設の認証済みPlaywright storageStateが必要。既存の
+//      generate-auth-state.tsは固定の単一テストユーザー用のため、こちらは
+//      supabase/__tests__/integration/helpers/seed-rls-idor.tsと同様の方式で
+//      施設A・施設B、それぞれに所属するユーザーA・ユーザーBを都度作成し、
+//      施設Aにloan_orders 1件をシードする。
+
+import { createClient } from '@supabase/supabase-js'
+import { loadEnvConfig } from '@next/env'
+import { randomUUID } from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
+import { assertTestSupabaseEnv } from './env-guard'
+import { signInAndSaveStorageState } from './generate-auth-state'
+
+;(process.env as Record<string, string>).NODE_ENV = 'test'
+loadEnvConfig(process.cwd())
+assertTestSupabaseEnv()
+
+export interface CrossFacilityFixtures {
+  facilityAId: string
+  facilityBId: string
+  loanOrderProcedureName: string
+}
+
+export const CROSS_FACILITY_FIXTURES_PATH = path.join(process.cwd(), 'e2e', '.auth', 'cross-facility-fixtures.json')
+export const CROSS_FACILITY_USER_A_AUTH_PATH = path.join(process.cwd(), 'e2e', '.auth', 'cross-facility-user-a.json')
+export const CROSS_FACILITY_USER_B_AUTH_PATH = path.join(process.cwd(), 'e2e', '.auth', 'cross-facility-user-b.json')
+
+/** cross-facility-boundary.spec.ts から読む。フィクスチャが無ければnull（specはskipする）。 */
+export function readCrossFacilityFixtures(): CrossFacilityFixtures | null {
+  if (!fs.existsSync(CROSS_FACILITY_FIXTURES_PATH)) return null
+  return JSON.parse(fs.readFileSync(CROSS_FACILITY_FIXTURES_PATH, 'utf-8')) as CrossFacilityFixtures
+}
+
+export async function generateCrossFacilityAuthState(): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  fs.mkdirSync(path.dirname(CROSS_FACILITY_FIXTURES_PATH), { recursive: true })
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.warn(
+      '[E2E cross-facility auth] SUPABASE_SERVICE_ROLE_KEY 等が未設定。' +
+        'cross-facility-boundary.spec.ts はフィクスチャ不在としてskipされます。'
+    )
+    return
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey)
+  const runId = randomUUID()
+
+  const { data: facilityA, error: facilityAError } = await supabase
+    .from('facilities')
+    .insert({ name: `テスト施設A-${runId}` })
+    .select('id')
+    .single()
+  if (facilityAError || !facilityA) {
+    throw new Error(`[E2E cross-facility auth] 施設A作成失敗: ${facilityAError?.message}`)
+  }
+
+  const { data: facilityB, error: facilityBError } = await supabase
+    .from('facilities')
+    .insert({ name: `テスト施設B-${runId}` })
+    .select('id')
+    .single()
+  if (facilityBError || !facilityB) {
+    throw new Error(`[E2E cross-facility auth] 施設B作成失敗: ${facilityBError?.message}`)
+  }
+
+  const emailA = `e2e-cross-facility-user-a-${runId}@example.test`
+  const emailB = `e2e-cross-facility-user-b-${runId}@example.test`
+
+  const { data: userAData, error: userAError } = await supabase.auth.admin.createUser({
+    email: emailA,
+    email_confirm: true,
+  })
+  if (userAError || !userAData.user) {
+    throw new Error(`[E2E cross-facility auth] ユーザーA作成失敗: ${userAError?.message}`)
+  }
+
+  const { data: userBData, error: userBError } = await supabase.auth.admin.createUser({
+    email: emailB,
+    email_confirm: true,
+  })
+  if (userBError || !userBData.user) {
+    throw new Error(`[E2E cross-facility auth] ユーザーB作成失敗: ${userBError?.message}`)
+  }
+
+  const { error: linkAError } = await supabase
+    .from('user_facilities')
+    .insert({ user_id: userAData.user.id, facility_id: facilityA.id, role: 'staff' })
+  if (linkAError) {
+    throw new Error(`[E2E cross-facility auth] ユーザーAの施設紐付け失敗: ${linkAError.message}`)
+  }
+
+  const { error: linkBError } = await supabase
+    .from('user_facilities')
+    .insert({ user_id: userBData.user.id, facility_id: facilityB.id, role: 'staff' })
+  if (linkBError) {
+    throw new Error(`[E2E cross-facility auth] ユーザーBの施設紐付け失敗: ${linkBError.message}`)
+  }
+
+  // シード用の1件はservice role client（RLSをバイパスする）で直接作成する。
+  const loanOrderProcedureName = `クロス施設境界テスト用術式-${runId}`
+  const { error: loanOrderError } = await supabase
+    .from('loan_orders')
+    .insert({
+      facility_id: facilityA.id,
+      procedure_name: loanOrderProcedureName,
+      maker: 'クロス施設境界テスト用メーカー',
+    })
+  if (loanOrderError) {
+    throw new Error(`[E2E cross-facility auth] loan_ordersシード失敗: ${loanOrderError.message}`)
+  }
+
+  await signInAndSaveStorageState(supabase, emailA, CROSS_FACILITY_USER_A_AUTH_PATH)
+  await signInAndSaveStorageState(supabase, emailB, CROSS_FACILITY_USER_B_AUTH_PATH)
+
+  const fixtures: CrossFacilityFixtures = {
+    facilityAId: facilityA.id as string,
+    facilityBId: facilityB.id as string,
+    loanOrderProcedureName,
+  }
+  fs.writeFileSync(CROSS_FACILITY_FIXTURES_PATH, JSON.stringify(fixtures))
+  console.log(`[E2E cross-facility auth] フィクスチャを書き出しました: ${CROSS_FACILITY_FIXTURES_PATH}`)
+}
+
+const isMainModule = process.argv[1]?.endsWith('generate-cross-facility-auth-state.ts')
+if (isMainModule) {
+  generateCrossFacilityAuthState().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,10 @@
 import { generateAuthState } from './generate-auth-state'
+import { generateCrossFacilityAuthState } from './generate-cross-facility-auth-state'
 
 async function globalSetup() {
   await generateAuthState()
+  // issue #321: cross-facility-boundary.spec.ts用の2ユーザー×2施設フィクスチャ
+  await generateCrossFacilityAuthState()
 }
 
 export default globalSetup


### PR DESCRIPTION
## Summary
- `e2e/generate-auth-state.ts` からマジックリンクサインイン＋storageState保存処理を `signInAndSaveStorageState` として共通化した
- `e2e/generate-cross-facility-auth-state.ts` を新規追加し、`supabase/__tests__/integration/helpers/seed-rls-idor.ts` と同様の方式で施設A・施設B、それぞれに所属するユーザーA・ユーザーBを都度作成し、施設Aに `loan_orders` を1件シードした上で2ユーザー分の認証済みstorageStateを生成するようにした
- `e2e/global-setup.ts` にこの新しいセットアップを配線し、`npm run test:e2e`（Playwrightの`globalSetup`経由）で自動的に実行されるようにした（`.github/workflows/e2e.yml`の変更は不要）
- `e2e/cross-facility-boundary.spec.ts` を追加し、ユーザーBが施設Aの `/facilities/{facilityAId}/loan-orders` を開くと `requireFacilityAccess` の403により「一覧の取得に失敗しました」というエラーが表示され、シード済み発注（procedure_name）が見えないことを検証する
- `.gitignore` を `e2e/.auth/user.json` → `e2e/.auth/*.json` に一般化し、新しく増えたauth stateファイルも誤ってコミットされないようにした

## 背景（issue #315からの切り出し）
issue #315にはe2e/smoke.spec.tsへのUIレベルクロス施設境界テスト追加も含まれていたが、調査の結果:
- 実際のページは静的な`/loan-orders`ではなく`/facilities/[id]/loan-orders`という動的ルートだった
- 現状のe2e基盤（`e2e/generate-auth-state.ts`）は単一の固定テストユーザー分のstorageStateしか生成せず、複数ユーザー・複数施設の認証済み状態を扱う仕組みが存在しなかった

このPRで上記の不足していたインフラ（複数ユーザー認証状態生成・動的facility ID・実際のUI境界アサーション）を実装した。

## Test plan
- [x] `npx tsc --noEmit -p .` — 型エラーなし
- [x] `npx vitest run` — 既存含む全604件（98ファイル）pass
- [x] `npm run lint` — 0 error（既存の無関係な警告2件のみ）
- [x] `npx playwright test --list` — 新規スペックを含む全15件のテストが正しく登録されることを確認（構文・importエラーなし）
- [ ] 実際に`npm run test:e2e`を実行しての動作確認 — **この開発環境（sandbox）にはローカルSupabase・dev serverが無く未実施**。ただしCI（`.github/workflows/e2e.yml`）は`supabase start`で毎回フレッシュなローカルDBを用意する構成のため、CI上での実行結果を確認する

Closes #321