### PR TITLE
chore: 未使用の変数・importを削除する

### DIFF
--- a/src/app/api/admin/user-facilities/__tests__/route.test.ts
+++ b/src/app/api/admin/user-facilities/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST, DELETE } from '../route'
 import { NextRequest } from 'next/server'
 
-const mockInsert = vi.fn() // DELETE テストで使用
 const mockGetUser = vi.fn()
 const mockFrom = vi.fn()
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, Suspense, FormEvent, useEffect } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { createSupabaseBrowserClient } from '@/lib/supabase/client'
 
 function LoginForm() {
@@ -12,7 +12,6 @@ function LoginForm() {
 
   const searchParams = useSearchParams()
   const urlError = searchParams.get('error')
-  const router = useRouter()
 
   useEffect(() => {
     const hash = window.location.hash


### PR DESCRIPTION
## Summary
- login/page.tsxの未使用useRouter呼び出しを削除（遷移はwindow.location.hrefで実施済み）
- user-facilities route.test.tsの未参照mockInsertを削除

## Test plan
- [x] `npm run lint` 0 warnings
- [x] `npx vitest run src/app/login src/app/api/admin/user-facilities` 19件PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)