### PR TITLE
fix: issue #25 技術負債の一部対応(SET D・SET I)

### DIFF
--- a/src/app/facilities/[id]/case-orders/new/page.tsx
+++ b/src/app/facilities/[id]/case-orders/new/page.tsx
@@ -15,7 +15,7 @@ export default function NewCaseOrderPage({ params }: { params: Promise<{ id: str
   const [patientInitials, setPatientInitials] = useState('')
   const [gender, setGender] = useState<'male' | 'female' | 'other'>('male')
   const [doctorName, setDoctorName] = useState('')
-  const [items, setItems] = useState<ItemRow[]>([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+  const [items, setItems] = useState<ItemRow[]>(() => [{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/src/app/facilities/[id]/loan-returns/new/page.tsx
+++ b/src/app/facilities/[id]/loan-returns/new/page.tsx
@@ -10,7 +10,7 @@ export default function NewLoanReturnPage({ params }: { params: Promise<{ id: st
   const router = useRouter()
 
   const [returnDatetime, setReturnDatetime] = useState('')
-  const [items, setItems] = useState<ItemRow[]>([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+  const [items, setItems] = useState<ItemRow[]>(() => [{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/src/components/orders/CaseOrderModal.tsx
+++ b/src/components/orders/CaseOrderModal.tsx
@@ -17,7 +17,7 @@ export function CaseOrderModal({ facilityId, isOpen, onClose, onSuccess }: Props
   const [patientInitials, setPatientInitials] = useState('')
   const [gender, setGender] = useState<'male' | 'female' | 'other'>('male')
   const [doctorName, setDoctorName] = useState('')
-  const [items, setItems] = useState<ItemRow[]>([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+  const [items, setItems] = useState<ItemRow[]>(() => [{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -28,7 +28,7 @@ export function CaseOrderModal({ facilityId, isOpen, onClose, onSuccess }: Props
     setPatientInitials('')
     setGender('male')
     setDoctorName('')
-    setItems([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+    setItems([{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
     setError(null)
   }
 

--- a/src/components/orders/ItemRowInput.tsx
+++ b/src/components/orders/ItemRowInput.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 export type ItemRow = {
+  id: string
   jan: string
   lot: string
   ubd: string
@@ -13,7 +14,7 @@ type Props = {
 }
 
 export function ItemRowInput({ rows, onChange }: Props) {
-  const addRow = () => onChange([...rows, { jan: '', lot: '', ubd: '', quantity: 1 }])
+  const addRow = () => onChange([...rows, { id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
   const removeRow = (i: number) => onChange(rows.filter((_, idx) => idx !== i))
   const updateRow = (i: number, field: keyof ItemRow, value: string | number) =>
     onChange(rows.map((r, idx) => (idx === i ? { ...r, [field]: value } : r)))
@@ -27,7 +28,7 @@ export function ItemRowInput({ rows, onChange }: Props) {
         <span className="text-xs font-semibold w-16" style={{ color: '#6B7280' }}>数量</span>
       </div>
       {rows.map((row, i) => (
-        <div key={i} className="flex gap-2 mb-2 items-center">
+        <div key={row.id} className="flex gap-2 mb-2 items-center">
           <input
             type="text"
             value={row.jan}

--- a/src/components/orders/LoanReturnModal.tsx
+++ b/src/components/orders/LoanReturnModal.tsx
@@ -12,13 +12,13 @@ type Props = {
 
 export function LoanReturnModal({ facilityId, isOpen, onClose, onSuccess }: Props) {
   const [returnDatetime, setReturnDatetime] = useState('')
-  const [items, setItems] = useState<ItemRow[]>([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+  const [items, setItems] = useState<ItemRow[]>(() => [{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const resetForm = () => {
     setReturnDatetime('')
-    setItems([{ jan: '', lot: '', ubd: '', quantity: 1 }])
+    setItems([{ id: crypto.randomUUID(), jan: '', lot: '', ubd: '', quantity: 1 }])
     setError(null)
   }
 

--- a/src/components/orders/__tests__/ItemRowInput.nan.test.tsx
+++ b/src/components/orders/__tests__/ItemRowInput.nan.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { ItemRowInput, type ItemRow } from '../ItemRowInput'
 
 describe('ItemRowInput quantity NaNガード', () => {
-  const rows: ItemRow[] = [{ jan: '', lot: '', ubd: '', quantity: 1 }]
+  const rows: ItemRow[] = [{ id: 'row-1', jan: '', lot: '', ubd: '', quantity: 1 }]
 
   it('数量を空文字にしてもNaNではなく0以上の数値がonChangeに渡る', () => {
     const onChange = vi.fn()

--- a/src/components/orders/__tests__/ItemRowInput.test.tsx
+++ b/src/components/orders/__tests__/ItemRowInput.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { ItemRowInput, type ItemRow } from '../ItemRowInput'
 
 describe('ItemRowInput', () => {
-  const defaultRows: ItemRow[] = [{ jan: '', lot: '', ubd: '', quantity: 1 }]
+  const defaultRows: ItemRow[] = [{ id: 'row-1', jan: '', lot: '', ubd: '', quantity: 1 }]
 
   it('初期行のJAN/LOT/UBD/数量フィールドが表示される', () => {
     render(<ItemRowInput rows={defaultRows} onChange={vi.fn()} />)
@@ -13,32 +13,48 @@ describe('ItemRowInput', () => {
     expect(screen.getByPlaceholderText('UBD')).toBeInTheDocument()
   })
 
-  it('「+ 行を追加」クリックでonChangeが2行配列で呼ばれる', async () => {
+  it('「+ 行を追加」クリックでonChangeが2行配列で呼ばれ、新規行に一意なidが付与される', async () => {
     const onChange = vi.fn()
     render(<ItemRowInput rows={defaultRows} onChange={onChange} />)
     await userEvent.click(screen.getByRole('button', { name: '+ 行を追加' }))
-    expect(onChange).toHaveBeenCalledWith([
-      { jan: '', lot: '', ubd: '', quantity: 1 },
-      { jan: '', lot: '', ubd: '', quantity: 1 },
-    ])
+    const result = onChange.mock.calls[0][0] as ItemRow[]
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual(defaultRows[0])
+    expect(result[1]).toMatchObject({ jan: '', lot: '', ubd: '', quantity: 1 })
+    expect(result[1].id).toBeTruthy()
+    expect(result[1].id).not.toBe(result[0].id)
   })
 
   it('JANフィールドへの入力でonChangeが呼ばれる', async () => {
     const onChange = vi.fn()
     render(<ItemRowInput rows={defaultRows} onChange={onChange} />)
     await userEvent.type(screen.getByPlaceholderText('JAN'), 'A')
-    expect(onChange).toHaveBeenLastCalledWith([{ jan: 'A', lot: '', ubd: '', quantity: 1 }])
+    expect(onChange).toHaveBeenLastCalledWith([{ id: 'row-1', jan: 'A', lot: '', ubd: '', quantity: 1 }])
   })
 
   it('削除ボタンで行が取り除かれたonChangeが呼ばれる', async () => {
     const onChange = vi.fn()
     const rows: ItemRow[] = [
-      { jan: 'A', lot: '', ubd: '', quantity: 1 },
-      { jan: 'B', lot: '', ubd: '', quantity: 2 },
+      { id: 'row-1', jan: 'A', lot: '', ubd: '', quantity: 1 },
+      { id: 'row-2', jan: 'B', lot: '', ubd: '', quantity: 2 },
     ]
     render(<ItemRowInput rows={rows} onChange={onChange} />)
     const deleteButtons = screen.getAllByRole('button', { name: '削除' })
     await userEvent.click(deleteButtons[0])
-    expect(onChange).toHaveBeenCalledWith([{ jan: 'B', lot: '', ubd: '', quantity: 2 }])
+    expect(onChange).toHaveBeenCalledWith([{ id: 'row-2', jan: 'B', lot: '', ubd: '', quantity: 2 }])
+  })
+
+  it('行削除時、残った行のidが保持される（配列インデックスkeyによる状態崩れの回帰防止）', async () => {
+    const onChange = vi.fn()
+    const rows: ItemRow[] = [
+      { id: 'row-1', jan: 'A', lot: '', ubd: '', quantity: 1 },
+      { id: 'row-2', jan: 'B', lot: '', ubd: '', quantity: 2 },
+      { id: 'row-3', jan: 'C', lot: '', ubd: '', quantity: 3 },
+    ]
+    render(<ItemRowInput rows={rows} onChange={onChange} />)
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' })
+    await userEvent.click(deleteButtons[0])
+    const result = onChange.mock.calls[0][0] as ItemRow[]
+    expect(result.map(r => r.id)).toEqual(['row-2', 'row-3'])
   })
 })

--- a/src/lib/case-orders/__tests__/repository.test.ts
+++ b/src/lib/case-orders/__tests__/repository.test.ts
@@ -85,4 +85,22 @@ describe('createCaseOrder', () => {
       })
     ).rejects.toThrow('DB error')
   })
+
+  it('DBのgender/statusが想定外の値の場合はフォールバックする', async () => {
+    const db = makeMockRpcDb({
+      data: { ...mockRpcResult, gender: 'unknown', status: 'invalid' },
+      error: null,
+    })
+    const result = await createCaseOrder(db, 'f-1', {
+      caseDatetime: '2026-06-24T10:00:00Z',
+      procedureName: 'TAVI',
+      patientId: 'P001',
+      patientInitials: 'T.S.',
+      gender: 'male',
+      doctorName: '田中医師',
+      items: [],
+    })
+    expect(result.gender).toBe('other')
+    expect(result.status).toBe('draft')
+  })
 })

--- a/src/lib/case-orders/repository.ts
+++ b/src/lib/case-orders/repository.ts
@@ -1,6 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { asString, asOptionalString, asNumber } from '@/lib/mapping'
+import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
 import type { CaseOrder, CaseOrderInput, CaseOrderItem } from '@/types/order'
+
+const GENDERS = ['male', 'female', 'other'] as const
+const STATUSES = ['draft', 'submitted'] as const
 
 interface CaseOrderItemRow {
   id?: unknown
@@ -58,9 +61,9 @@ export async function listCaseOrders(
     procedureName: asString(o.procedure_name),
     patientId: asString(o.patient_id),
     patientInitials: asString(o.patient_initials),
-    gender: asString(o.gender) as 'male' | 'female' | 'other',
+    gender: asEnum(o.gender, GENDERS, 'other'),
     doctorName: asString(o.doctor_name),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: (o.case_order_items ?? []).map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),
@@ -96,9 +99,9 @@ export async function createCaseOrder(db: SupabaseClient, facilityId: string, in
     procedureName: asString(o.procedure_name),
     patientId: asString(o.patient_id),
     patientInitials: asString(o.patient_initials),
-    gender: asString(o.gender) as 'male' | 'female' | 'other',
+    gender: asEnum(o.gender, GENDERS, 'other'),
     doctorName: asString(o.doctor_name),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: itemRows.map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),

--- a/src/lib/consumable-orders/__tests__/repository.test.ts
+++ b/src/lib/consumable-orders/__tests__/repository.test.ts
@@ -49,4 +49,10 @@ describe('createConsumableOrder', () => {
       createConsumableOrder(db, 'f-1', { items: [] })
     ).rejects.toThrow('DB error')
   })
+
+  it('DBのstatusが想定外の値の場合はdraftにフォールバックする', async () => {
+    const db = makeMockRpcDb({ data: { ...mockRpcResult, status: 'invalid' }, error: null })
+    const result = await createConsumableOrder(db, 'f-1', { items: [] })
+    expect(result.status).toBe('draft')
+  })
 })

--- a/src/lib/consumable-orders/repository.ts
+++ b/src/lib/consumable-orders/repository.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { asString, asNumber } from '@/lib/mapping'
+import { asString, asNumber, asEnum } from '@/lib/mapping'
 import type { ConsumableOrder, ConsumableOrderInput, ConsumableOrderItem } from '@/types/order'
+
+const STATUSES = ['draft', 'submitted'] as const
 
 interface ConsumableOrderItemRow {
   id?: unknown
@@ -44,7 +46,7 @@ export async function listConsumableOrders(
   return ((data ?? []) as (ConsumableOrderRow & { consumable_order_items?: ConsumableOrderItemRow[] })[]).map(o => ({
     id: asString(o.id),
     facilityId: asString(o.facility_id),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: (o.consumable_order_items ?? []).map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),
@@ -68,7 +70,7 @@ export async function createConsumableOrder(db: SupabaseClient, facilityId: stri
   return {
     id: asString(o.id),
     facilityId: asString(o.facility_id),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: itemRows.map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),

--- a/src/lib/loan-orders/__tests__/repository.test.ts
+++ b/src/lib/loan-orders/__tests__/repository.test.ts
@@ -57,4 +57,10 @@ describe('createLoanOrder', () => {
       createLoanOrder(db, 'f-1', { procedureName: 'TAVI', maker: 'M', items: [] })
     ).rejects.toThrow('DB error')
   })
+
+  it('DBのstatusが想定外の値の場合はdraftにフォールバックする', async () => {
+    const db = makeMockRpcDb({ data: { ...mockRpcResult, status: 'invalid' }, error: null })
+    const result = await createLoanOrder(db, 'f-1', { procedureName: 'TAVI', maker: 'M', items: [] })
+    expect(result.status).toBe('draft')
+  })
 })

--- a/src/lib/loan-orders/repository.ts
+++ b/src/lib/loan-orders/repository.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { asString, asOptionalString, asNumber } from '@/lib/mapping'
+import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
 import type { LoanOrder, LoanOrderInput, LoanOrderItem } from '@/types/order'
+
+const STATUSES = ['draft', 'submitted'] as const
 
 interface LoanOrderItemRow {
   id?: unknown
@@ -50,7 +52,7 @@ export async function listLoanOrders(
     facilityId: asString(o.facility_id),
     procedureName: asString(o.procedure_name),
     maker: asString(o.maker),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: (o.loan_order_items ?? []).map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),
@@ -79,7 +81,7 @@ export async function createLoanOrder(db: SupabaseClient, facilityId: string, in
     facilityId: asString(o.facility_id),
     procedureName: asString(o.procedure_name),
     maker: asString(o.maker),
-    status: asString(o.status) as 'draft' | 'submitted',
+    status: asEnum(o.status, STATUSES, 'draft'),
     items: itemRows.map(mapItem),
     createdAt: asString(o.created_at),
     updatedAt: asString(o.updated_at),

--- a/src/lib/loan-returns/__tests__/repository.test.ts
+++ b/src/lib/loan-returns/__tests__/repository.test.ts
@@ -31,4 +31,23 @@ describe('createLoanReturn', () => {
     expect(result.status).toBe('draft')
     expect(result.items[0].jan).toBe('490001')
   })
+
+  it('DBのstatusが想定外の値の場合はdraftにフォールバックする', async () => {
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === 'loan_returns') {
+          return { insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { ...mockReturn, status: 'invalid' }, error: null }) })) })) }
+        }
+        if (table === 'loan_return_items') {
+          return { insert: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ data: mockItems, error: null }) })) }
+        }
+      }),
+    } as unknown as SupabaseClient
+
+    const result = await createLoanReturn(db, 'f-1', {
+      returnDatetime: '2026-06-24T15:00:00Z',
+      items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+    })
+    expect(result.status).toBe('draft')
+  })
 })

--- a/src/lib/loan-returns/repository.ts
+++ b/src/lib/loan-returns/repository.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { asString, asOptionalString, asNumber } from '@/lib/mapping'
+import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
 import type { LoanReturn, LoanReturnInput, LoanReturnItem } from '@/types/order'
+
+const STATUSES = ['draft', 'returned'] as const
 
 const LOAN_RETURN_COLUMNS = 'id, facility_id, return_datetime, status, created_at, updated_at'
 // 注: updated_at は Group A のマイグレーション適用前のため明細列挙には含めない
@@ -54,7 +56,7 @@ export async function listLoanReturns(
     id: asString(r.id),
     facilityId: asString(r.facility_id),
     returnDatetime: asString(r.return_datetime),
-    status: asString(r.status) as 'draft' | 'returned',
+    status: asEnum(r.status, STATUSES, 'draft'),
     items: (r.loan_return_items ?? []).map(mapItem),
     createdAt: asString(r.created_at),
     updatedAt: asString(r.updated_at),
@@ -89,7 +91,7 @@ export async function createLoanReturn(db: SupabaseClient, facilityId: string, i
     id: asString(r.id),
     facilityId: asString(r.facility_id),
     returnDatetime: asString(r.return_datetime),
-    status: asString(r.status) as 'draft' | 'returned',
+    status: asEnum(r.status, STATUSES, 'draft'),
     items: (items as LoanReturnItemRow[]).map(mapItem),
     createdAt: asString(r.created_at),
     updatedAt: asString(r.updated_at),


### PR DESCRIPTION
## Summary
issue #25「コードベース技術負債の残作業（SET A-E, G, I）」のうち、規模が小さく着手可能だった2項目に対応。

- **SET I（型安全性改善）**: case-orders/loan-orders/consumable-orders/loan-returns の repository.ts に残っていた無条件asキャスト（`asString(o.status) as 'draft' | 'submitted'` 等、計8箇所）を、既存の asEnum()（price-histories/user-facilities/newsで採用済み）に置き換え。DBから想定外の値が来ても安全側にフォールバックするよう統一
- **SET D（ItemRowInputのkeyバグ）**: `key={i}`（配列インデックス）をReact keyに使っていたのを、ItemRow型に安定したidフィールドを追加しrow.idをkeyに使うよう修正。行削除時にReactが誤って別行のDOM/状態を再利用する不具合を回避

## 未対応（別途トリアージが必要）
- **SET G（セキュリティヘッダー）**: 調査の結果、next.config.ts に既に X-Frame-Options/X-Content-Type-Options/Referrer-Policy が設定済みでした。コード変更不要、issue側のチェックのみで良さそうです
- **SET A/B/C/E**: 範囲調査が必要なため本PRの対象外

## Test plan
- [x] `npm run lint` 0 errors（既存の別PR #327 由来の警告2件のみ残存、本PRのスコープ外）
- [x] `npx tsc --noEmit` 0 errors
- [x] `npm test` 624件全PASS（新規追加分含む: asEnumフォールバック4件、ItemRowInput id関連2件）
- [ ] ブラウザでの実地確認は本worktree環境にSupabase接続情報が無く未実施（ユニットテストで行削除時のid保持を検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
