### PR TITLE
feat: npm run ai:check を新設する(issue #28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "e2e:auth": "npx -y tsx e2e/generate-auth-state.ts",
+    "ai:check": "npm run typecheck && npm run lint && npm run test",
     "loop-summary": "bash scripts/summarize-loop-observability.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
issue #28「AIDD運用改善: 検証コマンド・スコープ明文化・引き継ぎフォーマット整備」のうち、`npm run ai:check`（標準検証コマンド）の新設に対応。

- `typecheck` スクリプトを新設（`tsc --noEmit`。従来script化されていなかった）
- `ai:check` を新設し `typecheck` → `lint` → `test` をまとめて実行

### スコープ判断: e2e/integrationは対象外
issueの原文は「typecheck/lint/test/e2e をまとめる」だが、`test:e2e`/`test:integration` は `.env.test` のテスト専用Supabase接続が前提（docs/agents/common.md）で、未セットアップの環境では `ai:check` 自体が毎回失敗してしまう。標準検証コマンドとして誰でも・どの環境でも安定して回せることを優先し、意図的にインフラ非依存の3つ（typecheck/lint/test）のみを `ai:check` の対象にした。e2e/integrationは従来通り個別コマンドで実行する運用のまま。

### 未対応（本PRの対象外）
- `docs/domain.md` / `docs/decisions/` の整備 → 調査の結果、既に `docs/agents/domain.md` / `docs/agents/decisions.md` として存在しており対応不要
- `AGENTS.md` / `.claude` / `.codex` への作業ルール・引き継ぎフォーマット明記
- hookifyによる `ai:check` 実行漏れ検知

## Test plan
- [x] `npm run ai:check` 実行し typecheck 0 errors → lint 0 errors → test 624件PASS の順で完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
