### PR TITLE
fix: issue #25 技術負債の残作業対応(SET B) - 他SETは対応済み確認

### DIFF
--- a/docs/sessions/2026-07-13-issue25-tech-debt-remaining.md
+++ b/docs/sessions/2026-07-13-issue25-tech-debt-remaining.md
@@ -1,0 +1,41 @@
+# 2026-07-13 issue25-tech-debt-remaining
+
+## 概要
+GitHub issue #25「コードベース技術負債の残作業（SET A-E, G, I）」のうち、SET D・SET IはPR #328で対応済み。
+本セッションでは残るSET A・B・C・E・Gを調査し、実装が必要だったSET Bのみ対応した。
+
+## フロー実行統計
+
+### Phase 1 調査（並列）
+- Explore Sweeper: 5台 × 1ラウンド（SET A/B/C/E/Gそれぞれ担当）
+- 指摘あり: SET B（実質未着手）、SET A・G（軽微な追加改善余地）/ 4セット中3セット
+
+### Phase 2〜5 実装・検証
+- implementer: 5台（並列。新規/編集フォーム10ファイル、一覧ページ4ファイル、admin/users、useEffect cleanup 6ファイル、news/page.tsx）
+- integrator: 0台（実装後の統合検証はメインセッションで直接実施）
+- reviewer: 0台
+- 合計エージェント: 10台（Phase1調査5 + Phase2実装5）
+- 実装成功: 5 / 5グループ
+
+## 結果
+
+### 調査結果（コード変更なし・対応済みと確認）
+- SET A（`data`キー二重化）: 二重化なし。成功レスポンスのキー名不統一（`products`/`orders`/`items`等）は別途の改善余地として見送り
+- SET C（金額入力の空文字→0変換）: 唯一のNULL許容金額カラム`reimbursement_price`は既に正しく処理済み
+- SET E（発注系GET API）: 4種（case-orders/loan-orders/consumable-orders/loan-returns）すべて実装・RLS適用済み
+- SET G（セキュリティヘッダー）: 基本3種（X-Frame-Options等）はissue #13で対応済み。CSP/HSTS/Permissions-Policyの追加は見送り
+
+### 実装結果（SET B: UIエラーハンドリング統一）
+- 新規/編集フォーム10ファイル: `handleSubmit`のfetchをtry/catchで保護
+- 一覧ページ4ファイル: products/page.tsxはエラー表示自体が皆無だったため`error` state新設、他3ファイルは`handleDelete`のtry/catch漏れを修正
+- admin/users/page.tsx: 4ハンドラをtry/catchで保護（テスト新規作成）
+- 6ファイル: `useEffect`に`cancelled`フラグのcleanupガードを追加（AbortControllerではなく既存の軽量パターンを踏襲）
+- news/page.tsx: 成功時に`setError(null)`を呼びエラー残存を解消
+
+### 検証
+- `npm test`: 100ファイル / 640テスト全通過
+- `npm run lint`: エラーなし
+- `npx tsc --noEmit`: エラーなし
+
+## 次の課題
+- SET A（レスポンスキー名統一）・SET C（バリデーションユーティリティ切り出し）・SET G（CSP/HSTS追加）は、本来のissue指摘（二重化・実バグ・基本ヘッダー）は解消済みのため今回は対応せず。将来必要になれば別issueとして起票する

--- a/src/app/admin/users/__tests__/page.test.tsx
+++ b/src/app/admin/users/__tests__/page.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminUsersPage from '../page'
+
+const users = [
+  {
+    id: 'u1',
+    email: 'user1@example.com',
+    lastSignInAt: null,
+    facilities: [{ id: 'f1', role: 'staff' as const }],
+  },
+]
+
+const facilities = [
+  { id: 'f1', name: '施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'f2', name: '施設B', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+]
+
+// 各テストの共通セットアップ: 初回GETを成功させ、一覧展開まで進める
+async function renderExpanded(fetchMock: ReturnType<typeof vi.spyOn>) {
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ users }) } as Response)
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ facilities }) } as Response)
+
+  render(<AdminUsersPage />)
+  await screen.findByText('user1@example.com')
+
+  await userEvent.click(screen.getByText('▼ 展開して設定'))
+}
+
+describe('AdminUsersPage エラーハンドリング', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('handleToggleFacility: fetch自体が例外を投げた場合エラーを表示する', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    await renderExpanded(fetchMock)
+
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    await userEvent.click(screen.getByRole('checkbox', { name: '施設B' }))
+
+    expect(await screen.findByText('エラー: 通信に失敗しました')).toBeInTheDocument()
+  })
+
+  it('handleChangeRole: fetch自体が例外を投げた場合エラーを表示する', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    await renderExpanded(fetchMock)
+
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: '施設Aのrole' }), 'admin')
+
+    expect(await screen.findByText('エラー: 通信に失敗しました')).toBeInTheDocument()
+  })
+
+  it('handleDeleteUser: fetch自体が例外を投げた場合エラーを表示する', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await renderExpanded(fetchMock)
+
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    await userEvent.click(screen.getByText('削除'))
+
+    expect(await screen.findByText('エラー: 通信に失敗しました')).toBeInTheDocument()
+  })
+
+  it('handleInvite: fetch自体が例外を投げた場合エラーを表示する', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    await renderExpanded(fetchMock)
+
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    await userEvent.click(screen.getByText('+ 招待'))
+    await userEvent.type(screen.getByPlaceholderText('メールアドレス'), 'new-user@example.com')
+    await userEvent.click(screen.getByText('招待する'))
+
+    expect(await screen.findByText('エラー: 通信に失敗しました')).toBeInTheDocument()
+  })
+
+  it('全ハンドラでfetch成功時は従来通りエラーを表示しない', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    await renderExpanded(fetchMock)
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+
+    await userEvent.click(screen.getByRole('checkbox', { name: '施設B' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('エラー: 通信に失敗しました')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -45,81 +45,97 @@ export default function AdminUsersPage() {
   }, [refreshKey])
 
   const handleToggleFacility = async (userId: string, facilityId: string, add: boolean) => {
-    const res = await fetch('/api/admin/user-facilities', {
-      method: add ? 'POST' : 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      // add=true 時は role='staff' をデフォルト送信
-      body: JSON.stringify(add ? { userId, facilityId, role: 'staff' } : { userId, facilityId }),
-    })
-    if (!res.ok) {
-      const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
-      showToast(`エラー: ${error}`)
-      return
-    }
-    setUsers(prev =>
-      prev.map(u =>
-        u.id !== userId ? u : {
-          ...u,
-          facilities: add
-            ? [...u.facilities, { id: facilityId, role: 'staff' as const }]
-            : u.facilities.filter(f => f.id !== facilityId),
-        }
+    try {
+      const res = await fetch('/api/admin/user-facilities', {
+        method: add ? 'POST' : 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        // add=true 時は role='staff' をデフォルト送信
+        body: JSON.stringify(add ? { userId, facilityId, role: 'staff' } : { userId, facilityId }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
+        showToast(`エラー: ${error}`)
+        return
+      }
+      setUsers(prev =>
+        prev.map(u =>
+          u.id !== userId ? u : {
+            ...u,
+            facilities: add
+              ? [...u.facilities, { id: facilityId, role: 'staff' as const }]
+              : u.facilities.filter(f => f.id !== facilityId),
+          }
+        )
       )
-    )
+    } catch {
+      showToast('エラー: 通信に失敗しました')
+    }
   }
 
   const handleChangeRole = async (userId: string, facilityId: string, role: 'admin' | 'staff') => {
-    const res = await fetch('/api/admin/user-facilities', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, facilityId, role }),
-    })
-    if (!res.ok) {
-      const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
-      showToast(`エラー: ${error}`)
-      return
-    }
-    setUsers(prev =>
-      prev.map(u =>
-        u.id !== userId ? u : {
-          ...u,
-          facilities: u.facilities.map(f =>
-            f.id === facilityId ? { ...f, role } : f
-          ),
-        }
+    try {
+      const res = await fetch('/api/admin/user-facilities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, facilityId, role }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
+        showToast(`エラー: ${error}`)
+        return
+      }
+      setUsers(prev =>
+        prev.map(u =>
+          u.id !== userId ? u : {
+            ...u,
+            facilities: u.facilities.map(f =>
+              f.id === facilityId ? { ...f, role } : f
+            ),
+          }
+        )
       )
-    )
+    } catch {
+      showToast('エラー: 通信に失敗しました')
+    }
   }
 
   const handleDeleteUser = async (userId: string, email: string) => {
     if (!confirm(`${email} を削除しますか？`)) return
-    const res = await fetch('/api/admin/users', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId }),
-    })
-    if (!res.ok) {
-      const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
-      showToast(`エラー: ${error}`)
-      return
+    try {
+      const res = await fetch('/api/admin/users', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
+        showToast(`エラー: ${error}`)
+        return
+      }
+      setUsers(prev => prev.filter(u => u.id !== userId))
+      showToast('ユーザーを削除しました')
+    } catch {
+      showToast('エラー: 通信に失敗しました')
     }
-    setUsers(prev => prev.filter(u => u.id !== userId))
-    showToast('ユーザーを削除しました')
   }
 
   const handleInvite = async (email: string) => {
-    const res = await fetch('/api/admin/users', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email }),
-    })
-    if (res.ok) {
-      setInviteOpen(false)
-      showToast(`${email} に招待メールを送信しました`)
-      reload()
-    } else {
-      const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
-      showToast(`エラー: ${error}`)
+    try {
+      const res = await fetch('/api/admin/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      if (res.ok) {
+        setInviteOpen(false)
+        showToast(`${email} に招待メールを送信しました`)
+        reload()
+      } else {
+        const { error } = await res.json().catch(() => ({ error: 'エラーが発生しました' }))
+        showToast(`エラー: ${error}`)
+      }
+    } catch {
+      showToast('エラー: 通信に失敗しました')
     }
   }
 

--- a/src/app/categories/[id]/edit/__tests__/page.test.tsx
+++ b/src/app/categories/[id]/edit/__tests__/page.test.tsx
@@ -72,6 +72,22 @@ describe('EditCategoryPage', () => {
     })
   })
 
+  it('更新時のネットワークエラーでエラーメッセージを表示し遷移しない', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ category }) } as Response)
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    await renderPage(params)
+    await waitFor(() => {
+      expect(screen.getByLabelText('カテゴリ名')).toHaveValue('消耗品')
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: '更新' }))
+
+    expect(await screen.findByText('network error')).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
+
   it('取得失敗でエラーメッセージを表示する', async () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
 

--- a/src/app/categories/[id]/edit/page.tsx
+++ b/src/app/categories/[id]/edit/page.tsx
@@ -27,19 +27,23 @@ export default function EditCategoryPage({ params }: { params: Promise<{ id: str
 
   async function handleSubmit(data: CategoryInput) {
     setSubmitError(null)
-    const res = await fetch(`/api/categories/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch(`/api/categories/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setSubmitError(body.error ?? '更新に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSubmitError(body.error ?? '更新に失敗しました')
+        return
+      }
+
+      router.push('/categories')
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '更新に失敗しました')
     }
-
-    router.push('/categories')
   }
 
   if (fetchError && !category) {

--- a/src/app/categories/__tests__/page.test.tsx
+++ b/src/app/categories/__tests__/page.test.tsx
@@ -108,4 +108,20 @@ describe('CategoriesPage', () => {
 
     expect(await screen.findByText('このカテゴリは使用中です')).toBeInTheDocument()
   })
+
+  it('削除でfetchが例外を投げた場合もエラーバナーを表示する', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const fetchMock = vi.spyOn(global, 'fetch')
+    // 初回 GET
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ categories }) } as Response)
+    // DELETE -> ネットワーク例外
+    fetchMock.mockRejectedValueOnce(new Error('network error'))
+
+    render(<CategoriesPage />)
+    await screen.findByText('消耗品')
+
+    await userEvent.click(screen.getAllByText('削除')[0])
+
+    expect(await screen.findByText('削除に失敗しました')).toBeInTheDocument()
+  })
 })

--- a/src/app/categories/new/__tests__/page.test.tsx
+++ b/src/app/categories/new/__tests__/page.test.tsx
@@ -49,6 +49,18 @@ describe('NewCategoryPage', () => {
     expect(push).not.toHaveBeenCalled()
   })
 
+  it('ネットワークエラーでエラーメッセージを表示し遷移しない', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network error'))
+
+    render(<NewCategoryPage />)
+
+    await userEvent.type(screen.getByLabelText('カテゴリ名'), '消耗品')
+    await userEvent.click(screen.getByRole('button', { name: '登録' }))
+
+    expect(await screen.findByText('network error')).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
+
   it('一覧に戻るリンクがある', () => {
     render(<NewCategoryPage />)
     const link = screen.getByRole('link', { name: /カテゴリ一覧に戻る/ })

--- a/src/app/categories/new/page.tsx
+++ b/src/app/categories/new/page.tsx
@@ -12,19 +12,23 @@ export default function NewCategoryPage() {
 
   async function handleSubmit(data: CategoryInput) {
     setSubmitError(null)
-    const res = await fetch('/api/categories', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setSubmitError(body.error ?? '登録に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSubmitError(body.error ?? '登録に失敗しました')
+        return
+      }
+
+      router.push('/categories')
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '登録に失敗しました')
     }
-
-    router.push('/categories')
   }
 
   return (

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -23,13 +23,17 @@ export default function CategoriesPage() {
   async function handleDelete(id: string) {
     if (!confirm('削除しますか？')) return
     setError(null)
-    const res = await fetch(`/api/categories/${id}`, { method: 'DELETE' })
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setError(body.error ?? '削除に失敗しました')
-      return
+    try {
+      const res = await fetch(`/api/categories/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? '削除に失敗しました')
+        return
+      }
+      refresh()
+    } catch {
+      setError('削除に失敗しました')
     }
-    refresh()
   }
 
   return (

--- a/src/app/distributor-products/[id]/edit/__tests__/page.test.tsx
+++ b/src/app/distributor-products/[id]/edit/__tests__/page.test.tsx
@@ -84,6 +84,22 @@ describe('EditDistributorProductPage', () => {
     expect(pushMock).not.toHaveBeenCalled()
   })
 
+  it('ネットワークエラーで submitError を表示する', async () => {
+    global.fetch = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') return Promise.reject(new Error('network error'))
+      if (url === '/api/distributor-products/dp1') {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ item }) })
+      }
+      if (url === '/api/products') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ products }) })
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ categories }) })
+    }) as unknown as typeof fetch
+    render(<EditDistributorProductPage params={params()} />)
+    await screen.findByDisplayValue('商品A')
+    await userEvent.click(screen.getByRole('button', { name: '更新' }))
+    expect(await screen.findByText('network error')).toBeInTheDocument()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
   it('item 取得失敗でエラーメッセージを表示する', async () => {
     global.fetch = setupFetch({ itemOk: false }) as unknown as typeof fetch
     render(<EditDistributorProductPage params={params()} />)

--- a/src/app/distributor-products/[id]/edit/page.tsx
+++ b/src/app/distributor-products/[id]/edit/page.tsx
@@ -40,19 +40,23 @@ export default function EditDistributorProductPage({ params }: { params: Promise
 
   async function handleSubmit(data: DistributorProductInput) {
     setSubmitError(null)
-    const res = await fetch(`/api/distributor-products/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch(`/api/distributor-products/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setSubmitError(body.error ?? '更新に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSubmitError(body.error ?? '更新に失敗しました')
+        return
+      }
+
+      router.push('/distributor-products')
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '更新に失敗しました')
     }
-
-    router.push('/distributor-products')
   }
 
   if (loadError && !item) {

--- a/src/app/distributor-products/__tests__/page.test.tsx
+++ b/src/app/distributor-products/__tests__/page.test.tsx
@@ -111,4 +111,19 @@ describe('DistributorProductsPage', () => {
     await userEvent.click(screen.getByText('削除'))
     expect(await screen.findByText('削除に失敗しました')).toBeInTheDocument()
   })
+
+  it('削除でfetchが例外を投げた場合もエラーバナーを表示する', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return Promise.reject(new Error('network error'))
+      if (url === '/api/distributor-products') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ items }) })
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ categories }) })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<DistributorProductsPage />)
+    await screen.findByText('商品A')
+    await userEvent.click(screen.getByText('削除'))
+    expect(await screen.findByText('削除に失敗しました')).toBeInTheDocument()
+  })
 })

--- a/src/app/distributor-products/new/__tests__/page.test.tsx
+++ b/src/app/distributor-products/new/__tests__/page.test.tsx
@@ -66,4 +66,18 @@ describe('NewDistributorProductPage', () => {
     expect(await screen.findByText('登録に失敗しました')).toBeInTheDocument()
     expect(pushMock).not.toHaveBeenCalled()
   })
+
+  it('ネットワークエラーで submitError を表示する', async () => {
+    global.fetch = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') return Promise.reject(new Error('network error'))
+      if (url === '/api/products') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ products }) })
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ categories }) })
+    }) as unknown as typeof fetch
+    render(<NewDistributorProductPage />)
+    await screen.findByText('カテゴリA')
+    await fillForm()
+    await userEvent.click(screen.getByRole('button', { name: '登録' }))
+    expect(await screen.findByText('network error')).toBeInTheDocument()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/app/distributor-products/new/page.tsx
+++ b/src/app/distributor-products/new/page.tsx
@@ -32,19 +32,23 @@ export default function NewDistributorProductPage() {
 
   async function handleSubmit(data: DistributorProductInput) {
     setSubmitError(null)
-    const res = await fetch('/api/distributor-products', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch('/api/distributor-products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setSubmitError(body.error ?? '登録に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSubmitError(body.error ?? '登録に失敗しました')
+        return
+      }
+
+      router.push('/distributor-products')
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '登録に失敗しました')
     }
-
-    router.push('/distributor-products')
   }
 
   return (

--- a/src/app/distributor-products/page.tsx
+++ b/src/app/distributor-products/page.tsx
@@ -30,14 +30,18 @@ export default function DistributorProductsPage() {
 
   async function handleDelete(id: string) {
     if (!window.confirm('削除しますか？')) return
-    const res = await fetch(`/api/distributor-products/${id}`, { method: 'DELETE' })
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      setError(body.error ?? '削除に失敗しました')
-      return
+    try {
+      const res = await fetch(`/api/distributor-products/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? '削除に失敗しました')
+        return
+      }
+      setError(null)
+      refresh()
+    } catch {
+      setError('削除に失敗しました')
     }
-    setError(null)
-    refresh()
   }
 
   return (

--- a/src/app/facilities/[id]/case-orders/page.tsx
+++ b/src/app/facilities/[id]/case-orders/page.tsx
@@ -16,11 +16,15 @@ export default function CaseOrdersPage({ params }: { params: Promise<{ id: strin
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     fetch(`/api/case-orders?facility_id=${id}`)
       .then(r => { if (!r.ok) throw new Error(); return r.json() })
-      .then(d => setOrders(d.orders ?? []))
-      .catch(() => setError('一覧の取得に失敗しました'))
-      .finally(() => setLoading(false))
+      .then(d => { if (!cancelled) setOrders(d.orders ?? []) })
+      .catch(() => { if (!cancelled) setError('一覧の取得に失敗しました') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => {
+      cancelled = true
+    }
   }, [id])
 
   const labelClass = 'text-xs font-semibold uppercase tracking-widest'

--- a/src/app/facilities/[id]/consumable-orders/new/page.tsx
+++ b/src/app/facilities/[id]/consumable-orders/new/page.tsx
@@ -19,10 +19,14 @@ export default function NewConsumableOrderPage({ params }: { params: Promise<{ i
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     fetch(`/api/consumables?facilityId=${id}`)
       .then(r => r.json())
-      .then(d => setConsumables(d.consumables ?? []))
-      .catch(() => setError('消耗品の取得に失敗しました'))
+      .then(d => { if (!cancelled) setConsumables(d.consumables ?? []) })
+      .catch(() => { if (!cancelled) setError('消耗品の取得に失敗しました') })
+    return () => {
+      cancelled = true
+    }
   }, [id])
 
   const filtered = activeTab === 'ALL' ? consumables : consumables.filter(c => c.purpose === activeTab)

--- a/src/app/facilities/[id]/consumable-orders/page.tsx
+++ b/src/app/facilities/[id]/consumable-orders/page.tsx
@@ -16,11 +16,15 @@ export default function ConsumableOrdersPage({ params }: { params: Promise<{ id:
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     fetch(`/api/consumable-orders?facility_id=${id}`)
       .then(r => { if (!r.ok) throw new Error(); return r.json() })
-      .then(d => setOrders(d.orders ?? []))
-      .catch(() => setError('一覧の取得に失敗しました'))
-      .finally(() => setLoading(false))
+      .then(d => { if (!cancelled) setOrders(d.orders ?? []) })
+      .catch(() => { if (!cancelled) setError('一覧の取得に失敗しました') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => {
+      cancelled = true
+    }
   }, [id])
 
   const labelStyle = { color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }

--- a/src/app/facilities/[id]/edit/page.tsx
+++ b/src/app/facilities/[id]/edit/page.tsx
@@ -23,23 +23,27 @@ export default function EditFacilityPage({ params }: { params: Promise<{ id: str
 
   async function handleSubmit(data: FacilityInput) {
     setError(null)
-    const res = await fetch(`/api/facilities/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch(`/api/facilities/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      if (res.status === 409) {
-        setError('施設名は既に使用されています')
+      if (!res.ok) {
+        if (res.status === 409) {
+          setError('施設名は既に使用されています')
+          return
+        }
+        const body = await res.json()
+        setError(body.error ?? '更新に失敗しました')
         return
       }
-      const body = await res.json()
-      setError(body.error ?? '更新に失敗しました')
-      return
-    }
 
-    router.push('/facilities')
+      router.push('/facilities')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました')
+    }
   }
 
   if (error && !facility) {

--- a/src/app/facilities/[id]/loan-orders/page.tsx
+++ b/src/app/facilities/[id]/loan-orders/page.tsx
@@ -16,11 +16,15 @@ export default function LoanOrdersPage({ params }: { params: Promise<{ id: strin
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     fetch(`/api/loan-orders?facility_id=${id}`)
       .then(r => { if (!r.ok) throw new Error(); return r.json() })
-      .then(d => setOrders(d.orders ?? []))
-      .catch(() => setError('一覧の取得に失敗しました'))
-      .finally(() => setLoading(false))
+      .then(d => { if (!cancelled) setOrders(d.orders ?? []) })
+      .catch(() => { if (!cancelled) setError('一覧の取得に失敗しました') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => {
+      cancelled = true
+    }
   }, [id])
 
   const labelStyle = { color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }

--- a/src/app/facilities/[id]/loan-returns/page.tsx
+++ b/src/app/facilities/[id]/loan-returns/page.tsx
@@ -16,11 +16,15 @@ export default function LoanReturnsPage({ params }: { params: Promise<{ id: stri
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     fetch(`/api/loan-returns?facility_id=${id}`)
       .then(r => { if (!r.ok) throw new Error(); return r.json() })
-      .then(d => setReturns(d.returns ?? []))
-      .catch(() => setError('一覧の取得に失敗しました'))
-      .finally(() => setLoading(false))
+      .then(d => { if (!cancelled) setReturns(d.returns ?? []) })
+      .catch(() => { if (!cancelled) setError('一覧の取得に失敗しました') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => {
+      cancelled = true
+    }
   }, [id])
 
   const labelStyle = { color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }

--- a/src/app/facilities/new/page.tsx
+++ b/src/app/facilities/new/page.tsx
@@ -12,23 +12,27 @@ export default function NewFacilityPage() {
 
   async function handleSubmit(data: FacilityInput) {
     setError(null)
-    const res = await fetch('/api/facilities', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch('/api/facilities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      if (res.status === 409) {
-        setError('施設名は既に使用されています')
+      if (!res.ok) {
+        if (res.status === 409) {
+          setError('施設名は既に使用されています')
+          return
+        }
+        const body = await res.json()
+        setError(body.error ?? '登録に失敗しました')
         return
       }
-      const body = await res.json()
-      setError(body.error ?? '登録に失敗しました')
-      return
-    }
 
-    router.push('/facilities')
+      router.push('/facilities')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '登録に失敗しました')
+    }
   }
 
   return (

--- a/src/app/hospital-prices/[id]/edit/page.tsx
+++ b/src/app/hospital-prices/[id]/edit/page.tsx
@@ -41,27 +41,31 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
 
   async function handleSubmit(data: HospitalPriceInput) {
     setError(null)
-    const res = await fetch(`/api/hospital-prices/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch(`/api/hospital-prices/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      if (res.status === 404) {
-        setError('価格情報が見つかりません')
-      } else if (res.status === 422) {
-        setError('施設または代理店商品が存在しません')
-      } else if (res.status === 409) {
-        setError('この施設と商品の組み合わせは既に登録されています')
-      } else {
-        const body = await res.json()
-        setError(body.error ?? '更新に失敗しました')
+      if (!res.ok) {
+        if (res.status === 404) {
+          setError('価格情報が見つかりません')
+        } else if (res.status === 422) {
+          setError('施設または代理店商品が存在しません')
+        } else if (res.status === 409) {
+          setError('この施設と商品の組み合わせは既に登録されています')
+        } else {
+          const body = await res.json()
+          setError(body.error ?? '更新に失敗しました')
+        }
+        return
       }
-      return
-    }
 
-    router.push('/hospital-prices')
+      router.push('/hospital-prices')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました')
+    }
   }
 
   if (error && !price) {

--- a/src/app/hospital-prices/__tests__/page.test.tsx
+++ b/src/app/hospital-prices/__tests__/page.test.tsx
@@ -219,4 +219,23 @@ describe('HospitalPricesPage', () => {
     const select = screen.getByRole('combobox') as HTMLSelectElement
     expect(select.children.length).toBe(0)
   })
+
+  it('削除でfetchが例外を投げた場合もエラーバナーを表示する', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return Promise.reject(new Error('network error'))
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [facilities[0]] }))
+      if (url === '/api/distributor-products') return Promise.resolve(jsonResponse({ items: distributorProducts }))
+      const match = url.match(/^\/api\/hospital-prices\?facilityId=(.+)$/)
+      if (match) return Promise.resolve(jsonResponse({ prices }))
+      return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<HospitalPricesPage />)
+    await screen.findByText('テスト商品A')
+
+    await userEvent.click(screen.getAllByRole('button', { name: '削除' })[0])
+
+    expect(await screen.findByText('削除に失敗しました')).toBeInTheDocument()
+  })
 })

--- a/src/app/hospital-prices/new/page.tsx
+++ b/src/app/hospital-prices/new/page.tsx
@@ -33,25 +33,29 @@ export default function NewHospitalPricePage() {
 
   async function handleSubmit(data: HospitalPriceInput) {
     setError(null)
-    const res = await fetch('/api/hospital-prices', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch('/api/hospital-prices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      if (res.status === 409) {
-        setError('この施設と商品の組み合わせは既に登録されています')
-      } else if (res.status === 422) {
-        setError('施設または代理店商品が存在しません')
-      } else {
-        const body = await res.json()
-        setError(body.error ?? '登録に失敗しました')
+      if (!res.ok) {
+        if (res.status === 409) {
+          setError('この施設と商品の組み合わせは既に登録されています')
+        } else if (res.status === 422) {
+          setError('施設または代理店商品が存在しません')
+        } else {
+          const body = await res.json()
+          setError(body.error ?? '登録に失敗しました')
+        }
+        return
       }
-      return
-    }
 
-    router.push('/hospital-prices')
+      router.push('/hospital-prices')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '登録に失敗しました')
+    }
   }
 
   return (

--- a/src/app/hospital-prices/page.tsx
+++ b/src/app/hospital-prices/page.tsx
@@ -88,13 +88,17 @@ function HospitalPricesPageInner() {
 
   async function handleDelete(id: string) {
     setError(null)
-    const res = await fetch(`/api/hospital-prices/${id}`, { method: 'DELETE' })
-    if (!res.ok) {
-      const body = await res.json()
-      setError(body.error ?? '削除に失敗しました')
-      return
+    try {
+      const res = await fetch(`/api/hospital-prices/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json()
+        setError(body.error ?? '削除に失敗しました')
+        return
+      }
+      refresh()
+    } catch {
+      setError('削除に失敗しました')
     }
-    refresh()
   }
 
   function handleFacilityChange(newId: string) {

--- a/src/app/news/__tests__/page.test.tsx
+++ b/src/app/news/__tests__/page.test.tsx
@@ -192,6 +192,40 @@ describe('NewsPage', () => {
     expect(screen.queryByRole('option', { name: '全施設' })).not.toBeInTheDocument()
   })
 
+  it('一度エラーが表示された後、「もっと見る」の再取得が成功したらエラーメッセージが消える（issue #25）', async () => {
+    const page0 = Array.from({ length: 20 }, (_, i) => makeItem(`p0-${i}`, '2026-07-08T00:00:00Z'))
+    const page1 = [makeItem('p1-0', '2026-07-07T00:00:00Z')]
+    let loadMoreCallCount = 0
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [facilities[0]] }))
+      if (url === '/api/news?facilityId=f1&limit=20&offset=0') return Promise.resolve(jsonResponse({ items: page0 }))
+      if (url === '/api/news?facilityId=f1&limit=20&offset=20') {
+        loadMoreCallCount += 1
+        if (loadMoreCallCount === 1) {
+          return Promise.resolve(jsonResponse({ error: 'server error' }, { status: 500 }))
+        }
+        return Promise.resolve(jsonResponse({ items: page1 }))
+      }
+      return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+
+    render(<NewsPage />)
+    const loadMoreButton = await screen.findByRole('button', { name: 'もっと見る' })
+
+    // 1回目: もっと見るの取得が失敗し、エラーメッセージが表示される
+    await user.click(loadMoreButton)
+    expect(await screen.findByText('データの取得に失敗しました')).toBeInTheDocument()
+
+    // 2回目: 再度もっと見るを押して取得が成功すると、古いエラーメッセージが消える
+    await user.click(loadMoreButton)
+    await waitFor(() => {
+      expect(screen.queryByText('データの取得に失敗しました')).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText('商品p1-0', { exact: false })).toBeInTheDocument()
+  })
+
   it('施設が0件の場合、お知らせはありませんと表示される', async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [] }))

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -52,6 +52,8 @@ function NewsPageInner() {
         if (resolvedFacilityId !== urlFacilityId && resolvedFacilityId) {
           router.replace(`/news?facilityId=${encodeURIComponent(resolvedFacilityId)}`)
         }
+
+        setError(null)
       } catch {
         if (!cancelled) setError('データの取得に失敗しました')
       }
@@ -72,6 +74,7 @@ function NewsPageInner() {
       if (!selectedFacilityId && !isAdmin) {
         setItems([])
         setHasMore(false)
+        setError(null)
         return
       }
       try {
@@ -85,6 +88,7 @@ function NewsPageInner() {
         setItems(data.items)
         setOffset(PAGE_SIZE)
         setHasMore(data.items.length === PAGE_SIZE)
+        setError(null)
       } catch {
         if (!cancelled) setError('データの取得に失敗しました')
       }
@@ -107,6 +111,7 @@ function NewsPageInner() {
       setItems((prev) => [...prev, ...data.items])
       setOffset((prev) => prev + PAGE_SIZE)
       setHasMore(data.items.length === PAGE_SIZE)
+      setError(null)
     } catch {
       setError('データの取得に失敗しました')
     }

--- a/src/app/products/[id]/edit/__tests__/page.test.tsx
+++ b/src/app/products/[id]/edit/__tests__/page.test.tsx
@@ -1,9 +1,14 @@
 import { Suspense } from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import EditProductPage from '../page'
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 async function renderPage(p: Promise<{ id: string }>) {
   await act(async () => {
@@ -41,5 +46,39 @@ describe('EditProductPage', () => {
     expect(screen.getByLabelText('メーカー名')).toHaveValue('テルモ')
     expect(screen.getByLabelText('JAN コード')).toHaveValue('4900000000001')
     expect(screen.getByLabelText('REF コード')).toHaveValue('REF-1')
+  })
+
+  it('更新時にネットワークエラーが発生した場合エラーメッセージを表示する', async () => {
+    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            product: {
+              id: '1',
+              jan: '4900000000001',
+              ref: 'REF-1',
+              name: 'カテーテルAB型',
+              maker: 'テルモ',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          }),
+      })
+      .mockRejectedValueOnce(new Error('network error')) as unknown as typeof fetch
+
+    await renderPage(Promise.resolve({ id: '1' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('製品名')).toHaveValue('カテーテルAB型')
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: '更新' }))
+
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith('network error')
+    })
   })
 })

--- a/src/app/products/[id]/edit/page.tsx
+++ b/src/app/products/[id]/edit/page.tsx
@@ -26,19 +26,23 @@ export default function EditProductPage({ params }: { params: Promise<{ id: stri
   }, [id])
 
   async function handleSubmit(data: ProductInput) {
-    const res = await fetch(`/api/products/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch(`/api/products/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json()
-      alert(body.error ?? '更新に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json()
+        alert(body.error ?? '更新に失敗しました')
+        return
+      }
+
+      router.push('/products')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : '更新に失敗しました')
     }
-
-    router.push('/products')
   }
 
   if (error) {

--- a/src/app/products/__tests__/page.test.tsx
+++ b/src/app/products/__tests__/page.test.tsx
@@ -40,4 +40,26 @@ describe('ProductsPage handleDelete', () => {
     await waitFor(() => expect(calls.filter((c) => c === 'list')).toHaveLength(2))
     expect(calls.indexOf('delete-end')).toBeLessThan(calls.lastIndexOf('list'))
   })
+
+  it('一覧取得(GET)が失敗した場合、エラーバナーを表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+    render(<ProductsPage />)
+
+    expect(await screen.findByText('一覧の取得に失敗しました')).toBeInTheDocument()
+  })
+
+  it('削除(DELETE)がネットワーク例外を投げた場合、alertでユーザーに通知する', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return Promise.reject(new Error('network error'))
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ products: [{ id: '1', jan: '4900000000001', ref: 'R1' }] }) })
+    }) as unknown as typeof fetch
+
+    render(<ProductsPage />)
+    await screen.findByText('4900000000001')
+
+    await userEvent.click(screen.getAllByRole('button', { name: '削除' })[0])
+
+    await waitFor(() => expect(global.alert).toHaveBeenCalledWith('削除に失敗しました'))
+  })
 })

--- a/src/app/products/new/page.tsx
+++ b/src/app/products/new/page.tsx
@@ -9,19 +9,23 @@ export default function NewProductPage() {
   const router = useRouter()
 
   async function handleSubmit(data: ProductInput) {
-    const res = await fetch('/api/products', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
+    try {
+      const res = await fetch('/api/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
 
-    if (!res.ok) {
-      const body = await res.json()
-      alert(body.error ?? '登録に失敗しました')
-      return
+      if (!res.ok) {
+        const body = await res.json()
+        alert(body.error ?? '登録に失敗しました')
+        return
+      }
+
+      router.push('/products')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : '登録に失敗しました')
     }
-
-    router.push('/products')
   }
 
   return (

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -8,26 +8,32 @@ import { ProductList } from '@/components/products/ProductList'
 export default function ProductsPage() {
   const router = useRouter()
   const [products, setProducts] = useState<Product[]>([])
+  const [error, setError] = useState<string | null>(null)
   const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
 
   useEffect(() => {
     let cancelled = false
     fetch('/api/products')
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
       .then((d) => { if (!cancelled) setProducts(d.products) })
+      .catch(() => { if (!cancelled) setError('一覧の取得に失敗しました') })
     return () => { cancelled = true }
   }, [refreshKey])
 
   async function handleDelete(id: string) {
     if (!confirm('削除しますか？')) return
-    // WHY: DELETE完了をawaitで待ってから再取得しないと、削除前のデータが再描画され不整合が起きるため
-    const res = await fetch(`/api/products/${id}`, { method: 'DELETE' })
-    if (!res.ok) {
-      const body = await res.json()
-      alert(body.error ?? '削除に失敗しました')
-      return
+    try {
+      // WHY: DELETE完了をawaitで待ってから再取得しないと、削除前のデータが再描画され不整合が起きるため
+      const res = await fetch(`/api/products/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json()
+        alert(body.error ?? '削除に失敗しました')
+        return
+      }
+      refresh()
+    } catch {
+      alert('削除に失敗しました')
     }
-    refresh()
   }
 
   return (
@@ -49,6 +55,8 @@ export default function ProductsPage() {
           + 新規登録
         </button>
       </div>
+
+      {error && <p className="mb-4 text-red-600">{error}</p>}
 
       <div className="rounded bg-white shadow-sm overflow-hidden" style={{ border: '1px solid #E5E7EB' }}>
         <ProductList

--- a/src/components/orders/ConsumableOrderModal.tsx
+++ b/src/components/orders/ConsumableOrderModal.tsx
@@ -21,10 +21,14 @@ export function ConsumableOrderModal({ facilityId, isOpen, onClose, onSuccess }:
 
   useEffect(() => {
     if (!isOpen) return
+    let cancelled = false
     fetch(`/api/consumables?facilityId=${facilityId}`)
       .then(r => r.json())
-      .then(d => setConsumables(d.consumables ?? []))
-      .catch(() => setError('消耗品の取得に失敗しました'))
+      .then(d => { if (!cancelled) setConsumables(d.consumables ?? []) })
+      .catch(() => { if (!cancelled) setError('消耗品の取得に失敗しました') })
+    return () => {
+      cancelled = true
+    }
   }, [isOpen, facilityId])
 
   const resetForm = () => {


### PR DESCRIPTION
## Summary
- issue #25「コードベース技術負債の残作業（SET A-E, G, I）」のうち、SET D・SET IはPR #328で対応済み。残るSET A・B・C・E・Gを調査した結果、実質対応が必要だったのはSET Bのみだった
- SET B（UIエラーハンドリング統一）: fetch呼び出しのtry/catch漏れ・useEffectのcleanupガード漏れ・エラー残存を、既存の確立済みパターン（発注フォームのtry/catch、hospital-pricesの`cancelled`フラグ）に合わせて修正
- SET A（レスポンス`data`キー二重化）・SET C（金額バリデーション）・SET E（発注系GET API）・SET G（セキュリティヘッダー）は調査の結果、既存issueで対応済み・実バグなしと確認（コード変更なし）

Closes #25

## Test plan
- [x] `npm test` (100 files / 640 tests, all passing)
- [x] `npm run lint` (no errors)
- [x] `npx tsc --noEmit` (no errors)
- [x] 変更前後のパターン整合性を目視確認（発注フォームtry/catch、hospital-pricesのcancelledフラグと同一パターンを踏襲）

## 作業サマリ
- 変更した目的: issue #25の残SET（A/B/C/E/G）の棚卸しと、実質未着手だったSET B（UIエラーハンドリング統一）の実装
- 変更した範囲: src/app/products,distributor-products,categories,facilities,hospital-prices,admin/users,news配下の一覧・新規・編集ページ、src/components/orders/ConsumableOrderModal.tsx（計32ファイル）。いずれもクライアント側fetchのtry/catch追加・useEffect cleanupガード追加・エラーstateクリア処理の追加のみ
- 触っていない範囲: API Routes・DBスキーマ・RLS・型定義は一切変更していない。SET A（レスポンスキー名統一）・SET C（バリデーションユーティリティ切り出し）・SET G（CSP/HSTS追加）は本来のissue指摘（二重化・実バグ・基本ヘッダー）が解消済みのため見送り

## 検証済み
- 実行したコマンド: `npm test`（640件全パス）、`npm run lint`（エラーなし）、`npx tsc --noEmit`（エラーなし）。`npm run ai:check`は未実行（本変更はTRI/RISK基準のうちfacilityドメインのパスに触れるがDB/RLS/authロジック自体には触れていないクライアント側UIロジックのみのため）
- 確認した画面: なし（ブラウザでの目視確認は未実施。ロジック変更は各ページ対応の単体テストで検証）
- 確認したDB/RLS: 対象外（本PRはクライアント側のfetchエラーハンドリングのみでDB/RLSに関与しない）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（RLS/facility境界のロジック自体は変更していないため）

## 既知の未対応
- 今回あえて対応しなかったこと: SET A（成功レスポンスのキー名がエンドポイントごとに不統一）、SET C（金額バリデーションの共通ユーティリティ化）、SET G（CSP/HSTS/Permissions-Policy追加）
- 理由: これらは元issueが本来指摘していた問題（二重化・実バグ・基本ヘッダー欠如）ではなく、調査の過程で見つかった別種の改善余地のため。ユーザーとスコープを確認した上で今回は見送りとした
- 次に触るなら見る場所: 上記3点を実施する場合は別issueとして起票し、SET Aは全APIエンドポイント+呼び出し元フロントの横断変更になるため影響範囲の洗い出しから始めること

## 後任AIへの注意
- この実装で壊してはいけない前提: `products/page.tsx`のみ`alert()`ベースのエラー通知（他は`error` state + バナー表示）。意図的な使い分けなので統一する場合は別途検討が必要
- 似ているが別物の用語: 本PRの`cancelled`フラグ（setState抑止のみ）とAbortController（実際のリクエスト中断、本PRでは未導入）は別物。issue原文はAbortControllerを明記しているが、既存コードベースの確立済みパターンに合わせてcancelledフラグ方式を採用した（ユーザー承認済み）
- 勝手にリファクタしない場所: 各ファイルへのインライン try/catch のみで、共通hook（useFetch等）は意図的に導入していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)