### PR TITLE
fix: issue #26 既存バグ・DB問題の残作業を修正する

### DIFF
--- a/docs/sessions/2026-07-13-issue26-bugfix-triage.md
+++ b/docs/sessions/2026-07-13-issue26-bugfix-triage.md
@@ -1,0 +1,59 @@
+# 2026-07-13 issue26-bugfix-triage
+
+## 対応issue
+- issue #26「既存バグ・DB問題の修正（旧Phase1調査214件ベース）」
+
+## やったこと
+issue #26 の5項目それぞれについて、既にissue #24（closed）・issue #25（open, PR #328でSET D/I対応済み）で
+重複解消されていないかを5並列Exploreエージェントで調査した上で、実際に残っていた項目のみ修正した。
+
+### 項目ごとの判定と対応
+
+| 項目 | 判定 | 対応 |
+|---|---|---|
+| 1. セキュリティ修正（RLS・SECURITY DEFINER最小権限化等） | 対応済み（issue #24等） | 変更なし |
+| 2. DB設計バグ（CASCADE・JAN未紐付け・インデックス） | CASCADE/インデックスは対応済み。consumables.janが未FK化だったため一部残課題 | `supabase/migrations/20260714000004_link_consumables_jan_and_validate_fk.sql` でconsumables.janのFK追加＋既存jan FK群のVALIDATE CONSTRAINT実行 |
+| 3. エラーハンドリング統一 | APIレスポンス統一・handleDelete await漏れは対応済み。products/page.tsxのcatch漏れのみ残課題 | `src/app/products/page.tsx` にcatch追加・エラー表示UI追加 |
+| 4. 型安全性（無条件キャスト） | repository層はPR #328で対応済み。admin/users/route.tsのみ未対応 | `src/app/api/admin/users/route.ts` の `role as 'admin'\|'staff'` を `asEnum()` に置換 |
+| 5. UI・フォームバグ | ホバースタイル・ItemRowInput key・金額バリデーションは対応済み。CaseOrderModalの必須項目バリデーション欠落のみ残課題 | `src/components/orders/CaseOrderModal.tsx` に caseDatetime/patientId/patientInitials/doctorName の空送信バリデーションを追加 |
+
+### あえて対応しなかったこと
+- **AbortController未導入・注文一覧4ページ（case-orders/consumable-orders/loan-orders/loan-returns）のcancelledガード**: React 19ではアンマウント後のsetStateが無害化される（警告も出ない）ため、実害のある不具合として再現できなかった。プロジェクト全体へのAbortController導入は本issueのスコープを超える大掛かりな変更になるため見送った。issue #25 SET Bとして引き続き管理する。
+- **LoanReturnModalのreturnDatetimeバリデーション**: 現状HTML `required` 属性で空送信は防げており機能的なバグではない（CaseOrderModalは`*`表示があるのにJSチェックが完全に欠落していた点が実バグだった）。実装方式の不統一のみで、今回は対象外とした。
+
+## フロー実行時間
+- Phase 1（調査・重複確認）: 並列Exploreエージェント5台、約3.5分
+- Phase 2〜5（実装）: TDD（Red→Green）で4項目を直列実装
+- AI稼働合計: 約40分
+- セッション総時間: 人間レビュー（進め方確認の1回）含め約45分
+
+## フロー実行統計
+### Phase 1 調査
+- Sweeper: Explore agent 5台 × 1ラウンド（並列）
+- 指摘あり軸数: 4 / 5（項目1は指摘なし＝対応済み確認のみ）
+
+### Phase 2〜5 実装・検証
+- implementer: 本セッション内で直接実装（1名・直列、TDD Red→Green）
+- integrator: 該当なし（単一セッション内完結）
+- reviewer: 該当なし（npm test / lint / tsc --noEmit で検証）
+- 合計エージェント: 5台（Phase1のみ）
+- 実装成功: 4 / 4項目
+
+## Loop Observability要約
+このセッション中の新規記録なし（AIDDフロー本体を経由しないTDD直接実装のため対象外）
+
+## 検証済み
+- 実行したコマンド: `npx vitest run`（630件全緑）, `npm run lint`（エラーなし）, `npx tsc --noEmit`（エラーなし）, `supabase db reset --local`（新規マイグレーション適用確認）。`npm run ai:check` は `test:e2e` が `.env.test` 未設定によりこの環境では実行不可（既存の環境制約であり今回の変更による回帰ではない）
+- 確認した画面: なし（バックエンド・単体テストのみで検証）
+- 確認したDB/RLS: ローカルSupabaseで新規migrationの冪等性・既存jan FKのVALIDATE CONSTRAINT成功（孤児データ0件）を確認
+- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（今回の変更はRLS/facility境界に触れていない）
+
+## 結果
+- うまくいったこと: 5並列調査により214件ベースの旧issueのうち大部分が既に他issueで解消済みと判明し、実装が必要な範囲を4件の小さな変更に絞り込めた
+- 問題・気になった点: consumables.jan FKはNOT VALIDで追加後にVALIDATE CONSTRAINTしているが、本番DBに孤児データが存在する場合はデプロイ時にマイグレーションが失敗する（意図的な挙動だが、事前に本番データを確認できていない）
+- 次の課題: issue #25 SET B（AbortController・catch漏れの残り）、issue #25 SET A/C/E/Gは本issueの対象外のため引き続きissue #25側で管理
+
+## 後任AIへの注意
+- この実装で壊してはいけない前提: `consumables.jan` は nullable のまま（NOT NULL化はしていない）。FKはNULLを許容する
+- 似ているが別物の用語: issue #26項目2の「SET A由来のインデックス追加」という記述は誤り。実際のインデックス追加は`20260629000003`（SET F/H系列）
+- 勝手にリファクタしない場所: `src/lib/mapping.ts` の `asEnum` 等の型ガード関数はissue #25 SET Iの成果物であり、シグネチャを変えると他repositoryとの整合性が崩れる

--- a/src/app/api/admin/users/__tests__/route.test.ts
+++ b/src/app/api/admin/users/__tests__/route.test.ts
@@ -81,6 +81,24 @@ describe('GET /api/admin/users', () => {
     expect(body.users[1].facilities).toEqual([])
   })
 
+  it('DBのroleが想定外の値の場合はstaffにフォールバックする', async () => {
+    mockListUsers.mockResolvedValue({
+      data: { users: [{ id: 'u1', email: 'a@test.com', last_sign_in_at: null }] },
+      error: null,
+    })
+    const mockIn = vi.fn().mockResolvedValue({
+      data: [{ user_id: 'u1', facility_id: 'f1', role: 'superadmin' }],
+      error: null,
+    })
+    const mockSelect = vi.fn().mockReturnValue({ in: mockIn })
+    mockFrom.mockReturnValue({ select: mockSelect })
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(body.users[0].facilities).toEqual([{ id: 'f1', role: 'staff' }])
+  })
+
   it('非管理者は 403 を返す', async () => {
     mockGetUser.mockResolvedValue({
       data: { user: { email: 'other@test.com' } },

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createAdminSupabase } from '@/lib/supabase/server'
 import { apiError } from '@/lib/api-error'
 import { requireAdmin } from '@/lib/admin-auth'
+import { asEnum } from '@/lib/mapping'
 import type { AdminUser } from '@/types/admin'
 
 export async function GET() {
@@ -26,7 +27,7 @@ export async function GET() {
   const facilityMap = new Map<string, { id: string; role: 'admin' | 'staff' }[]>()
   for (const row of (facilityRows ?? [])) {
     const list = facilityMap.get(row.user_id) ?? []
-    list.push({ id: row.facility_id, role: row.role as 'admin' | 'staff' })
+    list.push({ id: row.facility_id, role: asEnum(row.role, ['admin', 'staff'] as const, 'staff') })
     facilityMap.set(row.user_id, list)
   }
 

--- a/src/app/products/__tests__/page.test.tsx
+++ b/src/app/products/__tests__/page.test.tsx
@@ -11,6 +11,14 @@ describe('ProductsPage handleDelete', () => {
     vi.stubGlobal('alert', vi.fn())
   })
 
+  it('一覧取得が失敗した場合はエラーメッセージを表示する（catch漏れ防止）', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch
+
+    render(<ProductsPage />)
+
+    await screen.findByText('デバイスの取得に失敗しました')
+  })
+
   it('削除はDELETEの完了(await)を待ってから再取得する', async () => {
     const calls: string[] = []
     let resolveDelete: (v: unknown) => void = () => {}

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -8,13 +8,15 @@ import { ProductList } from '@/components/products/ProductList'
 export default function ProductsPage() {
   const router = useRouter()
   const [products, setProducts] = useState<Product[]>([])
+  const [error, setError] = useState<string | null>(null)
   const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
 
   useEffect(() => {
     let cancelled = false
     fetch('/api/products')
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
       .then((d) => { if (!cancelled) setProducts(d.products) })
+      .catch(() => { if (!cancelled) setError('デバイスの取得に失敗しました') })
     return () => { cancelled = true }
   }, [refreshKey])
 
@@ -49,6 +51,13 @@ export default function ProductsPage() {
           + 新規登録
         </button>
       </div>
+
+      {error && (
+        <div className="mb-6 flex items-center gap-3 rounded px-4 py-3 text-sm font-medium text-white" style={{ backgroundColor: '#DC2626', borderRadius: '2px' }}>
+          <span>⚠</span>
+          <span>{error}</span>
+        </div>
+      )}
 
       <div className="rounded bg-white shadow-sm overflow-hidden" style={{ border: '1px solid #E5E7EB' }}>
         <ProductList

--- a/src/components/orders/CaseOrderModal.tsx
+++ b/src/components/orders/CaseOrderModal.tsx
@@ -38,7 +38,11 @@ export function CaseOrderModal({ facilityId, isOpen, onClose, onSuccess }: Props
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!caseDatetime.trim()) { setError('症例日時を入力してください'); return }
     if (!procedureName.trim()) { setError('手技名を入力してください'); return }
+    if (!patientId.trim()) { setError('患者IDを入力してください'); return }
+    if (!patientInitials.trim()) { setError('患者イニシャルを入力してください'); return }
+    if (!doctorName.trim()) { setError('担当医師を入力してください'); return }
     setSubmitting(true)
     setError(null)
     try {

--- a/src/components/orders/__tests__/CaseOrderModal.empty.test.tsx
+++ b/src/components/orders/__tests__/CaseOrderModal.empty.test.tsx
@@ -15,6 +15,45 @@ describe('CaseOrderModal 空送信防止', () => {
     render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
     await userEvent.click(screen.getByRole('button', { name: '発注する' }))
     expect(fetch).not.toHaveBeenCalled()
-    expect(await screen.findByText('手技名を入力してください')).toBeInTheDocument()
+    expect(await screen.findByText('症例日時を入力してください')).toBeInTheDocument()
+  })
+
+  it('手技名以外の必須項目（患者ID等）が空のまま送信するとfetchが呼ばれずエラーが表示される', async () => {
+    render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/手技名/), 'カテーテル手技')
+    await userEvent.click(screen.getByRole('button', { name: '発注する' }))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(await screen.findByText('症例日時を入力してください')).toBeInTheDocument()
+  })
+
+  it('症例日時のみ入力し患者IDが空のまま送信するとfetchが呼ばれず患者ID未入力のエラーが表示される', async () => {
+    render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText('症例日時 *'), '2026-07-13T10:00')
+    await userEvent.type(screen.getByLabelText(/手技名/), 'カテーテル手技')
+    await userEvent.click(screen.getByRole('button', { name: '発注する' }))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(await screen.findByText('患者IDを入力してください')).toBeInTheDocument()
+  })
+
+  it('患者ID・患者イニシャルまで入力し担当医師が空のまま送信するとfetchが呼ばれず担当医師未入力のエラーが表示される', async () => {
+    render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText('症例日時 *'), '2026-07-13T10:00')
+    await userEvent.type(screen.getByLabelText(/手技名/), 'カテーテル手技')
+    await userEvent.type(screen.getByLabelText(/患者ID/), 'P-001')
+    await userEvent.type(screen.getByLabelText(/患者イニシャル/), 'AB')
+    await userEvent.click(screen.getByRole('button', { name: '発注する' }))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(await screen.findByText('担当医師を入力してください')).toBeInTheDocument()
+  })
+
+  it('全必須項目を入力すればfetchが呼ばれる', async () => {
+    render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText('症例日時 *'), '2026-07-13T10:00')
+    await userEvent.type(screen.getByLabelText(/手技名/), 'カテーテル手技')
+    await userEvent.type(screen.getByLabelText(/患者ID/), 'P-001')
+    await userEvent.type(screen.getByLabelText(/患者イニシャル/), 'AB')
+    await userEvent.type(screen.getByLabelText(/担当医師/), '山田太郎')
+    await userEvent.click(screen.getByRole('button', { name: '発注する' }))
+    expect(fetch).toHaveBeenCalled()
   })
 })

--- a/src/components/orders/__tests__/CaseOrderModal.test.tsx
+++ b/src/components/orders/__tests__/CaseOrderModal.test.tsx
@@ -53,7 +53,11 @@ describe('CaseOrderModal', () => {
       json: () => Promise.resolve({ error: '送信に失敗しました' }),
     })
     render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/症例日時/), '2026-06-24T10:00')
     await userEvent.type(screen.getByLabelText(/手技名/), 'TAVI')
+    await userEvent.type(screen.getByLabelText(/患者ID/), 'P001')
+    await userEvent.type(screen.getByLabelText(/患者イニシャル/), 'T.S.')
+    await userEvent.type(screen.getByLabelText(/担当医師/), '田中医師')
     await userEvent.click(screen.getByRole('button', { name: '発注する' }))
     expect(await screen.findByText('送信に失敗しました')).toBeInTheDocument()
   })
@@ -61,6 +65,7 @@ describe('CaseOrderModal', () => {
   it('性別「女」を選択して送信するとgender:femaleが送信される', async () => {
     render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
     await userEvent.selectOptions(screen.getByLabelText(/性別/), 'female')
+    await userEvent.type(screen.getByLabelText(/症例日時/), '2026-06-24T10:00')
     await userEvent.type(screen.getByLabelText(/手技名/), 'TAVI')
     await userEvent.type(screen.getByLabelText(/患者ID/), 'P001')
     await userEvent.type(screen.getByLabelText(/患者イニシャル/), 'T.S.')
@@ -72,6 +77,7 @@ describe('CaseOrderModal', () => {
 
   it('+ 行を追加で物品行を増やして送信できる', async () => {
     render(<CaseOrderModal facilityId="f-1" isOpen={true} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/症例日時/), '2026-06-24T10:00')
     await userEvent.type(screen.getByLabelText(/手技名/), 'TAVI')
     await userEvent.type(screen.getByLabelText(/患者ID/), 'P001')
     await userEvent.type(screen.getByLabelText(/患者イニシャル/), 'T.S.')

--- a/supabase/migrations/20260714000004_link_consumables_jan_and_validate_fk.sql
+++ b/supabase/migrations/20260714000004_link_consumables_jan_and_validate_fk.sql
@@ -1,0 +1,33 @@
+-- supabase/migrations/20260714000004_link_consumables_jan_and_validate_fk.sql
+-- issue #26: consumables.jan が products と未紐付けだった問題の解消。
+-- あわせて 20260626000000 で NOT VALID のまま残っていた jan FK 群を検証する。
+-- すべて冪等（再実行しても失敗しない）に記述する。
+
+-- =========================================================================
+-- 1. consumables.jan を products(jan) への FK にする。
+--    既存データに孤児 jan があっても適用できるよう NOT VALID で追加する
+--    （20260626000000 の case_order_items 等と同じ方針）。
+-- =========================================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'consumables_jan_fkey'
+  ) THEN
+    ALTER TABLE consumables
+      ADD CONSTRAINT consumables_jan_fkey
+        FOREIGN KEY (jan) REFERENCES products (jan) NOT VALID;
+  END IF;
+END
+$$;
+
+-- =========================================================================
+-- 2. NOT VALID のまま残っていた jan FK を検証する。
+--    VALIDATE CONSTRAINT は対象行を読むだけでテーブル全体をロックしないため、
+--    運用中のテーブルに対しても安全に実行できる。
+--    既存データに孤児 jan が残っている場合はここで失敗する
+--    （サイレントに無視せず、データ修正が必要なことを明示するため意図的な挙動）。
+-- =========================================================================
+ALTER TABLE case_order_items VALIDATE CONSTRAINT case_order_items_jan_fkey;
+ALTER TABLE loan_order_items VALIDATE CONSTRAINT loan_order_items_jan_fkey;
+ALTER TABLE loan_return_items VALIDATE CONSTRAINT loan_return_items_jan_fkey;
+ALTER TABLE consumables VALIDATE CONSTRAINT consumables_jan_fkey;


### PR DESCRIPTION
## Summary
issue #26「既存バグ・DB問題の修正（旧Phase1調査214件ベース）」の5項目を、5並列Exploreエージェントで現状コードと照合した上で対応した。

- **項目1（セキュリティ）**: issue #24等で既に対応済みと確認。変更なし
- **項目2（DB設計）**: CASCADE・インデックスは対応済み。`consumables.jan` が products と未紐付けだったため、FK追加＋既存jan FK群のVALIDATE CONSTRAINTを実施
- **項目3（エラーハンドリング）**: APIレスポンス統一・await漏れは対応済み。`products/page.tsx` のcatch漏れのみ修正
- **項目4（型安全性）**: repository層はPR #328で対応済み。`admin/users/route.ts` の無条件キャストのみ `asEnum()` に置換
- **項目5（UI/フォーム）**: ホバー・key・金額バリデーションは対応済み。`CaseOrderModal` の必須項目（症例日時・患者ID・患者イニシャル・担当医師）にJSバリデーションが完全に欠けていたため追加

あえて対応しなかった項目（詳細は `docs/sessions/2026-07-13-issue26-bugfix-triage.md` 参照）:
- AbortController未導入・注文一覧ページのcancelledガード → React 19では実害なしのため見送り、issue #25 SET Bとして継続管理
- LoanReturnModalのreturnDatetimeバリデーション → HTML `required` で機能的には問題なし

Closes #26

## Test plan
- [x] `npx vitest run` — 630件全緑
- [x] `npm run lint` — エラーなし
- [x] `npx tsc --noEmit` — エラーなし
- [x] `supabase db reset --local` — 新規migration適用・既存jan FKのVALIDATE CONSTRAINT成功（孤児データ0件）を確認
- [ ] `npm run test:e2e` — この環境では `.env.test` 未設定のため実行不可（既存の環境制約、CI側では別途確認要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)