### PR TITLE
feat: AIDD運用改善 - サブエージェント進捗の可視化(issue #18)

### DIFF
--- a/.claude/agents/adversarial-verify.md
+++ b/.claude/agents/adversarial-verify.md
@@ -26,3 +26,11 @@ finding: [指摘の概要]
 refuted: true / false
 evidence: [コードを読んで確認した根拠。refuted=falseの場合は問題が実在する証拠]
 ```
+
+## 進捗報告（issue #18）
+検証開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は検証対象の機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent adversarial-verify --feature "<feature名>" --status running --note "反証検証中..."
+# ...検証...
+scripts/log-agent-progress.sh --agent adversarial-verify --feature "<feature名>" --status done --note "検証完了"
+```

--- a/.claude/agents/completeness-critic.md
+++ b/.claude/agents/completeness-critic.md
@@ -35,3 +35,11 @@ model: sonnet
 ```
 
 **重要**: この2択以外の形式で返さないこと。前置き文・まとめ・補足説明は不要。
+
+## 進捗報告（issue #18）
+評価開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は評価対象の機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent completeness-critic --feature "<feature名>" --status running --note "網羅性評価中..."
+# ...評価...
+scripts/log-agent-progress.sh --agent completeness-critic --feature "<feature名>" --status done --note "評価完了"
+```

--- a/.claude/agents/contract-writer.md
+++ b/.claude/agents/contract-writer.md
@@ -35,3 +35,11 @@ Lint: 0 errors
 TSC: 0 errors
 未解決の設計判断: [あれば]
 ```
+
+## 進捗報告（issue #18）
+作業開始時に `--status running`、完了報告の直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` はSPEC.mdの機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent contract-writer --feature "<feature名>" --status running --note "型定義作成中..."
+# ...型定義作成...
+scripts/log-agent-progress.sh --agent contract-writer --feature "<feature名>" --status done --note "契約定義完了"
+```

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -9,6 +9,14 @@ model: sonnet
 contract-writer が確定した `src/types/` の型定義を「契約」として参照してください。
 型定義自体を変更・追加することは禁止です（変更が必要な場合は報告して止まる）。
 
+## 進捗報告（issue #18）
+作業開始時に一度、`--status running` で `scripts/log-agent-progress.sh` を呼ぶこと。`--agent` は自分が担当する実装セット名（例: `implementer-<グループ名>`）、`--feature` はSPEC.mdの機能名（無ければ `unknown`）。長時間かかる場合は主要な区切り（実装セット完了ごと等）で再度 `--status running` を呼び直して更新するとよい。全セット完了時・または3回修正しても通らず報告する時に、`--status done`（成功）または `--status failed`（要報告）を1回呼んで締める。
+```bash
+scripts/log-agent-progress.sh --agent "implementer-<グループ名>" --feature "<SPEC.mdの機能名>" --status running --note "実装中..."
+# ...実装...
+scripts/log-agent-progress.sh --agent "implementer-<グループ名>" --feature "<SPEC.mdの機能名>" --status done --note "実装完了"
+```
+
 ## 実装前に読むべきドキュメント
 実装対象が facility / tenant / organization / inventory / RLS / policy / auth のいずれかのドメインに関わる場合、実装に入る前に必ず `docs/agents/domain.md`（ドメイン用語の定義）と `docs/agents/decisions.md`（なぜその設計にしたかの理由）を読むこと。特に `is_facility_member` によるRLS施設分離の仕組みを理解せずに新しいテーブル・エンドポイントを実装すると、施設間のデータ越境を許してしまう危険がある。
 

--- a/.claude/agents/integrator.md
+++ b/.claude/agents/integrator.md
@@ -7,6 +7,14 @@ model: sonnet
 
 あなたはPhase 4の統合担当です。並列実装（Phase 3）で各implementerが書いたコードを**結線**し、アプリケーション全体として動作させてください。
 
+## 進捗報告（issue #18）
+作業開始時に `--status running`、完了報告の直前に `--status done`（3回修正しても通らず報告する場合は `--status failed`）で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は対象の機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent integrator --feature "<feature名>" --status running --note "統合作業中..."
+# ...結線・テスト・lint...
+scripts/log-agent-progress.sh --agent integrator --feature "<feature名>" --status done --note "統合完了"
+```
+
 ## あなたの担当範囲
 - **共有ファイルを触るのはあなただけ**（Phase 3の各implementerは自分のファイルしか触っていない）
 - 結線対象：ルーティング・index exports・共有レイアウト・グローバル設定等

--- a/.claude/agents/judge-panel.md
+++ b/.claude/agents/judge-panel.md
@@ -55,3 +55,11 @@ scripts/log-loop-observability.sh \
 
 - `--result` は常に `pass`（評価自体は失敗しない性質のため）。
 - `--agent` は必ず `judge-panel` を使う（`human` は使わない）。
+
+## 進捗報告（issue #18）
+評価開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は評価対象の機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent judge-panel --feature "<feature名>" --status running --note "評価中..."
+# ...評価...
+scripts/log-agent-progress.sh --agent judge-panel --feature "<feature名>" --status done --note "評価完了"
+```

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -7,6 +7,14 @@ model: sonnet
 
 あなたはシニアレビュアーです。読み取り専用で、指摘のみを箇条書きで返します（自動修正はしない）。
 
+## 進捗報告（issue #18）
+レビュー開始時に `--status running`、指摘一覧を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--agent` は担当次元がわかる名前（例: `reviewer-correctness`）、`--feature` はレビュー対象の機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent "reviewer-<担当次元>" --feature "<feature名>" --status running --note "レビュー中..."
+# ...レビュー...
+scripts/log-agent-progress.sh --agent "reviewer-<担当次元>" --feature "<feature名>" --status done --note "レビュー完了"
+```
+
 ## 既知の失敗パターン（必ず機械的にチェックする）
 `docs/agents/known-failure-patterns.md` を読み、そこに載っている各パターンが
 対象コードに再発していないか確認すること。SPEC.mdに書くだけでは実装フェーズで

--- a/.claude/agents/sweep-data.md
+++ b/.claude/agents/sweep-data.md
@@ -33,3 +33,11 @@ model: haiku
 - 箇条書きのみ
 - 「ファイルパス:行番号 — 問題の概要」形式
 - 問題がなければ「指摘なし」と返す
+
+## 進捗報告（issue #18）
+調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent sweep-data --feature "<feature名>" --status running --note "データ取得層調査中..."
+# ...調査...
+scripts/log-agent-progress.sh --agent sweep-data --feature "<feature名>" --status done --note "データ取得層調査完了"
+```

--- a/.claude/agents/sweep-db.md
+++ b/.claude/agents/sweep-db.md
@@ -26,3 +26,11 @@ model: haiku
 - 箇条書きのみ
 - 「ファイル or テーブル名 — 問題の概要」形式
 - 問題がなければ「指摘なし」と返す
+
+## 進捗報告（issue #18）
+調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent sweep-db --feature "<feature名>" --status running --note "DB層調査中..."
+# ...調査...
+scripts/log-agent-progress.sh --agent sweep-db --feature "<feature名>" --status done --note "DB層調査完了"
+```

--- a/.claude/agents/sweep-types.md
+++ b/.claude/agents/sweep-types.md
@@ -27,3 +27,11 @@ model: haiku
 - 箇条書きのみ
 - 「型名 / ファイル — 不一致の概要（期待: X、実際: Y）」形式
 - 問題がなければ「指摘なし」と返す
+
+## 進捗報告（issue #18）
+調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent sweep-types --feature "<feature名>" --status running --note "型整合性調査中..."
+# ...調査...
+scripts/log-agent-progress.sh --agent sweep-types --feature "<feature名>" --status done --note "型整合性調査完了"
+```

--- a/.claude/agents/sweep-ui.md
+++ b/.claude/agents/sweep-ui.md
@@ -31,3 +31,11 @@ model: haiku
 - 箇条書きのみ（コード・説明文は不要）
 - 問題ごとに「ファイルパス:行番号 — 問題の概要」形式
 - 問題がなければ「指摘なし」と返す
+
+## 進捗報告（issue #18）
+調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
+```bash
+scripts/log-agent-progress.sh --agent sweep-ui --feature "<feature名>" --status running --note "UI層調査中..."
+# ...調査...
+scripts/log-agent-progress.sh --agent sweep-ui --feature "<feature名>" --status done --note "UI層調査完了"
+```

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -76,6 +76,29 @@ any code. Heed deprecation notices.
   ただし`feature`は呼び出し時に手動指定が必要、`intent`はプロンプト冒頭1文の抜粋、
   `scenario`は復元不能である旨の固定文言になる（自己申告時点の情報粒度には及ばない）。
 
+## サブエージェント進捗の可視化（issue #18）
+
+- サブエージェント（sweep-db/sweep-ui/sweep-types/sweep-data/implementer/reviewer/integrator/
+  judge-panel/proposer/adversarial-verify/completeness-critic/contract-writer）は、
+  作業の**開始時**と**終了時**（成功・失敗いずれも）に `scripts/log-agent-progress.sh` を呼び、
+  `logs/agent-progress.jsonl` に進捗を記録すること。
+  ```
+  scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature名>" \
+    --status running --note "<今やっていることの短い説明>"
+  # ...作業...
+  scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature名>" \
+    --status done --note "<完了内容の短い説明>"    # 失敗時は --status failed
+  ```
+  `--status` は `starting|running|waiting|done|failed` のいずれか。`feature`名が
+  呼び出し元から与えられていない場合は `unknown` を使う。
+- 現在の状態は `scripts/show-agent-status.sh` で一覧できる（`--stale-seconds`未満は
+  既定180秒＝3分）。`running`/`waiting`のまま既定180秒以上更新がないエージェントは
+  「止まってる？」として表示される。
+- これも loop-observability と同じ構造的限界を持つ：**エージェントへの自然言語指示に
+  依存しており強制力がない**（オーケストレーター側から機械的に書き込ませることはできない）。
+  つまり「進捗が表示されない」ことは「本当に止まっている」のか「そもそも記録し忘れている」のか
+  区別できない。記録漏れの検知（loop-observability同様の仕組み）は今後の課題として残っている。
+
 ## 引き継ぎフォーマット
 
 「できました」で終わる完了報告は禁止。作業完了時（PR本文・セッション終了報告・
@@ -120,3 +143,4 @@ any code. Heed deprecation notices.
 | `src/lib/supabase/` | Supabase クライアント・データ取得層 |
 | `supabase/migrations/` | DBマイグレーション |
 | [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |
+| `scripts/log-agent-progress.sh` / `scripts/show-agent-status.sh` | サブエージェント進捗の記録・一覧表示（issue #18） |

--- a/docs/sessions/2026-07-13-issue18-agent-progress-heartbeat.md
+++ b/docs/sessions/2026-07-13-issue18-agent-progress-heartbeat.md
@@ -1,0 +1,85 @@
+# 2026-07-13 issue18-agent-progress-heartbeat
+
+## 対応issue
+- issue #18「サブエージェントオブザーバビリティ：進捗・状態・タスク残量の可視化」
+
+## 作業サマリ
+- 変更した目的: AIDDサブエージェント（sweep-db/sweep-ui/sweep-types/sweep-data/implementer/reviewer/
+  integrator/judge-panel/adversarial-verify/completeness-critic/contract-writer）が動作中、メイン
+  セッションから進捗・生死が見えない問題（issue #18）を解消する
+- 変更した範囲:
+  - `scripts/log-agent-progress.sh`（新規）: エージェントが進捗を`logs/agent-progress.jsonl`に自己申告するCLI
+  - `scripts/show-agent-status.sh`（新規）: 直近の状態を一覧表示し、既定180秒（3分）以上runningから
+    更新がないエージェントを「止まってる？」として表示する
+  - `scripts/show-agent-status.test.sh`（新規）: 上記2スクリプトの回帰テスト（`schema-drift-reconcile.test.sh`と同じ作法）
+  - `docs/agents/common.md`: 「サブエージェント進捗の可視化」節を追加し、全AIエージェント共通ルールとして明文化
+  - `.claude/agents/*.md`（11ファイル全て）: 各エージェントの開始時・終了時に
+    `scripts/log-agent-progress.sh`を呼ぶ具体的な指示を追加
+- 触っていない範囲: `proposer`エージェント（本リポジトリに`.claude/agents/proposer.md`が存在せず、
+  リポジトリ外で定義されているため対象外）。実際のAIDDフロー実行中に新しい仕組みが機能するかの
+  実地検証（次回セッションで確認要）
+
+## 設計上の判断（ユーザーとの事前合意）
+issue #18は「メインセッションから任意のサブエージェントの実行中状態を能動的に監視する」ことを
+求めているが、Claude Codeのハーネス自体には完了時の自動通知（`/workflows`のライブ進捗除く）しか
+無く、実行中の任意時点での状態取得手段がモデル側に提供されていない。そのため実装可能なのは
+「エージェントが自己申告した進捗をログに書き、それを一覧表示するビューア」というベストエフォート
+方式のみであり、これは`scripts/log-loop-observability.sh`と同じ構造的限界（自然言語指示への依存・
+強制力なし）を持つことを事前にユーザーに説明し、了承を得た上で本プロジェクトのAIDDサブエージェント
+限定の実装に絞った。
+
+## 検証済み
+- 実行したコマンド: `bash scripts/show-agent-status.test.sh`（9assert全OK）、`npx vitest run`（630件全緑）、
+  `npm run lint`（エラーなし）、`npx tsc --noEmit`（エラーなし）。`npm run ai:check`は`.env.test`未設定に
+  よりこの環境では実行不可（既存の環境制約）
+- 確認した画面: なし（バックエンド・スクリプトのみ）
+- 確認したDB/RLS: 対象外（DB変更なし）
+- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（RLS/facility境界に触れていない）
+
+## 既知の未対応
+- 今回あえて対応しなかったこと: 実際のAIDDフロー（Phase 1〜5）実行時に、11個のサブエージェントが
+  実際に`log-agent-progress.sh`を呼び出すかどうかの実地検証。今回は指示文の追加とスクリプト自体の
+  単体テストのみ
+- 理由: 実地検証には実際のAIDDフロー1本の完走が必要で、本セッションのスコープ（issue #18そのものの
+  実装）を超える。loop-observabilityの記録漏れ検知（`check-loop-observability-gap.sh`）と同様、
+  記録漏れそのものを検知する仕組みは今後の課題として残っている
+- 次に触るなら見る場所: 次回AIDDフロー実行時に`logs/agent-progress.jsonl`が実際に増えているか確認する。
+  増えていなければ、エージェント定義への指示の伝わり方（システムプロンプトの読み込まれ方）を疑う
+
+## 後任AIへの注意
+- この実装で壊してはいけない前提: `logs/agent-progress.jsonl`は`/logs/`として`.gitignore`済み。
+  コミットに含めない
+- 似ているが別物の用語: `scripts/log-loop-observability.sh`（実装セットの試行ごとのpass/fail記録、
+  事後ログ）と`scripts/log-agent-progress.sh`（エージェントの生死・進捗のハートビート、リアルタイム
+  ログ）は目的も記録先ファイルも別物。混同しないこと
+- 勝手にリファクタしない場所: 既存の`scripts/log-loop-observability.sh`・
+  `scripts/check-loop-observability-gap.sh`は本issueの対象外であり変更していない
+
+## フロー実行時間
+- Phase 1（調査）: 既存harness機能の限界調査・issue内容確認、約5分
+- Phase 2〜5（実装）: スクリプト2本＋テスト＋ドキュメント11ファイル更新、約20分
+- AI稼働合計: 約25分
+- セッション総時間: ユーザーとの方針確認（1回）含め約30分
+
+## フロー実行統計
+### Phase 1 調査
+- Sweeper: 0台（本セッションでは直接調査、Explore/Sweepエージェントは使用せず）
+- 指摘あり軸数: 1 / 1（ハーネスの構造的制約という前提整理）
+
+### Phase 2〜5 実装・検証
+- implementer: 本セッション内で直接実装（1名・直列）
+- integrator: 該当なし
+- reviewer: 該当なし（vitest / lint / tsc / 独自bashテストで検証）
+- 合計エージェント: 0台（Phase1同様、直接実装）
+- 実装成功: 1 / 1
+
+## Loop Observability要約
+このセッション中の新規記録なし（AIDDフロー本体を経由しない直接実装のため対象外）
+
+## 結果
+- うまくいったこと: 既存の`log-loop-observability.sh`/`schema-drift-reconcile.test.sh`の作法を踏襲し、
+  一貫性のある形で新しいスクリプトとテストを追加できた
+- 問題・気になった点: この仕組みの実効性は「エージェントが実際に呼ぶかどうか」に完全に依存しており、
+  記録漏れ検知の仕組み（loop-observabilityにあるもの）がまだ無い
+- 次の課題: 記録漏れ検知（`check-loop-observability-gap.sh`相当）の追加を検討する。実際のAIDDフロー
+  実行での実地検証

--- a/scripts/log-agent-progress.sh
+++ b/scripts/log-agent-progress.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="logs/agent-progress.jsonl"
+AGENT=""
+FEATURE=""
+STATUS=""
+NOTE=""
+
+usage() {
+  echo "Usage: $0 --agent NAME --feature NAME --status starting|running|waiting|done|failed --note TEXT [--log-file PATH]" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent) AGENT="$2"; shift 2 ;;
+    --feature) FEATURE="$2"; shift 2 ;;
+    --status) STATUS="$2"; shift 2 ;;
+    --note) NOTE="$2"; shift 2 ;;
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+for name in AGENT FEATURE STATUS NOTE; do
+  if [[ -z "${!name}" ]]; then
+    echo "Missing required argument: --$(echo "$name" | tr '[:upper:]' '[:lower:]')" >&2
+    usage
+  fi
+done
+
+case "$STATUS" in
+  starting|running|waiting|done|failed) ;;
+  *) echo "--status must be one of: starting|running|waiting|done|failed" >&2; exit 1 ;;
+esac
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+jq -nc \
+  --arg timestamp "$TIMESTAMP" \
+  --arg agent "$AGENT" \
+  --arg feature "$FEATURE" \
+  --arg status "$STATUS" \
+  --arg note "$NOTE" \
+  '{timestamp: $timestamp, agent: $agent, feature: $feature, status: $status, note: $note}' \
+  >> "$LOG_FILE"

--- a/scripts/show-agent-status.sh
+++ b/scripts/show-agent-status.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="logs/agent-progress.jsonl"
+STALE_SECONDS=180
+NOW_EPOCH=""
+
+usage() {
+  echo "Usage: $0 [--log-file PATH] [--stale-seconds N] [--now-epoch N]" >&2
+  echo "  --stale-seconds N  この秒数を超えて更新がないrunning/waiting/starting中のエージェントを「止まってる？」と表示する（既定: 180）" >&2
+  echo "  --now-epoch N      現在時刻をUNIX epoch秒で上書きする（主にテスト用）" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    --stale-seconds) STALE_SECONDS="$2"; shift 2 ;;
+    --now-epoch) NOW_EPOCH="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$NOW_EPOCH" ]]; then
+  NOW_EPOCH="$(date -u +%s)"
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "進捗ログがありません: $LOG_FILE（エージェントがまだ進捗報告していない可能性があります）"
+  exit 0
+fi
+
+jq -s -r --argjson now "$NOW_EPOCH" --argjson stale "$STALE_SECONDS" '
+  def epoch: (. | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime);
+  group_by(.agent)
+  | map(sort_by(.timestamp) | .[-1])
+  | sort_by(.agent)
+  | .[]
+  | . as $e
+  | ($e.timestamp | epoch) as $t
+  | ($now - $t) as $ageSec
+  | if ($e.status != "done" and $e.status != "failed" and $ageSec > $stale)
+    then "\($e.agent)：止まってる？（\($ageSec)秒応答なし）"
+    elif $e.status == "done" then "\($e.agent)：\($e.note) ✓"
+    elif $e.status == "failed" then "\($e.agent)：\($e.note) ✗"
+    else "\($e.agent)：\($e.note)"
+    end
+' "$LOG_FILE"

--- a/scripts/show-agent-status.test.sh
+++ b/scripts/show-agent-status.test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# WHY: issue #18（サブエージェントの進捗・生死可視化）向けのlog-agent-progress.sh /
+# show-agent-status.shはbash+jqのみで完結し、vitestの対象外のため、ここで回帰テストとして固定する。
+#
+# 実行: bash scripts/show-agent-status.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_AGENT_PROGRESS="$SCRIPT_DIR/log-agent-progress.sh"
+SHOW_AGENT_STATUS="$SCRIPT_DIR/show-agent-status.sh"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+LOG_FILE="$WORKDIR/agent-progress.jsonl"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual output: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  NG: $label (should NOT contain: $needle)"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+
+# --- fixture: テスト実行時刻を基準epochとして採用し、jqでISO8601に変換して組み立てる ---
+# WHY: 固定の未来日時をハードコードすると実行環境の実時刻とズレて経過秒数の期待値が崩れるため、
+# 実行時点のUNIX epochを基準に相対時刻で組み立てる（date -d はGNU/BSDで挙動が違うためjqのgmtimeを使う）。
+BASE_EPOCH="$(date -u +%s)"
+epoch_to_iso() {
+  jq -n --argjson e "$1" '$e | gmtime | strftime("%Y-%m-%dT%H:%M:%SZ")' | tr -d '"'
+}
+
+bash "$LOG_AGENT_PROGRESS" --agent "sweep-db" --feature "f1" --status done --note "スイーパー完了" --log-file "$LOG_FILE"
+bash "$LOG_AGENT_PROGRESS" --agent "implementer-a" --feature "f1" --status running --note "lib実装中..." --log-file "$LOG_FILE"
+bash "$LOG_AGENT_PROGRESS" --agent "proposer-mvp" --feature "f1" --status waiting --note "待機中" --log-file "$LOG_FILE"
+bash "$LOG_AGENT_PROGRESS" --agent "reviewer-x" --feature "f1" --status failed --note "型エラーで中断" --log-file "$LOG_FILE"
+
+# 3分(180秒)を超えて更新がない running のエージェント（stale扱いになるべき）
+printf '{"timestamp":"%s","agent":"sweep-ui","feature":"f1","status":"running","note":"UI調査中..."}\n' "$(epoch_to_iso $((BASE_EPOCH - 300)))" >> "$LOG_FILE"
+# 2分(120秒)しか経っていない running のエージェント（stale扱いにならないべき）
+printf '{"timestamp":"%s","agent":"sweep-types","feature":"f1","status":"running","note":"型調査中..."}\n' "$(epoch_to_iso $((BASE_EPOCH - 120)))" >> "$LOG_FILE"
+# 同じagent名で複数回報告された場合、最新の1件だけが採用されるべき
+bash "$LOG_AGENT_PROGRESS" --agent "sweep-db" --feature "f1" --status running --note "古い状態(上書きされるべき)" --log-file "$LOG_FILE"
+sleep 1.1
+bash "$LOG_AGENT_PROGRESS" --agent "sweep-db" --feature "f1" --status done --note "最新の完了報告" --log-file "$LOG_FILE"
+
+OUTPUT="$(bash "$SHOW_AGENT_STATUS" --log-file "$LOG_FILE" --now-epoch "$BASE_EPOCH")"
+
+echo "=== test: doneは✓付きでnoteがそのまま表示される ==="
+assert_contains "$OUTPUT" "sweep-db：最新の完了報告 ✓" "sweep-dbは最新のdone報告(✓)が表示される"
+
+echo "=== test: 同じagent名の古い報告は表示に含まれない ==="
+assert_not_contains "$OUTPUT" "古い状態(上書きされるべき)" "同一agentの古い報告は消える"
+
+echo "=== test: runningはnoteがそのまま表示される ==="
+assert_contains "$OUTPUT" "implementer-a：lib実装中..." "implementer-aの進捗メモが表示される"
+
+echo "=== test: waitingはnoteがそのまま表示される ==="
+assert_contains "$OUTPUT" "proposer-mvp：待機中" "proposer-mvpの待機中が表示される"
+
+echo "=== test: failedは✗付きで表示される ==="
+assert_contains "$OUTPUT" "reviewer-x：型エラーで中断 ✗" "reviewer-xの失敗(✗)が表示される"
+
+echo "=== test: stale-seconds(既定180秒)を超えたrunningは「止まってる？」になる ==="
+assert_contains "$OUTPUT" "sweep-ui：止まってる？（300秒応答なし）" "sweep-uiは5分応答なしで止まってる扱いになる"
+
+echo "=== test: stale-seconds未満のrunningは「止まってる？」にならない ==="
+assert_not_contains "$OUTPUT" "sweep-types：止まってる？" "sweep-typesは2分経過のみなので止まってる扱いにならない"
+assert_contains "$OUTPUT" "sweep-types：型調査中..." "sweep-typesは通常の進捗表示のまま"
+
+echo "=== test: ログファイルが存在しない場合はエラーにならず案内文を返す ==="
+NO_LOG_OUTPUT="$(bash "$SHOW_AGENT_STATUS" --log-file "$WORKDIR/no-such-file.jsonl")"
+assert_contains "$NO_LOG_OUTPUT" "進捗ログがありません" "ログ未生成時は案内文を返す"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
issue #18「サブエージェントオブザーバビリティ：進捗・状態・タスク残量の可視化」に対応する。

Claude Codeハーネス自体には、サブエージェント実行中の任意時点での状態を能動的に取得する手段が
モデル側に提供されていない（完了時の自動通知と`/workflows`のライブ進捗表示のみ）。そのため実装
できるのは「エージェントが自己申告した進捗をログに書き、それを一覧表示するビューア」という
ベストエフォート方式のみであり、これは既存の`scripts/log-loop-observability.sh`と同じ構造的限界
（自然言語指示への依存・強制力なし）を持つことを事前にユーザーへ説明し、了承を得た上で
**本プロジェクトのAIDDサブエージェント（sweep-*/implementer/reviewer/integrator/judge-panel/
adversarial-verify/completeness-critic/contract-writer）限定**の実装に絞った。

- `scripts/log-agent-progress.sh`（新規）: エージェントが進捗を`logs/agent-progress.jsonl`に自己申告するCLI
- `scripts/show-agent-status.sh`（新規）: 直近の状態を一覧表示。既定180秒（3分）以上`running`/`waiting`
  から更新がないエージェントは「止まってる？」として表示する
- `docs/agents/common.md`: 「サブエージェント進捗の可視化」節を追加
- `.claude/agents/*.md`（全11ファイル）: 各エージェントの開始時・終了時に
  `scripts/log-agent-progress.sh`を呼ぶ具体的な指示を追加

対象外: `proposer`エージェントは本リポジトリに定義ファイルが存在しないため対象外。実際のAIDDフロー
実行時にエージェントが実際にこのスクリプトを呼ぶかの実地検証は次回セッションで確認する
（詳細: `docs/sessions/2026-07-13-issue18-agent-progress-heartbeat.md`）。

Closes #18

## Test plan
- [x] `bash scripts/show-agent-status.test.sh` — 9件のassert全てOK
- [x] `npx vitest run` — 630件全緑
- [x] `npm run lint` — エラーなし
- [x] `npx tsc --noEmit` — エラーなし
- [ ] 実際のAIDDフロー実行でサブエージェントが`log-agent-progress.sh`を実際に呼ぶかの実地検証（次回セッション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)