### PR TITLE
fix: issue #305 スキーマドリフト検知ワークフローの本番Secretsを既存値に統一

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -2,7 +2,8 @@
 # DB側（20260714000001_create_schema_drift_detection.sql）が毎日pg_cronでドリフトを検知・記録し、
 # このワークフローはその結果を日次でポーリングしてGitHub Issueを自動作成・自動クローズする。
 #
-# secrets.PROD_SUPABASE_URL / secrets.PROD_SUPABASE_ANON_KEY は「公開して問題ない値」（anon key）
+# secrets.NEXT_PUBLIC_SUPABASE_URL / secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY は「公開して問題ない値」
+# （anon key。クライアントバンドルにも埋め込まれる値で、本番Next.jsアプリと同じSecretsを再利用する）
 # のみを使う。本番DBパスワード・service role key・SUPABASE_ACCESS_TOKENはこのワークフローに
 # 一切渡さない（docs/agents/decisions.md「なぜスキーマドリフト検知を自前cronではなく
 # Supabase GitHub Integrationで始めたか」と同じ制約を維持する）。
@@ -32,11 +33,11 @@ jobs:
     steps:
       - name: Fetch unresolved schema drifts
         env:
-          SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
           if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
-            echo "::error::PROD_SUPABASE_URL / PROD_SUPABASE_ANON_KEY が未設定です。リポジトリのSecretsを確認してください。"
+            echo "::error::NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY が未設定です。リポジトリのSecretsを確認してください。"
             exit 1
           fi
           curl -sf "${SUPABASE_URL}/rest/v1/drift_alert_view?select=drift_type,object_name,detected_at" \

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,7 +63,7 @@ SQL Editor等でPRを介さず本番DBのスキーマが直接変更された場
 
 #### GitHub Issue連携
 
-> 以下4項目のロジック自体は`scripts/schema-drift-reconcile.test.sh`（gh CLIをスタブ化した回帰テスト、リポジトリにコミット済み・実行して4アサーション全通過を確認済み）で検証済み。ただし実際のSupabase本番環境に対する動作は`PROD_SUPABASE_URL`/`PROD_SUPABASE_ANON_KEY`のGitHub Secrets登録後、`workflow_dispatch`での手動実行で別途確認が必要（**未実施**。マージ後の運用開始タスクとして残る）。
+> 以下4項目のロジック自体は`scripts/schema-drift-reconcile.test.sh`（gh CLIをスタブ化した回帰テスト、リポジトリにコミット済み・実行して4アサーション全通過を確認済み）で検証済み。実際のSupabase本番環境に対する動作確認は、本番プロジェクト（`dddwaoooqzrtlbtcnwso`）が既存Secrets `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` と一致することを確認できたため、新規Secrets登録は不要と判断し、ワークフロー側をこの既存Secrets参照に変更した。`workflow_dispatch`での実地確認は本変更後に実施する。
 
 - [x] 未解決ドリフトが1件以上ある状態でGitHub Actionsを実行すると、`schema-drift`・`bug`ラベル付きのIssueが作成される（ロジックはテストで検証済み。本番環境での実地確認は上記の通り未実施）
 - [x] 既にIssueが作成済みの未解決ドリフトについては、再実行してもIssueが重複作成されない（タイトルベースの突合ロジックをテストで検証済み）
@@ -72,7 +72,7 @@ SQL Editor等でPRを介さず本番DBのスキーマが直接変更された場
 
 #### セキュリティ
 
-- [x] 本番DBの接続パスワード・Service Role Key・Supabase Access TokenはGitHub Secretsに一切登録しない（`PROD_SUPABASE_URL`/`PROD_SUPABASE_ANON_KEY`の2つのみ使用。ワークフローファイルにコメントで明記）
+- [x] 本番DBの接続パスワード・Service Role Key・Supabase Access TokenはGitHub Secretsに一切登録しない（既存の`NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`の2つのみを再利用。新規Secrets登録は行わない。ワークフローファイルにコメントで明記）
 - [x] GitHub Actionsが読み取るビュー（`drift_alert_view`）はanon keyで読める設計だが、公開される情報はドリフトの種類・対象オブジェクト名・検知日時のみで、それ以上の詳細情報（`detail`列の中身）は公開されない（実装確認済み）
 - [x] `check_schema_drift()`はservice_roleのみ実行可能（GRANT EXECUTEがservice_roleに限定されている）（実装確認済み）
 


### PR DESCRIPTION
## Summary
- PR #325（issue #305本体）はコード実装済みだったが、Test planに「本PRの範囲外」として運用作業（PROD_SUPABASE_URL/PROD_SUPABASE_ANON_KEYのSecrets登録・pg_cron有効化・workflow_dispatch実地確認）が残っていた
- 本番Supabaseプロジェクト(`dddwaoooqzrtlbtcnwso`)が既存Secrets `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` と一致することをユーザーがダッシュボードで確認（調査の過程で、本番middlewareが古いプロジェクトrefを参照しDNS解決失敗→504障害が起きていたことが判明し、Vercel環境変数を修正・Redeployして復旧済み）
- migration(20260714000001〜4)適用済み・pg_cron有効化(ON)も確認済み
- 上記により新規Secrets登録が不要と判断し、ワークフローを既存Secrets参照に変更

Closes #305

## Test plan
- [x] YAML構文チェック（`python3 -c "import yaml; yaml.safe_load(...)"`）
- [x] `scripts/schema-drift-reconcile.test.sh`（gh CLIスタブ回帰テスト、4アサーション全通過）
- [ ] マージ後、`workflow_dispatch`での本番向け実地確認（手動運用タスクとして残る）

## 作業サマリ
- 変更した目的: issue #305の残運用タスクのうち、Secrets登録を新規に増やさず既存値を再利用する形に倒すためのワークフロー修正
- 変更した範囲: `.github/workflows/schema-drift-check.yml`（Secrets参照名の変更のみ）、`SPEC.md`（該当チェックリスト記述の更新）
- 触っていない範囲: DB側の検知ロジック（`20260714000001〜3`のmigration）・GitHub Issue自動作成/クローズのロジック自体は無変更

## 検証済み
- 実行したコマンド: YAML構文チェック、`scripts/schema-drift-reconcile.test.sh`（4件全パス）
- 確認した画面: なし（ワークフローのGitHub Actions実行はマージ後の`workflow_dispatch`で確認予定）
- 確認したDB/RLS: 対象外（本PRはワークフローのSecrets参照名変更のみ）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外

## 既知の未対応
- 今回あえて対応しなかったこと: `workflow_dispatch`での本番実地確認
- 理由: マージ後でないと実際のワークフロー実行はできないため
- 次に触るなら見る場所: マージ後に`gh workflow run schema-drift-check.yml`で手動実行し、GitHub Issueが期待通り作成/クローズされるか確認する

## 後任AIへの注意
- この実装で壊してはいけない前提: `NEXT_PUBLIC_SUPABASE_ANON_KEY`はRLSで保護される前提の公開可能な値であり、機密情報ではない。今後もこのワークフローにservice role key等の機密値を渡さないこと
- 似ているが別物の用語: なし
- 勝手にリファクタしない場所: GitHub Issue自動作成/クローズのタイトル突合ロジック自体（`scripts/schema-drift-reconcile.test.sh`が担保している挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
