### PR TITLE
fix: schema-drift-check.ymlのGH_REPO未設定によるgh issueコマンド失敗を修正

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Reconcile GitHub Issues (create new / close resolved)
         env:
           GH_TOKEN: ${{ github.token }}
+          # WHY: このジョブはactions/checkoutを行わないため、ghコマンドがgitリモートから
+          # 対象リポジトリを推測できず「fatal: not a git repository」で失敗する。
+          # GH_REPOで対象リポジトリを明示することでcheckoutなしでも動作させる
+          GH_REPO: ${{ github.repository }}
         run: |
           # WHY: --limit 100は既知の制約。100件を超えるopen issueが積み上がった場合、
           # 古いissueが取得漏れし重複作成・クローズ漏れが起こりうる（v1では許容。


### PR DESCRIPTION
## Summary
- issue #305 の本番実地確認（workflow_dispatch）で、PR #334マージ後に新たな独立したバグが発覚
- `Reconcile GitHub Issues` ステップは `actions/checkout` を行っていないため、`gh issue list` / `gh issue create` がリポジトリをgitリモートから推測できず `fatal: not a git repository` で失敗していた
- 修正: 同ステップの `env` に `GH_REPO: ${{ github.repository }}` を追加し、checkoutなしで対象リポジトリを明示

## Test plan
- [x] `fix/schema-drift-check-gh-repo` ブランチで `gh workflow run schema-drift-check.yml --ref fix/schema-drift-check-gh-repo` を実行し、修正前に失敗していた箇所を含め全ステップ成功を確認（conclusion=success、`未解決ドリフト件数: 0`、Reconcileステップも `GH_REPO` 反映済みでエラーなく完走）

## 経緯
- PR #334マージ直後の本番実地確認で `NEXT_PUBLIC_SUPABASE_ANON_KEY` がHTTP 401（Invalid API key）を返す問題が先に見つかり、そちらは別セッションで修正済み（Secrets更新）
- 401解消後の再実行で本PRが修正する `fatal: not a git repository` が新たに顕在化した

🤖 Generated with [Claude Code](https://claude.com/claude-code)