### PR TITLE
feat: 発注履歴ページ(/orders)を新設し4種別を横断表示する(issue #20)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,9 +1,10 @@
-# 機能仕様書 — issue #305: PRを介さない本番スキーマ変更の定期ドリフト検知
+# 機能仕様書 — issue #20: 発注履歴ページ（/orders）: 4種別の発注を横断して一覧・検索
 
 > ステータス: **承認済み（停止①クリア）— Phase 3実装へ**
-> 作成日: 2026-07-13 / 承認日: 2026-07-13
-> 由来: Phase 1深掘り調査（Sweep→Draft Spec→Adversarial Verify→Judge Panel→Synthesize、98エージェント）の統合提案
-> 承認内容: 5点の判断事項すべて提案通り（v1スコープ3種のみ・GitHub Issueのみ通知・既存ドリフト封印・drift_alert_view anon公開・pg_cron有効化）で承認
+> 作成日: 2026-07-14 / 承認日: 2026-07-14
+> 由来: Phase 1深掘り調査（Sweep→Draft Spec→Find→Adversarial Verify→Completeness Critic→Judge Panel→Synthesize、92エージェント）の統合提案
+> 承認内容: 判断が必要な点6点すべて回答済み（未返却バッジ見送り・80件固定表示・先頭施設デフォルト・単純ilike・総件数非表示、②は保留でよい）。実装時の技術的懸念2点（summaryLabelのJOIN経路・facility_id自動送信ロジック）もSPEC.mdに反映済み
+> 前提: issue #23（分析・レポート `/reports`）はissue自身が「本issue完了後に着手推奨（案5）」としており、本issueはその前提条件
 
 ---
 
@@ -11,322 +12,266 @@
 
 ### 背景・課題
 
-issue #30でSupabase GitHub Integrationを有効化したが、これはPR/ブランチトリガーでのみ動作する。SQL Editor等でPRを介さず直接本番DBに変更が入るケース（`rls_auto_enable`イベントトリガーが実際にPRを介さず入っていた事故パターン、`20260707000001_capture_rls_auto_enable_event_trigger.sql`参照）は、次にPRが発生するまで検知が遅延する。
+発注登録モーダル（症例出荷・消耗品・貸出・返却）とDB・RPCは実装済みだが、それらを横断して参照する一覧ページが存在しない。施設ごとの個別ページ（`/facilities/[id]/case-orders` 等）はあるが、種別をまたいだ検索・一覧性がない。
 
-### 何ができるようになるか
+### 何ができるようになるか（利用者目線）
 
-SQL Editor等でPRを介さず本番DBのスキーマが直接変更された場合、**翌日までに自動でGitHub Issueが作成され**、気づけるようになる。具体的には以下の3種類の変更を検知する（v1スコープ）：
+- `/orders` を開くと、自施設に関係する4種別の発注（症例発注・消耗品発注・貸出発注・貸出返却）を1つの表で時系列に確認できる
+- 画面上部のフィルタで「期間」「製品名」「発注種別」を絞り込める
+- 管理者は施設フィルタも使用でき、複数施設をまたいで確認できる
+- 各行から関連する既存ページへ遷移できる（※実装時に判明した齟齬: 個別レコード単位の詳細ページは現行コードベースに存在しないため、施設スコープの一覧ページ（例: `/facilities/{facilityId}/loan-orders`）へのリンクとして実装。単票詳細ページの新設要否は別issueで検討）
 
-1. **テーブルのRLS（行レベルセキュリティ）が無効化された**（最も危険な変更。他施設のデータが見えてしまう等の事故に直結する）
-2. **想定外のテーブルが追加された**
-3. **既存のテーブルが削除された**
+### v1スコープで**やらないこと**（Phase 1調査でコードレベルの矛盾が確定したため除外）
 
-検知は毎日1回、自動で実行される。ドリフトがなければ何も起きない（誤通知なし）。
+- **貸出の「未返却」バッジ表示** — issue原文の要件だが、下記「判断が必要な点①」に理由を記載。v1では見送り、別issueで再検討
+- **「さらに読み込む」による追加ページネーション** — 各種別最新20件（計最大80件）の固定表示に変更。理由は「判断が必要な点③」参照
+- **JAN（バーコード）での製品検索** — 品名検索のみに統一。理由は下記
+- 発注詳細の編集・削除
+- CSVエクスポート
 
-### 採用する方式（v1・最小スコープ）
+### 操作の流れ
 
-- **DB内部の関数（`check_schema_drift()`）が毎日1回、自動実行**され、上記3種のドリフトをチェックしてログテーブルに記録する
-- **GitHub Actionsが毎日そのログを確認**し、未対応のドリフトがあれば自動でGitHub Issueを作成する
-- 本番DBへの接続情報（パスワード・アクセストークン）はGitHub Secretsに一切置かない（既存方針を継続。`docs/agents/decisions.md`参照）
-- Edge Function・外部HTTP通信は使わない（v1では省略し、実績のあるDB内部完結の仕組みに絞る）
-
-### 今回やらないこと（v2以降）
-
-- 関数の追加・削除・シグネチャ変更の検知
-- カラムの追加・削除の検知
-- イベントトリガーの追加・削除の検知
-- 制約（外部キー・一意制約・チェック制約）・インデックスの変更検知
-- RLSポリシー個別の削除検知（テーブルのRLS有効/無効のみを見る。ポリシーの中身までは見ない）
-- Slack通知等、GitHub Issue以外の通知経路
-
-理由：これらを最初から全部やろうとすると実装・検証コストが跳ね上がり着手が遅れる。まずセキュリティ影響が最大の3種（RLS無効化・テーブル追加・削除）を確実に検知できる状態を最速で作り、対象を広げるのは次のissueで行う。
-
-### 操作の流れ（人間が見るもの）
-
-1. 何もしなくてよい。毎日自動でチェックが走る
-2. ドリフトが検知されると、GitHub Issueが自動作成される（ラベル: `schema-drift`, `bug`）📸
-3. Issueには「何が」「いつ検知されたか」が書かれている
-4. 対応（マイグレーション作成 or 意図した変更なら追認）した後、次回チェックでドリフトが消えていれば自動でIssueがクローズされる
-
-> 📸 本機能はブラウザ画面を伴わない自動処理（DB関数 + GitHub Actions）のため、動作確認はGitHub Issue作成の実物とAction実行ログで行う。E2E（Playwright）のスクリーンショット撮影ポイントはない。
+1. サイドバー等から「発注履歴」を開く → `/orders` に遷移
+2. 施設スコープで最新80件（種別ごと最新20件ずつ）の発注が日付降順で表示される
+3. フィルタ変更 → URLクエリパラメータ更新 → 再フェッチ
+4. 各行の「詳細」から該当施設・種別の一覧ページに遷移（上記「利用者目線」の※注記参照）
 
 ### 受け入れ条件（チェックリスト）
 
-#### 検知の正確性
+#### 表示
+- [ ] case_orders / consumable_orders / loan_orders / loan_returns の4種別が1テーブルに表示される（各種別最新20件、計最大80件、`displayDatetime`降順・同時刻は`id`を第2キーに安定ソート）
+- [ ] 表示カラム: 発注日時・種別ラベル（症例発注/消耗品発注/貸出発注/貸出返却）・ステータス・製品名（主要1品＋残n件）・施設名（adminのみ）
+- [ ] 空結果時は「該当する発注履歴がありません」を表示
 
-- [x] ローカルSupabaseで `SELECT * FROM check_schema_drift();` を実行し、ドリフトがない状態でゼロ行が返る（`db reset`直後に実測確認済み）
-- [x] SQL Editorで `CREATE TABLE public.zz_test_drift (id uuid);` を実行後に再実行すると、`table_added` の1行が検知される（実測確認済み。後片付け済み）
-- [x] SQL Editorで既存テーブルの `ALTER TABLE ... DISABLE ROW LEVEL SECURITY;` を実行後に再実行すると、`rls_disabled` の1行が検知される（実測確認済み）
-- [x] baseline snapshotに存在するテーブルをSQL Editorで `DROP TABLE` すると、`table_removed` の1行が検知される（`case_order_items`で実測確認済み。確認後`db reset`で復元）
-- [x] 同じドリフトが未解決のまま複数回チェックが走っても、ログに重複して記録されない（冪等性）（`record_schema_drift()`を2回連続実行し重複なしを実測確認済み）
-- [x] `schema_drift_log` / `schema_baseline_snapshots` テーブル自体が削除された場合、`check_schema_drift()` の実行がエラーとして失敗し、その失敗がpg_cronの実行履歴に残る（`schema_drift_log`を実際にDROPして例外発生を実測確認済み）
+#### フィルタ
+- [ ] 期間フィルタ（date_from/date_to）: `CaseOrder→case_datetime` / `ConsumableOrder・LoanOrder→created_at` / `LoanReturn→return_datetime` で絞り込む。境界は両端とも含む（`gte`/`lte`）。日付単位で選択されたJST日付は「選択日 00:00:00+09:00」（date_from）〜「選択日 23:59:59.999+09:00」（date_to、選択日を含む終端）としてUTC変換した上でAPIへ渡す（変換はSET-Fのクライアント側で行い、API層では変換しない。前提制約参照）
+- [ ] 製品フィルタ（product_search）: 品名の部分一致（ilike）のみ。JAN検索は対象外
+- [ ] 種別フィルタ（order_type）: チェックボックスで複数選択（デフォルト全選択）。`order_kinds`に`OrderKind`以外の未知の値が1つでも含まれる場合はリクエスト全体を400で拒否する（黙って無視すると意図しない種別で絞り込まれたことに呼び出し元が気づけないため）
+- [ ] 施設フィルタ（adminのみ表示）: 施設ドロップダウン
+- [ ] 非adminで所属施設が複数ある場合、施設選択ドロップダウンを表示し、先頭施設を初期選択する（判断が必要な点④参照）。所属施設が1件のみなら自動セットしUI非表示。非adminで所属施設が0件の場合はドロップダウンを出さず「所属施設がありません」を表示し、`/api/orders`へのリクエスト自体を送らない（`facility_id`未確定のままリクエストするとAPI層に400で弾かれ続けるだけで無意味なため）
 
-#### GitHub Issue連携
+#### アクセス制御
+- [ ] 非adminユーザーは自分が所属する施設のデータのみ閲覧できる
+- [ ] 非adminがfacility_id省略・不正指定 → 400、他施設facility_id指定 → 403
+- [ ] 未認証 → API層は401を返し、ページ層が/loginへリダイレクトする（責務分離）
 
-> 以下4項目のロジック自体は`scripts/schema-drift-reconcile.test.sh`（gh CLIをスタブ化した回帰テスト、リポジトリにコミット済み・実行して4アサーション全通過を確認済み）で検証済み。ただし実際のSupabase本番環境に対する動作は`PROD_SUPABASE_URL`/`PROD_SUPABASE_ANON_KEY`のGitHub Secrets登録後、`workflow_dispatch`での手動実行で別途確認が必要（**未実施**。マージ後の運用開始タスクとして残る）。
-
-- [x] 未解決ドリフトが1件以上ある状態でGitHub Actionsを実行すると、`schema-drift`・`bug`ラベル付きのIssueが作成される（ロジックはテストで検証済み。本番環境での実地確認は上記の通り未実施）
-- [x] 既にIssueが作成済みの未解決ドリフトについては、再実行してもIssueが重複作成されない（タイトルベースの突合ロジックをテストで検証済み）
-- [x] ドリフトが解消された後の実行で、対応するIssueが自動でクローズされる（テストで検証済み）
-- [x] GitHub Actions用のトークンは標準の`GITHUB_TOKEN`（`issues:write`権限のみ）を使い、個人アクセストークンの発行・管理は不要である（`permissions: issues: write`のみ宣言、PAT不使用）
-
-#### セキュリティ
-
-- [x] 本番DBの接続パスワード・Service Role Key・Supabase Access TokenはGitHub Secretsに一切登録しない（`PROD_SUPABASE_URL`/`PROD_SUPABASE_ANON_KEY`の2つのみ使用。ワークフローファイルにコメントで明記）
-- [x] GitHub Actionsが読み取るビュー（`drift_alert_view`）はanon keyで読める設計だが、公開される情報はドリフトの種類・対象オブジェクト名・検知日時のみで、それ以上の詳細情報（`detail`列の中身）は公開されない（実装確認済み）
-- [x] `check_schema_drift()`はservice_roleのみ実行可能（GRANT EXECUTEがservice_roleに限定されている）（実装確認済み）
-
-#### 運用
-
-- [x] テスト専用Supabase環境ではこのスケジュールチェックは動作しない（本番環境限定）（`schedule`/`workflow_dispatch`のみでPRトリガーなし。構造的にテスト/PR環境では実行されない）
-- [x] `docs/agents/decisions.md` に本設計（Edge Function不使用・GitHub Actions日次ポーリング方式を選んだ理由、および実装時に発覚したrecord_issue_url()矛盾の解決）が追記される
+#### エラー・ローディングUI
+- [ ] 4種別の一部取得に失敗しても、成功した種別は表示する（`Promise.allSettled`）。失敗種別がある場合は「一部の発注種別を取得できませんでした」バナーを表示
+- [ ] フィルタ変更中はスケルトンUIを表示
+- [ ] APIエラー・ネットワークエラー時はエラーバナー＋リトライボタンを表示
 
 ---
 
 ### 判断が必要な点（レビュー時に確認）
 
-1. **pg_cron拡張の有効化を承認するか** — Supabase Dashboard → Database → Extensionsから有効化する。DB内部スケジューラとして必須。無効化できない/したくない場合は、GitHub Actions側からRPC経由で`check_schema_drift()`を直接呼ぶ代替方式に変更する（フォールバックとして実装計画には両方含める）
-2. **v1の検知スコープ（RLS無効化・テーブル追加・テーブル削除の3種のみ）で妥当か** — 関数・カラム・トリガー等はv2に先送りするが、これで最初の一歩として十分な価値があるか
-3. **通知先はGitHub Issueのみで確定してよいか**（Slack等は今回対象外）
-4. **本番の「既存の未記録ドリフト」の扱い** — 本仕様の初回マイグレーション適用時点のテーブル一覧を「あるべき状態」としてそのまま封印する設計にする（過去に本当にドリフトしていたものがあっても、そこは合格ラインとして扱われる）。適用前に本番の棚卸しを別途行うべきか、それともこのまま封印してよいか
-5. **`drift_alert_view`をanon keyで公開すること**への承認 — ドリフト種別・対象オブジェクト名・検知日時が匿名で読み取り可能になる（詳細情報は非公開）。この程度の情報公開は許容できるか
+1. **「未返却」バッジをv1で本当に見送るか**
+   Phase 1調査でコード確認済み: `loan_orders.status`の許容値は`['draft','submitted']`のみで`'returned'`は存在せず、`loan_returns`に`loan_order_id`列も無く、`createLoanReturn`は`loan_order.status`を更新しない。つまりissue原文が想定する「未返却ステータス表示」を単純な`status`判定（案A）で実装すると、**返却済みレコードを100%誤検知して常に「未返却」と表示してしまう**バグになることが確定している。
+   正確に実装するには`loan_returns`に`loan_order_id`FKを追加するマイグレーション（案B）が必要。
+   → **推奨: v1では見送り、案Bを別issueで先行実施してから再度対応**。ただしバッジがビジネス上必須なら、本issueのスコープを広げて案Bを含める判断もありうる
+
+2. **既存`loan_returns`データの案B移行戦略**（①で案B採用の場合のみ関係）
+   FK後付け時、既存レコードの`loan_order_id`をNULLのまま残すか、lot/jan/facilityで推測紐付けするか。データ整合性に関わるため人間判断が必要（v1では扱わないため今回は保留でよい）
+
+3. **ページネーションをv1で「各種別最新20件・計最大80件の固定表示」に絞ることの受容**
+   種別ごとにoffsetを取ると全体の日付降順マージと矛盾し重複・抜けが確定的に発生するため、cursor-basedページネーションが必要になるが、v1にはコストが見合わない。この制約（それより古いデータは期間フィルタで絞り込む必要がある）を運用上許容できるか
+
+4. **複数施設所属ユーザーのデフォルト施設**
+   「先頭施設を初期選択」でよいか、「前回選択を復元」等の要望があるか
+
+5. **製品フィルタのスペース区切りOR検索の要否**
+   単純な部分一致（ilike）のみで十分か、複数キーワードのOR検索に対応するか（対応する場合UIヘルプテキストが追加で必要）
+
+6. **総件数表示は不要か**
+   「全n件中m件表示」等の件数表示要件は無しとする前提（`counts`フィールドを削除）で問題ないか
 
 ---
 
-## Part 2 — 実装計画（AI用・技術詳細・レビュー不要）
+## Part 2 — 実装計画（AI用・技術詳細）
 
-### 前提
+### 前提制約（調査結果から）
 
-- RISK判定: `supabase/migrations/`・RLS・policyドメインに触れるため **RISK=はい（M/Lレーン必須）**
-- 既存方針の継承: 本番Supabase接続情報をGitHub Secretsに置かない（`docs/agents/decisions.md`「なぜスキーマドリフト検知を自前cronではなくSupabase GitHub Integrationで始めたか」と同じ制約を維持する。本仕様はそれを補完するもので、置き換えではない）
-- `check_schema_drift()`のテーブル追加/削除判定は、`schema_baseline_snapshots`にmigration適用時点の`pg_tables`実データをそのまま記録する方式（手動でのテーブル名列挙はしない。導出漏れリスクを構造的に避けるため）
-- **[Phase 5レビューで追加]** 今後publicスキーマのテーブル構成を変える（テーブルを追加/削除する）migrationは、末尾で`SELECT refresh_schema_baseline_snapshot('<そのmigrationのタイムスタンプ>');`を呼ぶこと（`20260714000003_schema_drift_v1_hardening.sql`で追加）。呼ばないと、正規のPRレビュー済み変更でもtable_added/table_removedとして恒久的に誤検知され続ける（`docs/agents/common.md`にも運用ルールとして明記）
+1. **facility_id必須制約**: `requireFacilityAccess`は非adminでfacility_id=nullを拒否する。新規APIエンドポイント（`/api/orders`）ではadmin時のみfacility_id=nullを許可し、非adminは所属施設のfacility_idを解決して渡す
+2. **RLSは追加不要**: `20260628010001_update_rls_admin.sql`で4テーブルに`facility_member_or_admin`ポリシーが存在済み。`/api/orders`は`requireFacilityAccess`を呼ぶだけでRLSが自動適用される（API側チェックはdefense-in-depth）
+3. **既存4 APIのクエリパラメータバリデーション漏れ**（`limit`/`offset`のNumber.isFinite・負数・上限チェックなし）のHTTPステータスコードへのマッピングは本issueのスコープ外（別issue推奨、pending_issues.jsonlで追跡）。ただし repository層（SET-C）の list* 関数自体には limit/offset の不変条件チェック（`limit`は1〜100の整数、`offset`は0以上の整数。外れる場合はErrorを投げる）を defense-in-depth として実装する（呼び出し元でのHTTPステータスへの変換は各APIの責務のまま）。新設する`/api/orders`（SET-D）は`limit`をユーザー入力から受け取らず`LIMIT_PER_KIND=20`固定で呼ぶため、この検証には通常抵触しない
+4. **use(params) + Suspense**: 新設`/orders`ページは`useSearchParams`を使うため`Suspense`でのラップ＋`fallback`指定が必須（既知の失敗パターン：`src/app/login/page.tsx:110`で同種の指摘あり、本issueでは新規実装側で確実に対応する）
+5. **facilityName（admin表示用）の解決元**: `facilities`テーブルは authenticated であれば全件SELECT可能な共有マスタ（`auth_only`ポリシー）。SET-D（`unified-repository.ts`）が`listFacilities(db)`を1回呼び、`id→name`のMapを作って各`UnifiedOrder.facilityName`に適用する。4種別ごとに個別JOINしない（N+1回避）
+6. **admin用施設一覧（フィルタドロップダウン・全施設対象時の対象施設ID解決）の取得元**: 既存`GET /api/facilities`は`listFacilities(db)`の全件をそのまま返す仕様で、非adminにも全施設が見えてしまい「非adminは所属施設のみ選択可」という受け入れ条件と矛盾する。そのため`/orders`ページ（SET-F）専用の軽量エンドポイント`GET /api/user-facilities`を新設し、adminには全施設、非adminには`listUserFacilities`で解決した所属施設のみを返す（`{ facilities: Facility[], isAdmin: boolean }`）。既存`GET /api/dashboard`は施設ごとの重い集計を含むため流用しない。同様に、SET-Dの`unified-repository.ts`はサーバー側関数のため`listFacilities`を直接呼べるが、SET-Fはクライアントコンポーネント（`'use client'`）であり`src/lib/facilities/repository.ts`等のサーバー専用DBアクセス関数を直接importできない。そのため両者は独立した経路（サーバー内部呼び出し vs 新設APIのfetch）で施設一覧を取得する
 
-### drift_type / event_kind の値と判定基準（Part 3セルフチェック対応）
+### 実装セット一覧（依存順）に対する補足: `/api/user-facilities`
 
-**`drift_type`**（`schema_drift_log.drift_type`、TEXT、CHECK制約で下記3値に限定）
+上記前提制約6により、統合時点で以下のセットを追加実装済み（元のSET-F計画にはAPIエンドポイントの記載が無く、`listUserFacilities`をクライアント側から直接呼ぶ想定になっていたが、クライアントコンポーネントからサーバー専用のrepository関数を直接呼ぶことはできないため、この不足を補うAPIが必要だった）:
 
-| 値 | 判定基準 | 下流の反応 |
-|---|---|---|
-| `rls_disabled` | `pg_class.relrowsecurity = false` のpublicスキーマテーブルが1件でもある | `drift_alert_view`に表示 → GitHub Actionsが`[priority:high]`をタイトルに付与してIssue作成 |
-| `table_added` | 最新snapshotの`snapshot`配列に存在しないテーブルが`pg_tables`に存在する | `drift_alert_view`に表示 → 通常のIssue作成対象 |
-| `table_removed` | 最新snapshotの`snapshot`配列に存在するテーブルが`pg_tables`に存在しない | `drift_alert_view`に表示 → 通常のIssue作成対象 |
+- ファイル: `src/app/api/user-facilities/route.ts`（新規）
+- GET: `requireAuth`（401） → `resolveIsAdmin` → admin時は`listFacilities`の全件、非admin時は`listUserFacilities`で絞り込んだ所属施設のみを返す
+- SET-Fはこのエンドポイントをfetchして`facilities`・`isAdmin`を取得し、施設ドロップダウンの選択肢と初期選択施設を決定する
 
-**[Phase 5レビューで削除]** 原案にあった`error`種別（想定外例外の捕捉）は、対応する例外ハンドラが実装されておらず実装と乖離したドキュメントのみの状態だったため、v1スコープから削除した。基盤テーブル消失・baseline空の2ケースは`check_schema_drift()`が`RAISE EXCEPTION`で直接失敗する設計のままとし（`cron.job_run_details`に残る）、それ以外の想定外例外を`schema_drift_log`に記録する機能はv2以降の検討課題とする。
+### 型定義（`src/types/order.ts` に追記）
 
-**`event_kind`**（`schema_drift_log.event_kind`、TEXT CHECK IN ('detected','acknowledged','resolved')）
+```typescript
+export type OrderKind = 'case' | 'consumable' | 'loan' | 'loan_return'
 
-| 値 | 判定基準 | 下流の反応 |
-|---|---|---|
-| `detected` | `check_schema_drift()`が新規ドリフトを検知した瞬間にINSERTする初期値 | `drift_alert_view`の対象（`resolved_at IS NULL`かつ`event_kind='detected'`） |
-| `acknowledged` | 人間がドリフトを「意図した変更」と確認し、対応するmigrationを作らずクローズしたい場合に手動でUPDATEする（v1では専用UIなし、SQLで直接更新） | `drift_alert_view`の対象から除外（`resolved_at`が設定される想定、またはWHERE句で`event_kind != 'acknowledged'`も対象外にする） |
-| `resolved` | 次回`check_schema_drift()`実行時に、同一`drift_type`+`object_name`の組が再検知されなかった場合、対応する`detected`行の`resolved_at`を自動更新する | `drift_alert_view`の対象から除外。GitHub Actions側が対応するIssueをクローズする |
+// raw原案は削除（union型のtype guardが強制されず実行時エラーリスクがあるため）。
+// 詳細遷移はid+kindのみで既存個別ページへのリンクで完結する
+export type UnifiedOrder = {
+  id: string
+  kind: OrderKind
+  facilityId: string
+  facilityName?: string          // admin表示用（JOIN先から）
+  displayDatetime: string        // case→case_datetime / consumable・loan→created_at / loan_return→return_datetime。生成責任はAPI層(SET-D)
+  status: string
+  summaryLabel: string           // 代表製品名 + 残n件。生成責任はAPI層(SET-D)
+}
 
-**合計3種類の`drift_type`・3種類の`event_kind`、本文中の記載件数と一致することを確認済み。**
+export type OrdersFilter = {
+  facilityId?: string
+  dateFrom?: string   // ISO 8601 (UTC)
+  dateTo?: string     // ISO 8601 (UTC)
+  productSearch?: string
+  orderKinds?: OrderKind[]
+}
+```
 
 ### 実装セット一覧（依存順）
 
-#### セット1: DBスキーマ（マイグレーション、直列内で最初）
+#### SET-A: DBマイグレーション — インデックス追加
+- ファイル: `supabase/migrations/YYYYMMDDHHMMSS_add_orders_search_indexes.sql`
+- 追加インデックス:
+  - `case_orders`: `(facility_id, case_datetime)` ★既存の`idx_case_orders_facility_created_at`とは別に必要（期間フィルタは`case_datetime`を使うため）
+  - `consumable_orders`: `(facility_id, created_at)`
+  - `loan_orders`: `(facility_id, created_at)`
+  - `loan_returns`: `(facility_id, return_datetime)`
+- `refresh_schema_baseline_snapshot`は呼ばない（テーブル追加/削除を伴わないインデックス追加のみのため。common.md記載の対象外。念のためmigration内に1行コメントで根拠を明記する）
+- テスト観点: マイグレーション適用が冪等に成功すること（`IF NOT EXISTS`）
 
-**触るファイル（新規）:**
-- `supabase/migrations/20260714000001_create_schema_drift_detection.sql`
+#### SET-B: 型定義追加
+- ファイル: `src/types/order.ts`（上記型定義を追記）
+- 依存: なし（先行実装可）
 
-**内容（骨格）:**
-```sql
--- 1. baseline snapshot（append-only）
-CREATE TABLE schema_baseline_snapshots (
-  epoch TEXT PRIMARY KEY,
-  snapshot JSONB NOT NULL,
-  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-ALTER TABLE schema_baseline_snapshots ENABLE ROW LEVEL SECURITY;
--- service_role以外ポリシーなし = service_roleのみアクセス可（既存パターンに合わせる）
+#### SET-C: Repository層フィルタ拡張
+- ファイル（4ファイル）: `src/lib/case-orders/repository.ts` / `src/lib/consumable-orders/repository.ts` / `src/lib/loan-orders/repository.ts` / `src/lib/loan-returns/repository.ts`
+- 各`list*`関数に`dateFrom?`, `dateTo?`, `productSearch?`引数を追加
+- 品名JOIN経路（M-3・M-5対応。**このJOINはproductSearchフィルタの絞り込み専用**であり、SET-Dが行うsummaryLabel表示用の名前解決とは目的・実行タイミングが異なる別クエリである。両者は同じ`products`/`consumables`テーブルに触れるが、前者は「検索条件に一致するID群を求める」ため、後者は「取得済みレコードの代表製品名を表示用に解決する」ためであり、責務が重複しているわけではない。productSearch未指定時はSET-C側のJOINは発生しない）:
+  - `loan_order_items.name`（直接、name列あり）
+  - `case_order_items.jan → products.name`（JOIN必須、case_order_itemsにname列なし）
+  - `loan_return_items.jan → products.name`（JOIN必須、loan_return_itemsにname列なし）
+  - `consumable_order_items.consumable_id → consumables.name`（JOIN）
+- 生の`status`をそのまま返す（isUnreturned等の判定はSET-Cでは行わない。将来案B採用時もAPI層1箇所の修正で完結させるため）
+- `limit`/`offset`の不変条件チェックを共通ヘルパー（`src/lib/orders/list-options-validation.ts`想定）に集約し、4つの`list*`関数の先頭で呼ぶ（前提制約3参照）。`limit`は1〜100の整数以外、`offset`は0以上の整数以外でErrorを投げる。HTTPステータスへの変換は行わない（呼び出し元APIの責務）
+- `.order()`は必ず`dateFrom`/`dateTo`の絞り込みに使っているカラムと同じキーを使うこと（`case_orders→case_datetime` / `loan_returns→return_datetime` / それ以外→`created_at`）。フィルタキーとソートキーがズレると、施設ごとの該当件数がlimitを超えた場合にDB側で誤ったキーで先に切り詰められ、SET-Dのunified-repositoryが前提とする「displayDatetime降順で上位N件」という不変条件が崩れる（型安全・データ層整合レビューで確認された実バグ）。同時刻の安定ページングのため`id`昇順を第2キーとして併用する
+- テスト観点:
+  - dateFrom/dateTo境界値テスト（UTC/JST変換を含む）
+  - `.order()`のキーがdateFrom/dateToで絞り込むカラムと一致していること（case_orders→case_datetime、loan_returns→return_datetime）
+  - productSearchが空の場合はフィルタを適用しない
+  - limit上限: 最大100（100超はrepository層でError）、負数もrepository層でError（offsetの負数も同様）
 
--- 2. ドリフトログ（append-only、冪等性は部分ユニーク制約で担保）
-CREATE TABLE schema_drift_log (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  drift_type TEXT NOT NULL,
-  object_name TEXT,
-  detail JSONB,
-  event_kind TEXT NOT NULL DEFAULT 'detected' CHECK (event_kind IN ('detected','acknowledged','resolved')),
-  detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  resolved_at TIMESTAMPTZ,
-  issue_url TEXT
-);
-CREATE UNIQUE INDEX schema_drift_log_open_unique
-  ON schema_drift_log (drift_type, object_name) WHERE resolved_at IS NULL;
-ALTER TABLE schema_drift_log ENABLE ROW LEVEL SECURITY;
+#### SET-D: 横断APIエンドポイント新設 `/api/orders`
+- ファイル: `src/app/api/orders/route.ts`
+- 内部構造として`src/lib/orders/unified-repository.ts`を新設し、4種別の並列取得・マージ・summaryLabel解決・facilityName解決をここに集約する（API routeを薄く保ち、将来の種別追加を1箇所で完結させるため）
+- GETパラメータ: `facility_id`, `date_from`, `date_to`, `product_search`, `order_kinds`（CSV）
+- 実装方針:
+  - `requireAuth`（未認証→401） → `requireFacilityAccess`（非adminはfacility_id必須、省略/不正→400、他施設→403）
+  - `order_kinds`に`OrderKind`以外の未知の値が含まれる場合は400（前提制約・受け入れ条件参照）
+  - `listFacilities(db)`を1回呼び、`id→name`のMapを作成する。admin時に`facility_id`未指定なら、このMapのキー（全施設ID）を対象施設IDリストとして使う（facilityNameの解決と対象施設ID列挙を同じ1回のクエリ結果で兼ねる。前提制約5参照）
+  - `Promise.allSettled`で4種別を並列取得（各種別limit=20固定、v1ではoffset無し）。admin全施設対象時は種別ごとに対象施設分`list*`を並列呼び出しし、施設をまたいでdisplayDatetime降順にマージしてから上位20件に絞り込む（=1種別あたり最大「施設数×20件」を一時的に取得してから絞り込むため、施設数が多い環境ではクエリ数・レイテンシが線形に増える。既知の未対応・今後の課題を参照）
+  - マージ後、日時降順・同時刻は`id`昇順で安定ソート
+  - summaryLabelの解決はjan経路とconsumable_id経路を分けてバッチ化する（いずれもN+1回避のため個別クエリにしない。**SET-Cのproduct/consumable JOINとは別の、表示専用の名前解決クエリ**であり、取得済みレコードの代表1品目分のキーのみをバッチでIN句解決する）:
+    - case_orders・loan_returnsから収集したjan（各注文の代表1明細分）をまとめて`products`へIN句1本
+    - consumable_ordersから収集したconsumable_id（代表1明細分）をまとめて`consumables`へIN句1本
+    - loan_ordersは`loan_order_items.name`を直接使うためJOIN/IN句不要
+- レスポンス: `{ orders: UnifiedOrder[], errors: Array<{ kind: OrderKind; message: string }> }`
+  - 失敗種別は`orders`に含めず、`errors`に理由を記録。`counts`フィールドは持たない
+- バリデーション: `date_from`/`date_to`はISO 8601 UTC文字列として受け取り、API側での変換はしない
+- テスト観点:
+  - 非adminがfacility_id省略 → 400 / 他施設facility_id → 403 / 未認証 → 401
+  - `order_kinds`に未知の値が含まれる → 400
+  - 4種別すべて空 → `{ orders: [], errors: [] }`
+  - 1種別が失敗しても他の結果は返すこと（`errors`に該当種別が入ること）
+  - `src/lib/orders/unified-repository.ts`自体の単体テスト（route.test.tsでの`fetchUnifiedOrders`モック化とは別に必須）: displayDatetime降順・同時刻id昇順の安定ソート、summaryLabelの代表製品名+残n件表示、品目0件時の表示文言、facilityNameの解決、admin全施設ファンアウト時の種別ごと上位20件への絞り込み
 
--- 3. 初期snapshot（このmigration適用時点の実データをそのまま封印）
-INSERT INTO schema_baseline_snapshots (epoch, snapshot)
-SELECT '20260714000001', jsonb_agg(tablename ORDER BY tablename)
-FROM pg_tables WHERE schemaname = 'public';
+#### SET-E: UIコンポーネント
+- ファイル（新規）:
+  - `src/components/orders/OrderHistoryFilters.tsx` — フィルタフォーム（期間・品名・種別・施設）。複数施設所属時は施設ドロップダウンを表示
+  - `src/components/orders/OrderHistoryTable.tsx` — `UnifiedOrder[]`を受け取るテーブル。空状態・エラーバナー・スケルトンを含む
+  - `src/components/orders/OrderKindBadge.tsx` — `OrderKind`を受け取り種別カラーバッジを返す
+- テスト観点:
+  - `OrderHistoryTable`: `orders=[]`で「該当する発注履歴がありません」表示、`errors`が空でなければ「一部の発注種別を取得できませんでした」バナー表示、`loading=true`時はスケルトンUIを表示し行を描画しないこと、`showFacilityColumn=false`時は施設名カラム自体を出さないこと（非adminには不要なため）
+  - `OrderKindBadge`: 4種別（case/consumable/loan/loan_return）すべてで対応する日本語ラベル（症例発注/消耗品発注/貸出発注/貸出返却）が表示されること、未知の値を渡してもクラッシュしないこと
+  - `OrderHistoryFilters`: 種別チェックボックスの初期状態は全選択、施設ドロップダウンは`showFacilitySelect=false`時に表示されないこと
+  - アクセシビリティ: テーブル見出し（`<th>`）に`scope="col"`属性、`OrderKindBadge`のルート要素に`aria-label`（例: `症例発注`）
 
--- 4. check_schema_drift() 本体
-CREATE OR REPLACE FUNCTION check_schema_drift()
-RETURNS TABLE (drift_type TEXT, object_name TEXT, detail JSONB)
-LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
-DECLARE
-  latest_snapshot JSONB;
-BEGIN
-  -- 自己参照ガード: 基盤テーブル自体の消失を最優先で検知
-  IF to_regclass('public.schema_drift_log') IS NULL
-     OR to_regclass('public.schema_baseline_snapshots') IS NULL THEN
-    RAISE EXCEPTION 'schema drift detection base tables are missing (self-referential integrity failure)';
-  END IF;
-
-  SELECT snapshot INTO latest_snapshot
-  FROM schema_baseline_snapshots ORDER BY epoch DESC LIMIT 1;
-
-  -- 1. RLS無効化検知（ホワイトリスト不要、public全テーブル対象）
-  --    自テーブル(schema_baseline_snapshots/schema_drift_log)もRLS有効化前提のため対象に含む
-  RETURN QUERY
-  SELECT 'rls_disabled', c.relname, jsonb_build_object('schema', 'public')
-  FROM pg_class c
-  JOIN pg_namespace n ON n.oid = c.relnamespace
-  WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relrowsecurity = false;
-
-  -- 2. テーブル追加検知
-  RETURN QUERY
-  SELECT 'table_added', t.tablename, jsonb_build_object('schema', 'public')
-  FROM pg_tables t
-  WHERE t.schemaname = 'public'
-    AND NOT (latest_snapshot ? t.tablename);
-
-  -- 3. テーブル削除検知
-  RETURN QUERY
-  SELECT 'table_removed', s.name, jsonb_build_object('schema', 'public')
-  FROM jsonb_array_elements_text(latest_snapshot) AS s(name)
-  WHERE NOT EXISTS (
-    SELECT 1 FROM pg_tables t WHERE t.schemaname = 'public' AND t.tablename = s.name
-  );
-END;
-$$;
-GRANT EXECUTE ON FUNCTION check_schema_drift TO service_role;
-
--- 5. ドリフト記録関数（check_schema_drift()の結果をログに冪等insertし、resolved自動更新も行う）
-CREATE OR REPLACE FUNCTION record_schema_drift()
-RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
-BEGIN
-  -- 新規ドリフトを記録（既存の未解決行があればスキップ）
-  INSERT INTO schema_drift_log (drift_type, object_name, detail)
-  SELECT d.drift_type, d.object_name, d.detail FROM check_schema_drift() d
-  ON CONFLICT (drift_type, object_name) WHERE resolved_at IS NULL DO NOTHING;
-
-  -- 前回検知されたが今回検知されなかった行はresolvedにする
-  UPDATE schema_drift_log l
-  SET event_kind = 'resolved', resolved_at = now()
-  WHERE l.event_kind = 'detected' AND l.resolved_at IS NULL
-    AND NOT EXISTS (
-      SELECT 1 FROM check_schema_drift() d
-      WHERE d.drift_type = l.drift_type AND d.object_name = l.object_name
-    );
-END;
-$$;
-GRANT EXECUTE ON FUNCTION record_schema_drift TO service_role;
-
--- 6. GitHub Actions公開用ビュー（詳細非公開・未解決分のみ）
-CREATE VIEW drift_alert_view AS
-SELECT id, drift_type, object_name, detected_at, issue_url
-FROM schema_drift_log
-WHERE event_kind = 'detected' AND resolved_at IS NULL;
-GRANT SELECT ON drift_alert_view TO anon;
-```
-
-**テスト観点:**
-- `supabase/migrations/__tests__/schema_drift_detection.test.ts`（既存`tech_debt_migrations.test.ts`と同じ静的SQL検証方式）
-  - `record_schema_drift()`・`check_schema_drift()`・`drift_alert_view`が定義されていること
-  - `schema_drift_log_open_unique`部分ユニークインデックスの`WHERE resolved_at IS NULL`条件が含まれること
-  - `GRANT SELECT ON drift_alert_view TO anon`が含まれること（過剰付与ではなくSELECTのみであることも確認）
-- ローカル`supabase db reset`後、`SELECT * FROM check_schema_drift();`がゼロ行を返すことを手動確認（受け入れ条件1件目に対応）
-
-**触るファイル:**
-- `supabase/migrations/20260714000001_create_schema_drift_detection.sql`（新規）
-- `supabase/migrations/__tests__/schema_drift_detection.test.ts`（新規）
-
----
-
-#### セット2: pg_cronスケジュール設定（セット1完了後・直列）
-
-**触るファイル（新規）:**
-- `supabase/migrations/20260714000002_schedule_schema_drift_check.sql`
-
-**内容（骨格）:**
-```sql
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-
-SELECT cron.schedule(
-  'schema-drift-daily-check',
-  '0 23 * * *', -- UTC 23:00 = JST 8:00
-  $$ SELECT record_schema_drift(); $$
-);
-```
-
-**補足（pg_cronが有効化できない場合のフォールバック）:**
-- 前提確認1（Part 1参照）でpg_cron不可の判断が出た場合、このセットはスキップし、代わりにセット3（GitHub Actions）側から`record_schema_drift()`をRPC経由（service_role key使用、ただしこれはGitHub Secretsではなく別途安全な経路の検討が必要—**この場合は追加の人間判断が必要なため、pg_cron不可判定が出た時点でこのセットの実装者は着手せず、統合ゲートで報告すること**）
-
-**テスト観点:**
-- ローカルで`SELECT * FROM cron.job WHERE jobname = 'schema-drift-daily-check';`でスケジュール登録を確認
-- `SELECT cron.run_job((SELECT jobid FROM cron.job WHERE jobname = 'schema-drift-daily-check'));`で手動実行し、エラーが出ないことを確認
-
-**触るファイル:**
-- `supabase/migrations/20260714000002_schedule_schema_drift_check.sql`（新規）
-
----
-
-#### セット3（セット1と並列可）: GitHub Actionsワークフロー
-
-**触るファイル（新規）:**
-- `.github/workflows/schema-drift-check.yml`
-
-**内容（実装済み。原案からの変更点はテスト観点の後に記載）:**
-- `schedule: cron: '0 0 * * *'`（UTC 0:00、DB側チェックより後に実行されるよう時刻をずらす）+ `workflow_dispatch`（手動実行可能に）
-- `curl`で`drift_alert_view`をanon keyで取得（本番Supabase URLとanon keyのみ使用。パスワード・service role key不使用）
-- 未解決ドリフトごとに、タイトル`[schema-drift] <drift_type>: <object_name>`で`gh issue create`。既存open issueとタイトル突合し重複作成を防ぐ
-- 未解決一覧に存在しなくなったドリフトに対応するopen issueは`gh issue close`する
-
-**テスト観点:**
-- `workflow_dispatch`での手動実行が成功すること（実装後に一度手動トリガーして確認する統合ゲート項目とする）
-- モックの`drift.json`/`open_issues.json`に対する新規作成・重複防止・クローズの3パターンをbashスクリプトのドライランで検証済み（実装時に実施）
-
-**原案からの変更点（実装時に判明した矛盾の解決）:**
-原案は`issue_url`を`record_issue_url()` RPC経由でDBに書き戻す設計だったが、その関数はservice_role限定であり、anon keyのみで動くこのワークフローからは呼び出せないという矛盾が実装時に判明した（Part1「本番DBの接続パスワード・Service Role Key…はGitHub Secretsに一切登録しない」という受け入れ条件と直接衝突するため、この矛盾を解消せずに進めることはできない）。
-DBへの書き込みを一切行わず、GitHub Issue自体を状態源にする方式に変更した（詳細は`docs/agents/decisions.md`参照）。`record_issue_url()`関数自体はセット1に実装済みだが、このワークフローからは呼び出さない（将来DB側の運用ツールから使う可能性を考慮し残置）。
-
-**触るファイル:**
-- `.github/workflows/schema-drift-check.yml`（新規）
-
----
-
-#### セット4（独立・並列可）: decisions.md更新
-
-**触るファイル（既存）:**
-- `docs/agents/decisions.md`
-
-**内容:**
-- 「なぜPRの外側のスキーマドリフト検知にEdge Functionを使わずpg_cron + GitHub Actionsポーリングを採用したか」を追記
-- 検討した代替案（Edge Function + Webhook方式）を不採用にした理由（pg_net依存・デプロイパイプライン未定義・GITHUB_TOKEN管理コストの3点）を記録
-
----
+#### SET-F: `/orders`ページ実装
+- ファイル: `src/app/orders/page.tsx`
+- 実装方針:
+  - `'use client'`、`useSearchParams()`でURLクエリを読み取り
+  - `Suspense`で`OrdersPageContent`をラップし、`fallback`を必ず指定する
+  - フィルタ変更 → `router.replace`でURL更新 → `useEffect`で再フェッチ
+  - JST日付をUTCに変換してからAPIへ渡す変換ロジックはクライアントユーティリティに集約（選択日00:00:00+09:00 → UTC変換）
+  - admin判定・施設一覧の取得は`GET /api/user-facilities`（前提制約6・実装セット一覧の補足参照）をfetchして行う。クライアントコンポーネントから`listUserFacilities`等のサーバー専用repository関数を直接importすることはできないため、既存`useUser`フックのみでは施設一覧を取得できない
+  - facility_idの決定ロジック（APIの400/403ルールと対応させる）:
+    - admin: 施設フィルタ未選択なら`facility_id`を付けずにリクエスト（API側でfacility_id=null許可）。選択時はその値を付ける
+    - 非admin・所属施設1件: `/api/user-facilities`が返した唯一の施設を自動的に`facility_id`としてリクエストに付与（UI非表示）
+    - 非admin・所属施設2件以上: 施設ドロップダウンで選択された値（初期値は先頭施設）を`facility_id`として必ず付与する。ドロップダウン未選択のまま初回リクエストを送らない（先頭施設をstateの初期値にしてから初回フェッチする）
+    - 非admin・所属施設0件: ドロップダウンを表示せず「所属施設がありません」を表示し、`/api/orders`へのリクエストを送らない（受け入れ条件・フィルタ節参照）
+- テスト観点:
+  - 非adminでページが開けること（自施設facility_idが自動セットされること）
+  - フィルタ変更でURLが更新されること
+  - ローディング中にスケルトンUIが表示されること
+  - 非adminで所属施設が0件の場合に「所属施設がありません」を表示し、無限ローディングにならないこと
 
 ### 並列グループ宣言
 
 ```
-Wave 1 ──┬── Set 1 (DBスキーマ)     supabase/migrations/20260714000001_*.sql + __tests__
-          └── Set 4 (decisions.md)  docs/agents/decisions.md
-             ↓ Set 1完了後
-Wave 2 ──┬── Set 2 (pg_cronスケジュール)  supabase/migrations/20260714000002_*.sql
-          └── Set 3 (GitHub Actions)      .github/workflows/schema-drift-check.yml
-             （Set 3はSet 1のrecord_issue_url関数シグネチャに依存するため、Set 1完了後に着手）
-統合ゲート:
-  - migrationのローカル適用確認（db reset）
-  - pg_cronジョブの手動実行確認
-  - GitHub Actionsのworkflow_dispatch手動実行確認（可能な範囲で）
+グループ1（並列）: SET-A + SET-B
+  - SET-A 触るファイル: supabase/migrations/（新規1ファイル）
+  - SET-B 触るファイル: src/types/order.ts
+
+グループ2（グループ1完了後、並列）: SET-C + SET-E
+  - SET-C 触るファイル:
+      src/lib/case-orders/repository.ts
+      src/lib/consumable-orders/repository.ts
+      src/lib/loan-orders/repository.ts
+      src/lib/loan-returns/repository.ts
+  - SET-E 触るファイル:
+      src/components/orders/OrderHistoryFilters.tsx（新規）
+      src/components/orders/OrderHistoryTable.tsx（新規）
+      src/components/orders/OrderKindBadge.tsx（新規）
+
+グループ3（SET-C完了後、SET-B完了後）: SET-D
+  - 触るファイル:
+      src/app/api/orders/route.ts（新規）
+      src/lib/orders/unified-repository.ts（新規）
+
+グループ4（SET-D + SET-E完了後）: SET-F
+  - 触るファイル: src/app/orders/page.tsx（新規）
 ```
 
-Set 1とSet 4は互いに別ファイルのみを触るため並列可能。Set 2・Set 3はSet 1完了後（関数シグネチャ確定後）に着手する。
+### 既知の未対応・今後の課題
 
-### 型・データアクセス層の方針
+| 事項 | 理由 | 対応時期 |
+|---|---|---|
+| 未返却バッジ（案B: loan_order_id FK追加） | 停止①「判断が必要な点①」で確定待ち | 停止①後、別issue推奨 |
+| 全体横断のcursor-basedページネーション | v1は固定80件表示で対応、それ以上はコスト超過 | 別issue |
+| JAN単独フィルタ | 種別間で挙動が不統一（case/loan_returnはjan、consumableはjan NULL可） | 別issue |
+| 既存4 API（case-orders等）のlimit/offsetのHTTPステータスコードへのバリデーション修正 | 本issueのスコープ外（repository層の不変条件チェックのみSET-Cで対応済み） | 別issue（pending_issues.jsonlで追跡） |
+| モバイル表示 | v1はテーブル横スクロール（`overflow-x:auto`）で対応、カード切替は対象外 | 別issue |
+| admin全施設対象時のファンアウトクエリ数（施設数×4種別分の`list*`呼び出し） | v1は施設数が少数（数十施設程度）である前提で許容。施設数が数百規模に増える場合はDB側での集約（マテリアライズドビュー等）かcursor-based全体ページネーションへの再設計が必要 | 施設数増加時に別issueで再検討 |
 
-- 本機能はDB関数・SQLマイグレーション・GitHub Actionsのみで完結し、`src/`配下のTypeScriptコード・APIルートは一切変更しない
-- 型安全性はPostgreSQLのCHECK制約（`event_kind`）とSQLの静的検証テスト（既存`tech_debt_migrations.test.ts`パターン踏襲）で担保する
+### 後任AIへの注意
+
+- `/orders`は`/facilities/[id]/`配下ではなくトップレベルに置く
+- `requireFacilityAccess`は非adminでfacility_id=nullを`FACILITY_ID_REQUIRED`として弾く。非adminユーザーの施設ID取得（サーバー側）には`user_facilities`テーブルを参照する既存関数（`listUserFacilities`等）を再利用すること。ただしクライアントコンポーネント（SET-F）からはこれらのサーバー専用repository関数を直接importできないため、`GET /api/user-facilities`（前提制約6）を経由すること
+- v1では「未返却」判定を一切実装しない（`isUnreturned`フィールドも型に含めない）。案B採用が決まった場合のみ、API層（SET-D）に`loan_returns`へのLEFT JOINを1箇所追加する設計とする
+- `/api/orders`レスポンスキーは`orders`（`returns`ではない）に統一する。`counts`フィールドは持たない
+- ConsumableOrderの製品検索は`consumables`テーブルへのJOINが必要（janはconsumable_order_itemsにはない）。JAN検索自体はv1スコープ外
+- `case_orders`・`loan_returns`の`list*`は`dateFrom`/`dateTo`のフィルタキー（`case_datetime`/`return_datetime`）と`.order()`のソートキーを必ず一致させること。ズレるとfetchTopN前提の「displayDatetime降順で上位N件」が崩れる（型安全・データ層整合レビューで実際に検出されたcriticalバグ。修正済みだが再発させないこと）
+- `src/types/order.ts`の`OrdersQueryParams`型は現状どのファイルからも参照されていない未使用の型定義。型定義は契約（contract-writer確定分）のため本レビュー対応では削除していない。次に`src/types/order.ts`を触る機会があれば、契約管理者の判断で削除を検討すること
+
+---
+
+## Part 3 — セルフチェック
+
+- 受け入れ条件の各項目は上記「実装計画」のいずれかのSETに対応している。ただし当初のSET-F計画には`GET /api/user-facilities`エンドポイントの記載が抜けており（クライアントコンポーネントからサーバー専用repository関数を直接呼べないというアーキテクチャ上の制約を見落としていたため）、統合時点で実装が追加された。前提制約6・実装セット一覧の補足に事後反映済み
+- 「v1スコープでやらないこと」に列挙した3項目（未返却バッジ・追加ページネーション・JAN検索）は、いずれもPhase 1調査でコードレベルの矛盾・非対称性が確認された上での除外であり、対応する「既知の未対応」に将来対応の道筋を記載済み
+- RLS/facility境界: 新規テーブル・新規RLSポリシーは追加しない（既存ポリシーを再利用）。API層の`requireFacilityAccess`呼び出しがdefense-in-depthとして機能する
+- 中核集約ロジック（`src/lib/orders/unified-repository.ts`）は`route.test.ts`での`fetchUnifiedOrders`モック化とは別に、実装本体を直接検証する単体テスト（`src/lib/orders/__tests__/unified-repository.test.ts`）が存在すること
+- `case_orders`・`loan_returns`の`list*`は、dateFrom/dateToで絞り込むカラムと`.order()`のソートキーが一致していること（型安全・データ層整合レビュー対応）

--- a/docs/sessions/2026-07-14-orders-history-page.md
+++ b/docs/sessions/2026-07-14-orders-history-page.md
@@ -1,0 +1,32 @@
+# 2026-07-14 orders-history-page（issue #20）
+
+## 作業サマリ
+- 変更した目的: issue #20「発注履歴ページ（/orders）: 4種別の発注を横断して一覧・検索」の実装。症例発注・消耗品発注・短貸発注・短貸返却を横断表示するページを新設した
+- 変更した範囲: `.aidd/run-manifest.json`記載の実装一式（マイグレーション・型定義・repository4本のフィルタ拡張・unified-repository・`/api/orders`・`/api/user-facilities`・UIコンポーネント3点・`/orders`ページ）＋停止②（構造化レビュー）で発見した2件の修正（用語統一・本ファイル）
+- 触っていない範囲: issue #23（分析・レポート）関連コード。issue自身が「本issue完了後に着手推奨（案5）」としており、本issueはその前提条件
+
+## 経緯（AIDDフロー）
+- Phase 1: `aidd-1-1-deep-task`（92エージェント）でコード調査・SPEC.mdドラフト生成
+- 停止①: 判断が必要な点6件を人間が回答し承認（2026-07-14T19:40:00+09:00）
+- Phase 3-5: `aidd-phase2`で並列実装・統合ゲートまで完了したが、4観点レビューが3回差し戻しても以下2件のimportant指摘を解消できずblocked
+  1. `parseKinds()`が`order_kinds=`（空文字＝0種別選択）を「未指定」と誤判定し、全チェックボックス解除後にURL直リンク/リロードすると無警告で全種別表示される不具合
+  2. SPEC.mdが「詳細ページへ遷移」を前提にしていたが実際は単票詳細ページが存在せず一覧ページへリンクという乖離が仕様書に未反映
+- 局所上限（3回）到達のため人間（Claude Codeセッション）が直接修正・独立レビューエージェントでPASS確認
+- 停止②（`/structured-review`）で追加2件を発見・修正: (1) 用語不一致（`貸出発注/貸出返却` → 用語集`docs/agents/domain.md`および既存UI(`OrderButtons.tsx`)に合わせ`短貸発注/短貸返却`に統一）、(2) 本ファイル（空テンプレの重複記録2件を統合・実内容に書き換え）
+
+## 検証済み
+- 実行したコマンド: `npx vitest run`（739テスト全pass）、`npm run lint`（0件）、`npx tsc --noEmit`（0件）。`npm run ai:check`はE2E（要ローカルSupabase起動）を含むため未実行
+- 確認した画面: なし（ブラウザでの実動作確認は未実施）
+- 確認したDB/RLS: 新規RLSポリシー追加なし。既存の`facility_member_or_admin`ポリシーを踏襲
+- 他テナントのIDでアクセスし、弾かれることを確認したか: 既存の`case/consumable/loan-orders-rls-idor.integration.test.ts`（DB層IDORテスト、変更なし）でカバー済みの範囲を再利用。`/api/orders`自体の専用IDOR統合テストは未追加（route.test.tsのモックDBレベルでの403/400確認のみ）
+
+## 既知の未対応
+- `/api/orders`専用のRLS/IDOR統合テスト（実DB）は未追加。理由: 新規RLSポリシーは追加しておらず既存テスト済みの関数を再利用しているため優先度を下げた
+- レビューで検出されたminor指摘2件は未修正（minorのみのfailは品質ゲート通過扱いのため）: (1) `assertValidListOptions`の専用テストファイルが無く、4つのrepository testに同種テストが不揃いに重複、(2) jan経由の2段階検索クエリがcase-orders/loan-returns間で重複
+- ブラウザでの実動作確認（Playwright等）は未実施
+- 既存コードベース内に「短貸発注/短貸返却」（`OrderButtons.tsx`・`LoanOrderModal.tsx`等）と「貸出発注/貸出返却」（dashboard・既存`/api/loan-orders`コメント等）の用語混在が本issue着手前から存在することが判明した。本issueの新規ファイルは前者に統一したが、既存箇所の統一は本issueのスコープ外として対応していない
+
+## 後任AIへの注意
+- この実装で壊してはいけない前提: `parseKinds()`は`param === null`（未指定）と`param === ''`（0種別明示選択）を区別する。`!param`のようなfalsy判定に戻すと空文字誤判定バグが再発する
+- 似ているが別物の用語: `case_orders.created_at`（レコード作成日時）と`case_orders.case_datetime`（症例実施日時）は別カラム。期間フィルタは`case_datetime`を使う。「短貸」（loan_order/loan_return、正式名称）と「貸出」表記の混在は既知の技術負債であり、本issueの範囲では新規ファイルのみ統一済み
+- 勝手にリファクタしない場所: `src/lib/orders/unified-repository.ts`のjan/consumable_id経由サマリーラベル解決ロジック（N+1回避のためバッチIN句設計、SPEC.md記載通り）

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -6,6 +6,12 @@ import { listFacilities, createFacility } from '@/lib/facilities/repository'
 import { apiError } from '@/lib/api-error'
 import type { FacilityInput } from '@/types/facility'
 
+// WHY(issue #20 統合ゲート・重複・過剰実装レビュー対応): このエンドポイントは
+// listFacilities(db) の全件を非adminにもそのまま返す（施設管理画面など「全施設を見せてよい」
+// 用途向け）。`{ facilities, isAdmin }` という同一形状を返す GET /api/user-facilities は
+// 非adminには所属施設のみへ絞り込む別エンドポイントであり、「非adminは自分の所属施設のみ
+// 選択可能」という制約が必要な画面（/orders の施設フィルタ等）はそちらを使うこと。
+// 使い分けの詳細は src/app/api/user-facilities/route.ts のコメントを参照
 export async function GET() {
   try {
     const db = await createServerSupabase()

--- a/src/app/api/orders/__tests__/route.test.ts
+++ b/src/app/api/orders/__tests__/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+const mockGetUser = vi.fn()
+const mockRequireFacilityAccess = vi.fn()
+const mockFetchUnifiedOrders = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/supabase/require-facility-access', () => ({
+  requireFacilityAccess: (...args: unknown[]) => mockRequireFacilityAccess(...args),
+}))
+
+// WHY: src/lib/orders/unified-repository.ts はSET-D内の別ファイル（本セットの担当範囲外）。
+// SPEC.md Part2 SET-D記載の型（OrdersFilter → OrdersGetResponse）に従い、
+// fetchUnifiedOrders(db, filter) というシグネチャを前提にモックする
+vi.mock('@/lib/orders/unified-repository', () => ({
+  fetchUnifiedOrders: (...args: unknown[]) => mockFetchUnifiedOrders(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireFacilityAccess.mockResolvedValue({ facilityId: 'f1' })
+  mockFetchUnifiedOrders.mockResolvedValue({ orders: [], errors: [] })
+})
+
+describe('GET /api/orders', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const res = await GET(new NextRequest('http://localhost/api/orders'))
+    expect(res.status).toBe(401)
+    expect(mockFetchUnifiedOrders).not.toHaveBeenCalled()
+  })
+
+  it('非adminがfacility_idを省略した場合は400を返す', async () => {
+    authenticated()
+    mockRequireFacilityAccess.mockRejectedValue(new Error('FACILITY_ID_REQUIRED'))
+    const res = await GET(new NextRequest('http://localhost/api/orders'))
+    expect(res.status).toBe(400)
+    expect(mockFetchUnifiedOrders).not.toHaveBeenCalled()
+  })
+
+  it('非adminが他施設のfacility_idを指定した場合は403を返す', async () => {
+    authenticated()
+    mockRequireFacilityAccess.mockRejectedValue(new Error('FORBIDDEN'))
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f9'))
+    expect(res.status).toBe(403)
+    expect(mockFetchUnifiedOrders).not.toHaveBeenCalled()
+  })
+
+  it('4種別すべて空の場合は { orders: [], errors: [] } を返す', async () => {
+    authenticated()
+    mockFetchUnifiedOrders.mockResolvedValue({ orders: [], errors: [] })
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ orders: [], errors: [] })
+  })
+
+  it('正常系: facility_id・date_from・date_to・product_search・order_kindsをフィルタとして渡す', async () => {
+    authenticated()
+    mockRequireFacilityAccess.mockResolvedValue({ facilityId: 'f1' })
+    mockFetchUnifiedOrders.mockResolvedValue({
+      orders: [
+        { id: 'o1', kind: 'case', facilityId: 'f1', displayDatetime: '2026-07-10T00:00:00Z', status: 'submitted', summaryLabel: '製品A' },
+      ],
+      errors: [],
+    })
+
+    const res = await GET(
+      new NextRequest(
+        'http://localhost/api/orders?facility_id=f1&date_from=2026-07-01T00:00:00Z&date_to=2026-07-31T00:00:00Z&product_search=%E8%A3%BD%E5%93%81&order_kinds=case,loan'
+      )
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.orders).toHaveLength(1)
+    expect(mockFetchUnifiedOrders).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        facilityId: 'f1',
+        dateFrom: '2026-07-01T00:00:00Z',
+        dateTo: '2026-07-31T00:00:00Z',
+        productSearch: '製品',
+        orderKinds: ['case', 'loan'],
+      }
+    )
+  })
+
+  it('order_kinds省略時はorderKinds:undefinedとして渡す（全種別対象）', async () => {
+    authenticated()
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1'))
+    expect(res.status).toBe(200)
+    expect(mockFetchUnifiedOrders).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ orderKinds: undefined })
+    )
+  })
+
+  it('order_kindsに不正な値が含まれる場合は400を返す', async () => {
+    authenticated()
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1&order_kinds=case,unknown_kind'))
+    expect(res.status).toBe(400)
+    expect(mockFetchUnifiedOrders).not.toHaveBeenCalled()
+  })
+
+  // issue #20 レビュー指摘（important）回帰テスト: 種別チェックボックスを全て外した場合、
+  // order_kinds= という空値付きパラメータがリクエストされる。これを「未指定（=全種別対象）」
+  // と誤解釈すると、UIは0件選択なのに実データは全種別分が返るという矛盾が生じる。
+  // orderKindsParamがnullでなければ（パラメータキー自体は存在する）、空配列をそのまま渡すこと。
+  it('order_kindsが空文字（全チェックボックス解除）の場合はorderKinds:[]として渡す（全種別対象にフォールバックしない）', async () => {
+    authenticated()
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1&order_kinds='))
+    expect(res.status).toBe(200)
+    expect(mockFetchUnifiedOrders).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ orderKinds: [] })
+    )
+  })
+
+  it('admin・facility_id省略時はfacilityId:undefinedとして渡す（全施設対象）', async () => {
+    authenticated()
+    mockRequireFacilityAccess.mockResolvedValue({ facilityId: null })
+    const res = await GET(new NextRequest('http://localhost/api/orders'))
+    expect(res.status).toBe(200)
+    expect(mockFetchUnifiedOrders).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ facilityId: undefined })
+    )
+  })
+
+  it('1種別が失敗しても他の結果とerrorsを合わせて返す', async () => {
+    authenticated()
+    mockFetchUnifiedOrders.mockResolvedValue({
+      orders: [
+        { id: 'o1', kind: 'case', facilityId: 'f1', displayDatetime: '2026-07-10T00:00:00Z', status: 'submitted', summaryLabel: '製品A' },
+      ],
+      errors: [{ kind: 'loan', message: 'DB error' }],
+    })
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.orders).toHaveLength(1)
+    expect(body.errors).toEqual([{ kind: 'loan', message: 'DB error' }])
+  })
+
+  it('例外発生時は500を返す', async () => {
+    authenticated()
+    mockFetchUnifiedOrders.mockRejectedValue(new Error('DB error'))
+    const res = await GET(new NextRequest('http://localhost/api/orders?facility_id=f1'))
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/supabase/require-auth'
+import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
+import { fetchUnifiedOrders } from '@/lib/orders/unified-repository'
+import { apiError } from '@/lib/api-error'
+import type { OrderKind, OrdersFilter, OrdersGetResponse } from '@/types/order'
+
+const VALID_ORDER_KINDS: OrderKind[] = ['case', 'consumable', 'loan', 'loan_return']
+
+// WHY(issue #20 SET-D): 4種別(症例発注・消耗品発注・貸出発注・貸出返却)を横断取得するAPI。
+// 認可はrequireAuth(401) → requireFacilityAccess(400/403)で既存パターンを踏襲し、
+// RLSの`facility_member_or_admin`ポリシー（defense-in-depth）に加えてAPI層でも施設境界を担保する。
+// 実データの並列取得・マージ・summaryLabel解決はsrc/lib/orders/unified-repository.tsに集約し、
+// route.tsはパラメータの検証とレスポンス整形のみを担当する（SPEC.md Part2 SET-D）
+export async function GET(request: NextRequest) {
+  try {
+    const db = await createServerSupabase()
+    let user
+    try {
+      user = await requireAuth(db)
+    } catch {
+      return apiError('認証が必要です', 401)
+    }
+
+    const facilityIdParam = request.nextUrl.searchParams.get('facility_id')
+    let grantedFacilityId: string | null
+    try {
+      ;({ facilityId: grantedFacilityId } = await requireFacilityAccess(db, user, facilityIdParam))
+    } catch (e) {
+      if (e instanceof Error && e.message === 'FACILITY_ID_REQUIRED') return apiError('facility_id は必須です', 400)
+      return apiError('アクセス権限がありません', 403)
+    }
+
+    const dateFrom = request.nextUrl.searchParams.get('date_from')
+    const dateTo = request.nextUrl.searchParams.get('date_to')
+    const productSearch = request.nextUrl.searchParams.get('product_search')
+
+    // WHY: order_kinds はCSV。パラメータ自体が未指定（null）の場合のみ「全種別対象」として
+    // undefinedを渡す。パラメータが存在するが値が空（例: order_kinds=、全チェックボックス解除）
+    // の場合は「0種別を明示的に選択した」とみなし、空配列をそのまま渡す（fetchUnifiedOrders側で
+    // 空配列は「全種別」にフォールバックさせない。さもないと4種別すべてのチェックを外したのに
+    // 実データは全種別表示されるというUI状態と矛盾する結果になる）。
+    // 未知のkind文字列が1つでも混入していたらリクエスト全体を400で弾く
+    // （黙って無視すると呼び出し元が意図しない種別で絞り込まれたことに気づけないため）
+    const orderKindsParam = request.nextUrl.searchParams.get('order_kinds')
+    let orderKinds: OrderKind[] | undefined
+    if (orderKindsParam !== null) {
+      const parsed = orderKindsParam
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+      const invalid = parsed.filter((k) => !VALID_ORDER_KINDS.includes(k as OrderKind))
+      if (invalid.length > 0) {
+        return apiError(`order_kinds に不正な値が含まれています: ${invalid.join(', ')}`, 400)
+      }
+      orderKinds = parsed as OrderKind[]
+    }
+
+    const filter: OrdersFilter = {
+      facilityId: grantedFacilityId ?? undefined,
+      dateFrom: dateFrom ?? undefined,
+      dateTo: dateTo ?? undefined,
+      productSearch: productSearch ?? undefined,
+      orderKinds,
+    }
+
+    const result: OrdersGetResponse = await fetchUnifiedOrders(db, filter)
+    return NextResponse.json(result)
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : '発注履歴の取得に失敗しました')
+  }
+}

--- a/src/app/api/user-facilities/__tests__/route.test.ts
+++ b/src/app/api/user-facilities/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockListUserFacilities = vi.fn()
+const mockListFacilities = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/user-facilities/repository', () => ({
+  listUserFacilities: (...args: unknown[]) => mockListUserFacilities(...args),
+}))
+
+vi.mock('@/lib/facilities/repository', () => ({
+  listFacilities: (...args: unknown[]) => mockListFacilities(...args),
+}))
+
+const ALL_FACILITIES = [
+  { id: 'f1', name: 'facility1', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'f2', name: 'facility2', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'f3', name: 'facility3', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockListFacilities.mockResolvedValue(ALL_FACILITIES)
+})
+
+describe('GET /api/user-facilities', () => {
+  it('未認証の場合は401を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  // WHY(issue #20統合): /orders(SET-F)が非adminに他施設を選択肢として見せてしまう
+  // 不整合を防ぐための回帰テスト。非adminには所属施設のみが返ることを検証する
+  it('非adminの場合は所属施設のみを返す（全施設は含めない）', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+    mockResolveIsAdmin.mockResolvedValue(false)
+    mockListUserFacilities.mockResolvedValue([
+      { facilityId: 'f2', facilityName: 'facility2', role: 'staff' },
+    ])
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.isAdmin).toBe(false)
+    expect(body.facilities).toEqual([ALL_FACILITIES[1]])
+  })
+
+  it('adminの場合は全施設を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+    mockResolveIsAdmin.mockResolvedValue(true)
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.isAdmin).toBe(true)
+    expect(body.facilities).toEqual(ALL_FACILITIES)
+    expect(mockListUserFacilities).not.toHaveBeenCalled()
+  })
+
+  it('所属施設が0件の非adminは空配列を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+    mockResolveIsAdmin.mockResolvedValue(false)
+    mockListUserFacilities.mockResolvedValue([])
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.facilities).toEqual([])
+  })
+
+  it('例外発生時は500を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+    mockResolveIsAdmin.mockRejectedValue(new Error('DB error'))
+
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/user-facilities/route.ts
+++ b/src/app/api/user-facilities/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
+import { listUserFacilities } from '@/lib/user-facilities/repository'
+import { listFacilities } from '@/lib/facilities/repository'
+import { apiError } from '@/lib/api-error'
+
+// WHY(issue #20 統合ゲート): /orders ページ(SET-F)は「非adminは自分の所属施設のみを
+// 選択肢にする」という受け入れ条件を持つが、既存の GET /api/facilities は
+// listFacilities(db) が返す全施設をそのまま返す仕様（施設管理画面向けで、非adminにも
+// 全施設が見えても問題ない用途のため）。/orders でこれを使うと非adminにも他施設が
+// 選択肢として見えてしまい、初期選択施設が所属外になって403になる不整合が生じる
+// （requireFacilityAccess は所属施設のみ許可するため）。
+// 既存 GET /api/dashboard は所属施設を正しく絞り込むが、施設サマリー等の重い集計を
+// 含み流用に適さないため、施設一覧のみを返す軽量な専用エンドポイントを新設する。
+export async function GET() {
+  try {
+    const db = await createServerSupabase()
+    let user
+    try {
+      user = await requireAuth(db)
+    } catch {
+      return apiError('認証が必要です', 401)
+    }
+
+    const isAdmin = await resolveIsAdmin(db, user)
+    const allFacilities = await listFacilities(db)
+
+    if (isAdmin) {
+      return NextResponse.json({ facilities: allFacilities, isAdmin: true })
+    }
+
+    const memberships = await listUserFacilities(db, user.id)
+    const memberFacilityIds = new Set(memberships.map((m) => m.facilityId))
+    const facilities = allFacilities.filter((f) => memberFacilityIds.has(f.id))
+    return NextResponse.json({ facilities, isAdmin: false })
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : '施設情報の取得に失敗しました')
+  }
+}

--- a/src/app/orders/__tests__/page.test.tsx
+++ b/src/app/orders/__tests__/page.test.tsx
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OrdersPage from '../page'
+
+const push = vi.fn()
+const replace = vi.fn()
+let currentSearchParams = new URLSearchParams()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, replace }),
+  useSearchParams: () => currentSearchParams,
+}))
+
+type FacilitiesResponse = { facilities: { id: string; name: string; createdAt: string; updatedAt: string }[]; isAdmin: boolean }
+
+const f1 = { id: 'f1', name: 'テスト施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }
+const f2 = { id: 'f2', name: 'テスト施設B', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return {
+    ok: init.status === undefined || init.status < 400,
+    status: init.status ?? 200,
+    json: async () => body,
+  } as Response
+}
+
+function mockFetch({
+  facilitiesResponse,
+  ordersHandler,
+}: {
+  facilitiesResponse: FacilitiesResponse
+  ordersHandler: (url: string) => Response
+}) {
+  return vi.fn((url: string) => {
+    // WHY(issue #20統合ゲート): 非adminに全施設が見えてしまう不整合を解消するため
+    // /api/facilities から所属施設のみを返す /api/user-facilities に呼び出し先を変更した
+    if (url === '/api/user-facilities') return Promise.resolve(jsonResponse(facilitiesResponse))
+    if (url.startsWith('/api/orders')) return Promise.resolve(ordersHandler(url))
+    return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))
+  })
+}
+
+describe('OrdersPage', () => {
+  beforeEach(() => {
+    push.mockReset()
+    replace.mockReset()
+    currentSearchParams = new URLSearchParams()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('非adminで所属施設が1件のみの場合、facility_idが自動セットされ施設ドロップダウンは表示されない', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('facility_id=f1'))
+    })
+    expect(screen.queryByRole('combobox', { name: '施設' })).not.toBeInTheDocument()
+  })
+
+  it('非adminで所属施設が複数の場合、施設ドロップダウンが表示され先頭施設で初回フェッチする', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1, f2], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: '施設' })).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('facility_id=f1'))
+    })
+  })
+
+  it('adminの場合、初回フェッチにfacility_idを含めない', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1, f2], isAdmin: true },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/^\/api\/orders(\?(?!.*facility_id).*)?$/))
+    })
+  })
+
+  it('ローディング中はスケルトンUIを表示する', async () => {
+    // WHY: loading初期値がtrueのため、スケルトン自体はマウント直後から表示される。
+    // このテストで検証したいのは「/api/ordersへの実フェッチが完了するまでスケルトンが
+    // 表示され続け、レスポンス到着後に消える」ことなので、resolveOrdersを呼ぶ前に
+    // 実際に/api/ordersへのfetch呼び出しが発生済みであることを先に確認する
+    // （そうしないとresolveOrdersがまだ未割り当てのプレースホルダーを呼ぶだけで、
+    // 実際のfetch Promiseは永遠に未解決のままになってしまう）
+    let resolveOrders: (r: Response) => void = () => {}
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/user-facilities') return Promise.resolve(jsonResponse({ facilities: [f1], isAdmin: false }))
+      if (url.startsWith('/api/orders')) {
+        return new Promise<Response>((resolve) => {
+          resolveOrders = resolve
+        })
+      }
+      return Promise.resolve(jsonResponse({ error: 'unexpected' }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    expect(screen.getByTestId('order-history-skeleton')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/orders'))
+    })
+
+    resolveOrders(jsonResponse({ orders: [], errors: [] }))
+    await waitFor(() => {
+      expect(screen.queryByTestId('order-history-skeleton')).not.toBeInTheDocument()
+    })
+  })
+
+  // issue #20 レビュー指摘（仕様カバレッジ）回帰テスト: 期間フィルタのJST→UTC境界変換
+  // （date_fromは選択日00:00:00+09:00、date_toは選択日23:59:59.999+09:00＝選択日を含む終端）
+  // を検証する自動テストが存在しなかったため追加
+  it('期間フィルタは選択したJST日付を00:00:00+09:00〜23:59:59.999+09:00の範囲としてUTC変換してAPIへ渡す', async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('facility_id=f1'))
+    })
+    fetchMock.mockClear()
+
+    await user.type(screen.getByLabelText('期間（開始）'), '2026-07-15')
+    await user.type(screen.getByLabelText('期間（終了）'), '2026-07-15')
+    await user.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      const calledUrls = fetchMock.mock.calls.map((c) => c[0] as string)
+      const target = calledUrls.find((u) => u.startsWith('/api/orders'))
+      expect(target).toBeDefined()
+      const url = new URL(target!, 'http://localhost')
+      // 選択日 2026-07-15 の 00:00:00+09:00 は UTC で 2026-07-14T15:00:00.000Z
+      expect(url.searchParams.get('date_from')).toBe('2026-07-14T15:00:00.000Z')
+      // 選択日 2026-07-15 の 23:59:59.999+09:00（選択日を含む終端）は UTC で 2026-07-15T14:59:59.999Z
+      expect(url.searchParams.get('date_to')).toBe('2026-07-15T14:59:59.999Z')
+    })
+  })
+
+  it('種別チェックボックスを外すとURLが更新され再フェッチされる', async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('facility_id=f1'))
+    })
+    fetchMock.mockClear()
+
+    await user.click(screen.getByRole('checkbox', { name: '症例発注' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(expect.stringContaining('order_kinds=consumable%2Cloan%2Cloan_return'))
+    })
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('order_kinds=consumable%2Cloan%2Cloan_return'))
+    })
+  })
+
+  // issue #20 レビュー指摘（important）回帰テスト: 種別チェックボックスを全て外した場合、
+  // order_kinds パラメータ自体を省略する（=全種別対象と誤解釈される）のではなく、
+  // 明示的に空値の order_kinds= を付与してリクエストする（UI状態と実データの矛盾を防ぐ）。
+  it('種別チェックボックスを全て外すと order_kinds= を明示的に付与してリクエストする', async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('facility_id=f1'))
+    })
+
+    await user.click(screen.getByRole('checkbox', { name: '症例発注' }))
+    await user.click(screen.getByRole('checkbox', { name: '消耗品発注' }))
+    await user.click(screen.getByRole('checkbox', { name: '短貸発注' }))
+    fetchMock.mockClear()
+    await user.click(screen.getByRole('checkbox', { name: '短貸返却' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(expect.stringContaining('order_kinds='))
+    })
+    await waitFor(() => {
+      const calledUrls = fetchMock.mock.calls.map((c) => c[0] as string)
+      expect(calledUrls.some((u) => u.startsWith('/api/orders') && u.includes('order_kinds='))).toBe(true)
+    })
+  })
+
+  // issue #20 レビュー指摘（正しさ）回帰テスト: order_kinds=（空文字）を含むURLから
+  // 初期マウント（リロード・直リンク）した場合、「未指定→全種別」に誤フォールバックせず
+  // 0種別選択の状態を維持してリクエストする（以前は !param のfalsy判定により
+  // 空文字も未指定と誤判定し、無警告で全種別が表示されるバグがあった）
+  it('order_kinds=を含むURLから初期マウントすると、0種別選択のまま維持してリクエストする', async () => {
+    currentSearchParams = new URLSearchParams('order_kinds=')
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      const calledUrls = fetchMock.mock.calls.map((c) => c[0] as string)
+      expect(calledUrls.some((u) => u.startsWith('/api/orders') && u.includes('order_kinds='))).toBe(true)
+    })
+    expect(screen.getByRole('checkbox', { name: '症例発注' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '消耗品発注' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '短貸発注' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '短貸返却' })).not.toBeChecked()
+  })
+
+  it('APIが失敗した場合、エラーバナーとリトライボタンを表示する', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ error: 'internal error' }, { status: 500 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    expect(await screen.findByRole('button', { name: 'リトライ' })).toBeInTheDocument()
+  })
+
+  it('/api/ordersが401を返した場合、/loginにリダイレクトする', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () => jsonResponse({ error: '認証が必要です' }, { status: 401 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  it('非adminで所属施設が0件の場合、専用メッセージを表示しAPIを呼ばない', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [], isAdmin: false },
+      ordersHandler: () => jsonResponse({ orders: [], errors: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    expect(await screen.findByText('所属施設がありません。管理者にお問い合わせください。')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('/api/orders'))
+  })
+
+  it('取得成功時、一部の種別でerrorsが返るとバナーを表示する', async () => {
+    const fetchMock = mockFetch({
+      facilitiesResponse: { facilities: [f1], isAdmin: false },
+      ordersHandler: () =>
+        jsonResponse({
+          orders: [
+            {
+              id: 'o1',
+              kind: 'case',
+              facilityId: 'f1',
+              displayDatetime: '2026-07-10T01:00:00Z',
+              status: 'submitted',
+              summaryLabel: 'テスト製品A',
+            },
+          ],
+          errors: [{ kind: 'loan', message: 'timeout' }],
+        }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<OrdersPage />)
+
+    expect(await screen.findByText('一部の発注種別を取得できませんでした')).toBeInTheDocument()
+    expect(screen.getByText('テスト製品A')).toBeInTheDocument()
+  })
+})

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { Facility } from '@/types/facility'
+import type { OrderKind, UnifiedOrder, OrdersFetchError } from '@/types/order'
+import { OrderHistoryFilters } from '@/components/orders/OrderHistoryFilters'
+import { OrderHistoryTable } from '@/components/orders/OrderHistoryTable'
+
+const ALL_KINDS: OrderKind[] = ['case', 'consumable', 'loan', 'loan_return']
+
+// WHY: /orders は施設・種別をまたいだ横断表示のため、行ごとの「詳細」リンクは
+// 個別レコードの詳細ページが存在しない（既存4ページはいずれも一覧のみ、単票詳細URLが無い）。
+// SPEC.mdは「既存の詳細ページへ遷移できる」を前提にしていたが実装調査の結果そのページは
+// 存在しないため、次善として施設スコープの既存一覧ページへリンクする
+function detailHrefFor(order: UnifiedOrder): string {
+  switch (order.kind) {
+    case 'case':
+      return `/facilities/${order.facilityId}/case-orders`
+    case 'consumable':
+      return `/facilities/${order.facilityId}/consumable-orders`
+    case 'loan':
+      return `/facilities/${order.facilityId}/loan-orders`
+    case 'loan_return':
+      return `/facilities/${order.facilityId}/loan-returns`
+    default:
+      return `/facilities/${order.facilityId}`
+  }
+}
+
+// WHY: 選択日（JST, yyyy-mm-dd）を UTC ISO文字列に変換するユーティリティ。
+// date_from は選択日 00:00:00+09:00、date_to は選択日 23:59:59.999+09:00（その日を含む終端）
+// をそれぞれ UTC に変換してAPIへ渡す。SPEC.mdはdate_toの境界仕様（以上/未満）を明記していないため、
+// 「選択した日を含む」という直感的な解釈を採用した
+function jstDateStartToUtcIso(dateStr: string): string {
+  return new Date(`${dateStr}T00:00:00+09:00`).toISOString()
+}
+function jstDateEndToUtcIso(dateStr: string): string {
+  return new Date(`${dateStr}T23:59:59.999+09:00`).toISOString()
+}
+
+// WHY: order_kinds が未指定（param === null）の場合のみ「全種別」を意味する。
+// order_kinds=（空文字）はAPI層（/api/orders）の契約と同じく「0種別を明示的に選択した」
+// として扱う必要がある。以前は空文字も !param で「未指定」と誤判定してALL_KINDSに
+// フォールバックしており、全チェックボックス解除後にURL直リンク/リロードすると
+// 無警告で全種別が表示されるバグがあった（レビューで検出）
+function parseKinds(param: string | null): OrderKind[] {
+  if (param === null) return ALL_KINDS
+  return param.split(',').filter((v): v is OrderKind => (ALL_KINDS as string[]).includes(v))
+}
+
+type CommittedFilters = {
+  dateFrom: string
+  dateTo: string
+  productSearch: string
+  kinds: OrderKind[]
+}
+
+function buildQueryString(filters: CommittedFilters, facilityId: string): string {
+  const params = new URLSearchParams()
+  if (facilityId) params.set('facility_id', facilityId)
+  if (filters.dateFrom) params.set('date_from', jstDateStartToUtcIso(filters.dateFrom))
+  if (filters.dateTo) params.set('date_to', jstDateEndToUtcIso(filters.dateTo))
+  if (filters.productSearch) params.set('product_search', filters.productSearch)
+  if (filters.kinds.length < ALL_KINDS.length) params.set('order_kinds', filters.kinds.join(','))
+  return params.toString()
+}
+
+// WHY: URL表示用は date_from/date_to をJST日付のまま保持し（UTC変換前のraw値）、
+// order_kinds・facility_idはAPIリクエストと同じ形式にする。UTC変換済みISO文字列を
+// URLに出すとユーザーには読みにくいため、URL表示とAPIリクエストのクエリを分離する
+function buildDisplayQueryString(filters: CommittedFilters, facilityId: string): string {
+  const params = new URLSearchParams()
+  if (facilityId) params.set('facility_id', facilityId)
+  if (filters.dateFrom) params.set('date_from', filters.dateFrom)
+  if (filters.dateTo) params.set('date_to', filters.dateTo)
+  if (filters.productSearch) params.set('product_search', filters.productSearch)
+  if (filters.kinds.length < ALL_KINDS.length) params.set('order_kinds', filters.kinds.join(','))
+  return params.toString()
+}
+
+function OrdersPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const [facilities, setFacilities] = useState<Facility[]>([])
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [facilitiesLoaded, setFacilitiesLoaded] = useState(false)
+  const [selectedFacilityId, setSelectedFacilityId] = useState<string>('')
+
+  const [draftDateFrom, setDraftDateFrom] = useState(searchParams.get('date_from') ?? '')
+  const [draftDateTo, setDraftDateTo] = useState(searchParams.get('date_to') ?? '')
+  const [draftProductSearch, setDraftProductSearch] = useState(searchParams.get('product_search') ?? '')
+
+  const [committed, setCommitted] = useState<CommittedFilters>({
+    dateFrom: searchParams.get('date_from') ?? '',
+    dateTo: searchParams.get('date_to') ?? '',
+    productSearch: searchParams.get('product_search') ?? '',
+    kinds: parseKinds(searchParams.get('order_kinds')),
+  })
+
+  const [orders, setOrders] = useState<UnifiedOrder[]>([])
+  const [fetchErrors, setFetchErrors] = useState<OrdersFetchError[]>([])
+  const [loading, setLoading] = useState(true)
+  const [apiError, setApiError] = useState<string | null>(null)
+  const [refreshToken, setRefreshToken] = useState(0)
+
+  // 初回: /api/user-facilities から isAdmin・所属施設一覧を取得し、初期選択施設を決定する。
+  // WHY(issue #20 統合ゲート): /api/facilities は全施設を返す仕様のため、非adminが
+  // 所属していない施設まで選択肢に出てしまい、初期選択施設が所属外で403になる不整合が
+  // あった。非adminは所属施設のみを返す /api/user-facilities を使うことで解消する
+  useEffect(() => {
+    let cancelled = false
+    async function loadFacilities() {
+      try {
+        const res = await fetch('/api/user-facilities')
+        if (res.status === 401) {
+          router.push('/login')
+          return
+        }
+        if (!res.ok) throw new Error()
+        const data = await res.json()
+        if (cancelled) return
+        const loadedFacilities: Facility[] = data.facilities ?? []
+        const admin: boolean = data.isAdmin ?? false
+        setFacilities(loadedFacilities)
+        setIsAdmin(admin)
+
+        const urlFacilityId = searchParams.get('facility_id')
+        if (admin) {
+          // admin: URLのfacility_idが有効ならそれを、無ければ空（全施設）
+          const isValid = urlFacilityId !== null && loadedFacilities.some((f) => f.id === urlFacilityId)
+          setSelectedFacilityId(isValid ? urlFacilityId! : '')
+        } else {
+          const isValid = urlFacilityId !== null && loadedFacilities.some((f) => f.id === urlFacilityId)
+          const resolved = isValid ? urlFacilityId! : (loadedFacilities[0]?.id ?? '')
+          setSelectedFacilityId(resolved)
+        }
+        setFacilitiesLoaded(true)
+      } catch {
+        if (!cancelled) {
+          setApiError('施設情報の取得に失敗しました')
+          setFacilitiesLoaded(true)
+        }
+      }
+    }
+    loadFacilities()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // 施設情報が確定した後、非adminはfacility_idが必須のため確定するまで待つ
+  const canFetch = facilitiesLoaded && (isAdmin || selectedFacilityId !== '')
+  // WHY: 非adminでどの施設にも所属していない場合、selectedFacilityIdが永遠に確定せず
+  // canFetchもtrueにならないため、何もせず放置すると読み込み中スケルトンが無限に表示され続ける。
+  // setLoading側で個別にハンドリングするとエフェクト内setStateのcascading renderになるため、
+  // 代わりに描画用のloadingフラグをレンダー時に導出し、このケースだけ強制的にfalse扱いにする
+  const noFacilityAccess = facilitiesLoaded && !isAdmin && facilities.length === 0
+  const displayLoading = loading && !noFacilityAccess
+
+  useEffect(() => {
+    if (!canFetch) return
+    let cancelled = false
+    async function loadOrders() {
+      setLoading(true)
+      setApiError(null)
+      try {
+        const qs = buildQueryString(committed, selectedFacilityId)
+        const res = await fetch(`/api/orders${qs ? `?${qs}` : ''}`)
+        if (res.status === 401) {
+          router.push('/login')
+          return
+        }
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}))
+          throw new Error(body.error ?? '発注履歴の取得に失敗しました')
+        }
+        const data = await res.json()
+        if (cancelled) return
+        setOrders(data.orders ?? [])
+        setFetchErrors(data.errors ?? [])
+      } catch (e) {
+        if (!cancelled) {
+          setApiError(e instanceof Error ? e.message : '発注履歴の取得に失敗しました')
+          setOrders([])
+          setFetchErrors([])
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    loadOrders()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canFetch, committed, selectedFacilityId, refreshToken])
+
+  const syncUrl = useCallback(
+    (nextCommitted: CommittedFilters, nextFacilityId: string) => {
+      const qs = buildDisplayQueryString(nextCommitted, nextFacilityId)
+      router.replace(`/orders${qs ? `?${qs}` : ''}`)
+    },
+    [router]
+  )
+
+  function handleKindsChange(kinds: OrderKind[]) {
+    const next = { ...committed, kinds }
+    setCommitted(next)
+    syncUrl(next, selectedFacilityId)
+  }
+
+  function handleFacilityChange(facilityId: string) {
+    setSelectedFacilityId(facilityId)
+    syncUrl(committed, facilityId)
+  }
+
+  function handleSearchSubmit() {
+    const next: CommittedFilters = {
+      ...committed,
+      dateFrom: draftDateFrom,
+      dateTo: draftDateTo,
+      productSearch: draftProductSearch,
+    }
+    setCommitted(next)
+    syncUrl(next, selectedFacilityId)
+  }
+
+  function handleRetry() {
+    setRefreshToken((t) => t + 1)
+  }
+
+  const showFacilitySelect = isAdmin || facilities.length > 1
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10">
+      <div className="mb-8 border-b pb-4" style={{ borderColor: '#072C2C33' }}>
+        <p className="text-xs font-semibold uppercase tracking-widest mb-1" style={{ color: '#FF5F03', fontFamily: 'var(--font-oswald), sans-serif' }}>
+          Order History
+        </p>
+        <h1 className="text-3xl font-bold" style={{ color: '#072C2C', fontFamily: 'var(--font-oswald), sans-serif', letterSpacing: '0.04em' }}>
+          発注履歴
+        </h1>
+      </div>
+
+      <OrderHistoryFilters
+        dateFrom={draftDateFrom}
+        dateTo={draftDateTo}
+        productSearch={draftProductSearch}
+        selectedKinds={committed.kinds}
+        onDateFromChange={setDraftDateFrom}
+        onDateToChange={setDraftDateTo}
+        onProductSearchChange={setDraftProductSearch}
+        onKindsChange={handleKindsChange}
+        onSearchSubmit={handleSearchSubmit}
+        showFacilitySelect={showFacilitySelect}
+        facilityOptions={facilities}
+        selectedFacilityId={selectedFacilityId}
+        onFacilityChange={handleFacilityChange}
+        allowEmptyFacility={isAdmin}
+      />
+
+      {apiError && (
+        <div
+          role="alert"
+          className="mb-4 flex items-center justify-between gap-4 rounded px-4 py-3 text-sm text-white"
+          style={{ backgroundColor: '#DC2626' }}
+        >
+          <span>{apiError}</span>
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="rounded bg-white px-3 py-1 text-xs font-semibold"
+            style={{ color: '#DC2626' }}
+          >
+            リトライ
+          </button>
+        </div>
+      )}
+
+      {noFacilityAccess ? (
+        <p className="px-6 py-8 text-center text-sm text-gray-500">
+          所属施設がありません。管理者にお問い合わせください。
+        </p>
+      ) : (
+        <OrderHistoryTable
+          orders={orders}
+          errors={fetchErrors}
+          loading={displayLoading}
+          showFacilityColumn={isAdmin}
+          getDetailHref={detailHrefFor}
+        />
+      )}
+    </div>
+  )
+}
+
+export default function OrdersPage() {
+  return (
+    <Suspense fallback={<div className="mx-auto max-w-6xl px-6 py-10">読み込み中...</div>}>
+      <OrdersPageInner />
+    </Suspense>
+  )
+}

--- a/src/components/dashboard/DashboardShortcuts.tsx
+++ b/src/components/dashboard/DashboardShortcuts.tsx
@@ -7,6 +7,7 @@ type DashboardShortcutsProps = {
 }
 
 const BASE_SHORTCUTS = [
+  { href: '/orders', label: '発注履歴' },
   { href: '/facilities', label: '施設一覧' },
   { href: '/products', label: '商品一覧' },
   { href: '/distributor-products', label: '販売店商品一覧' },

--- a/src/components/dashboard/__tests__/DashboardShortcuts.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardShortcuts.test.tsx
@@ -5,6 +5,9 @@ import { DashboardShortcuts } from '../DashboardShortcuts'
 describe('DashboardShortcuts', () => {
   it('管理ページへのショートカットリンクが表示される', () => {
     render(<DashboardShortcuts isAdmin={false} />)
+    // WHY(issue #20 統合): /orders（発注履歴ページ）への導線をダッシュボードに追加したため、
+    // 結線漏れ（リンクが無くページへ到達できない）を検知できるようテストにも追加する
+    expect(screen.getByRole('link', { name: '発注履歴' })).toHaveAttribute('href', '/orders')
     expect(screen.getByRole('link', { name: '施設一覧' })).toHaveAttribute('href', '/facilities')
     expect(screen.getByRole('link', { name: '商品一覧' })).toHaveAttribute('href', '/products')
     expect(screen.getByRole('link', { name: /販売店商品一覧/ })).toHaveAttribute('href', '/distributor-products')

--- a/src/components/orders/OrderHistoryFilters.tsx
+++ b/src/components/orders/OrderHistoryFilters.tsx
@@ -1,0 +1,147 @@
+import type { OrderKind } from '@/types/order'
+import type { Facility } from '@/types/facility'
+
+const KIND_OPTIONS: { kind: OrderKind; label: string }[] = [
+  { kind: 'case', label: '症例発注' },
+  { kind: 'consumable', label: '消耗品発注' },
+  { kind: 'loan', label: '短貸発注' },
+  { kind: 'loan_return', label: '短貸返却' },
+]
+
+type Props = {
+  dateFrom: string
+  dateTo: string
+  productSearch: string
+  selectedKinds: OrderKind[]
+  onDateFromChange: (value: string) => void
+  onDateToChange: (value: string) => void
+  onProductSearchChange: (value: string) => void
+  onKindsChange: (kinds: OrderKind[]) => void
+  onSearchSubmit: () => void
+  // WHY: 施設ドロップダウンの表示要否・選択肢・「全施設」オプションの有無は
+  // admin/非admin判定のロジックを含むため、呼び出し元（/ordersページ）が算出して渡す
+  showFacilitySelect: boolean
+  facilityOptions: Facility[]
+  selectedFacilityId: string
+  onFacilityChange: (facilityId: string) => void
+  allowEmptyFacility: boolean
+}
+
+export function OrderHistoryFilters({
+  dateFrom,
+  dateTo,
+  productSearch,
+  selectedKinds,
+  onDateFromChange,
+  onDateToChange,
+  onProductSearchChange,
+  onKindsChange,
+  onSearchSubmit,
+  showFacilitySelect,
+  facilityOptions,
+  selectedFacilityId,
+  onFacilityChange,
+  allowEmptyFacility,
+}: Props) {
+  function handleKindToggle(kind: OrderKind, checked: boolean) {
+    if (checked) {
+      onKindsChange([...selectedKinds, kind])
+    } else {
+      onKindsChange(selectedKinds.filter((k) => k !== kind))
+    }
+  }
+
+  return (
+    <form
+      className="mb-6 flex flex-wrap items-end gap-4 rounded bg-white p-4 shadow-sm"
+      style={{ border: '1px solid #E5E7EB' }}
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSearchSubmit()
+      }}
+    >
+      <div className="flex flex-col gap-1">
+        <label htmlFor="order-history-date-from" className="text-xs font-medium text-gray-500">
+          期間（開始）
+        </label>
+        <input
+          id="order-history-date-from"
+          type="date"
+          value={dateFrom}
+          onChange={(e) => onDateFromChange(e.target.value)}
+          className="rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="order-history-date-to" className="text-xs font-medium text-gray-500">
+          期間（終了）
+        </label>
+        <input
+          id="order-history-date-to"
+          type="date"
+          value={dateTo}
+          onChange={(e) => onDateToChange(e.target.value)}
+          className="rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="order-history-product-search" className="text-xs font-medium text-gray-500">
+          製品名
+        </label>
+        <input
+          id="order-history-product-search"
+          type="text"
+          value={productSearch}
+          onChange={(e) => onProductSearchChange(e.target.value)}
+          placeholder="製品名で絞り込み"
+          className="rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </div>
+
+      {showFacilitySelect && (
+        <div className="flex flex-col gap-1">
+          <label htmlFor="order-history-facility" className="text-xs font-medium text-gray-500">
+            施設
+          </label>
+          <select
+            id="order-history-facility"
+            aria-label="施設"
+            value={selectedFacilityId}
+            onChange={(e) => onFacilityChange(e.target.value)}
+            className="rounded border border-gray-300 px-2 py-1 text-sm"
+          >
+            {allowEmptyFacility && <option value="">全施設</option>}
+            {facilityOptions.map((facility) => (
+              <option key={facility.id} value={facility.id}>
+                {facility.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <fieldset className="flex flex-wrap gap-3">
+        <legend className="mb-1 text-xs font-medium text-gray-500">発注種別</legend>
+        {KIND_OPTIONS.map(({ kind, label }) => (
+          <label key={kind} className="flex items-center gap-1 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={selectedKinds.includes(kind)}
+              onChange={(e) => handleKindToggle(kind, e.target.checked)}
+            />
+            {label}
+          </label>
+        ))}
+      </fieldset>
+
+      <button
+        type="submit"
+        className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+      >
+        検索
+      </button>
+    </form>
+  )
+}

--- a/src/components/orders/OrderHistoryTable.tsx
+++ b/src/components/orders/OrderHistoryTable.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link'
+import type { UnifiedOrder, OrdersFetchError } from '@/types/order'
+import { OrderKindBadge } from './OrderKindBadge'
+
+// WHY: 生statusのラベル変換。4テーブルで許容値が異なる（case/consumable/loan: draft/submitted、
+// loan_return: draft/returned）ため、和名対応表は横断的にここで一元管理する
+const STATUS_LABEL: Record<string, string> = {
+  draft: '下書き',
+  submitted: '提出済み',
+  returned: '返却済み',
+}
+
+function formatDatetime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString('ja-JP')
+}
+
+type Props = {
+  orders: UnifiedOrder[]
+  errors: OrdersFetchError[]
+  loading: boolean
+  showFacilityColumn: boolean
+  getDetailHref: (order: UnifiedOrder) => string
+}
+
+export function OrderHistoryTable({ orders, errors, loading, showFacilityColumn, getDetailHref }: Props) {
+  const colCount = 5 + (showFacilityColumn ? 1 : 0)
+
+  return (
+    <div>
+      {errors.length > 0 && (
+        <div
+          role="alert"
+          className="mb-4 rounded px-4 py-3 text-sm text-white"
+          style={{ backgroundColor: '#D97706' }}
+        >
+          一部の発注種別を取得できませんでした
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">発注日時</th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">種別</th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">ステータス</th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">製品名</th>
+              {showFacilityColumn && (
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">施設名</th>
+              )}
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">操作</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {loading ? (
+              <tr data-testid="order-history-skeleton">
+                <td colSpan={colCount} className="px-6 py-8 text-center text-sm text-gray-500">
+                  読み込み中...
+                </td>
+              </tr>
+            ) : orders.length === 0 ? (
+              <tr>
+                <td colSpan={colCount} className="px-6 py-8 text-center text-sm text-gray-500">
+                  該当する発注履歴がありません
+                </td>
+              </tr>
+            ) : (
+              orders.map((order) => (
+                <tr key={`${order.kind}-${order.id}`}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {formatDatetime(order.displayDatetime)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    <OrderKindBadge kind={order.kind} />
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {STATUS_LABEL[order.status] ?? order.status}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-900">{order.summaryLabel}</td>
+                  {showFacilityColumn && (
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {order.facilityName ?? '-'}
+                    </td>
+                  )}
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    <Link href={getDetailHref(order)} className="text-indigo-600 hover:text-indigo-900 font-medium">
+                      詳細
+                    </Link>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/orders/OrderKindBadge.tsx
+++ b/src/components/orders/OrderKindBadge.tsx
@@ -1,0 +1,38 @@
+import type { OrderKind } from '@/types/order'
+
+// WHY: 発注種別ごとに色分けバッジを表示する。色はOrderButtons.tsxの発注種別ボタン色と
+// 揃えることで、同じ種別が画面をまたいでも同じ色として認識できるようにする
+const KIND_LABEL: Record<OrderKind, string> = {
+  case: '症例発注',
+  consumable: '消耗品発注',
+  loan: '短貸発注',
+  loan_return: '短貸返却',
+}
+
+const KIND_COLOR: Record<OrderKind, string> = {
+  case: '#FF5F03',
+  consumable: '#16A34A',
+  loan: '#2563EB',
+  loan_return: '#4B5563',
+}
+
+type Props = {
+  kind: OrderKind
+}
+
+export function OrderKindBadge({ kind }: Props) {
+  // WHY: UnifiedOrder.kindはAPI応答由来でTypeScriptの型保証が実行時に及ばないため、
+  // 未知の値が来てもクラッシュせずそのまま表示するフォールバックを持たせる（防御的実装）
+  const label = KIND_LABEL[kind] ?? kind
+  const color = KIND_COLOR[kind] ?? '#6B7280'
+
+  return (
+    <span
+      className="inline-block whitespace-nowrap rounded px-2 py-1 text-xs font-semibold text-white"
+      style={{ backgroundColor: color }}
+      aria-label={`種別: ${label}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/src/components/orders/__tests__/OrderHistoryFilters.test.tsx
+++ b/src/components/orders/__tests__/OrderHistoryFilters.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OrderHistoryFilters } from '../OrderHistoryFilters'
+import type { Facility } from '@/types/facility'
+
+const facilities: Facility[] = [
+  { id: 'f1', name: 'テスト施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: 'f2', name: 'テスト施設B', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+]
+
+function setup(overrides: Partial<React.ComponentProps<typeof OrderHistoryFilters>> = {}) {
+  const props: React.ComponentProps<typeof OrderHistoryFilters> = {
+    dateFrom: '',
+    dateTo: '',
+    productSearch: '',
+    selectedKinds: ['case', 'consumable', 'loan', 'loan_return'],
+    onDateFromChange: vi.fn(),
+    onDateToChange: vi.fn(),
+    onProductSearchChange: vi.fn(),
+    onKindsChange: vi.fn(),
+    onSearchSubmit: vi.fn(),
+    showFacilitySelect: false,
+    facilityOptions: [],
+    selectedFacilityId: '',
+    onFacilityChange: vi.fn(),
+    allowEmptyFacility: false,
+    ...overrides,
+  }
+  render(<OrderHistoryFilters {...props} />)
+  return props
+}
+
+describe('OrderHistoryFilters', () => {
+  it('4種別のチェックボックスがデフォルト全選択で表示される', () => {
+    setup()
+    expect(screen.getByRole('checkbox', { name: '症例発注' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '消耗品発注' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '短貸発注' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '短貸返却' })).toBeChecked()
+  })
+
+  it('チェックボックスを外すとonKindsChangeが呼ばれ、選択が更新される', async () => {
+    const user = userEvent.setup()
+    const props = setup()
+    await user.click(screen.getByRole('checkbox', { name: '症例発注' }))
+    expect(props.onKindsChange).toHaveBeenCalledWith(['consumable', 'loan', 'loan_return'])
+  })
+
+  it('全チェックが外れた状態でも一つ再選択するとonKindsChangeが正しく呼ばれる', async () => {
+    const user = userEvent.setup()
+    const props = setup({ selectedKinds: [] })
+    await user.click(screen.getByRole('checkbox', { name: '短貸発注' }))
+    expect(props.onKindsChange).toHaveBeenCalledWith(['loan'])
+  })
+
+  it('showFacilitySelect=falseの場合、施設ドロップダウンを表示しない', () => {
+    setup({ showFacilitySelect: false })
+    expect(screen.queryByRole('combobox', { name: '施設' })).not.toBeInTheDocument()
+  })
+
+  it('showFacilitySelect=trueの場合、施設ドロップダウンを表示する', () => {
+    setup({ showFacilitySelect: true, facilityOptions: facilities, selectedFacilityId: 'f1' })
+    const select = screen.getByRole('combobox', { name: '施設' })
+    expect(select).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'テスト施設A' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'テスト施設B' })).toBeInTheDocument()
+  })
+
+  it('allowEmptyFacility=trueの場合、「全施設」オプションが先頭に追加される', () => {
+    setup({
+      showFacilitySelect: true,
+      facilityOptions: facilities,
+      selectedFacilityId: '',
+      allowEmptyFacility: true,
+    })
+    expect(screen.getByRole('option', { name: '全施設' })).toBeInTheDocument()
+  })
+
+  it('allowEmptyFacility=falseの場合、「全施設」オプションを追加しない', () => {
+    setup({
+      showFacilitySelect: true,
+      facilityOptions: facilities,
+      selectedFacilityId: 'f1',
+      allowEmptyFacility: false,
+    })
+    expect(screen.queryByRole('option', { name: '全施設' })).not.toBeInTheDocument()
+  })
+
+  it('施設ドロップダウンを変更するとonFacilityChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const props = setup({ showFacilitySelect: true, facilityOptions: facilities, selectedFacilityId: 'f1' })
+    await user.selectOptions(screen.getByRole('combobox', { name: '施設' }), 'f2')
+    expect(props.onFacilityChange).toHaveBeenCalledWith('f2')
+  })
+
+  it('期間入力を変更するとonDateFromChange/onDateToChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const props = setup()
+    const from = screen.getByLabelText('期間（開始）')
+    await user.type(from, '2026-07-01')
+    expect(props.onDateFromChange).toHaveBeenCalled()
+  })
+
+  it('製品名検索フォームを送信するとonSearchSubmitが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const props = setup({ productSearch: 'テスト製品' })
+    await user.click(screen.getByRole('button', { name: '検索' }))
+    expect(props.onSearchSubmit).toHaveBeenCalled()
+  })
+
+  it('製品名入力を変更するとonProductSearchChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const props = setup()
+    await user.type(screen.getByLabelText('製品名'), 'x')
+    expect(props.onProductSearchChange).toHaveBeenCalled()
+  })
+})

--- a/src/components/orders/__tests__/OrderHistoryTable.test.tsx
+++ b/src/components/orders/__tests__/OrderHistoryTable.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OrderHistoryTable } from '../OrderHistoryTable'
+import type { UnifiedOrder, OrdersFetchError } from '@/types/order'
+
+const baseOrder: UnifiedOrder = {
+  id: 'o1',
+  kind: 'case',
+  facilityId: 'f1',
+  facilityName: 'テスト施設A',
+  displayDatetime: '2026-07-10T01:00:00Z',
+  status: 'submitted',
+  summaryLabel: 'テスト製品A 他2件',
+}
+
+const orders: UnifiedOrder[] = [
+  baseOrder,
+  {
+    id: 'o2',
+    kind: 'loan_return',
+    facilityId: 'f2',
+    facilityName: 'テスト施設B',
+    displayDatetime: '2026-07-09T01:00:00Z',
+    status: 'returned',
+    summaryLabel: 'テスト製品B',
+  },
+]
+
+function getDetailHref(order: UnifiedOrder) {
+  return `/facilities/${order.facilityId}/case-orders`
+}
+
+describe('OrderHistoryTable', () => {
+  it('ordersが空の場合、データなしメッセージを表示する', () => {
+    render(
+      <OrderHistoryTable
+        orders={[]}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.getByText('該当する発注履歴がありません')).toBeInTheDocument()
+  })
+
+  it('errorsが空でない場合、部分取得失敗バナーを表示する', () => {
+    const errors: OrdersFetchError[] = [{ kind: 'loan', message: 'timeout' }]
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={errors}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.getByText('一部の発注種別を取得できませんでした')).toBeInTheDocument()
+  })
+
+  it('errorsが空の場合、部分取得失敗バナーを表示しない', () => {
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.queryByText('一部の発注種別を取得できませんでした')).not.toBeInTheDocument()
+  })
+
+  it('loading中はスケルトンを表示し、データ行は表示しない', () => {
+    render(
+      <OrderHistoryTable
+        orders={[]}
+        errors={[]}
+        loading={true}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.getByTestId('order-history-skeleton')).toBeInTheDocument()
+    expect(screen.queryByText('該当する発注履歴がありません')).not.toBeInTheDocument()
+  })
+
+  it('showFacilityColumn=trueの場合、施設名カラムを表示する', () => {
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={true}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.getByRole('columnheader', { name: '施設名' })).toBeInTheDocument()
+    expect(screen.getByText('テスト施設A')).toBeInTheDocument()
+    expect(screen.getByText('テスト施設B')).toBeInTheDocument()
+  })
+
+  it('showFacilityColumn=falseの場合、施設名カラムを表示しない', () => {
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.queryByRole('columnheader', { name: '施設名' })).not.toBeInTheDocument()
+  })
+
+  it('各行に製品名サマリーとステータス・詳細リンクを表示する', () => {
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={getDetailHref}
+      />
+    )
+    expect(screen.getByText('テスト製品A 他2件')).toBeInTheDocument()
+    expect(screen.getByText('テスト製品B')).toBeInTheDocument()
+    const links = screen.getAllByRole('link', { name: '詳細' })
+    expect(links).toHaveLength(2)
+    expect(links[0]).toHaveAttribute('href', '/facilities/f1/case-orders')
+  })
+
+  it('テーブル見出しにscope=col属性が設定される', () => {
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={true}
+        getDetailHref={getDetailHref}
+      />
+    )
+    const headers = screen.getAllByRole('columnheader')
+    headers.forEach((header) => {
+      expect(header).toHaveAttribute('scope', 'col')
+    })
+  })
+
+  it('getDetailHrefが呼ばれ、各注文に対して個別に評価される', () => {
+    const spy = vi.fn(getDetailHref)
+    render(
+      <OrderHistoryTable
+        orders={orders}
+        errors={[]}
+        loading={false}
+        showFacilityColumn={false}
+        getDetailHref={spy}
+      />
+    )
+    expect(spy).toHaveBeenCalledTimes(orders.length)
+  })
+})

--- a/src/components/orders/__tests__/OrderKindBadge.test.tsx
+++ b/src/components/orders/__tests__/OrderKindBadge.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OrderKindBadge } from '../OrderKindBadge'
+import type { OrderKind } from '@/types/order'
+
+const KINDS: { kind: OrderKind; label: string }[] = [
+  { kind: 'case', label: '症例発注' },
+  { kind: 'consumable', label: '消耗品発注' },
+  { kind: 'loan', label: '短貸発注' },
+  { kind: 'loan_return', label: '短貸返却' },
+]
+
+describe('OrderKindBadge', () => {
+  it.each(KINDS)('$kind 種別のラベルが表示される', ({ kind, label }) => {
+    render(<OrderKindBadge kind={kind} />)
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it.each(KINDS)('$kind 種別に aria-label が設定される', ({ kind, label }) => {
+    render(<OrderKindBadge kind={kind} />)
+    expect(screen.getByLabelText(`種別: ${label}`)).toBeInTheDocument()
+  })
+
+  it('未知の種別が渡されてもエラーにならずフォールバック表示する', () => {
+    // @ts-expect-error 型安全性のテストではなく、防御的フォールバックの確認
+    render(<OrderKindBadge kind="unknown" />)
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+  })
+})

--- a/src/lib/case-orders/__tests__/repository.test.ts
+++ b/src/lib/case-orders/__tests__/repository.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createCaseOrder } from '@/lib/case-orders/repository'
+import { createCaseOrder, listCaseOrders } from '@/lib/case-orders/repository'
 
 function makeMockRpcDb(rpcResult: unknown): SupabaseClient {
   return { rpc: vi.fn().mockResolvedValue(rpcResult) } as unknown as SupabaseClient
+}
+
+// issue #20 SET-C: 複数ステップのSupabaseクエリ（.select().eq().gte()...）をチェーン可能な
+// モックとして表現するヘルパー。各メソッドは同一builderを返し、awaitされた時点で
+// resultをdata/errorとして解決する（実際のsupabase-jsのPostgrestFilterBuilderと同じ振る舞い）
+type QueryResult = { data: unknown; error: unknown }
+type ChainableBuilder = Record<string, ReturnType<typeof vi.fn>> & PromiseLike<QueryResult>
+
+function makeChainable(result: QueryResult): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const methods = ['select', 'eq', 'gte', 'lte', 'ilike', 'in', 'order', 'range']
+  for (const m of methods) {
+    ;(builder as Record<string, unknown>)[m] = vi.fn(() => builder)
+  }
+  builder.then = ((resolve: (value: QueryResult) => unknown, reject?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)) as ChainableBuilder['then']
+  return builder
 }
 
 describe('createCaseOrder', () => {
@@ -102,5 +119,168 @@ describe('createCaseOrder', () => {
     })
     expect(result.gender).toBe('other')
     expect(result.status).toBe('draft')
+  })
+})
+
+// issue #20 SET-C: listCaseOrders への dateFrom/dateTo/productSearch フィルタ拡張
+describe('listCaseOrders', () => {
+  const mockRow = {
+    id: 'co-1',
+    facility_id: 'f-1',
+    case_datetime: '2026-06-24T10:00:00Z',
+    procedure_name: 'TAVI',
+    patient_id: 'P001',
+    patient_initials: 'T.S.',
+    gender: 'male',
+    doctor_name: '田中医師',
+    status: 'draft',
+    created_at: '2026-06-24T00:00:00Z',
+    updated_at: '2026-06-24T00:00:00Z',
+    case_order_items: [],
+  }
+
+  // issue #20 型安全・データ層整合レビュー対応（critical）: dateFrom/dateTo は case_datetime で
+  // 絞り込むため、.order() も created_at ではなく case_datetime でなければ、施設ごとの
+  // 該当件数が limit を超えた場合にDB側で誤ったキーで先に切り詰められるバグになる
+  it('facility_id で絞り込み、case_datetime 降順・id昇順で limit/offset の範囲を取得する', async () => {
+    const caseOrdersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => caseOrdersBuilder) } as unknown as SupabaseClient
+
+    const result = await listCaseOrders(db, 'f-1', 50, 0)
+
+    expect(db.from).toHaveBeenCalledWith('case_orders')
+    expect(caseOrdersBuilder.eq).toHaveBeenCalledWith('facility_id', 'f-1')
+    expect(caseOrdersBuilder.order).toHaveBeenCalledWith('case_datetime', { ascending: false })
+    expect(caseOrdersBuilder.order).toHaveBeenCalledWith('id', { ascending: true })
+    expect(caseOrdersBuilder.range).toHaveBeenCalledWith(0, 49)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('co-1')
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(case_order_items(*))に明示的な
+  // ORDER BY が無いと代表製品名の選出が理論上非決定的になる。作成順（created_at昇順・
+  // id昇順を第2キー）を明示することで「最初に登録した明細」を安定して代表として選出する
+  it('case_order_items（埋め込み）にcreated_at昇順・id昇順の明示的なORDER BYを指定する', async () => {
+    const caseOrdersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => caseOrdersBuilder) } as unknown as SupabaseClient
+
+    await listCaseOrders(db, 'f-1', 50, 0)
+
+    expect(caseOrdersBuilder.order).toHaveBeenCalledWith('created_at', {
+      ascending: true,
+      referencedTable: 'case_order_items',
+    })
+    expect(caseOrdersBuilder.order).toHaveBeenCalledWith('id', {
+      ascending: true,
+      referencedTable: 'case_order_items',
+    })
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: SPEC.md Part2 SET-C テスト観点
+  // 「limit上限: 最大100（100超は400エラー）、負数は400エラー」の未実装・未テストを解消
+  it('limitが100を超える場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listCaseOrders(db, 'f-1', 101, 0)).rejects.toThrow('limit は 1〜100 の整数で指定してください')
+  })
+
+  it('limitが負数の場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listCaseOrders(db, 'f-1', -1, 0)).rejects.toThrow('limit は 1〜100 の整数で指定してください')
+  })
+
+  it('offsetが負数の場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listCaseOrders(db, 'f-1', 50, -1)).rejects.toThrow('offset は0以上の整数で指定してください')
+  })
+
+  it('dateFrom/dateTo を指定すると case_datetime に gte/lte を適用する', async () => {
+    const caseOrdersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => caseOrdersBuilder) } as unknown as SupabaseClient
+
+    await listCaseOrders(db, 'f-1', 50, 0, { dateFrom: '2026-06-01T00:00:00Z', dateTo: '2026-06-30T23:59:59Z' })
+
+    expect(caseOrdersBuilder.gte).toHaveBeenCalledWith('case_datetime', '2026-06-01T00:00:00Z')
+    expect(caseOrdersBuilder.lte).toHaveBeenCalledWith('case_datetime', '2026-06-30T23:59:59Z')
+  })
+
+  it('productSearch が空文字/未指定の場合は products / case_order_items を問い合わせない', async () => {
+    const caseOrdersBuilder = makeChainable({ data: [mockRow], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'case_orders') return caseOrdersBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    await listCaseOrders(db, 'f-1', 50, 0, { productSearch: '   ' })
+
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(from).toHaveBeenCalledWith('case_orders')
+  })
+
+  it('productSearch を指定すると products→case_order_items 経由で対象IDを絞り込む', async () => {
+    const productsBuilder = makeChainable({ data: [{ jan: '490001' }, { jan: '490002' }], error: null })
+    const itemsBuilder = makeChainable({ data: [{ case_order_id: 'co-1' }, { case_order_id: 'co-2' }], error: null })
+    const caseOrdersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === 'products') return productsBuilder
+        if (table === 'case_order_items') return itemsBuilder
+        if (table === 'case_orders') return caseOrdersBuilder
+        throw new Error(`unexpected table: ${table}`)
+      }),
+    } as unknown as SupabaseClient
+
+    const result = await listCaseOrders(db, 'f-1', 50, 0, { productSearch: 'カテーテル' })
+
+    expect(productsBuilder.select).toHaveBeenCalledWith('jan')
+    expect(productsBuilder.ilike).toHaveBeenCalledWith('name', '%カテーテル%')
+    expect(itemsBuilder.in).toHaveBeenCalledWith('jan', ['490001', '490002'])
+    expect(caseOrdersBuilder.in).toHaveBeenCalledWith('id', ['co-1', 'co-2'])
+    expect(result).toHaveLength(1)
+  })
+
+  it('productSearch にヒットする製品が無い場合は case_orders を問い合わせず空配列を返す', async () => {
+    const productsBuilder = makeChainable({ data: [], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'products') return productsBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    const result = await listCaseOrders(db, 'f-1', 50, 0, { productSearch: 'ヒットしない' })
+
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('productSearch にヒットする明細が無い場合は空配列を返す', async () => {
+    const productsBuilder = makeChainable({ data: [{ jan: '490001' }], error: null })
+    const itemsBuilder = makeChainable({ data: [], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'products') return productsBuilder
+      if (table === 'case_order_items') return itemsBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    const result = await listCaseOrders(db, 'f-1', 50, 0, { productSearch: 'ヒットしない' })
+
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledTimes(2)
+  })
+
+  it('Supabaseエラー時に例外を投げる（メインクエリ）', async () => {
+    const caseOrdersBuilder = makeChainable({ data: null, error: { message: 'DB error' } })
+    const db = { from: vi.fn(() => caseOrdersBuilder) } as unknown as SupabaseClient
+
+    await expect(listCaseOrders(db, 'f-1', 50, 0)).rejects.toThrow('DB error')
+  })
+
+  it('Supabaseエラー時に例外を投げる（productsサブクエリ）', async () => {
+    const productsBuilder = makeChainable({ data: null, error: { message: 'products error' } })
+    const db = { from: vi.fn(() => productsBuilder) } as unknown as SupabaseClient
+
+    await expect(listCaseOrders(db, 'f-1', 50, 0, { productSearch: 'x' })).rejects.toThrow('products error')
   })
 })

--- a/src/lib/case-orders/repository.ts
+++ b/src/lib/case-orders/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
-import type { CaseOrder, CaseOrderInput, CaseOrderItem } from '@/types/order'
+import { assertValidListOptions } from '@/lib/orders/list-options-validation'
+import type { CaseOrder, CaseOrderInput, CaseOrderItem, OrderListFilterOptions } from '@/types/order'
 
 const GENDERS = ['male', 'female', 'other'] as const
 const STATUSES = ['draft', 'submitted'] as const
@@ -45,13 +46,62 @@ export async function listCaseOrders(
   db: SupabaseClient,
   facilityId: string,
   limit = 50,
-  offset = 0
+  offset = 0,
+  options?: OrderListFilterOptions
 ): Promise<CaseOrder[]> {
-  const { data, error } = await db
+  assertValidListOptions(limit, offset)
+  // issue #20 SET-C: 品名検索（productSearch）は case_order_items に name 列が無く、
+  // jan → products.name の突合が必要。case_order_items.jan は products.jan への FK では
+  // ないため PostgREST の埋め込み(embed) join が使えず、2段階の絞り込みクエリで解決する
+  // （① products から該当jan群を取得 → ② case_order_items からその jan群に紐づく
+  // case_order_id群を取得 → ③ メインクエリに .in('id', ...) で適用）
+  const productSearch = options?.productSearch?.trim()
+  let caseOrderIds: string[] | undefined
+  if (productSearch) {
+    const { data: productRows, error: productError } = await db
+      .from('products')
+      .select('jan')
+      .ilike('name', `%${productSearch}%`)
+    if (productError) throw new Error(productError.message)
+    const jans = ((productRows ?? []) as { jan?: unknown }[]).map(p => asString(p.jan))
+    if (jans.length === 0) return []
+
+    const { data: itemRows, error: itemError } = await db
+      .from('case_order_items')
+      .select('case_order_id')
+      .in('jan', jans)
+    if (itemError) throw new Error(itemError.message)
+    caseOrderIds = Array.from(
+      new Set(((itemRows ?? []) as { case_order_id?: unknown }[]).map(r => asString(r.case_order_id)))
+    )
+    if (caseOrderIds.length === 0) return []
+  }
+
+  let query = db
     .from('case_orders')
     .select('*, case_order_items(*)')
     .eq('facility_id', facilityId)
-    .order('created_at', { ascending: false })
+  if (options?.dateFrom) query = query.gte('case_datetime', options.dateFrom)
+  if (options?.dateTo) query = query.lte('case_datetime', options.dateTo)
+  if (caseOrderIds) query = query.in('id', caseOrderIds)
+
+  // issue #20 型安全・データ層整合レビュー対応（critical）: dateFrom/dateTo は case_datetime で
+  // 絞り込んでいるため、.order() も created_at ではなく case_datetime にしないと、
+  // 施設ごとの該当件数が limit を超えた場合に DB 側で誤った基準（created_at）で先に
+  // 切り詰められ、unified-repository.ts の fetchTopN が前提とする
+  // 「displayDatetime(=case_datetime)降順で上位N件」という不変条件が壊れる。
+  // id を第2キーにして同時刻のページング順序も安定させる
+  //
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel（SET-D）は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(case_order_items(*))に明示的な
+  // ORDER BY を指定しないと代表製品名の選出が理論上非決定的になる。作成順
+  // （created_at昇順・id昇順を第2キー）を明示し、「最初に登録した明細」を安定して
+  // 代表として選出する
+  const { data, error } = await query
+    .order('case_datetime', { ascending: false })
+    .order('id', { ascending: true })
+    .order('created_at', { ascending: true, referencedTable: 'case_order_items' })
+    .order('id', { ascending: true, referencedTable: 'case_order_items' })
     .range(offset, offset + limit - 1)
   if (error) throw new Error(error.message)
   return ((data ?? []) as (CaseOrderRow & { case_order_items?: CaseOrderItemRow[] })[]).map(o => ({

--- a/src/lib/consumable-orders/__tests__/repository.test.ts
+++ b/src/lib/consumable-orders/__tests__/repository.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createConsumableOrder } from '@/lib/consumable-orders/repository'
+import { createConsumableOrder, listConsumableOrders } from '@/lib/consumable-orders/repository'
 
 function makeMockRpcDb(rpcResult: unknown): SupabaseClient {
   return { rpc: vi.fn().mockResolvedValue(rpcResult) } as unknown as SupabaseClient
+}
+
+// issue #20 SET-C: 複数ステップのSupabaseクエリ（.select().eq().gte()...）をチェーン可能な
+// モックとして表現するヘルパー。各メソッドは同一builderを返し、awaitされた時点で
+// resultをdata/errorとして解決する（実際のsupabase-jsのPostgrestFilterBuilderと同じ振る舞い）
+type QueryResult = { data: unknown; error: unknown }
+type ChainableBuilder = Record<string, ReturnType<typeof vi.fn>> & PromiseLike<QueryResult>
+
+function makeChainable(result: QueryResult): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const methods = ['select', 'eq', 'gte', 'lte', 'ilike', 'in', 'order', 'range']
+  for (const m of methods) {
+    ;(builder as Record<string, unknown>)[m] = vi.fn(() => builder)
+  }
+  builder.then = ((resolve: (value: QueryResult) => unknown, reject?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)) as ChainableBuilder['then']
+  return builder
 }
 
 describe('createConsumableOrder', () => {
@@ -54,5 +71,127 @@ describe('createConsumableOrder', () => {
     const db = makeMockRpcDb({ data: { ...mockRpcResult, status: 'invalid' }, error: null })
     const result = await createConsumableOrder(db, 'f-1', { items: [] })
     expect(result.status).toBe('draft')
+  })
+})
+
+// issue #20 SET-C: listConsumableOrders への dateFrom/dateTo/productSearch フィルタ拡張
+describe('listConsumableOrders', () => {
+  const mockRow = {
+    id: 'coo-1', facility_id: 'f-1', status: 'draft',
+    created_at: '2026-06-24T00:00:00Z', updated_at: '2026-06-24T00:00:00Z',
+    consumable_order_items: [],
+  }
+
+  it('facility_id で絞り込み、created_at 降順で limit/offset の範囲を取得する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    const result = await listConsumableOrders(db, 'f-1', 50, 0)
+
+    expect(db.from).toHaveBeenCalledWith('consumable_orders')
+    expect(ordersBuilder.eq).toHaveBeenCalledWith('facility_id', 'f-1')
+    expect(ordersBuilder.order).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(ordersBuilder.order).toHaveBeenCalledWith('id', { ascending: true })
+    expect(ordersBuilder.range).toHaveBeenCalledWith(0, 49)
+    expect(result).toHaveLength(1)
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(consumable_order_items(*))に明示的な
+  // ORDER BY が無いと代表製品名の選出が理論上非決定的になる。作成順（created_at昇順・
+  // id昇順を第2キー）を明示することで「最初に登録した明細」を安定して代表として選出する
+  it('consumable_order_items（埋め込み）にcreated_at昇順・id昇順の明示的なORDER BYを指定する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await listConsumableOrders(db, 'f-1', 50, 0)
+
+    expect(ordersBuilder.order).toHaveBeenCalledWith('created_at', {
+      ascending: true,
+      referencedTable: 'consumable_order_items',
+    })
+    expect(ordersBuilder.order).toHaveBeenCalledWith('id', {
+      ascending: true,
+      referencedTable: 'consumable_order_items',
+    })
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: SPEC.md Part2 SET-C テスト観点
+  // 「limit上限: 最大100（100超は400エラー）、負数は400エラー」の未実装・未テストを解消
+  it('limitが100を超える場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listConsumableOrders(db, 'f-1', 101, 0)).rejects.toThrow('limit は 1〜100 の整数で指定してください')
+  })
+
+  it('offsetが負数の場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listConsumableOrders(db, 'f-1', 50, -1)).rejects.toThrow('offset は0以上の整数で指定してください')
+  })
+
+  it('dateFrom/dateTo を指定すると created_at に gte/lte を適用する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await listConsumableOrders(db, 'f-1', 50, 0, { dateFrom: '2026-06-01T00:00:00Z', dateTo: '2026-06-30T23:59:59Z' })
+
+    expect(ordersBuilder.gte).toHaveBeenCalledWith('created_at', '2026-06-01T00:00:00Z')
+    expect(ordersBuilder.lte).toHaveBeenCalledWith('created_at', '2026-06-30T23:59:59Z')
+  })
+
+  it('productSearch が空文字/未指定の場合は consumables / consumable_order_items を問い合わせない', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'consumable_orders') return ordersBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    await listConsumableOrders(db, 'f-1', 50, 0, { productSearch: '' })
+
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('productSearch を指定すると consumables→consumable_order_items 経由で対象IDを絞り込む', async () => {
+    const consumablesBuilder = makeChainable({ data: [{ id: 'c-1' }, { id: 'c-2' }], error: null })
+    const itemsBuilder = makeChainable({ data: [{ consumable_order_id: 'coo-1' }], error: null })
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === 'consumables') return consumablesBuilder
+        if (table === 'consumable_order_items') return itemsBuilder
+        if (table === 'consumable_orders') return ordersBuilder
+        throw new Error(`unexpected table: ${table}`)
+      }),
+    } as unknown as SupabaseClient
+
+    const result = await listConsumableOrders(db, 'f-1', 50, 0, { productSearch: 'ガーゼ' })
+
+    expect(consumablesBuilder.select).toHaveBeenCalledWith('id')
+    expect(consumablesBuilder.eq).toHaveBeenCalledWith('facility_id', 'f-1')
+    expect(consumablesBuilder.ilike).toHaveBeenCalledWith('name', '%ガーゼ%')
+    expect(itemsBuilder.in).toHaveBeenCalledWith('consumable_id', ['c-1', 'c-2'])
+    expect(ordersBuilder.in).toHaveBeenCalledWith('id', ['coo-1'])
+    expect(result).toHaveLength(1)
+  })
+
+  it('productSearch にヒットする消耗品が無い場合は空配列を返す', async () => {
+    const consumablesBuilder = makeChainable({ data: [], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'consumables') return consumablesBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    const result = await listConsumableOrders(db, 'f-1', 50, 0, { productSearch: 'ヒットしない' })
+
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('Supabaseエラー時に例外を投げる（メインクエリ）', async () => {
+    const ordersBuilder = makeChainable({ data: null, error: { message: 'DB error' } })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await expect(listConsumableOrders(db, 'f-1', 50, 0)).rejects.toThrow('DB error')
   })
 })

--- a/src/lib/consumable-orders/repository.ts
+++ b/src/lib/consumable-orders/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asNumber, asEnum } from '@/lib/mapping'
-import type { ConsumableOrder, ConsumableOrderInput, ConsumableOrderItem } from '@/types/order'
+import { assertValidListOptions } from '@/lib/orders/list-options-validation'
+import type { ConsumableOrder, ConsumableOrderInput, ConsumableOrderItem, OrderListFilterOptions } from '@/types/order'
 
 const STATUSES = ['draft', 'submitted'] as const
 
@@ -34,13 +35,57 @@ export async function listConsumableOrders(
   db: SupabaseClient,
   facilityId: string,
   limit = 50,
-  offset = 0
+  offset = 0,
+  options?: OrderListFilterOptions
 ): Promise<ConsumableOrder[]> {
-  const { data, error } = await db
+  assertValidListOptions(limit, offset)
+  // issue #20 SET-C: 品名検索（productSearch）は consumable_order_items に name 列が無く、
+  // consumable_id → consumables.name の突合が必要。2段階の絞り込みクエリで解決する
+  // （① consumables から施設内で該当する消耗品群を取得 → ② consumable_order_items から
+  // その consumable_id群に紐づく consumable_order_id群を取得 → ③ メインクエリに適用）
+  const productSearch = options?.productSearch?.trim()
+  let orderIds: string[] | undefined
+  if (productSearch) {
+    const { data: consumableRows, error: consumableError } = await db
+      .from('consumables')
+      .select('id')
+      .eq('facility_id', facilityId)
+      .ilike('name', `%${productSearch}%`)
+    if (consumableError) throw new Error(consumableError.message)
+    const consumableIds = ((consumableRows ?? []) as { id?: unknown }[]).map(c => asString(c.id))
+    if (consumableIds.length === 0) return []
+
+    const { data: itemRows, error: itemError } = await db
+      .from('consumable_order_items')
+      .select('consumable_order_id')
+      .in('consumable_id', consumableIds)
+    if (itemError) throw new Error(itemError.message)
+    orderIds = Array.from(
+      new Set(((itemRows ?? []) as { consumable_order_id?: unknown }[]).map(r => asString(r.consumable_order_id)))
+    )
+    if (orderIds.length === 0) return []
+  }
+
+  let query = db
     .from('consumable_orders')
     .select('*, consumable_order_items(*)')
     .eq('facility_id', facilityId)
+  if (options?.dateFrom) query = query.gte('created_at', options.dateFrom)
+  if (options?.dateTo) query = query.lte('created_at', options.dateTo)
+  if (orderIds) query = query.in('id', orderIds)
+
+  // id を第2キーにして同時刻のページング順序も安定させる（case-orders/loan-returnsと統一）
+  //
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel（SET-D）は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(consumable_order_items(*))に明示的な
+  // ORDER BY を指定しないと代表製品名の選出が理論上非決定的になる。作成順
+  // （created_at昇順・id昇順を第2キー）を明示し、「最初に登録した明細」を安定して
+  // 代表として選出する
+  const { data, error } = await query
     .order('created_at', { ascending: false })
+    .order('id', { ascending: true })
+    .order('created_at', { ascending: true, referencedTable: 'consumable_order_items' })
+    .order('id', { ascending: true, referencedTable: 'consumable_order_items' })
     .range(offset, offset + limit - 1)
   if (error) throw new Error(error.message)
   return ((data ?? []) as (ConsumableOrderRow & { consumable_order_items?: ConsumableOrderItemRow[] })[]).map(o => ({

--- a/src/lib/loan-orders/__tests__/repository.test.ts
+++ b/src/lib/loan-orders/__tests__/repository.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createLoanOrder } from '@/lib/loan-orders/repository'
+import { createLoanOrder, listLoanOrders } from '@/lib/loan-orders/repository'
 
 function makeMockRpcDb(rpcResult: unknown): SupabaseClient {
   return { rpc: vi.fn().mockResolvedValue(rpcResult) } as unknown as SupabaseClient
+}
+
+// issue #20 SET-C: 複数ステップのSupabaseクエリ（.select().eq().gte()...）をチェーン可能な
+// モックとして表現するヘルパー。各メソッドは同一builderを返し、awaitされた時点で
+// resultをdata/errorとして解決する（実際のsupabase-jsのPostgrestFilterBuilderと同じ振る舞い）
+type QueryResult = { data: unknown; error: unknown }
+type ChainableBuilder = Record<string, ReturnType<typeof vi.fn>> & PromiseLike<QueryResult>
+
+function makeChainable(result: QueryResult): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const methods = ['select', 'eq', 'gte', 'lte', 'ilike', 'in', 'order', 'range']
+  for (const m of methods) {
+    ;(builder as Record<string, unknown>)[m] = vi.fn(() => builder)
+  }
+  builder.then = ((resolve: (value: QueryResult) => unknown, reject?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)) as ChainableBuilder['then']
+  return builder
 }
 
 describe('createLoanOrder', () => {
@@ -62,5 +79,123 @@ describe('createLoanOrder', () => {
     const db = makeMockRpcDb({ data: { ...mockRpcResult, status: 'invalid' }, error: null })
     const result = await createLoanOrder(db, 'f-1', { procedureName: 'TAVI', maker: 'M', items: [] })
     expect(result.status).toBe('draft')
+  })
+})
+
+// issue #20 SET-C: listLoanOrders への dateFrom/dateTo/productSearch フィルタ拡張
+describe('listLoanOrders', () => {
+  const mockRow = {
+    id: 'lo-1', facility_id: 'f-1', procedure_name: 'TAVI', maker: 'メドトロニック',
+    status: 'draft', created_at: '2026-06-24T00:00:00Z', updated_at: '2026-06-24T00:00:00Z',
+    loan_order_items: [],
+  }
+
+  it('facility_id で絞り込み、created_at 降順で limit/offset の範囲を取得する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    const result = await listLoanOrders(db, 'f-1', 50, 0)
+
+    expect(db.from).toHaveBeenCalledWith('loan_orders')
+    expect(ordersBuilder.eq).toHaveBeenCalledWith('facility_id', 'f-1')
+    expect(ordersBuilder.order).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(ordersBuilder.order).toHaveBeenCalledWith('id', { ascending: true })
+    expect(ordersBuilder.range).toHaveBeenCalledWith(0, 49)
+    expect(result).toHaveLength(1)
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(loan_order_items(*))に明示的な
+  // ORDER BY が無いと代表製品名の選出が理論上非決定的になる。作成順（created_at昇順・
+  // id昇順を第2キー）を明示することで「最初に登録した明細」を安定して代表として選出する
+  it('loan_order_items（埋め込み）にcreated_at昇順・id昇順の明示的なORDER BYを指定する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await listLoanOrders(db, 'f-1', 50, 0)
+
+    expect(ordersBuilder.order).toHaveBeenCalledWith('created_at', {
+      ascending: true,
+      referencedTable: 'loan_order_items',
+    })
+    expect(ordersBuilder.order).toHaveBeenCalledWith('id', {
+      ascending: true,
+      referencedTable: 'loan_order_items',
+    })
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: SPEC.md Part2 SET-C テスト観点
+  // 「limit上限: 最大100（100超は400エラー）、負数は400エラー」の未実装・未テストを解消
+  it('limitが100を超える場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listLoanOrders(db, 'f-1', 101, 0)).rejects.toThrow('limit は 1〜100 の整数で指定してください')
+  })
+
+  it('offsetが負数の場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listLoanOrders(db, 'f-1', 50, -1)).rejects.toThrow('offset は0以上の整数で指定してください')
+  })
+
+  it('dateFrom/dateTo を指定すると created_at に gte/lte を適用する', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await listLoanOrders(db, 'f-1', 50, 0, { dateFrom: '2026-06-01T00:00:00Z', dateTo: '2026-06-30T23:59:59Z' })
+
+    expect(ordersBuilder.gte).toHaveBeenCalledWith('created_at', '2026-06-01T00:00:00Z')
+    expect(ordersBuilder.lte).toHaveBeenCalledWith('created_at', '2026-06-30T23:59:59Z')
+  })
+
+  it('productSearch が空文字/未指定の場合は loan_order_items を問い合わせない', async () => {
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'loan_orders') return ordersBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    await listLoanOrders(db, 'f-1', 50, 0, { productSearch: undefined })
+
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('productSearch を指定すると loan_order_items.name 経由で対象IDを絞り込む（productsテーブルは使わない）', async () => {
+    const itemsBuilder = makeChainable({ data: [{ loan_order_id: 'lo-1' }, { loan_order_id: 'lo-2' }], error: null })
+    const ordersBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === 'loan_order_items') return itemsBuilder
+        if (table === 'loan_orders') return ordersBuilder
+        throw new Error(`unexpected table: ${table}`)
+      }),
+    } as unknown as SupabaseClient
+
+    const result = await listLoanOrders(db, 'f-1', 50, 0, { productSearch: 'カテーテル' })
+
+    expect(itemsBuilder.select).toHaveBeenCalledWith('loan_order_id')
+    expect(itemsBuilder.ilike).toHaveBeenCalledWith('name', '%カテーテル%')
+    expect(ordersBuilder.in).toHaveBeenCalledWith('id', ['lo-1', 'lo-2'])
+    expect(result).toHaveLength(1)
+  })
+
+  it('productSearch にヒットする明細が無い場合は空配列を返す', async () => {
+    const itemsBuilder = makeChainable({ data: [], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'loan_order_items') return itemsBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    const result = await listLoanOrders(db, 'f-1', 50, 0, { productSearch: 'ヒットしない' })
+
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('Supabaseエラー時に例外を投げる（メインクエリ）', async () => {
+    const ordersBuilder = makeChainable({ data: null, error: { message: 'DB error' } })
+    const db = { from: vi.fn(() => ordersBuilder) } as unknown as SupabaseClient
+
+    await expect(listLoanOrders(db, 'f-1', 50, 0)).rejects.toThrow('DB error')
   })
 })

--- a/src/lib/loan-orders/repository.ts
+++ b/src/lib/loan-orders/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
-import type { LoanOrder, LoanOrderInput, LoanOrderItem } from '@/types/order'
+import { assertValidListOptions } from '@/lib/orders/list-options-validation'
+import type { LoanOrder, LoanOrderInput, LoanOrderItem, OrderListFilterOptions } from '@/types/order'
 
 const STATUSES = ['draft', 'submitted'] as const
 
@@ -38,13 +39,47 @@ export async function listLoanOrders(
   db: SupabaseClient,
   facilityId: string,
   limit = 50,
-  offset = 0
+  offset = 0,
+  options?: OrderListFilterOptions
 ): Promise<LoanOrder[]> {
-  const { data, error } = await db
+  assertValidListOptions(limit, offset)
+  // issue #20 SET-C: 品名検索（productSearch）は loan_order_items.name を直接使う
+  // （name 列がそのまま存在するため products テーブルへのJOINは不要）。
+  // 先に対象の loan_order_id 群を絞り込んでからメインクエリに .in() で適用する
+  const productSearch = options?.productSearch?.trim()
+  let orderIds: string[] | undefined
+  if (productSearch) {
+    const { data: itemRows, error: itemError } = await db
+      .from('loan_order_items')
+      .select('loan_order_id')
+      .ilike('name', `%${productSearch}%`)
+    if (itemError) throw new Error(itemError.message)
+    orderIds = Array.from(
+      new Set(((itemRows ?? []) as { loan_order_id?: unknown }[]).map(r => asString(r.loan_order_id)))
+    )
+    if (orderIds.length === 0) return []
+  }
+
+  let query = db
     .from('loan_orders')
     .select('*, loan_order_items(*)')
     .eq('facility_id', facilityId)
+  if (options?.dateFrom) query = query.gte('created_at', options.dateFrom)
+  if (options?.dateTo) query = query.lte('created_at', options.dateTo)
+  if (orderIds) query = query.in('id', orderIds)
+
+  // id を第2キーにして同時刻のページング順序も安定させる（case-orders/loan-returnsと統一）
+  //
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel（SET-D）は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(loan_order_items(*))に明示的な
+  // ORDER BY を指定しないと代表製品名の選出が理論上非決定的になる。作成順
+  // （created_at昇順・id昇順を第2キー）を明示し、「最初に登録した明細」を安定して
+  // 代表として選出する
+  const { data, error } = await query
     .order('created_at', { ascending: false })
+    .order('id', { ascending: true })
+    .order('created_at', { ascending: true, referencedTable: 'loan_order_items' })
+    .order('id', { ascending: true, referencedTable: 'loan_order_items' })
     .range(offset, offset + limit - 1)
   if (error) throw new Error(error.message)
   return ((data ?? []) as (LoanOrderRow & { loan_order_items?: LoanOrderItemRow[] })[]).map(o => ({

--- a/src/lib/loan-returns/__tests__/repository.test.ts
+++ b/src/lib/loan-returns/__tests__/repository.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createLoanReturn } from '@/lib/loan-returns/repository'
+import { createLoanReturn, listLoanReturns } from '@/lib/loan-returns/repository'
+
+// issue #20 SET-C: 複数ステップのSupabaseクエリ（.select().eq().gte()...）をチェーン可能な
+// モックとして表現するヘルパー。各メソッドは同一builderを返し、awaitされた時点で
+// resultをdata/errorとして解決する（実際のsupabase-jsのPostgrestFilterBuilderと同じ振る舞い）
+type QueryResult = { data: unknown; error: unknown }
+type ChainableBuilder = Record<string, ReturnType<typeof vi.fn>> & PromiseLike<QueryResult>
+
+function makeChainable(result: QueryResult): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const methods = ['select', 'eq', 'gte', 'lte', 'ilike', 'in', 'order', 'range']
+  for (const m of methods) {
+    ;(builder as Record<string, unknown>)[m] = vi.fn(() => builder)
+  }
+  builder.then = ((resolve: (value: QueryResult) => unknown, reject?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)) as ChainableBuilder['then']
+  return builder
+}
 
 describe('createLoanReturn', () => {
   const mockReturn = {
@@ -49,5 +66,129 @@ describe('createLoanReturn', () => {
       items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
     })
     expect(result.status).toBe('draft')
+  })
+})
+
+// issue #20 SET-C: listLoanReturns への dateFrom/dateTo/productSearch フィルタ拡張
+describe('listLoanReturns', () => {
+  const mockRow = {
+    id: 'lr-1', facility_id: 'f-1', return_datetime: '2026-06-24T15:00:00Z',
+    status: 'draft', created_at: '2026-06-24T00:00:00Z', updated_at: '2026-06-24T00:00:00Z',
+    loan_return_items: [],
+  }
+
+  // issue #20 型安全・データ層整合レビュー対応（critical）: dateFrom/dateTo は return_datetime で
+  // 絞り込むため、.order() も created_at ではなく return_datetime でなければ、施設ごとの
+  // 該当件数が limit を超えた場合にDB側で誤ったキーで先に切り詰められるバグになる
+  it('facility_id で絞り込み、return_datetime 降順・id昇順で limit/offset の範囲を取得する', async () => {
+    const returnsBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => returnsBuilder) } as unknown as SupabaseClient
+
+    const result = await listLoanReturns(db, 'f-1', 50, 0)
+
+    expect(db.from).toHaveBeenCalledWith('loan_returns')
+    expect(returnsBuilder.eq).toHaveBeenCalledWith('facility_id', 'f-1')
+    expect(returnsBuilder.order).toHaveBeenCalledWith('return_datetime', { ascending: false })
+    expect(returnsBuilder.order).toHaveBeenCalledWith('id', { ascending: true })
+    expect(returnsBuilder.range).toHaveBeenCalledWith(0, 49)
+    expect(result).toHaveLength(1)
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(loan_return_items(...))に明示的な
+  // ORDER BY が無いと代表製品名の選出が理論上非決定的になる。作成順（created_at昇順・
+  // id昇順を第2キー）を明示することで「最初に登録した明細」を安定して代表として選出する
+  it('loan_return_items（埋め込み）にcreated_at昇順・id昇順の明示的なORDER BYを指定する', async () => {
+    const returnsBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => returnsBuilder) } as unknown as SupabaseClient
+
+    await listLoanReturns(db, 'f-1', 50, 0)
+
+    expect(returnsBuilder.order).toHaveBeenCalledWith('created_at', {
+      ascending: true,
+      referencedTable: 'loan_return_items',
+    })
+    expect(returnsBuilder.order).toHaveBeenCalledWith('id', {
+      ascending: true,
+      referencedTable: 'loan_return_items',
+    })
+  })
+
+  // issue #20 型安全・データ層整合レビュー対応（important）: SPEC.md Part2 SET-C テスト観点
+  // 「limit上限: 最大100（100超は400エラー）、負数は400エラー」の未実装・未テストを解消
+  it('limitが100を超える場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listLoanReturns(db, 'f-1', 101, 0)).rejects.toThrow('limit は 1〜100 の整数で指定してください')
+  })
+
+  it('offsetが負数の場合はエラーを投げる', async () => {
+    const db = { from: vi.fn() } as unknown as SupabaseClient
+    await expect(listLoanReturns(db, 'f-1', 50, -1)).rejects.toThrow('offset は0以上の整数で指定してください')
+  })
+
+  it('dateFrom/dateTo を指定すると return_datetime に gte/lte を適用する', async () => {
+    const returnsBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = { from: vi.fn(() => returnsBuilder) } as unknown as SupabaseClient
+
+    await listLoanReturns(db, 'f-1', 50, 0, { dateFrom: '2026-06-01T00:00:00Z', dateTo: '2026-06-30T23:59:59Z' })
+
+    expect(returnsBuilder.gte).toHaveBeenCalledWith('return_datetime', '2026-06-01T00:00:00Z')
+    expect(returnsBuilder.lte).toHaveBeenCalledWith('return_datetime', '2026-06-30T23:59:59Z')
+  })
+
+  it('productSearch が空文字/未指定の場合は products / loan_return_items を問い合わせない', async () => {
+    const returnsBuilder = makeChainable({ data: [mockRow], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'loan_returns') return returnsBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    await listLoanReturns(db, 'f-1', 50, 0, { productSearch: '' })
+
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('productSearch を指定すると products→loan_return_items 経由で対象IDを絞り込む', async () => {
+    const productsBuilder = makeChainable({ data: [{ jan: '490001' }], error: null })
+    const itemsBuilder = makeChainable({ data: [{ loan_return_id: 'lr-1' }], error: null })
+    const returnsBuilder = makeChainable({ data: [mockRow], error: null })
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === 'products') return productsBuilder
+        if (table === 'loan_return_items') return itemsBuilder
+        if (table === 'loan_returns') return returnsBuilder
+        throw new Error(`unexpected table: ${table}`)
+      }),
+    } as unknown as SupabaseClient
+
+    const result = await listLoanReturns(db, 'f-1', 50, 0, { productSearch: 'カテーテル' })
+
+    expect(productsBuilder.select).toHaveBeenCalledWith('jan')
+    expect(productsBuilder.ilike).toHaveBeenCalledWith('name', '%カテーテル%')
+    expect(itemsBuilder.in).toHaveBeenCalledWith('jan', ['490001'])
+    expect(returnsBuilder.in).toHaveBeenCalledWith('id', ['lr-1'])
+    expect(result).toHaveLength(1)
+  })
+
+  it('productSearch にヒットする製品が無い場合は空配列を返す', async () => {
+    const productsBuilder = makeChainable({ data: [], error: null })
+    const from = vi.fn((table: string) => {
+      if (table === 'products') return productsBuilder
+      throw new Error(`unexpected table: ${table}`)
+    })
+    const db = { from } as unknown as SupabaseClient
+
+    const result = await listLoanReturns(db, 'f-1', 50, 0, { productSearch: 'ヒットしない' })
+
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledTimes(1)
+  })
+
+  it('Supabaseエラー時に例外を投げる（メインクエリ）', async () => {
+    const returnsBuilder = makeChainable({ data: null, error: { message: 'DB error' } })
+    const db = { from: vi.fn(() => returnsBuilder) } as unknown as SupabaseClient
+
+    await expect(listLoanReturns(db, 'f-1', 50, 0)).rejects.toThrow('DB error')
   })
 })

--- a/src/lib/loan-returns/repository.ts
+++ b/src/lib/loan-returns/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
-import type { LoanReturn, LoanReturnInput, LoanReturnItem } from '@/types/order'
+import { assertValidListOptions } from '@/lib/orders/list-options-validation'
+import type { LoanReturn, LoanReturnInput, LoanReturnItem, OrderListFilterOptions } from '@/types/order'
 
 const STATUSES = ['draft', 'returned'] as const
 
@@ -43,13 +44,62 @@ export async function listLoanReturns(
   db: SupabaseClient,
   facilityId: string,
   limit = 50,
-  offset = 0
+  offset = 0,
+  options?: OrderListFilterOptions
 ): Promise<LoanReturn[]> {
-  const { data, error } = await db
+  assertValidListOptions(limit, offset)
+  // issue #20 SET-C: 品名検索（productSearch）は loan_return_items に name 列が無く、
+  // jan → products.name の突合が必要。loan_return_items.jan は products.jan への FK では
+  // ないため PostgREST の埋め込み(embed) join が使えず、2段階の絞り込みクエリで解決する
+  // （① products から該当jan群を取得 → ② loan_return_items からその jan群に紐づく
+  // loan_return_id群を取得 → ③ メインクエリに .in('id', ...) で適用）
+  const productSearch = options?.productSearch?.trim()
+  let loanReturnIds: string[] | undefined
+  if (productSearch) {
+    const { data: productRows, error: productError } = await db
+      .from('products')
+      .select('jan')
+      .ilike('name', `%${productSearch}%`)
+    if (productError) throw new Error(productError.message)
+    const jans = ((productRows ?? []) as { jan?: unknown }[]).map(p => asString(p.jan))
+    if (jans.length === 0) return []
+
+    const { data: itemRows, error: itemError } = await db
+      .from('loan_return_items')
+      .select('loan_return_id')
+      .in('jan', jans)
+    if (itemError) throw new Error(itemError.message)
+    loanReturnIds = Array.from(
+      new Set(((itemRows ?? []) as { loan_return_id?: unknown }[]).map(r => asString(r.loan_return_id)))
+    )
+    if (loanReturnIds.length === 0) return []
+  }
+
+  let query = db
     .from('loan_returns')
     .select(`${LOAN_RETURN_COLUMNS}, loan_return_items(${LOAN_RETURN_ITEM_COLUMNS})`)
     .eq('facility_id', facilityId)
-    .order('created_at', { ascending: false })
+  if (options?.dateFrom) query = query.gte('return_datetime', options.dateFrom)
+  if (options?.dateTo) query = query.lte('return_datetime', options.dateTo)
+  if (loanReturnIds) query = query.in('id', loanReturnIds)
+
+  // issue #20 型安全・データ層整合レビュー対応（critical）: dateFrom/dateTo は return_datetime で
+  // 絞り込んでいるため、.order() も created_at ではなく return_datetime にしないと、
+  // 施設ごとの該当件数が limit を超えた場合に DB 側で誤った基準（created_at）で先に
+  // 切り詰められ、unified-repository.ts の fetchTopN が前提とする
+  // 「displayDatetime(=return_datetime)降順で上位N件」という不変条件が壊れる。
+  // id を第2キーにして同時刻のページング順序も安定させる
+  //
+  // issue #20 型安全・データ層整合レビュー対応（important）: summaryLabel（SET-D）は
+  // items[0]（代表1品目）を使うが、埋め込みクエリ(loan_return_items(...))に明示的な
+  // ORDER BY を指定しないと代表製品名の選出が理論上非決定的になる。作成順
+  // （created_at昇順・id昇順を第2キー）を明示し、「最初に登録した明細」を安定して
+  // 代表として選出する
+  const { data, error } = await query
+    .order('return_datetime', { ascending: false })
+    .order('id', { ascending: true })
+    .order('created_at', { ascending: true, referencedTable: 'loan_return_items' })
+    .order('id', { ascending: true, referencedTable: 'loan_return_items' })
     .range(offset, offset + limit - 1)
   if (error) throw new Error(error.message)
   return ((data ?? []) as (LoanReturnRow & { loan_return_items?: LoanReturnItemRow[] })[]).map(r => ({

--- a/src/lib/orders/__tests__/unified-repository.test.ts
+++ b/src/lib/orders/__tests__/unified-repository.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { fetchUnifiedOrders } from '@/lib/orders/unified-repository'
+import type { CaseOrder, ConsumableOrder, LoanOrder, LoanReturn, OrdersFilter } from '@/types/order'
+
+// issue #20 型安全・データ層整合レビュー対応（critical）:
+// src/lib/orders/unified-repository.ts はSET-D中核の集約ロジック（並列取得・
+// summaryLabel解決・displayDatetime降順の安定ソート・admin全施設ファンアウト）を
+// 担うが、これまでroute.test.tsではfetchUnifiedOrders自体をモックしていたため
+// 直接のユニットテストが1件も存在しなかった。ここで実装の中身を直接検証する。
+
+const mockListCaseOrders = vi.fn()
+const mockListConsumableOrders = vi.fn()
+const mockListLoanOrders = vi.fn()
+const mockListLoanReturns = vi.fn()
+const mockListFacilities = vi.fn()
+
+vi.mock('@/lib/case-orders/repository', () => ({
+  listCaseOrders: (...args: unknown[]) => mockListCaseOrders(...args),
+}))
+vi.mock('@/lib/consumable-orders/repository', () => ({
+  listConsumableOrders: (...args: unknown[]) => mockListConsumableOrders(...args),
+}))
+vi.mock('@/lib/loan-orders/repository', () => ({
+  listLoanOrders: (...args: unknown[]) => mockListLoanOrders(...args),
+}))
+vi.mock('@/lib/loan-returns/repository', () => ({
+  listLoanReturns: (...args: unknown[]) => mockListLoanReturns(...args),
+}))
+vi.mock('@/lib/facilities/repository', () => ({
+  listFacilities: (...args: unknown[]) => mockListFacilities(...args),
+}))
+
+type QueryResult = { data: unknown; error: unknown }
+type ChainableBuilder = Record<string, ReturnType<typeof vi.fn>> & PromiseLike<QueryResult>
+
+function makeChainable(result: QueryResult): ChainableBuilder {
+  const builder = {} as ChainableBuilder
+  const methods = ['select', 'in']
+  for (const m of methods) {
+    ;(builder as Record<string, unknown>)[m] = vi.fn(() => builder)
+  }
+  builder.then = ((resolve: (value: QueryResult) => unknown, reject?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)) as ChainableBuilder['then']
+  return builder
+}
+
+function makeCaseOrder(overrides: Partial<CaseOrder> = {}): CaseOrder {
+  return {
+    id: 'co-1',
+    facilityId: 'f-1',
+    caseDatetime: '2026-07-10T00:00:00Z',
+    procedureName: 'TAVI',
+    patientId: 'P1',
+    patientInitials: 'T.S.',
+    gender: 'male',
+    doctorName: '田中医師',
+    status: 'submitted',
+    items: [{ id: 'i-1', caseOrderId: 'co-1', jan: '490001', quantity: 1, createdAt: '2026-07-10T00:00:00Z' }],
+    createdAt: '2026-07-10T00:00:00Z',
+    updatedAt: '2026-07-10T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeConsumableOrder(overrides: Partial<ConsumableOrder> = {}): ConsumableOrder {
+  return {
+    id: 'coo-1',
+    facilityId: 'f-1',
+    status: 'submitted',
+    items: [{ id: 'i-1', consumableOrderId: 'coo-1', consumableId: 'c-1', quantity: 2, createdAt: '2026-07-09T00:00:00Z' }],
+    createdAt: '2026-07-09T00:00:00Z',
+    updatedAt: '2026-07-09T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLoanOrder(overrides: Partial<LoanOrder> = {}): LoanOrder {
+  return {
+    id: 'lo-1',
+    facilityId: 'f-1',
+    procedureName: 'TAVI',
+    maker: 'メドトロニック',
+    status: 'submitted',
+    items: [{ id: 'i-1', loanOrderId: 'lo-1', name: 'カテーテルA', quantity: 1, createdAt: '2026-07-08T00:00:00Z' }],
+    createdAt: '2026-07-08T00:00:00Z',
+    updatedAt: '2026-07-08T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLoanReturn(overrides: Partial<LoanReturn> = {}): LoanReturn {
+  return {
+    id: 'lr-1',
+    facilityId: 'f-1',
+    returnDatetime: '2026-07-07T00:00:00Z',
+    status: 'returned',
+    items: [{ id: 'i-1', loanReturnId: 'lr-1', jan: '490002', quantity: 1, createdAt: '2026-07-07T00:00:00Z' }],
+    createdAt: '2026-07-07T00:00:00Z',
+    updatedAt: '2026-07-07T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeDb(productsResult: QueryResult = { data: [], error: null }, consumablesResult: QueryResult = { data: [], error: null }): SupabaseClient {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'products') return makeChainable(productsResult)
+      if (table === 'consumables') return makeChainable(consumablesResult)
+      throw new Error(`unexpected table: ${table}`)
+    }),
+  } as unknown as SupabaseClient
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockListFacilities.mockResolvedValue([
+    { id: 'f-1', name: '施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  ])
+  mockListCaseOrders.mockResolvedValue([])
+  mockListConsumableOrders.mockResolvedValue([])
+  mockListLoanOrders.mockResolvedValue([])
+  mockListLoanReturns.mockResolvedValue([])
+})
+
+describe('fetchUnifiedOrders', () => {
+  it('4種別すべて空の場合は { orders: [], errors: [] } を返す', async () => {
+    const db = makeDb()
+    const filter: OrdersFilter = { facilityId: 'f-1' }
+    const result = await fetchUnifiedOrders(db, filter)
+    expect(result).toEqual({ orders: [], errors: [] })
+  })
+
+  it('displayDatetime降順・同時刻はid昇順で4種別を安定ソートする', async () => {
+    mockListCaseOrders.mockResolvedValue([makeCaseOrder({ id: 'co-1', caseDatetime: '2026-07-10T00:00:00Z' })])
+    mockListConsumableOrders.mockResolvedValue([makeConsumableOrder({ id: 'coo-1', createdAt: '2026-07-09T00:00:00Z' })])
+    mockListLoanOrders.mockResolvedValue([makeLoanOrder({ id: 'lo-1', createdAt: '2026-07-08T00:00:00Z' })])
+    mockListLoanReturns.mockResolvedValue([makeLoanReturn({ id: 'lr-1', returnDatetime: '2026-07-07T00:00:00Z' })])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1' })
+
+    expect(result.orders.map(o => o.id)).toEqual(['co-1', 'coo-1', 'lo-1', 'lr-1'])
+    expect(result.orders.map(o => o.kind)).toEqual(['case', 'consumable', 'loan', 'loan_return'])
+  })
+
+  it('同時刻の場合はidの昇順で安定ソートする', async () => {
+    const sameTime = '2026-07-10T00:00:00Z'
+    mockListCaseOrders.mockResolvedValue([
+      makeCaseOrder({ id: 'co-2', caseDatetime: sameTime }),
+      makeCaseOrder({ id: 'co-1', caseDatetime: sameTime }),
+    ])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: ['case'] })
+
+    expect(result.orders.map(o => o.id)).toEqual(['co-1', 'co-2'])
+  })
+
+  it('orderKindsで指定した種別のみ取得する（未指定種別のlist関数は呼ばれない）', async () => {
+    const db = makeDb()
+    await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: ['case'] })
+
+    expect(mockListCaseOrders).toHaveBeenCalled()
+    expect(mockListConsumableOrders).not.toHaveBeenCalled()
+    expect(mockListLoanOrders).not.toHaveBeenCalled()
+    expect(mockListLoanReturns).not.toHaveBeenCalled()
+  })
+
+  // issue #20 レビュー指摘（important）回帰テスト: orderKindsが明示的な空配列（種別チェックボックスを
+  // 全て外した状態）の場合、ALL_KINDSへフォールバックせず「0種別」として扱う（=いずれのlist関数も
+  // 呼ばれず、結果は空になる）。undefined（パラメータ自体が未指定）の場合のみ全種別対象にする。
+  it('orderKindsが明示的な空配列の場合は全種別にフォールバックせず、いずれのlist関数も呼ばない', async () => {
+    mockListCaseOrders.mockResolvedValue([makeCaseOrder()])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: [] })
+
+    expect(mockListCaseOrders).not.toHaveBeenCalled()
+    expect(mockListConsumableOrders).not.toHaveBeenCalled()
+    expect(mockListLoanOrders).not.toHaveBeenCalled()
+    expect(mockListLoanReturns).not.toHaveBeenCalled()
+    expect(result).toEqual({ orders: [], errors: [] })
+  })
+
+  it('1種別の取得が失敗しても他の結果は返しerrorsに理由を積む', async () => {
+    mockListCaseOrders.mockRejectedValue(new Error('DB error'))
+    mockListLoanOrders.mockResolvedValue([makeLoanOrder()])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1' })
+
+    expect(result.errors).toEqual([{ kind: 'case', message: 'DB error' }])
+    expect(result.orders).toHaveLength(1)
+    expect(result.orders[0].kind).toBe('loan')
+  })
+
+  it('summaryLabelはproducts/consumablesから解決した代表製品名+残n件になる', async () => {
+    mockListCaseOrders.mockResolvedValue([
+      makeCaseOrder({
+        items: [
+          { id: 'i-1', caseOrderId: 'co-1', jan: '490001', quantity: 1, createdAt: '2026-07-10T00:00:00Z' },
+          { id: 'i-2', caseOrderId: 'co-1', jan: '490002', quantity: 1, createdAt: '2026-07-10T00:00:00Z' },
+        ],
+      }),
+    ])
+    mockListConsumableOrders.mockResolvedValue([makeConsumableOrder()])
+    const db = makeDb(
+      { data: [{ jan: '490001', name: 'カテーテルA' }], error: null },
+      { data: [{ id: 'c-1', name: 'ガーゼ' }], error: null }
+    )
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: ['case', 'consumable'] })
+
+    const caseOrder = result.orders.find(o => o.kind === 'case')!
+    const consumableOrder = result.orders.find(o => o.kind === 'consumable')!
+    expect(caseOrder.summaryLabel).toBe('カテーテルA 他1件')
+    expect(consumableOrder.summaryLabel).toBe('ガーゼ')
+  })
+
+  it('品目が0件の場合は「(品目なし)」を表示する', async () => {
+    mockListLoanOrders.mockResolvedValue([makeLoanOrder({ items: [] })])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: ['loan'] })
+
+    expect(result.orders[0].summaryLabel).toBe('(品目なし)')
+  })
+
+  it('facilityNameはlistFacilitiesの結果から解決される', async () => {
+    mockListCaseOrders.mockResolvedValue([makeCaseOrder({ facilityId: 'f-1' })])
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { facilityId: 'f-1', orderKinds: ['case'] })
+
+    expect(result.orders[0].facilityName).toBe('施設A')
+  })
+
+  it('adminがfacility_id未指定の場合は全施設をファンアウトして種別ごとに上位20件へ絞り込む', async () => {
+    mockListFacilities.mockResolvedValue([
+      { id: 'f-1', name: '施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 'f-2', name: '施設B', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+    ])
+    mockListCaseOrders.mockImplementation((_db: unknown, facilityId: string) => {
+      if (facilityId === 'f-1') return Promise.resolve([makeCaseOrder({ id: 'co-f1', facilityId: 'f-1', caseDatetime: '2026-07-10T00:00:00Z' })])
+      if (facilityId === 'f-2') return Promise.resolve([makeCaseOrder({ id: 'co-f2', facilityId: 'f-2', caseDatetime: '2026-07-11T00:00:00Z' })])
+      return Promise.resolve([])
+    })
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { orderKinds: ['case'] })
+
+    expect(mockListCaseOrders).toHaveBeenCalledTimes(2)
+    expect(result.orders.map(o => o.id)).toEqual(['co-f2', 'co-f1'])
+  })
+
+  // issue #20 レビュー指摘（minor）回帰テスト: admin全施設ファンアウト時、displayDatetimeが
+  // 完全一致する複数施設分のレコードが上位20件への切り詰め境界をまたぐ場合でも、idの昇順を
+  // 第2キーとして安定的に切り詰めること（施設の列挙順や返却順に依存して結果が変わらないこと）。
+  it('admin全施設ファンアウト時、同時刻タイが上位20件境界をまたいでもidを第2キーに決定的に切り詰める', async () => {
+    mockListFacilities.mockResolvedValue([
+      { id: 'f-1', name: '施設A', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 'f-2', name: '施設B', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+    ])
+    const sameTime = '2026-07-10T00:00:00Z'
+    // f-1（施設列挙順で先頭）からは辞書順で大きいid 'z-00' を1件、f-2からは辞書順で小さいid群
+    // 'a-00'〜'a-19'（20件）を同時刻で返す。マージ後の配列は施設列挙順のまま [z-00, a-00, ..., a-19]
+    // となるため、idタイブレークを使わず時刻のみでslice(0,20)すると（Array.sortの安定性により）
+    // 元の並び順がそのまま残り、本来は辞書順で最小の20件（a-00〜a-19）が選ばれるべきところ、
+    // 誤って z-00 を含み最後の a-19 を取りこぼす。idを第2キーに昇順ソートしてから切り詰めれば
+    // 常に辞書順最小の20件（a-00〜a-19）が選ばれ、施設の列挙順・返却順に依存しない決定的な結果になる。
+    mockListCaseOrders.mockImplementation((_db: unknown, facilityId: string) => {
+      if (facilityId === 'f-1') {
+        return Promise.resolve([makeCaseOrder({ id: 'z-00', facilityId: 'f-1', caseDatetime: sameTime })])
+      }
+      if (facilityId === 'f-2') {
+        return Promise.resolve(
+          Array.from({ length: 20 }, (_, i) =>
+            makeCaseOrder({ id: `a-${String(i).padStart(2, '0')}`, facilityId: 'f-2', caseDatetime: sameTime })
+          )
+        )
+      }
+      return Promise.resolve([])
+    })
+    const db = makeDb()
+
+    const result = await fetchUnifiedOrders(db, { orderKinds: ['case'] })
+
+    expect(result.orders).toHaveLength(20)
+    expect(result.orders.map(o => o.id)).not.toContain('z-00')
+    expect(result.orders.map(o => o.id)).toContain('a-19')
+  })
+})

--- a/src/lib/orders/list-options-validation.ts
+++ b/src/lib/orders/list-options-validation.ts
@@ -1,0 +1,19 @@
+// issue #20 型安全・データ層整合レビュー対応（important）:
+// SPEC.md Part2 SET-C のテスト観点「limit上限: 最大100（100超は400エラー）、負数は400エラー」が
+// 未実装・未テストだった。4つの list*（listCaseOrders / listConsumableOrders / listLoanOrders /
+// listLoanReturns）で個別に実装すると分岐が重複しズレるリスクがあるため、共通バリデータに集約する。
+//
+// 注: ここでの「400エラー」はHTTPステータスではなく、repository層が投げるErrorを指す。
+// 既存4 API（/api/case-orders 等）のクエリパラメータ検証・ステータスコードへのマッピングは
+// SPEC.md 前提制約3で明示的にスコープ外（別issue）としているため、このバリデータは
+// repository層の不変条件チェック（defense-in-depth）としてのみ機能する。
+// 新設 /api/orders（SET-D）は limit を LIMIT_PER_KIND=20 固定で渡すためユーザー入力を
+// 経由せず、このバリデーションには通常抵触しない。
+export function assertValidListOptions(limit: number, offset: number): void {
+  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit <= 0 || limit > 100) {
+    throw new Error('limit は 1〜100 の整数で指定してください')
+  }
+  if (!Number.isFinite(offset) || !Number.isInteger(offset) || offset < 0) {
+    throw new Error('offset は0以上の整数で指定してください')
+  }
+}

--- a/src/lib/orders/unified-repository.ts
+++ b/src/lib/orders/unified-repository.ts
@@ -1,0 +1,231 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { listCaseOrders } from '@/lib/case-orders/repository'
+import { listConsumableOrders } from '@/lib/consumable-orders/repository'
+import { listLoanOrders } from '@/lib/loan-orders/repository'
+import { listLoanReturns } from '@/lib/loan-returns/repository'
+import { listFacilities } from '@/lib/facilities/repository'
+import { asString } from '@/lib/mapping'
+import type {
+  CaseOrder,
+  ConsumableOrder,
+  LoanOrder,
+  LoanReturn,
+  OrderKind,
+  OrderListFilterOptions,
+  OrdersFetchError,
+  OrdersFilter,
+  OrdersGetResponse,
+  UnifiedOrder,
+} from '@/types/order'
+
+const ALL_KINDS: OrderKind[] = ['case', 'consumable', 'loan', 'loan_return']
+// SPEC.md Part2 SET-D: 「各種別limit=20固定、v1ではoffset無し」
+const LIMIT_PER_KIND = 20
+
+// WHY(issue #20 SET-D): /api/orders route.ts から呼ばれる集約関数。SET-Cの4つの list*
+// リポジトリ関数を Promise.allSettled で並列取得し、summaryLabel解決（jan→products.name /
+// consumable_id→consumables.name のバッチIN句、N+1回避）を経て
+// displayDatetime降順・同時刻id昇順で安定ソートした結果を返す。
+// route.tsを薄く保ち、将来の種別追加をこのファイル1箇所に閉じ込める設計とする（SPEC.md記載通り）。
+//
+// 注: SET-C の list*() は facilityId を必須の単一文字列でしか受け取らない設計のため、
+// admin が施設フィルタ未選択（filter.facilityId === undefined、全施設対象）の場合は
+// 全施設分をここでループして種別ごとにマージ→上位20件へ絞り込む（SET-C側の実装は変更しない）。
+export async function fetchUnifiedOrders(db: SupabaseClient, filter: OrdersFilter): Promise<OrdersGetResponse> {
+  // WHY: orderKindsが「未指定(undefined)」の場合のみ「全種別対象」にフォールバックする。
+  // 呼び出し元（route.ts）は種別チェックボックスを全て外した明示的な選択を空配列として渡すため、
+  // ここで空配列をALL_KINDSにフォールバックさせると「0件選択」というUI状態と「全種別のデータが
+  // 返る」という実データが矛盾してしまう（issue #20 レビュー指摘: 境界条件バグ）。
+  const kinds = new Set<OrderKind>(filter.orderKinds ?? ALL_KINDS)
+  const options: OrderListFilterOptions = {
+    dateFrom: filter.dateFrom,
+    dateTo: filter.dateTo,
+    productSearch: filter.productSearch,
+  }
+
+  // facilities は authenticated であれば全件SELECT可能な共有マスタ（auth_onlyポリシー）。
+  // facilityName表示（admin向け）と、admin全施設対象時の対象facilityId解決の両方に使う
+  const facilities = await listFacilities(db)
+  const facilityNameById = new Map(facilities.map(f => [f.id, f.name]))
+  const targetFacilityIds = filter.facilityId ? [filter.facilityId] : facilities.map(f => f.id)
+
+  const [caseResult, consumableResult, loanResult, loanReturnResult] = await Promise.allSettled([
+    kinds.has('case')
+      ? fetchTopN(db, listCaseOrders, targetFacilityIds, options, o => o.caseDatetime)
+      : Promise.resolve<CaseOrder[]>([]),
+    kinds.has('consumable')
+      ? fetchTopN(db, listConsumableOrders, targetFacilityIds, options, o => o.createdAt)
+      : Promise.resolve<ConsumableOrder[]>([]),
+    kinds.has('loan')
+      ? fetchTopN(db, listLoanOrders, targetFacilityIds, options, o => o.createdAt)
+      : Promise.resolve<LoanOrder[]>([]),
+    kinds.has('loan_return')
+      ? fetchTopN(db, listLoanReturns, targetFacilityIds, options, o => o.returnDatetime)
+      : Promise.resolve<LoanReturn[]>([]),
+  ])
+
+  const errors: OrdersFetchError[] = []
+  const caseOrders = unwrap(caseResult, 'case', errors)
+  const consumableOrders = unwrap(consumableResult, 'consumable', errors)
+  const loanOrders = unwrap(loanResult, 'loan', errors)
+  const loanReturns = unwrap(loanReturnResult, 'loan_return', errors)
+
+  // summaryLabelの解決: jan経路(case_orders・loan_returns)とconsumable_id経路(consumable_orders)を
+  // それぞれバッチ化してIN句1本で解決する（N+1回避。loan_ordersはloan_order_items.nameを
+  // 直接使うためJOIN/IN句不要。SPEC.md Part2 SET-D記載通り）
+  const jans = Array.from(
+    new Set(
+      [...caseOrders.map(o => o.items[0]?.jan), ...loanReturns.map(o => o.items[0]?.jan)].filter(
+        (v): v is string => !!v
+      )
+    )
+  )
+  const consumableIds = Array.from(
+    new Set(consumableOrders.map(o => o.items[0]?.consumableId).filter((v): v is string => !!v))
+  )
+
+  const [productNameByJan, consumableNameById] = await Promise.all([
+    fetchNamesByKey(db, 'products', 'jan', jans),
+    fetchNamesByKey(db, 'consumables', 'id', consumableIds),
+  ])
+
+  const orders: UnifiedOrder[] = [
+    ...caseOrders.map(o =>
+      toUnifiedOrder(
+        o.id,
+        'case',
+        o.facilityId,
+        facilityNameById.get(o.facilityId),
+        o.caseDatetime,
+        o.status,
+        o.items.length,
+        o.items[0] ? productNameByJan.get(o.items[0].jan) : undefined
+      )
+    ),
+    ...consumableOrders.map(o =>
+      toUnifiedOrder(
+        o.id,
+        'consumable',
+        o.facilityId,
+        facilityNameById.get(o.facilityId),
+        o.createdAt,
+        o.status,
+        o.items.length,
+        o.items[0] ? consumableNameById.get(o.items[0].consumableId) : undefined
+      )
+    ),
+    ...loanOrders.map(o =>
+      toUnifiedOrder(
+        o.id,
+        'loan',
+        o.facilityId,
+        facilityNameById.get(o.facilityId),
+        o.createdAt,
+        o.status,
+        o.items.length,
+        o.items[0]?.name
+      )
+    ),
+    ...loanReturns.map(o =>
+      toUnifiedOrder(
+        o.id,
+        'loan_return',
+        o.facilityId,
+        facilityNameById.get(o.facilityId),
+        o.returnDatetime,
+        o.status,
+        o.items.length,
+        o.items[0] ? productNameByJan.get(o.items[0].jan) : undefined
+      )
+    ),
+  ]
+
+  // displayDatetime降順・同時刻はid昇順で安定ソート（SPEC.md受け入れ条件通り）
+  orders.sort((a, b) => {
+    const diff = new Date(b.displayDatetime).getTime() - new Date(a.displayDatetime).getTime()
+    if (diff !== 0) return diff
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+
+  return { orders, errors }
+}
+
+async function fetchTopN<T extends { id: string }>(
+  db: SupabaseClient,
+  listFn: (
+    db: SupabaseClient,
+    facilityId: string,
+    limit: number,
+    offset: number,
+    options?: OrderListFilterOptions
+  ) => Promise<T[]>,
+  facilityIds: string[],
+  options: OrderListFilterOptions,
+  dateOf: (t: T) => string
+): Promise<T[]> {
+  const perFacility = await Promise.all(
+    facilityIds.map(facilityId => listFn(db, facilityId, LIMIT_PER_KIND, 0, options))
+  )
+  const merged = perFacility.flat()
+  // WHY: admin全施設ファンアウト時、施設をまたいだ複数施設分のレコードをここで一旦マージしてから
+  // 上位LIMIT_PER_KIND件に切り詰める。displayDatetimeが完全に同一（ミリ秒単位で一致）の異なる施設の
+  // レコードが切り詰め境界をまたぐ場合、日時のみの比較では順序が不定（Array.sortの安定性はキー同値要素の
+  // 相対順序を保証するが、その相対順序自体が各施設の返却順に依存し決定的ではない）。
+  // SPEC.md受け入れ条件「同時刻はidを第2キーに安定ソート」を、最終マージ時だけでなくこの切り詰め時点でも
+  // 満たすため、id昇順を第2キーとして併用する（型安全・データ層整合レビュー指摘対応）
+  merged.sort((a, b) => {
+    const diff = new Date(dateOf(b)).getTime() - new Date(dateOf(a)).getTime()
+    if (diff !== 0) return diff
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+  return merged.slice(0, LIMIT_PER_KIND)
+}
+
+function unwrap<T>(result: PromiseSettledResult<T[]>, kind: OrderKind, errors: OrdersFetchError[]): T[] {
+  if (result.status === 'fulfilled') return result.value
+  errors.push({ kind, message: result.reason instanceof Error ? result.reason.message : String(result.reason) })
+  return []
+}
+
+function toUnifiedOrder(
+  id: string,
+  kind: OrderKind,
+  facilityId: string,
+  facilityName: string | undefined,
+  displayDatetime: string,
+  status: string,
+  itemCount: number,
+  firstItemName: string | undefined
+): UnifiedOrder {
+  return {
+    id,
+    kind,
+    facilityId,
+    facilityName,
+    displayDatetime,
+    status,
+    summaryLabel: buildSummaryLabel(itemCount, firstItemName),
+  }
+}
+
+// 代表製品名 + 残n件（SPEC.md表示カラム定義通り）
+function buildSummaryLabel(itemCount: number, firstItemName: string | undefined): string {
+  if (itemCount === 0) return '(品目なし)'
+  const label = firstItemName && firstItemName.trim() ? firstItemName : '(品名不明)'
+  return itemCount > 1 ? `${label} 他${itemCount - 1}件` : label
+}
+
+// products.jan→name / consumables.id→name のバッチ名前解決（IN句1本、N+1回避）
+async function fetchNamesByKey(
+  db: SupabaseClient,
+  table: 'products' | 'consumables',
+  keyColumn: 'jan' | 'id',
+  keys: string[]
+): Promise<Map<string, string>> {
+  if (keys.length === 0) return new Map()
+  const { data, error } = await db.from(table).select(`${keyColumn}, name`).in(keyColumn, keys)
+  if (error) throw new Error(error.message)
+  return new Map(
+    ((data ?? []) as Record<string, unknown>[]).map(row => [asString(row[keyColumn]), asString(row.name)])
+  )
+}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -145,3 +145,95 @@ export type LoanReturnItemInput = {
   ubd?: string
   quantity: number
 }
+
+// ---------------------------------------------------------------------------
+// issue #20: 発注履歴ページ（/orders）— 4種別横断の一覧・検索
+// ---------------------------------------------------------------------------
+
+/**
+ * 発注種別の判別キー
+ * case: 症例発注 / consumable: 消耗品発注 / loan: 短貸発注 / loan_return: 短貸返却
+ */
+export type OrderKind = 'case' | 'consumable' | 'loan' | 'loan_return'
+
+/**
+ * 4種別を横断表示するための正規化済み1レコード
+ * SET-D（/api/orders）が生成し、SET-E（OrderHistoryTable等）が描画に使う
+ * raw原案は削除済み（union型のtype guardが強制されず実行時エラーリスクがあるため）。
+ * 詳細遷移は id + kind のみで既存個別ページ（例: /loan-orders/{id}）へのリンクで完結する
+ * v1では isUnreturned 等の「未返却」判定フィールドを含めない（判断が必要な点①、案B未採用のため）
+ */
+export type UnifiedOrder = {
+  id: string
+  kind: OrderKind
+  facilityId: string
+  facilityName?: string // admin表示用（施設JOIN先から解決。非adminには不要なため省略可）
+  displayDatetime: string // case→case_datetime / consumable・loan→created_at / loan_return→return_datetime。生成責任はAPI層(SET-D)
+  status: string // 各テーブルの生status文字列をそのまま保持（判定ロジックはSET-Dに置かない）
+  summaryLabel: string // 代表製品名 + 残n件。生成責任はAPI層(SET-D)
+}
+
+/**
+ * /orders ページ・/api/orders が共有するフィルタ条件
+ * SET-F（ページ）がURLクエリから組み立て、SET-D（API）がクエリパラメータとして受け取る
+ */
+export type OrdersFilter = {
+  facilityId?: string
+  dateFrom?: string // ISO 8601 (UTC)
+  dateTo?: string // ISO 8601 (UTC)
+  productSearch?: string
+  orderKinds?: OrderKind[]
+}
+
+/**
+ * SET-C: 4種別の list*（listCaseOrders / listConsumableOrders / listLoanOrders / listLoanReturns）
+ * に追加する日付・製品名フィルタのオプション引数。既存の limit/offset 引数の後ろに追加する想定
+ * dateFrom/dateTo: ISO 8601 UTC文字列。省略時はその境界のフィルタを適用しない
+ * productSearch: 品名部分一致（ilike）。空文字/省略はフィルタを適用しない（受け入れ条件・SET-C記載どおり）
+ */
+export type OrderListFilterOptions = {
+  dateFrom?: string
+  dateTo?: string
+  productSearch?: string
+}
+
+/**
+ * GET /api/orders が返す1件分の取得失敗理由
+ * Promise.allSettled で失敗した種別のみ格納する。成功種別は errors に含めない
+ */
+export type OrdersFetchError = {
+  kind: OrderKind
+  message: string
+}
+
+/**
+ * SET-D: src/lib/orders/unified-repository.ts の集約関数、および
+ * GET /api/orders のレスポンス型（成功時、ステータス200）
+ * orders は displayDatetime 降順・同時刻は id 昇順で安定ソート済みの状態で返す
+ * counts フィールドは持たない（判断が必要な点⑥: 総件数表示は不要のため）
+ */
+export type OrdersGetResponse = {
+  orders: UnifiedOrder[]
+  errors: OrdersFetchError[]
+}
+
+/**
+ * GET /api/orders のエラーレスポンス型（400/401/403/500）
+ * apiError() が返す { error: string } 形式と一致させる
+ */
+export type OrdersErrorResponse = {
+  error: string
+}
+
+/**
+ * GET /api/orders のクエリパラメータをパース済みの形で表す型
+ * order_kinds は CSV文字列として受け取り、API層（SET-D）で OrderKind[] にバリデーション・変換する。
+ * 不正な値（未知のkind文字列等）が含まれる場合の扱いはSET-D実装側の責務とする
+ */
+export type OrdersQueryParams = {
+  facilityId: string | null
+  dateFrom: string | null
+  dateTo: string | null
+  productSearch: string | null
+  orderKinds: OrderKind[] | null
+}

--- a/supabase/migrations/20260714010001_add_orders_search_indexes.sql
+++ b/supabase/migrations/20260714010001_add_orders_search_indexes.sql
@@ -1,0 +1,22 @@
+-- supabase/migrations/20260714010001_add_orders_search_indexes.sql
+-- WHY: issue #20（発注履歴ページ /orders）の期間フィルタが、各テーブルの日時カラム
+--      （case_orders.case_datetime / consumable_orders.created_at / loan_orders.created_at /
+--      loan_returns.return_datetime）で絞り込むため、facility_id との複合インデックスを追加する。
+--      case_orders は既存の idx_case_orders_facility_created_at（facility_id, created_at）とは
+--      別カラム（case_datetime）での絞り込みのため、新規インデックスが別途必要（SPEC.md Part2 SET-A）。
+--
+-- refresh_schema_baseline_snapshot は呼ばない: このマイグレーションはインデックス追加のみで
+-- テーブルの追加/削除を伴わないため、docs/agents/common.md記載のスキーマドリフト検知baseline
+-- 更新の対象外（20260714000003_schema_drift_v1_hardening.sql 参照）。
+
+CREATE INDEX IF NOT EXISTS idx_case_orders_facility_case_datetime
+  ON case_orders (facility_id, case_datetime);
+
+CREATE INDEX IF NOT EXISTS idx_consumable_orders_facility_created_at
+  ON consumable_orders (facility_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_loan_orders_facility_created_at
+  ON loan_orders (facility_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_loan_returns_facility_return_datetime
+  ON loan_returns (facility_id, return_datetime);

--- a/supabase/migrations/__tests__/add_orders_search_indexes.test.ts
+++ b/supabase/migrations/__tests__/add_orders_search_indexes.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(SPEC.md Part2 SET-A)を
+//      満たすかを静的に検証することで、回帰テストとして固定する。
+//      (supabase/migrations/__tests__/add_products_name_maker.test.ts と同じ方針)
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_orders_search_indexes.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_orders_search_indexes.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('すべてのCREATE INDEXがIF NOT EXISTSで冪等である', () => {
+    const createIndexStatements = sql.match(/create\s+index[^;]*;/gi) ?? []
+    expect(createIndexStatements.length).toBeGreaterThan(0)
+    for (const stmt of createIndexStatements) {
+      expect(stmt.toLowerCase()).toContain('if not exists')
+    }
+  })
+
+  it('case_orders に (facility_id, case_datetime) の複合インデックスを追加する（既存の(facility_id, created_at)とは別）', () => {
+    expect(n).toMatch(
+      /create index if not exists \S+ on case_orders ?\(facility_id, ?case_datetime\)/
+    )
+  })
+
+  it('consumable_orders に (facility_id, created_at) の複合インデックスを追加する', () => {
+    expect(n).toMatch(
+      /create index if not exists \S+ on consumable_orders ?\(facility_id, ?created_at\)/
+    )
+  })
+
+  it('loan_orders に (facility_id, created_at) の複合インデックスを追加する', () => {
+    expect(n).toMatch(
+      /create index if not exists \S+ on loan_orders ?\(facility_id, ?created_at\)/
+    )
+  })
+
+  it('loan_returns に (facility_id, return_datetime) の複合インデックスを追加する', () => {
+    expect(n).toMatch(
+      /create index if not exists \S+ on loan_returns ?\(facility_id, ?return_datetime\)/
+    )
+  })
+
+  it('refresh_schema_baseline_snapshot は呼ばない（テーブル追加/削除を伴わないため）', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot/)
+  })
+
+  it('refresh_schema_baseline_snapshotを呼ばない根拠のコメントが1行ある', () => {
+    expect(sql).toMatch(/--.*refresh_schema_baseline_snapshot/i)
+  })
+})


### PR DESCRIPTION
## Summary
- 症例発注・消耗品発注・短貸発注・短貸返却の4種別を横断して一覧・検索できる `/orders` ページを新設 (closes #20)
- 施設・期間・製品名・種別でのフィルタ、非adminの施設境界チェック(既存RLS踏襲)、一部種別取得失敗時のエラーハンドリングを実装
- 期間検索用の複合インデックスをDBマイグレーションで追加

## 経緯
AIDDフロー(Phase 1調査92エージェント→停止①人間承認→Phase 3-5実装・統合・レビュー)で実装。4観点レビューが3回差し戻し後もimportant指摘が残ったため人間が直接修正し独立レビューで検証。停止②(構造化レビュー)でさらに2件(用語不一致・セッション記録の空テンプレ)を発見し修正済み。詳細は `docs/sessions/2026-07-14-orders-history-page.md` 参照。

## Test plan
- [x] `npx vitest run` — 739 tests all pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors
- [ ] `npm run ai:check`(E2E含む)は未実行 — ローカルSupabase起動が必要なため
- [ ] ブラウザでの実動作確認は未実施

## 既知の未対応(別issue化検討)
- `/api/orders`専用のRLS/IDOR統合テスト(実DB)は未追加。既存の`*-orders-rls-idor.integration.test.ts`でカバー済みの範囲を再利用
- レビュー指摘のうちminor 2件(limit/offsetバリデーションのテスト重複・不揃い、jan検索クエリの重複)は未修正
- 既存コードに前から存在する「短貸」/「貸出」用語混在は別issue化予定(pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)