### PR TITLE
fix: 既存コードの短貸用語表記ゆれを統一する(issue #337)

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -50,6 +50,9 @@ _Avoid_: 商品、product単体（hospital_priceとの対比で使う場合はdi
 **loan_return（短貸返却）**:
 `loan_order` で借りたものの返却記録。
 
+> 表記ゆれ注意: 「貸出発注」「貸出返却」は誤記（issue #337で修正済み）。
+> ユーザー向け文言・コメント・テストは必ず「短貸発注」「短貸返却」で統一する。
+
 すべての発注系テーブル（`case_orders` / `consumable_orders` / `loan_orders` / `loan_returns`）は
 `facility_id` を持ち、`is_facility_member` によるRLSで施設外からのアクセスを遮断する。
 

--- a/src/app/api/loan-orders/route.ts
+++ b/src/app/api/loan-orders/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const orders = await listLoanOrders(db, facilityId!, limit, offset)
     return NextResponse.json({ orders })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '貸出発注一覧の取得に失敗しました')
+    return apiError(error instanceof Error ? error.message : '短貸発注一覧の取得に失敗しました')
   }
 }
 

--- a/src/components/dashboard/FacilitySummaryList.tsx
+++ b/src/components/dashboard/FacilitySummaryList.tsx
@@ -71,7 +71,7 @@ export function FacilitySummaryList({ facilitySummaries, loanOutstanding }: Faci
                 <dd>{summary.consumableOrderCount}件 / {formatDateTime(summary.consumableOrderLatestAt)}</dd>
               </Link>
               <Link href={`/facilities/${summary.facilityId}/loan-orders`} className="flex justify-between rounded px-1 -mx-1 hover:bg-[#EDEADE]/40">
-                <dt>貸出発注</dt>
+                <dt>短貸発注</dt>
                 <dd>{summary.loanOrderCount}件 / {formatDateTime(summary.loanOrderLatestAt)}</dd>
               </Link>
             </dl>

--- a/src/components/dashboard/__tests__/FacilitySummaryList.test.tsx
+++ b/src/components/dashboard/__tests__/FacilitySummaryList.test.tsx
@@ -53,7 +53,7 @@ describe('FacilitySummaryList', () => {
     render(<FacilitySummaryList facilitySummaries={summaries} loanOutstanding={outstanding} />)
     expect(screen.getAllByRole('link', { name: /症例発注/ })[0]).toHaveAttribute('href', '/facilities/f1/case-orders')
     expect(screen.getAllByRole('link', { name: /消耗品発注/ })[0]).toHaveAttribute('href', '/facilities/f1/consumable-orders')
-    expect(screen.getAllByRole('link', { name: /貸出発注/ })[0]).toHaveAttribute('href', '/facilities/f1/loan-orders')
+    expect(screen.getAllByRole('link', { name: /短貸発注/ })[0]).toHaveAttribute('href', '/facilities/f1/loan-orders')
   })
 
   it('0件のとき「データがありません」が表示される', () => {

--- a/src/lib/dashboard/loan-outstanding.ts
+++ b/src/lib/dashboard/loan-outstanding.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-// WHY: 未返却件数 = submittedの貸出発注件数 - returnedの返却件数（施設単位のビジネスルール）
+// WHY: 未返却件数 = submittedの短貸発注件数 - returnedの返却件数（施設単位のビジネスルール）
 // loan_order_items と loan_return_items に直接の外部キーはないため、件数差分で近似する。
 // 差分が負になるケース（返却超過）は0に丸める。
 export async function getLoanOutstandingCount(


### PR DESCRIPTION
## Summary
- domain.mdの用語集（短貸発注/短貸返却）と食い違っていた「貸出発注/貸出返却」表記を、dashboard関連コード・API route・テストで統一
- `docs/agents/domain.md` に表記ゆれ再発防止の注意書きを追加

Closes #337

## Test plan
- [x] `npx vitest run src/components/dashboard/__tests__/FacilitySummaryList.test.tsx` が全件パス
- [x] 旧表記（貸出発注・貸出返却）がsrc/docs配下に残っていないことをgrepで確認（再発防止の注意書き以外は0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)