### PR TITLE
feat: 検証サブエージェント(Stop hook自動裏取り)を実装する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,8 @@
       "Bash(/Users/masanori/medical-inventory-vkumai/scripts/log-loop-observability.sh *)",
       "Bash(scripts/doc-suggest-check.sh *)",
       "Bash(scripts/ai-check-suggest.sh *)",
+      "Bash(scripts/verify-claims.sh *)",
+      "Bash(bash scripts/verify-claims.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -131,6 +133,12 @@
             "command": "scripts/ai-check-suggest.sh",
             "timeout": 15,
             "statusMessage": "ai:check実行有無を確認中..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/verify-claims.sh",
+            "timeout": 90,
+            "statusMessage": "直前ターンの主張を裏取り中..."
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ e2e/.auth/*.json
 # Stop hookのセッション内重複提案抑止用の一時状態（ローカル専用）
 /.claude/.doc-suggest-state/
 /.claude/.ai-check-suggest-state/
+/.claude/.verify-state/
 
 # AIDD Run Manifest（フロー実行ごとに生成される一時状態。スキーマはdocs/agents/run-manifest.md参照）
 /.aidd/

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hookから呼ばれる。直前アシスタントターンの主張（行番号・既存コード挙動・環境変数名の
+# 一致等）と実際のdiffを低コストモデル(Haiku, 読み取り専用)で突き合わせ、裏取りの取れていない
+# critical/important指摘があればStopをブロックする。
+# 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+#
+# テスト容易性のため、以下をすべて環境変数で上書き可能にしている（テストは
+# scripts/verify-claims.test.sh 参照）:
+#   VERIFY_CLAIMS_REPO_DIR      - git操作の基準ディレクトリ（省略時はこのスクリプトの親）
+#   VERIFY_CLAIMS_STATE_DIR     - 状態ファイル保存先（省略時は .claude/.verify-state）
+#   VERIFY_CLAIMS_MAX_RETRIES   - ブロック継続の上限回数（省略時は3、既存のMAX_REVIEW_RETRIESと揃える）
+#   VERIFY_CLAIMS_TIMEOUT_SECONDS - claude -p サブプロセスのタイムアウト秒数（省略時は60）
+#   VERIFY_CLAIMS_MODEL         - 検証に使うモデル（省略時は claude-haiku-4-5-20251001）
+#   VERIFY_CLAIMS_VERIFIER_CMD  - 実際の`claude -p`呼び出しの代わりに使うコマンド（標準入力で
+#                                 プロンプトを受け取り、findings JSONを標準出力に返すこと）
+
+REPO_DIR="${VERIFY_CLAIMS_REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$REPO_DIR"
+
+STATE_DIR="${VERIFY_CLAIMS_STATE_DIR:-.claude/.verify-state}"
+MAX_RETRIES="${VERIFY_CLAIMS_MAX_RETRIES:-3}"
+TIMEOUT_SECONDS="${VERIFY_CLAIMS_TIMEOUT_SECONDS:-60}"
+MODEL="${VERIFY_CLAIMS_MODEL:-claude-haiku-4-5-20251001}"
+
+mkdir -p "$STATE_DIR"
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
+TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')"
+
+# 7日より古い状態ファイルは掃除する（doc-suggest-check.shと同様のパターン）
+find "$STATE_DIR" -name '*.json' -mtime +7 -delete 2>/dev/null || true
+
+STATE_FILE="$STATE_DIR/${SESSION_ID}.json"
+SKIP_MARKER="$STATE_DIR/${SESSION_ID}.skip"
+
+emit_pass() {
+  local msg="${1:-}"
+  jq -n --arg msg "$msg" '{systemMessage: $msg}'
+  exit 0
+}
+
+emit_block() {
+  local msg="$1"
+  echo "$msg" >&2
+  exit 2
+}
+
+write_state() {
+  local hash="$1" verdict="$2" retry="$3" findings_msg="$4"
+  jq -n --arg h "$hash" --arg v "$verdict" --argjson r "$retry" --arg m "$findings_msg" \
+    '{last_diff_hash: $h, last_verdict: $v, retry_count: $r, last_findings_message: $m}' \
+    > "$STATE_FILE"
+}
+
+block_with_retry_check() {
+  local hash="$1" findings_msg="$2"
+  local new_retry=$((PREV_RETRY_COUNT + 1))
+  write_state "$hash" "blocked" "$new_retry" "$findings_msg"
+  if [ "$new_retry" -le "$MAX_RETRIES" ]; then
+    emit_block "$(printf 'verify-claims: 未解消の指摘を検出しました(試行%d/%d):\n%s' "$new_retry" "$MAX_RETRIES" "$findings_msg")"
+  else
+    emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが指摘が解消されませんでした。人間の介入待ちです。誤検知の場合は `touch %s` でスキップできます。\n%s' "$MAX_RETRIES" "$SKIP_MARKER" "$findings_msg")"
+  fi
+}
+
+# --- エスケープハッチ: .skipマーカーがあれば無条件pass（消費して削除） ---
+if [ -f "$SKIP_MARKER" ]; then
+  rm -f "$SKIP_MARKER"
+  emit_pass "verify-claims: 手動オーバーライド(.skipマーカー)が使用されたため、今回の検証をスキップしました。"
+fi
+
+# --- diffハッシュ計算 ---
+DIFF_CONTENT="$( { git diff HEAD; git status --porcelain; } 2>/dev/null || true)"
+CURRENT_HASH="$(printf '%s' "$DIFF_CONTENT" | shasum -a 256 | awk '{print $1}')"
+
+PREV_HASH=""
+PREV_VERDICT=""
+PREV_RETRY_COUNT=0
+PREV_FINDINGS_MSG=""
+if [ -f "$STATE_FILE" ]; then
+  PREV_HASH="$(jq -r '.last_diff_hash // ""' "$STATE_FILE")"
+  PREV_VERDICT="$(jq -r '.last_verdict // ""' "$STATE_FILE")"
+  PREV_RETRY_COUNT="$(jq -r '.retry_count // 0' "$STATE_FILE")"
+  PREV_FINDINGS_MSG="$(jq -r '.last_findings_message // ""' "$STATE_FILE")"
+fi
+
+# --- ケース1/2: diffハッシュ一致（前回状態あり） ---
+if [ -n "$PREV_HASH" ] && [ "$CURRENT_HASH" = "$PREV_HASH" ]; then
+  if [ "$PREV_VERDICT" = "pass" ]; then
+    emit_pass ""
+  fi
+  if [ "$PREV_VERDICT" = "blocked" ]; then
+    # 何も直さずに再Stopしようとした場合。LLM呼び出しはせずretry_countだけ消費する。
+    block_with_retry_check "$CURRENT_HASH" "$PREV_FINDINGS_MSG"
+  fi
+fi
+
+# --- ケース3: diffハッシュ不一致 → 検証を実行する ---
+LAST_ASSISTANT_EXCERPT=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  LAST_ASSISTANT_EXCERPT="$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null | jq -rs '
+    [.[] | select(.type == "assistant")] | last as $last
+    | if $last == null then "" else
+        ([$last.message.content[]? | select(.type == "text") | .text] | join("\n"))
+      end
+  ' 2>/dev/null || echo "")"
+fi
+
+PROMPT="$(cat <<PROMPT_EOF
+あなたは「主張の裏取り役」の検証サブエージェントです。以下の直前アシスタントターンの発言と、
+実際のコード差分を突き合わせ、発言中の技術的主張（行番号・既存コードの挙動・環境変数名の一致等）が
+実コードと矛盾していないか確認してください。読み取り専用ツールのみ使い、コードは変更しないこと。
+
+# 直前アシスタントターンの抜粋
+${LAST_ASSISTANT_EXCERPT}
+
+# 現在のdiff
+${DIFF_CONTENT}
+
+# 出力形式
+以下のJSON形式のみを出力してください。マークダウンのコードフェンスや説明文は付けないこと。
+{"findings": [{"severity": "critical" | "important" | "minor", "description": "...", "evidence": "file:line等"}]}
+指摘が無ければ {"findings": []} を返してください。
+PROMPT_EOF
+)"
+
+run_verifier() {
+  if [ -n "${VERIFY_CLAIMS_VERIFIER_CMD:-}" ]; then
+    printf '%s' "$PROMPT" | eval "$VERIFY_CLAIMS_VERIFIER_CMD"
+    return $?
+  fi
+  printf '%s' "$PROMPT" | claude -p --model "$MODEL" \
+    --allowedTools "Read,Grep,Glob,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat *),Bash(grep *),Bash(find *)"
+}
+
+# ポータブルなタイムアウト実装（macOSにGNU coreutilsのtimeoutが無い前提で、
+# バックグラウンド実行+ポーリングkillで代替する）
+run_verifier_with_timeout() {
+  local out_file
+  out_file="$(mktemp)"
+  ( run_verifier > "$out_file" 2>/dev/null; echo $? > "${out_file}.exit" ) &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$TIMEOUT_SECONDS" ]; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      cat "$out_file" 2>/dev/null || true
+      rm -f "$out_file" "${out_file}.exit"
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null || true
+  local status
+  status="$(cat "${out_file}.exit" 2>/dev/null || echo 1)"
+  cat "$out_file"
+  rm -f "$out_file" "${out_file}.exit"
+  return "$status"
+}
+
+VERIFIER_EXIT=0
+VERIFIER_OUTPUT="$(run_verifier_with_timeout)" || VERIFIER_EXIT=$?
+
+if [ "$VERIFIER_EXIT" -ne 0 ]; then
+  # インフラ障害時のfail-open: 検証プロセス自体の失敗はdeny-by-defaultの対象外とする
+  emit_pass "verify-claims: 検証エージェントの実行に失敗したため(exit=${VERIFIER_EXIT})、今回はスキップしました。"
+fi
+
+FINDINGS_JSON="$(printf '%s' "$VERIFIER_OUTPUT" | jq -c '.findings' 2>/dev/null || echo "")"
+if [ -z "$FINDINGS_JSON" ] || [ "$FINDINGS_JSON" = "null" ]; then
+  # 出力自体が壊れている場合も検証プロセスの不備として扱い、fail-open
+  emit_pass "verify-claims: 検証エージェントの出力を解析できなかったため、今回はスキップしました。"
+fi
+
+# deny-by-default: severity欠損・不明値はcriticalとして扱う
+NORMALIZED_FINDINGS="$(printf '%s' "$FINDINGS_JSON" | jq -c '
+  [.[] | .severity = (if (.severity == "critical" or .severity == "important" or .severity == "minor")
+    then .severity else "critical" end)]
+')"
+
+HAS_BLOCKING="$(printf '%s' "$NORMALIZED_FINDINGS" | jq 'any(.[]; .severity == "critical" or .severity == "important")')"
+FINDINGS_TEXT="$(printf '%s' "$NORMALIZED_FINDINGS" | jq -r '.[] | "- [" + .severity + "] " + .description + " (" + (.evidence // "evidence不明") + ")"')"
+MINOR_TEXT="$(printf '%s' "$NORMALIZED_FINDINGS" | jq -r '[.[] | select(.severity == "minor")] | .[] | "- " + .description + " (" + (.evidence // "evidence不明") + ")"')"
+
+if [ "$HAS_BLOCKING" = "true" ]; then
+  block_with_retry_check "$CURRENT_HASH" "$FINDINGS_TEXT"
+fi
+
+write_state "$CURRENT_HASH" "pass" 0 ""
+if [ -n "$MINOR_TEXT" ]; then
+  emit_pass "$(printf 'verify-claims: 軽微な指摘があります(ブロックはしません):\n%s' "$MINOR_TEXT")"
+fi
+emit_pass ""

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# WHY: issue #343（検証サブエージェント/Stop hook自動裏取り）向けのverify-claims.shは
+# claude -p のサブプロセス実行を含みコストがかかるため、VERIFY_CLAIMS_VERIFIER_CMDで
+# モックに差し替えて合成hook入力で回帰テストする。
+# 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+#
+# 実行: bash scripts/verify-claims.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/verify-claims.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+REPO="$WORKDIR/repo"
+mkdir -p "$REPO"
+(
+  cd "$REPO"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  echo "line1" > file.txt
+  git add file.txt
+  git commit -q -m "init"
+)
+
+STATE_DIR="$WORKDIR/state"
+MOCK_VERIFIER="$WORKDIR/mock-verifier.sh"
+MOCK_CALL_LOG="$WORKDIR/call.log"
+MOCK_FINDINGS_FILE="$WORKDIR/findings.json"
+
+cat > "$MOCK_VERIFIER" <<'MOCK_EOF'
+#!/usr/bin/env bash
+cat /dev/stdin > /dev/null
+echo "called" >> "$MOCK_CALL_LOG"
+if [ "${MOCK_SHOULD_FAIL:-0}" = "1" ]; then
+  exit 1
+fi
+cat "$MOCK_FINDINGS_FILE"
+MOCK_EOF
+chmod +x "$MOCK_VERIFIER"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+# 呼び出しヘルパー: $1=session_id $2=uncommitted diffの有無(yes/no) 戻り値はグローバル変数で受け渡す
+STDOUT_OUT=""
+STDERR_OUT=""
+EXIT_CODE=0
+run_hook() {
+  local session_id="$1"
+  local input
+  input="$(jq -n --arg sid "$session_id" --arg tp "$WORKDIR/no-transcript.jsonl" '{session_id: $sid, transcript_path: $tp}')"
+  local err_file="$WORKDIR/stderr.tmp"
+  set +e
+  STDOUT_OUT="$(
+    cd "$REPO"
+    printf '%s' "$input" | \
+      VERIFY_CLAIMS_REPO_DIR="$REPO" \
+      VERIFY_CLAIMS_STATE_DIR="$STATE_DIR" \
+      VERIFY_CLAIMS_MAX_RETRIES=3 \
+      VERIFY_CLAIMS_VERIFIER_CMD="$MOCK_VERIFIER" \
+      MOCK_CALL_LOG="$MOCK_CALL_LOG" \
+      MOCK_FINDINGS_FILE="$MOCK_FINDINGS_FILE" \
+      MOCK_SHOULD_FAIL="${MOCK_SHOULD_FAIL:-0}" \
+      bash "$SCRIPT" 2>"$err_file"
+  )"
+  EXIT_CODE=$?
+  STDERR_OUT="$(cat "$err_file")"
+  set -e
+}
+
+call_count() {
+  if [ -f "$MOCK_CALL_LOG" ]; then wc -l < "$MOCK_CALL_LOG" | tr -d ' '; else echo 0; fi
+}
+
+echo "=== scenario 1: diff無し → 即pass ==="
+rm -f "$MOCK_CALL_LOG"
+echo '{"findings": []}' > "$MOCK_FINDINGS_FILE"
+run_hook "s1"
+assert_eq "$EXIT_CODE" "0" "diff無しはexit 0"
+
+echo "=== scenario 2: diff一致・前回pass → 即pass(LLM呼び出し無し) ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line2" >> "$REPO/file.txt"
+echo '{"findings": []}' > "$MOCK_FINDINGS_FILE"
+run_hook "s2"
+assert_eq "$EXIT_CODE" "0" "1回目(新規diff)はpass"
+assert_eq "$(call_count)" "1" "1回目は検証エージェントが1回呼ばれる"
+run_hook "s2"
+assert_eq "$EXIT_CODE" "0" "2回目(同一diff)もpass"
+assert_eq "$(call_count)" "1" "2回目は検証エージェントが呼ばれない(回数据え置き)"
+
+echo "=== scenario 3: diff一致・前回blocked → LLM呼び出し無しでretry_count+1、再ブロック ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line3" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "critical", "description": "行番号の不一致", "evidence": "file.txt:99"}]}' > "$MOCK_FINDINGS_FILE"
+run_hook "s3"
+assert_eq "$EXIT_CODE" "2" "1回目(新規diff・critical)はブロック"
+assert_eq "$(call_count)" "1" "1回目は検証エージェントが1回呼ばれる"
+run_hook "s3"
+assert_eq "$EXIT_CODE" "2" "2回目(同一diff未解消)も再ブロック"
+assert_eq "$(call_count)" "1" "2回目は検証エージェントが呼ばれない(LLM呼び出し無しでretry消費)"
+RETRY_COUNT="$(jq -r '.retry_count' "$STATE_DIR/s3.json")"
+assert_eq "$RETRY_COUNT" "2" "retry_countが2まで進む"
+
+echo "=== scenario 4: diff不一致・critical finding → ブロック、状態ファイルに記録 ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line4" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "important", "description": "環境変数名の不一致", "evidence": "src/foo.ts:10"}]}' > "$MOCK_FINDINGS_FILE"
+run_hook "s4"
+assert_eq "$EXIT_CODE" "2" "critical/important findingでブロック"
+assert_contains "$STDERR_OUT" "環境変数名の不一致" "指摘内容がstderrに出力される"
+VERDICT="$(jq -r '.last_verdict' "$STATE_DIR/s4.json")"
+assert_eq "$VERDICT" "blocked" "状態ファイルにblockedが記録される"
+
+echo "=== scenario 5: retry_countが上限を超える → ブロック継続、エスケープハッチ案内 ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line5" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "critical", "description": "解消されない指摘", "evidence": "x:1"}]}' > "$MOCK_FINDINGS_FILE"
+run_hook "s5"   # retry 1
+run_hook "s5"   # retry 2 (diff不変)
+run_hook "s5"   # retry 3 (diff不変)
+run_hook "s5"   # retry 4 → 上限超過
+assert_eq "$EXIT_CODE" "2" "上限超過後もブロック継続"
+assert_contains "$STDERR_OUT" "touch" "エスケープハッチ(.skipマーカー作成方法)の案内が出力される"
+assert_contains "$STDERR_OUT" "s5.skip" "案内にセッション固有のskipマーカーパスが含まれる"
+
+echo "=== scenario 6: .skipマーカーあり → 無条件pass、マーカー削除 ==="
+rm -f "$MOCK_CALL_LOG"
+mkdir -p "$STATE_DIR"
+touch "$STATE_DIR/s6.skip"
+run_hook "s6"
+assert_eq "$EXIT_CODE" "0" ".skipマーカーがあれば無条件pass"
+assert_eq "$(call_count)" "0" ".skipマーカー時は検証エージェントを呼ばない"
+assert_contains "$STDOUT_OUT" "手動オーバーライド" "オーバーライド使用がsystemMessageに記録される"
+if [ -f "$STATE_DIR/s6.skip" ]; then
+  echo "  NG: .skipマーカーが消費(削除)されていない"
+  fail=1
+else
+  echo "  OK: .skipマーカーが消費(削除)される"
+fi
+
+echo "=== scenario 7: 検証プロセス自体が失敗 → fail-openでpass ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line7" >> "$REPO/file.txt"
+MOCK_SHOULD_FAIL=1
+run_hook "s7"
+MOCK_SHOULD_FAIL=0
+assert_eq "$EXIT_CODE" "0" "検証プロセス失敗時はfail-openでexit 0"
+assert_contains "$STDOUT_OUT" "実行に失敗" "fail-openの旨がsystemMessageに記録される"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- issue #343: CLIセッションが担っていた「主張の裏取り役」(行番号・既存コード挙動・環境変数名の一致等の確認)をVS Code側セッションに自動組み込みする
- `scripts/verify-claims.sh`をStop hookとして新規実装(`scripts/doc-suggest-check.sh`と並走)。diffハッシュベースのスキップ判定、`claude -p`(Haiku・読み取り専用ツールのみ)によるfindings検証、severity欠損時のdeny-by-default、最大3回のリトライ+ブロック継続、`.skip`マーカーによるエスケープハッチ、検証プロセス自体の失敗時のfail-openを実装
- 設計ドキュメント: #344 (`docs/superpowers/specs/2026-07-14-verification-subagent-design.md`)

## Test plan
- [x] `bash scripts/verify-claims.test.sh` — 設計書記載の7シナリオ(diff無し/一致pass/一致blocked/critical検知/リトライ超過/skipマーカー/検証プロセス失敗)すべてPASSED
- [x] `jq empty .claude/settings.json` — hook登録のJSON構文確認
- [ ] 実運用でのVS Code側Stop hook発火の実機確認は未実施(PRマージ後、実際のセッションで一度確認推奨)

## 既知の未対応
- `claude -p`サブプロセスの実際のCLIフラグ挙動は本セッション内では実行検証できていません
- 状態ファイルの7日自動削除ロジックは既存パターン(`doc-suggest-check.sh`)を踏襲したのみで単体テスト無し