### PR TITLE
fix: verify-claims.shのStop hook再帰発火を修正(緊急)

### DIFF
--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -132,8 +132,15 @@ run_verifier() {
     printf '%s' "$PROMPT" | eval "$VERIFY_CLAIMS_VERIFIER_CMD"
     return $?
   fi
+  # --setting-sources "": ユーザー/プロジェクトのsettings.jsonを一切読み込ませない。
+  # これが無いと、このサブプロセス自身がStopイベントでStop hook一式(このverify-claims.sh自身や
+  # グローバルのclaude_stop_notify.sh等)を継承・再発火させ、子プロセスが際限なく増殖する
+  # (2026-07-14に実際に発生、約15分で343セッションが生成されアラート音が鳴り続けた)。
+  # --no-session-persistence: 検証専用の使い捨てセッションのため、transcriptを永続化しない。
   printf '%s' "$PROMPT" | claude -p --model "$MODEL" \
-    --allowedTools "Read,Grep,Glob,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat *),Bash(grep *),Bash(find *)"
+    --allowedTools "Read,Grep,Glob,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat *),Bash(grep *),Bash(find *)" \
+    --setting-sources "" \
+    --no-session-persistence
 }
 
 # ポータブルなタイムアウト実装（macOSにGNU coreutilsのtimeoutが無い前提で、


### PR DESCRIPTION
## Summary
- `scripts/verify-claims.sh` が起動する検証用サブプロセス(`claude -p`)がsettings.json(hooks含む)を継承しており、サブプロセス自身のStopイベントで自分自身やグローバルのStop hook一式(通知音・`git add -A`等)を再発火させ、子プロセスが際限なく増殖するバグを修正
- 2026-07-14に実際に発生(約15分で343セッション生成、アラート音が鳴り続けた)。2026-07-15にも同一worktreeで再現し、暴走中のプロセスを14個kill後に本修正を適用
- `claude -p` 呼び出しに `--setting-sources ""`(settings.json読み込み自体を無効化=hooks非継承)と `--no-session-persistence`(使い捨てセッションのtranscript非永続化)を追加

## Test plan
- [x] 昨日時点で同内容の修正を別ブランチ(`claude/keen-bohr-fcd6a0`, commit 39d32b2)でテストスイート7シナリオ全てPASS確認済み
- [x] 本ブランチでも同一パッチを適用し、20秒程度待機して新規`claude -p`プロセスが再発しないことを確認
- [ ] マージ後、他セッションでStopが連続しても暴走しないことを継続的に監視

## 補足
- issue #350(claude -pサブプロセスへのhooks非継承を設計の必須制約として明文化する)の実装に相当
- 関連: issue #356(ブロックループ中の他hookとの相互作用が未設計) — 本PRとは別対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)