### PR TITLE
feat: verify-claims.shに検証プロセス同時実行数のサーキットブレーカーを実装

### DIFF
--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -15,6 +15,14 @@ set -euo pipefail
 #   VERIFY_CLAIMS_MODEL         - 検証に使うモデル（省略時は claude-haiku-4-5-20251001）
 #   VERIFY_CLAIMS_VERIFIER_CMD  - 実際の`claude -p`呼び出しの代わりに使うコマンド（標準入力で
 #                                 プロンプトを受け取り、findings JSONを標準出力に返すこと）
+#   VERIFY_CLAIMS_LOCK_DIR      - サーキットブレーカー用ロック置き場（省略時は .claude/.verify-lock）
+#   VERIFY_CLAIMS_MAX_CONCURRENT - 同時実行を許す検証プロセス数の上限（省略時は4）
+#
+# サーキットブレーカー（issue #359）: --setting-sources ""等の個別修正が正しくても、
+# それが適用され忘れる・マージされ忘れることで同種の再帰暴走が繰り返された実績がある
+# (2026-07-14初回発生・2026-07-15に修正未マージのまま再発)。個別修正の正しさに依存せず、
+# 同時に生きている検証プロセス数を機械的に頭打ちにすることで被害を抑える。
+# 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md の「サーキットブレーカー」節
 
 REPO_DIR="${VERIFY_CLAIMS_REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 cd "$REPO_DIR"
@@ -23,8 +31,10 @@ STATE_DIR="${VERIFY_CLAIMS_STATE_DIR:-.claude/.verify-state}"
 MAX_RETRIES="${VERIFY_CLAIMS_MAX_RETRIES:-3}"
 TIMEOUT_SECONDS="${VERIFY_CLAIMS_TIMEOUT_SECONDS:-60}"
 MODEL="${VERIFY_CLAIMS_MODEL:-claude-haiku-4-5-20251001}"
+LOCK_DIR="${VERIFY_CLAIMS_LOCK_DIR:-.claude/.verify-lock}"
+MAX_CONCURRENT="${VERIFY_CLAIMS_MAX_CONCURRENT:-4}"
 
-mkdir -p "$STATE_DIR"
+mkdir -p "$STATE_DIR" "$LOCK_DIR"
 
 INPUT="$(cat)"
 SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
@@ -169,6 +179,26 @@ run_verifier_with_timeout() {
   rm -f "$out_file" "${out_file}.exit"
   return "$status"
 }
+
+# --- サーキットブレーカー: 同時実行中の検証プロセス数が上限を超えたら新規起動を拒否しfail-open ---
+# 死んだプロセスのロックエントリ(前回異常終了で残った分)を先に掃除する。
+# mkdirはPOSIX上atomicなのでロック用途に使える(claude_auto_issue.shと同じパターン)。
+for entry in "$LOCK_DIR"/*; do
+  [ -e "$entry" ] || continue
+  entry_pid="$(basename "$entry")"
+  if ! kill -0 "$entry_pid" 2>/dev/null; then
+    rmdir "$entry" 2>/dev/null || true
+  fi
+done
+
+CURRENT_CONCURRENT="$(find "$LOCK_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$CURRENT_CONCURRENT" -ge "$MAX_CONCURRENT" ]; then
+  emit_pass "$(printf 'verify-claims: 検証プロセスの同時実行数が上限(%d)に達しているため、サーキットブレーカーが働き今回の検証をスキップしました(暴走防止のfail-open)。' "$MAX_CONCURRENT")"
+fi
+
+LOCK_ENTRY="$LOCK_DIR/$$"
+mkdir "$LOCK_ENTRY" 2>/dev/null || true
+trap 'rmdir "$LOCK_ENTRY" 2>/dev/null || true' EXIT
 
 VERIFIER_EXIT=0
 VERIFIER_OUTPUT="$(run_verifier_with_timeout)" || VERIFIER_EXIT=$?

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -170,6 +170,40 @@ MOCK_SHOULD_FAIL=0
 assert_eq "$EXIT_CODE" "0" "検証プロセス失敗時はfail-openでexit 0"
 assert_contains "$STDOUT_OUT" "実行に失敗" "fail-openの旨がsystemMessageに記録される"
 
+echo "=== scenario 8: 同時実行数が上限に達している → サーキットブレーカーでfail-open(LLM呼び出し無し) ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line8" >> "$REPO/file.txt"
+echo '{"findings": []}' > "$MOCK_FINDINGS_FILE"
+LOCK_DIR="$WORKDIR/lock"
+mkdir -p "$LOCK_DIR"
+# 上限(2)ぶん、実際に生きているプロセス(sleepのバックグラウンドジョブ)のPIDでロックエントリを作る。
+# 死んだPIDだと「前回異常終了で残ったロックの掃除」ロジックで消費されてしまうため、テストでは
+# 意図的に生きたプロセスを使う。
+sleep 60 & DUMMY_PID_1=$!
+sleep 60 & DUMMY_PID_2=$!
+mkdir -p "$LOCK_DIR/$DUMMY_PID_1" "$LOCK_DIR/$DUMMY_PID_2"
+set +e
+STDOUT_OUT="$(
+  cd "$REPO"
+  input="$(jq -n --arg sid "s8" --arg tp "$WORKDIR/no-transcript.jsonl" '{session_id: $sid, transcript_path: $tp}')"
+  printf '%s' "$input" | \
+    VERIFY_CLAIMS_REPO_DIR="$REPO" \
+    VERIFY_CLAIMS_STATE_DIR="$STATE_DIR" \
+    VERIFY_CLAIMS_LOCK_DIR="$LOCK_DIR" \
+    VERIFY_CLAIMS_MAX_CONCURRENT=2 \
+    VERIFY_CLAIMS_VERIFIER_CMD="$MOCK_VERIFIER" \
+    MOCK_CALL_LOG="$MOCK_CALL_LOG" \
+    MOCK_FINDINGS_FILE="$MOCK_FINDINGS_FILE" \
+    bash "$SCRIPT" 2>"$WORKDIR/stderr8.tmp"
+)"
+EXIT_CODE=$?
+set -e
+kill "$DUMMY_PID_1" "$DUMMY_PID_2" 2>/dev/null || true
+wait "$DUMMY_PID_1" "$DUMMY_PID_2" 2>/dev/null || true
+assert_eq "$EXIT_CODE" "0" "同時実行数が上限のときはfail-openでexit 0"
+assert_eq "$(call_count)" "0" "上限到達時は検証エージェントを呼ばない(claude -pを増やさない)"
+assert_contains "$STDOUT_OUT" "サーキットブレーカー" "サーキットブレーカーが働いた旨がsystemMessageに記録される"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- issue #359対応
- `--setting-sources ""`等の個別修正が正しくても、それが適用され忘れる・マージされ忘れることで同種の再帰暴走が繰り返された実績がある(2026-07-14初回発生・2026-07-15に修正未マージのまま再発、PR #357参照)
- 個別修正の正しさに依存しない構造的な安全策として、同時に生きている検証用`claude -p`プロセス数を機械的に頭打ちにするサーキットブレーカーを実装
- `VERIFY_CLAIMS_LOCK_DIR`(デフォルト`.claude/.verify-lock`)配下にPID名のディレクトリでロックエントリを作り(mkdirはatomic)、同時実行数が`VERIFY_CLAIMS_MAX_CONCURRENT`(デフォルト4)以上ならLLM呼び出し自体をスキップしてfail-open
- 死んだプロセスのロックエントリは`kill -0`で生死確認して都度掃除する

## 注意(設計書に明記済み)
- これは「同時実行数の増殖」という今回実際に起きた失敗モードを止める本丸の対策
- `--max-budget-usd`(1回の呼び出しの高額課金を防ぐ)とは別の失敗モードへの対策であり、後者の代わりにはならない

## Test plan
- [x] `bash scripts/verify-claims.test.sh` で新規シナリオ8(同時実行数上限到達時にLLM呼び出しが増えないこと)を含む全8シナリオPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)