### PR TITLE
fix: ログイン画面のSuspenseにfallbackを追加

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -107,7 +107,11 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <Suspense>
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: '#EDEADE' }} />
+      }
+    >
       <LoginForm />
     </Suspense>
   )


### PR DESCRIPTION
## Summary
- issue #347対応
- `useSearchParams()`を使う`LoginForm`が`fallback`無しの`Suspense`でラップされており、既知パターン(`docs/agents/known-failure-patterns.md`「Suspenseフォールバック未設定」)に該当していた
- 既存実装(`src/app/news/page.tsx`)を参考に、背景色を合わせた空divのfallbackを追加

## Test plan
- [x] `npx tsc --noEmit -p .` パス
- [x] `npm run lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)