### PR TITLE
docs: 検証サブエージェント設計書のスキーマにlast_findings_messageを追記

### DIFF
--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -17,8 +17,10 @@ VS Code側で実装 → スクリーンショットをCLIセッションに貼�
 - `git diff HEAD` + `git status --porcelain` を連結した内容のSHA256ハッシュを「現在のdiffハッシュ」として計算する(既存パターンを流用)
 - 状態は `.claude/.verify-state/<session_id>.json` に保存する:
   ```json
-  { "last_diff_hash": "...", "last_verdict": "pass" | "blocked", "retry_count": 0 }
+  { "last_diff_hash": "...", "last_verdict": "pass" | "blocked", "retry_count": 0, "last_findings_message": "..." }
   ```
+  `last_findings_message` は、ケース2(ハッシュ一致・前回blocked)で前回の指摘内容をLLM呼び出し
+  無しに再提示するために保持する(実装: `scripts/verify-claims.sh`の`write_state`/`block_with_retry_check`)
 - 7日より古い状態ファイルは `doc-suggest-check.sh` と同様に自動削除する
 
 ### スキップ・再判定ロジック


### PR DESCRIPTION
## Summary
- issue #349対応
- 状態ファイルのスキーマ定義(設計書18-21行目)に`last_findings_message`フィールドが無く、「前回と同じ指摘内容で再度exit 2」という設計と食い違っていた
- 実装(`scripts/verify-claims.sh`)は既にこのフィールドを持ち、`write_state`/`block_with_retry_check`で再提示していたため、設計書のスキーマ定義だけを実装に合わせて更新するドキュメントのみの変更

## Test plan
- ドキュメントのみの変更。データフロー節(76行目〜)は元々「前回findingsで再ブロック判定」と記述済みで、今回の変更と矛盾しないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)