### PR TITLE
fix: verify-claims.shのdiffハッシュにuntrackedファイルの中身を含める(issue #352)

### DIFF
--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -14,7 +14,9 @@ VS Code側で実装 → スクリーンショットをCLIセッションに貼�
 
 - Stop hookとして `scripts/verify-claims.sh` を追加する(既存の `scripts/doc-suggest-check.sh` と並走)
 - hookのJSON入力から `session_id` を取得する(既存の `doc-suggest-check.sh` と同じ形式)
-- `git diff HEAD` + `git status --porcelain` を連結した内容のSHA256ハッシュを「現在のdiffハッシュ」として計算する(既存パターンを流用)
+- `git diff HEAD` + `git status --porcelain` + untrackedファイル(`git ls-files --others --exclude-standard`)の中身を連結した内容のSHA256ハッシュを「現在のdiffハッシュ」として計算する(既存パターンを流用)
+  - **注意(issue #352)**: `git diff HEAD` はtrackedファイルの差分のみを含み、`git status --porcelain`はuntrackedファイルを `?? path` の1行としか出さず中身を含まない。そのため新規(untracked)ファイルの中身だけを直して再Stopしてもハッシュが変わらず、「何も直していない」ケース(上記スキップ・再判定ロジックの2)と誤判定されブロックが継続してしまう。これを防ぐため、`git ls-files --others --exclude-standard -z` で列挙したuntrackedファイルの中身(ファイル名込み)も直接読んでハッシュ対象に含める。`git add -N`等でindexを書き換える方式は採らない(このスクリプトがリポジトリ状態を副作用的に変えないようにするため)
+  - この方式により、既存の別Stop hook(`claude_stop_notify.sh`の`git add -A`)が先に走って untracked ファイルを tracked 化してくれることへの暗黙の依存が無くなる。`verify-claims.sh`単独でuntrackedファイルの中身を検知できるため、hookの実行順序に依存しない
 - 状態は `.claude/.verify-state/<session_id>.json` に保存する:
   ```json
   { "last_diff_hash": "...", "last_verdict": "pass" | "blocked", "retry_count": 0, "last_findings_message": "..." }
@@ -182,6 +184,8 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
   5. retry_countが3を超える → ブロック継続、エスケープハッチ案内が出力に含まれる
   6. `.skip`マーカーあり → 無条件pass、マーカーファイルが削除される
   7. 検証プロセス自体が失敗(モック) → fail-openでpass
+  8. 同時実行数が上限に達している → サーキットブレーカーでfail-open(LLM呼び出し無し)
+  9. **(issue #352)** untrackedファイルのみ追加・修正 → ハッシュが変わり再検証される(新規ファイル追加時に1回、その後中身を書き換えたときにもう1回、計2回LLM呼び出しが発生すること)
 - `claude -p` 呼び出し部分は実行コストがかかるため、テストではモック(固定のfindings JSONを返すダミースクリプト)に差し替えて検証する
 
 ## 対象範囲外(YAGNI)

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -83,8 +83,20 @@ if [ -f "$SKIP_MARKER" ]; then
 fi
 
 # --- diffハッシュ計算 ---
+# WHY(issue #352): `git diff HEAD` はtrackedファイルの差分のみを含み、`git status --porcelain`は
+# untrackedファイルを `?? path` の1行としか出さず中身を含まない。そのため新規(untracked)ファイルの
+# 中身だけを直して再Stopしてもハッシュが変わらず、「何も直していない」ケースと誤判定されてしまう。
+# claude_stop_notify.sh側のgit add -Aが先に走っていれば偶然trackedになり救われるが、hookの実行順序に
+# 依存する暗黙のカップリングだったため、ここではuntrackedファイルの中身を直接読んでハッシュ対象に含める
+# (indexは変更しない = git add -N等でこのスクリプトが副作用的にリポジトリ状態を書き換えない)。
 DIFF_CONTENT="$( { git diff HEAD; git status --porcelain; } 2>/dev/null || true)"
-CURRENT_HASH="$(printf '%s' "$DIFF_CONTENT" | shasum -a 256 | awk '{print $1}')"
+UNTRACKED_CONTENT="$(
+  while IFS= read -r -d '' f; do
+    printf '%s\0' "$f"
+    cat -- "$f" 2>/dev/null
+  done < <(git ls-files --others --exclude-standard -z 2>/dev/null || true)
+)"
+CURRENT_HASH="$(printf '%s%s' "$DIFF_CONTENT" "$UNTRACKED_CONTENT" | shasum -a 256 | awk '{print $1}')"
 
 PREV_HASH=""
 PREV_VERDICT=""

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -204,6 +204,19 @@ assert_eq "$EXIT_CODE" "0" "同時実行数が上限のときはfail-openでexit
 assert_eq "$(call_count)" "0" "上限到達時は検証エージェントを呼ばない(claude -pを増やさない)"
 assert_contains "$STDOUT_OUT" "サーキットブレーカー" "サーキットブレーカーが働いた旨がsystemMessageに記録される"
 
+echo "=== scenario 9: untrackedファイルのみ修正 → ハッシュが変わり再検証される(issue #352) ==="
+rm -f "$MOCK_CALL_LOG"
+echo '{"findings": []}' > "$MOCK_FINDINGS_FILE"
+echo "new-content-v1" > "$REPO/new-file.txt"
+run_hook "s9"
+assert_eq "$EXIT_CODE" "0" "untracked新規ファイル追加時はpass"
+assert_eq "$(call_count)" "1" "untracked新規ファイル追加は検証エージェントが1回呼ばれる"
+echo "new-content-v2" > "$REPO/new-file.txt"
+run_hook "s9"
+assert_eq "$EXIT_CODE" "0" "untrackedファイルの中身を書き換えてもpass"
+assert_eq "$(call_count)" "2" "untrackedファイルの中身の変更だけでも再検証される(ハッシュが変わる)"
+rm -f "$REPO/new-file.txt"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- `git diff HEAD` + `git status --porcelain` だけではuntrackedファイルの中身がハッシュに反映されず、新規ファイルの中身だけを直して再Stopしても「何も直していない」ケースと誤判定されブロックが継続していた問題を修正
- `git ls-files --others --exclude-standard -z` で列挙したuntrackedファイルの中身(ファイル名込み)もハッシュ対象に含めるようにした。`git add -N`等でindexを書き換える方式は採らず、副作用なしで実現
- これにより、別Stop hook(`claude_stop_notify.sh`の`git add -A`)が先に走ることへの暗黙依存も解消される
- 設計書(`docs/superpowers/specs/2026-07-14-verification-subagent-design.md`)にも修正内容とテストシナリオ9を追記

Closes #352

## Test plan
- [x] `bash scripts/verify-claims.test.sh` を実行し、既存シナリオ1-8含め全9シナリオPASS(シナリオ9: untracked新規ファイル追加→中身書き換えで2回検証エージェントが呼ばれることを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)