### PR TITLE
chore: log-agent-progress.sh/show-agent-status.shを許可リストに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,8 @@
       "Bash(~/write_aidd_stats.sh *)",
       "Bash(scripts/log-loop-observability.sh *)",
       "Bash(/Users/masanori/medical-inventory-vkumai/scripts/log-loop-observability.sh *)",
+      "Bash(scripts/log-agent-progress.sh *)",
+      "Bash(scripts/show-agent-status.sh *)",
       "Bash(scripts/doc-suggest-check.sh *)",
       "Bash(scripts/ai-check-suggest.sh *)",
       "Bash(scripts/verify-claims.sh *)",


### PR DESCRIPTION
## Summary
- `docs/agents/common.md`の規約でサブエージェントが作業の開始・終了時に毎回呼ぶことになっている`scripts/log-agent-progress.sh`が`.claude/settings.json`の許可リストに漏れており、呼ぶたびに確認プロンプトが出ていた
- 兄弟スクリプトの`scripts/log-loop-observability.sh`は既に許可済みだったため、抜けを揃えた(`scripts/show-agent-status.sh`も合わせて追加)

## Test plan
- [x] 設定ファイルの変更のみ(ロジック変更なし)。`.claude/settings.json`のJSON構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)