### PR TITLE
feat: agent-progress記録の正しさをtranscript突き合わせで検証(issue #369)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,7 @@
       "Bash(/Users/masanori/medical-inventory-vkumai/scripts/log-loop-observability.sh *)",
       "Bash(scripts/log-agent-progress.sh *)",
       "Bash(scripts/show-agent-status.sh *)",
+      "Bash(scripts/verify-agent-progress-transcript.sh *)",
       "Bash(scripts/doc-suggest-check.sh *)",
       "Bash(scripts/ai-check-suggest.sh *)",
       "Bash(scripts/verify-claims.sh *)",

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -113,6 +113,25 @@ any code. Heed deprecation notices.
     未対応のまま残っている（Sweep/Completeness Criticの一部のみが進捗記録対象agentTypeで、
     Find/Adversarial Verify/Judge Panel等の大半がそもそも進捗記録の対象外agentTypeで呼ばれて
     いるため、既存の期待値カウント方式をそのまま適用できない）。
+- **記録内容の正しさの検証（issue #369の②スコープ）も実装済み。**
+  `scripts/verify-agent-progress-transcript.sh` が `logs/agent-progress.jsonl` の自己申告
+  （status=done|failed）と、対応するtranscript（`~/.claude/projects/**/subagents/workflows/
+  wf_*/agent-<id>.jsonl` + `.meta.json`、`scripts/lib/reconstruct-loop-observability.ts`の
+  パース処理を再利用）のstatus/detailを機械比較し、食い違う行のみ検出する。LLM呼び出し不要。
+  - agent-progress.jsonlはagentId/workflow実行IDを保持しないため、`--agent`名から既知
+    agentType一覧への前方一致でagentTypeを復元し、同じagentType内で最も時刻が近い
+    transcriptに貪欲に対応付けるベストエフォート方式（`scripts/lib/
+    verify-agent-progress-transcript.ts`の`matchRecords`）。1:1のID突合ではないため、
+    高並行実行下では誤対応の可能性が残る。
+  - statusの食い違い（自己申告doneなのにtranscriptがfail等）は確定的な指摘として
+    `mismatches` に、detailの低一致（文字bigramのJaccard類似度が閾値未満）は
+    「要目視確認」の弱いシグナルとして `lowOverlapDetails` に分けて出力する
+    （表現が違うだけの正常なケースを誤検知しないため、detail側は自動ブロックしない）。
+  - issue #369の①（git diffとの突き合わせ）・③（LLMサンプリング検証）は解禁条件付きで
+    保留中。①はagent-progress.jsonlにagentTypeの書き込み系/読み取り専用分類を持たせてから、
+    ③は①②が安定稼働した後かつ`verify-claims.sh`と同型のサーキットブレーカー3点セット
+    （hooks非継承・セッション非永続化・同時実行数上限）を初回コミットから組み込んだ上でのみ
+    着手する。issue本文に理由を明記済み。
 
 ## 引き継ぎフォーマット
 

--- a/scripts/lib/verify-agent-progress-transcript.test.ts
+++ b/scripts/lib/verify-agent-progress-transcript.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildReport,
+  compareDetail,
+  compareStatus,
+  extractAgentType,
+  matchRecords,
+  type SelfReportRecord,
+  type TranscriptRecord,
+} from './verify-agent-progress-transcript'
+
+describe('extractAgentType', () => {
+  it('agentType単体の完全一致を認識する', () => {
+    expect(extractAgentType('reviewer')).toBe('reviewer')
+  })
+
+  it('役割サフィックス付き(reviewer-correctness)からagentTypeを復元する', () => {
+    expect(extractAgentType('reviewer-correctness')).toBe('reviewer')
+  })
+
+  it('implementer-groupAのようなグループ名サフィックスも復元する', () => {
+    expect(extractAgentType('implementer-groupA')).toBe('implementer')
+  })
+
+  it('既知agentTypeに前方一致しない場合はnullを返す', () => {
+    expect(extractAgentType('unknown-agent')).toBeNull()
+  })
+
+  it('sweep-uiとsweep-dataのように前方一致が紛らわしい場合でも正しく判定する', () => {
+    expect(extractAgentType('sweep-ui')).toBe('sweep-ui')
+    expect(extractAgentType('sweep-data-something')).toBe('sweep-data')
+  })
+})
+
+describe('compareStatus', () => {
+  it('自己申告doneとtranscript passは一致とみなす', () => {
+    expect(compareStatus('done', 'pass')).toBe('match')
+  })
+
+  it('自己申告doneとtranscript blockedは一致とみなす（仕様確認待ち等の正常停止もあるため）', () => {
+    expect(compareStatus('done', 'blocked')).toBe('match')
+  })
+
+  it('自己申告doneなのにtranscriptがfailなら食い違いとみなす', () => {
+    expect(compareStatus('done', 'fail')).toBe('mismatch')
+  })
+
+  it('自己申告failedとtranscript failは一致とみなす', () => {
+    expect(compareStatus('failed', 'fail')).toBe('match')
+  })
+
+  it('自己申告failedなのにtranscriptがpassなら食い違いとみなす', () => {
+    expect(compareStatus('failed', 'pass')).toBe('mismatch')
+  })
+
+  it('transcript側にstatusが無ければunknownとする', () => {
+    expect(compareStatus('done', null)).toBe('unknown')
+  })
+})
+
+describe('compareDetail', () => {
+  it('内容が近い場合はmatchとする', () => {
+    expect(compareDetail('UI層調査完了。propsの型不整合を2件検出', 'UI層の調査が完了した。propsの型不整合を2件検出した')).toBe(
+      'match',
+    )
+  })
+
+  it('内容が無関係な場合はlow_overlapとする', () => {
+    expect(compareDetail('実装完了', '別の話題について全く違う内容を書いています')).toBe('low_overlap')
+  })
+
+  it('どちらかが空文字の場合はunknownとする', () => {
+    expect(compareDetail('', '実装完了')).toBe('unknown')
+    expect(compareDetail('実装完了', null)).toBe('unknown')
+  })
+})
+
+describe('matchRecords', () => {
+  const baseTranscript: TranscriptRecord = {
+    wfDir: '/tmp/wf_1',
+    agentId: 'a1',
+    agentType: 'sweep-ui',
+    endTimestamp: '2026-07-15T03:00:10.000Z',
+    status: 'pass',
+    detail: 'UI層調査完了',
+  }
+
+  const baseSelf: SelfReportRecord = {
+    timestamp: '2026-07-15T03:00:12.000Z',
+    agent: 'sweep-ui',
+    feature: 'news-feed',
+    status: 'done',
+    note: 'UI層調査完了',
+  }
+
+  it('同一agentTypeで最も時刻が近いtranscriptと対応付ける', () => {
+    const { matched, unmatchedSelf } = matchRecords([baseSelf], [baseTranscript])
+    expect(matched).toHaveLength(1)
+    expect(matched[0].transcript.agentId).toBe('a1')
+    expect(unmatchedSelf).toHaveLength(0)
+  })
+
+  it('許容誤差を超えるtranscriptとは対応付けない', () => {
+    const farTranscript = { ...baseTranscript, endTimestamp: '2026-07-15T05:00:00.000Z' }
+    const { matched, unmatchedSelf } = matchRecords([baseSelf], [farTranscript], 60_000)
+    expect(matched).toHaveLength(0)
+    expect(unmatchedSelf).toHaveLength(1)
+  })
+
+  it('agentTypeが異なるtranscriptとは対応付けない', () => {
+    const otherType = { ...baseTranscript, agentType: 'reviewer' }
+    const { matched, unmatchedSelf } = matchRecords([baseSelf], [otherType])
+    expect(matched).toHaveLength(0)
+    expect(unmatchedSelf).toHaveLength(1)
+  })
+
+  it('同一agentTypeが複数ある場合、それぞれ最も近いtranscriptに1件ずつ割り当てる（使い回さない）', () => {
+    const self2: SelfReportRecord = { ...baseSelf, timestamp: '2026-07-15T03:10:12.000Z' }
+    const transcript2: TranscriptRecord = { ...baseTranscript, agentId: 'a2', endTimestamp: '2026-07-15T03:10:10.000Z' }
+    const { matched } = matchRecords([baseSelf, self2], [baseTranscript, transcript2])
+    expect(matched).toHaveLength(2)
+    const assignedIds = matched.map((m) => m.transcript.agentId).sort()
+    expect(assignedIds).toEqual(['a1', 'a2'])
+  })
+
+  it('既知agentTypeに復元できないagent名は未突合とする', () => {
+    const weirdSelf = { ...baseSelf, agent: 'totally-unknown-agent' }
+    const { matched, unmatchedSelf } = matchRecords([weirdSelf], [baseTranscript])
+    expect(matched).toHaveLength(0)
+    expect(unmatchedSelf).toHaveLength(1)
+  })
+})
+
+describe('buildReport', () => {
+  it('食い違いをmismatchesに、低一致をlowOverlapDetailsに分類する', () => {
+    const selfReports: SelfReportRecord[] = [
+      { timestamp: '2026-07-15T03:00:12.000Z', agent: 'sweep-ui', feature: 'f1', status: 'done', note: 'UI層調査完了' },
+      { timestamp: '2026-07-15T04:00:12.000Z', agent: 'reviewer-security', feature: 'f1', status: 'done', note: '完了' },
+    ]
+    const transcripts: TranscriptRecord[] = [
+      {
+        wfDir: '/tmp/wf_1',
+        agentId: 'a1',
+        agentType: 'sweep-ui',
+        endTimestamp: '2026-07-15T03:00:10.000Z',
+        status: 'fail',
+        detail: 'propsの型不整合を検出、未修正のまま終了',
+      },
+      {
+        wfDir: '/tmp/wf_2',
+        agentId: 'a2',
+        agentType: 'reviewer',
+        endTimestamp: '2026-07-15T04:00:10.000Z',
+        status: 'pass',
+        detail: '無関係な全く別のセキュリティ観点の長い説明文をここに書く',
+      },
+    ]
+
+    const report = buildReport(selfReports, transcripts)
+    expect(report.matchedCount).toBe(2)
+    expect(report.mismatches).toHaveLength(1)
+    expect(report.mismatches[0].self.agent).toBe('sweep-ui')
+    expect(report.lowOverlapDetails.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('自己申告が0件なら空のレポートを返す', () => {
+    const report = buildReport([], [])
+    expect(report.totalSelfReports).toBe(0)
+    expect(report.matchedCount).toBe(0)
+    expect(report.mismatches).toHaveLength(0)
+  })
+})

--- a/scripts/lib/verify-agent-progress-transcript.ts
+++ b/scripts/lib/verify-agent-progress-transcript.ts
@@ -1,0 +1,321 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability'
+
+// WHY: docs/agents/common.md「サブエージェント進捗の可視化（issue #18）」に列挙されている
+//      進捗記録対象agentType一覧。ここに無い名前（Find/Adversarial Verify等の一部）はそもそも
+//      進捗記録の対象外のため、突き合わせ対象からも自然に外れる。
+export const KNOWN_AGENT_TYPES = [
+  'sweep-db',
+  'sweep-ui',
+  'sweep-types',
+  'sweep-data',
+  'implementer',
+  'reviewer',
+  'integrator',
+  'judge-panel',
+  'proposer',
+  'adversarial-verify',
+  'completeness-critic',
+  'contract-writer',
+] as const
+
+export interface SelfReportRecord {
+  timestamp: string
+  agent: string
+  feature: string
+  status: string
+  note: string
+}
+
+export interface TranscriptRecord {
+  wfDir: string
+  agentId: string
+  agentType: string
+  endTimestamp: string | null
+  status: 'pass' | 'fail' | 'blocked' | null
+  detail: string | null
+}
+
+// WHY: 自己申告jsonlの--agentは「reviewer-correctness」「implementer-groupA」のように
+//      agentTypeへ役割サフィックスを付けた自由記述のため、transcript側のagentType（完全一致）と
+//      直接は一致しない。既知agentType一覧との前方一致（区切りは'-'または完全一致）で復元する。
+export function extractAgentType(selfAgentField: string): string | null {
+  const candidates = KNOWN_AGENT_TYPES.filter(
+    (type) => selfAgentField === type || selfAgentField.startsWith(`${type}-`),
+  )
+  if (candidates.length === 0) return null
+  return candidates.reduce((longest, current) => (current.length > longest.length ? current : longest))
+}
+
+function toEpochMs(timestamp: string): number | null {
+  const ms = Date.parse(timestamp)
+  return Number.isNaN(ms) ? null : ms
+}
+
+export interface MatchedPair {
+  self: SelfReportRecord
+  transcript: TranscriptRecord
+}
+
+export interface MatchOutcome {
+  matched: MatchedPair[]
+  unmatchedSelf: SelfReportRecord[]
+}
+
+// WHY: agent-progress.jsonlはagentId/workflow実行IDを保持しないため、transcriptとの対応は
+//      1:1のID突合ができない。同じagentType内で最も時刻が近いtranscriptに貪欲に割り当てる
+//      ベストエフォート方式（許容誤差外・使用済みtranscriptは対象外）。高並行実行下では
+//      誤対応の可能性が残ることをこの関数の利用側は認識すること。
+export function matchRecords(
+  selfReports: SelfReportRecord[],
+  transcripts: TranscriptRecord[],
+  toleranceMs = 30 * 60 * 1000,
+): MatchOutcome {
+  const usedTranscriptIndexes = new Set<number>()
+  const matched: MatchedPair[] = []
+  const unmatchedSelf: SelfReportRecord[] = []
+
+  const sortedSelf = [...selfReports].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+
+  for (const self of sortedSelf) {
+    const agentType = extractAgentType(self.agent)
+    const selfEpoch = toEpochMs(self.timestamp)
+    if (!agentType || selfEpoch === null) {
+      unmatchedSelf.push(self)
+      continue
+    }
+
+    let bestIndex = -1
+    let bestDiff = Infinity
+    transcripts.forEach((transcript, index) => {
+      if (usedTranscriptIndexes.has(index)) return
+      if (transcript.agentType !== agentType) return
+      if (!transcript.endTimestamp) return
+      const transcriptEpoch = toEpochMs(transcript.endTimestamp)
+      if (transcriptEpoch === null) return
+      const diff = Math.abs(transcriptEpoch - selfEpoch)
+      if (diff <= toleranceMs && diff < bestDiff) {
+        bestDiff = diff
+        bestIndex = index
+      }
+    })
+
+    if (bestIndex === -1) {
+      unmatchedSelf.push(self)
+    } else {
+      usedTranscriptIndexes.add(bestIndex)
+      matched.push({ self, transcript: transcripts[bestIndex] })
+    }
+  }
+
+  return { matched, unmatchedSelf }
+}
+
+export type StatusComparison = 'match' | 'mismatch' | 'unknown'
+
+// WHY: 自己申告は進捗ライフサイクル語彙(done/failed)、transcriptは成果語彙(pass/fail/blocked)で
+//      語彙が異なる。「done」は成功系(pass/blocked)、「failed」は失敗(fail)に対応すると解釈する。
+//      blockedは仕様確認待ち等の正常な停止でも起こりうるため、doneとの不一致とはみなさない。
+export function compareStatus(selfStatus: string, transcriptStatus: 'pass' | 'fail' | 'blocked' | null): StatusComparison {
+  if (transcriptStatus === null) return 'unknown'
+  if (selfStatus === 'done') {
+    return transcriptStatus === 'fail' ? 'mismatch' : 'match'
+  }
+  if (selfStatus === 'failed') {
+    return transcriptStatus === 'pass' ? 'mismatch' : 'match'
+  }
+  return 'unknown'
+}
+
+export type DetailComparison = 'match' | 'low_overlap' | 'unknown'
+
+function charBigrams(text: string): Set<string> {
+  const normalized = text.replace(/\s+/g, '')
+  const bigrams = new Set<string>()
+  for (let i = 0; i < normalized.length - 1; i++) {
+    bigrams.add(normalized.slice(i, i + 2))
+  }
+  return bigrams
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let intersection = 0
+  for (const item of a) {
+    if (b.has(item)) intersection += 1
+  }
+  const union = a.size + b.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+// WHY: LLMを使わずに日本語の自由記述同士の関連度を見るため、文字bigramのJaccard類似度を使う
+//      （分かち書き不要・軽量）。閾値未満は「低一致=要目視確認」という弱いシグナルに留め、
+//      機械的な確定NG扱いにはしない（自己申告note・transcript detailは表現が違って当然のため）。
+export const LOW_OVERLAP_THRESHOLD = 0.08
+
+export function compareDetail(note: string, detail: string | null): DetailComparison {
+  if (!detail || detail.trim().length === 0 || !note || note.trim().length === 0) return 'unknown'
+  const similarity = jaccardSimilarity(charBigrams(note), charBigrams(detail))
+  return similarity < LOW_OVERLAP_THRESHOLD ? 'low_overlap' : 'match'
+}
+
+export interface VerificationReportEntry {
+  self: SelfReportRecord
+  transcript: TranscriptRecord
+  statusComparison: StatusComparison
+  detailComparison: DetailComparison
+}
+
+export interface VerificationReport {
+  totalSelfReports: number
+  matchedCount: number
+  unmatchedSelf: SelfReportRecord[]
+  mismatches: VerificationReportEntry[]
+  lowOverlapDetails: VerificationReportEntry[]
+}
+
+export function buildReport(
+  selfReports: SelfReportRecord[],
+  transcripts: TranscriptRecord[],
+  toleranceMs?: number,
+): VerificationReport {
+  const { matched, unmatchedSelf } = matchRecords(selfReports, transcripts, toleranceMs)
+
+  const entries: VerificationReportEntry[] = matched.map(({ self, transcript }) => ({
+    self,
+    transcript,
+    statusComparison: compareStatus(self.status, transcript.status),
+    detailComparison: compareDetail(self.note, transcript.detail),
+  }))
+
+  return {
+    totalSelfReports: selfReports.length,
+    matchedCount: matched.length,
+    unmatchedSelf,
+    mismatches: entries.filter((entry) => entry.statusComparison === 'mismatch'),
+    lowOverlapDetails: entries.filter((entry) => entry.detailComparison === 'low_overlap'),
+  }
+}
+
+export function loadSelfReports(logFilePath: string): SelfReportRecord[] {
+  let content: string
+  try {
+    content = readFileSync(logFilePath, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as SelfReportRecord)
+    .filter((record) => record.status === 'done' || record.status === 'failed')
+}
+
+function findWorkflowDirs(projectDir: string): string[] {
+  const results: string[] = []
+  function walk(dir: string) {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry)
+      let stat
+      try {
+        stat = statSync(fullPath)
+      } catch {
+        continue
+      }
+      if (!stat.isDirectory()) continue
+      if (entry.startsWith('wf_')) {
+        results.push(fullPath)
+        continue
+      }
+      walk(fullPath)
+    }
+  }
+  walk(projectDir)
+  return results
+}
+
+export function loadTranscripts(projectDir: string): TranscriptRecord[] {
+  const records: TranscriptRecord[] = []
+  for (const wfDir of findWorkflowDirs(projectDir)) {
+    const filenames = readdirSync(wfDir)
+    const pairs = pairAgentFiles(filenames)
+    for (const { agentId, jsonlFile, metaFile } of pairs) {
+      let agentType = 'unknown'
+      try {
+        const meta = JSON.parse(readFileSync(join(wfDir, metaFile), 'utf-8')) as { agentType?: string }
+        agentType = meta.agentType ?? 'unknown'
+      } catch {
+        continue
+      }
+      const lines = readFileSync(join(wfDir, jsonlFile), 'utf-8').split('\n').filter(Boolean)
+      const summary = parseAgentTranscriptLines(lines)
+      records.push({
+        wfDir,
+        agentId,
+        agentType,
+        endTimestamp: summary.endTimestamp,
+        status: summary.status,
+        detail: summary.detail,
+      })
+    }
+  }
+  return records
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const getArg = (name: string, fallback: string) => {
+    const index = args.indexOf(name)
+    return index === -1 ? fallback : args[index + 1]
+  }
+
+  const logFilePath = getArg('--log-file', 'logs/agent-progress.jsonl')
+  const projectDir = getArg(
+    '--project-dir',
+    join(process.env.HOME ?? '', '.claude/projects/-Users-masanori-medical-inventory-vkumai'),
+  )
+  const asJson = args.includes('--json')
+
+  const selfReports = loadSelfReports(logFilePath)
+  const transcripts = loadTranscripts(projectDir)
+  const report = buildReport(selfReports, transcripts)
+
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log(
+      `自己申告(done/failed): ${report.totalSelfReports}件 / transcriptと突き合わせ成功: ${report.matchedCount}件 / 未対応(未突合): ${report.unmatchedSelf.length}件`,
+    )
+    if (report.mismatches.length > 0) {
+      console.log(`\n食い違い(status): ${report.mismatches.length}件`)
+      for (const entry of report.mismatches) {
+        console.log(
+          `  - agent=${entry.self.agent} feature=${entry.self.feature} 自己申告=${entry.self.status}(${entry.self.note}) transcript=${entry.transcript.status}(${entry.transcript.detail ?? ''})`,
+        )
+      }
+    }
+    if (report.lowOverlapDetails.length > 0) {
+      console.log(`\ndetail低一致(要目視確認・弱いシグナル): ${report.lowOverlapDetails.length}件`)
+      for (const entry of report.lowOverlapDetails) {
+        console.log(
+          `  - agent=${entry.self.agent} feature=${entry.self.feature} note="${entry.self.note}" detail="${entry.transcript.detail ?? ''}"`,
+        )
+      }
+    }
+  }
+
+  if (report.mismatches.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/verify-agent-progress-transcript.sh
+++ b/scripts/verify-agent-progress-transcript.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [--log-file PATH] [--project-dir PATH] [--json]" >&2
+  echo "  logs/agent-progress.jsonl の自己申告(status=done|failed)と" >&2
+  echo "  ~/.claude/projects/**/subagents/workflows/wf_*/agent-<id>.jsonl の実transcriptを" >&2
+  echo "  機械的に突き合わせ、status/detailの食い違いを検出する（issue #369の②スコープ）。" >&2
+  echo "  LLM呼び出しなし。食い違いがあればexit 1。" >&2
+  exit 1
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-file) ARGS+=(--log-file "$2"); shift 2 ;;
+    --project-dir) ARGS+=(--project-dir "$2"); shift 2 ;;
+    --json) ARGS+=(--json); shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+npx -y tsx "$SCRIPT_DIR/lib/verify-agent-progress-transcript.ts" "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- `logs/agent-progress.jsonl` の自己申告(status=done|failed)と、対応するサブエージェントtranscript(`~/.claude/projects/**/subagents/workflows/wf_*/agent-<id>.jsonl` + `.meta.json`)のstatus/detailを機械比較し、食い違う行のみ検出する `scripts/verify-agent-progress-transcript.sh` を追加(issue #369の②スコープ)。LLM呼び出し不要・コスト増なし。
- 突き合わせは`scripts/lib/reconstruct-loop-observability.ts`のtranscriptパース処理を再利用。agent-progress.jsonlはagentId/workflow実行IDを保持しないため、`--agent`名から既知agentType一覧への前方一致で復元し、同一agentType内で最も時刻が近いtranscriptに貪欲対応付けるベストエフォート方式(限界あり、コード内コメント・docs両方に明記)。
- statusの食い違い(確定的、`mismatches`)とdetailの低一致(文字bigram Jaccard類似度による弱いシグナル、`lowOverlapDetails`)を分けて出力し、detail側は自動ブロックしない。
- issue #369で保留とした①(git diffとの突き合わせ)・③(LLMサンプリング検証)の解禁条件をdocs/agents/common.mdに転記し、口頭記憶に頼らず追跡できるようにした。

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`(125ファイル955件、新規21件含め全パス)
- [x] `scripts/verify-agent-progress-transcript.sh --project-dir "$HOME/.claude/projects/-Users-masanori-medical-inventory-vkumai" --json` を実プロジェクトのtranscriptディレクトリに対して実行し、エラー無く完走することを確認

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
