### PR TITLE
feat: 分析・レポートページ（/admin/reports）の新設(issue #23)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -52,6 +52,7 @@ admin ユーザーのみが `/admin/reports` にアクセスし、任意の期�
 **期間フィルタ**
 - [ ] 開始日・終了日をYYYY-MM-DD形式で任意指定できる（両方省略時は全期間）
 - [ ] 開始日のみ指定時は「指定日(JST 00:00:00)以降」、終了日のみ指定時は「指定日(JST 23:59:59)以前」として集計される（`src/lib/jst-date-range.ts`の`jstDayStart`/`jstDayEnd`/`isValidDateString`を再利用する。独自実装しない）
+  - **既知のリスク（minor、本機能スコープ外）**: `jstDayEnd`は秒精度（`23:59:59`）までしか表現できず、`created_at`（TIMESTAMPTZ、マイクロ秒精度）が`23:59:59.xxxxxx`の場合に`<=`比較で終了日当日の最後の1秒未満の発注が期間集計から漏れる可能性がある。これは`jstDayEnd`が既存の複数機能（case-orders/consumable-orders/loan-orders/loan-returns/orders）で共有されている既存実装（issue #20由来）であり、本機能はそれを再利用する方針のため本SPECの対応範囲外とする。修正するなら`jstDayEnd`自体を`23:59:59.999999`等に改める必要があり、影響範囲が本機能を超えるため別issueで検討する。
 - [ ] 開始日 > 終了日の場合はバリデーションエラーを表示し、APIは呼ばない
 - [ ] 不正な日付形式は400エラーになる
 
@@ -59,8 +60,11 @@ admin ユーザーのみが `/admin/reports` にアクセスし、任意の期�
 - [ ] 全施設が行として表示される（発注が0件の施設も表示する）
 - [ ] 列は「施設名 / 症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」の5列
 - [ ] 各金額セルは該当期間・施設・発注種別の `unit_price × quantity` のSUM（ステータスは問わず全件対象。未解決事項2）
-- [ ] 発注0件の施設は「-」、発注はあるが単価データが一切ない場合は「-（金額データなし）」、集計値が0円の場合は「¥0」と表示が区別される（未解決事項4）
-- [ ] 合計列は各種別のNULLを0とみなして加算する。ただし全種別が「発注0件」の場合は合計も「-」
+- [ ] 発注0件の施設は「-」、発注はあるが単価データが一切ない場合は「-（金額データなし）」、集計値が0円の場合は「¥0」と表示が区別される（未解決事項4）。この区別は種別（症例/消耗品/短貸）単位で行われ、他種別の状態に引きずられない（critical指摘対応: `*_total_count`で「発注0件」と「単価データなし」を種別ごとに判定する）
+- [ ] 合計列は以下の優先順位で判定する（コードレビューでSPEC文言の自己矛盾＝critical指摘を修正済み。`src/components/reports/ReportTable.tsx`の`formatTotal`実装が正）:
+  1. **3種別すべての`*_total_count === 0`**（=施設に発注が1件もない）→ 合計は「-」
+  2. 上記に該当せず、かつ**3種別すべての`amount === null`**（=発注はあるが、どの種別にも金額データがない）→ 合計は「-（金額データなし）」
+  3. 上記いずれにも該当しない（=少なくとも1種別に確定金額がある）→ 各種別の`amount`のNULLを0とみなして合計し「¥N,NNN」で表示（他種別が「発注0件」または「金額データなし」でも、確定金額がある種別が1つでもあれば合計は算出できる）
 - [ ] ページ下部に「YYYY-MM-DD以前の発注は金額データがありません」旨の注釈を表示する
 - [ ] 集計中はテーブル領域にローディング表示をする
 
@@ -81,7 +85,7 @@ admin ユーザーのみが `/admin/reports` にアクセスし、任意の期�
 | 集計対象ステータス | 問わず全件 | 同上。将来submitフロー実装時にWHERE句一行で絞れる設計にしておく |
 | JST日付変換 | `src/lib/jst-date-range.ts`を再利用 | 既存の`jstDayStart`/`jstDayEnd`/`isValidDateString`と重複実装しない |
 | 単価解決パス | `case_order_items.jan → products(jan) → distributor_products(product_id) → hospital_prices(distributor_product_id, facility_id)` | 実際のスキーマに基づく正しいJOINパス（`hospital_prices`は`distributor_product_id`+`facility_id`で一意） |
-| 認可 | API層`requireAdmin()`（403）+ RPC層`is_admin()`（permission denied→403変換） | 既存`admin-auth.ts`パターンを踏襲。`createAdminSupabase()`は不要 |
+| 認可 | API層`requireAuth()`（401）+`resolveIsAdmin()`（403）+ RPC層`is_admin()`（permission denied→403変換） | `requireAdmin()`は401/403を区別できないため個別判定パターンを採用。`createAdminSupabase()`は不要 |
 
 不採用（検討したが見送り）: クエリ時に現在の`hospital_prices`をJOINして計算する方式（未解決事項1で確定）。過去発注の履歴的単価精度が失われるため。
 
@@ -100,10 +104,9 @@ ALTER TABLE loan_order_items       ADD COLUMN unit_price NUMERIC(12,2);
 -- 既存データはNULL（過去発注は金額データなし）。カラム追加のみでテーブル新設/削除ではないため
 -- refresh_schema_baseline_snapshot は不要（issue #305要件の対象外。実装時に最新スキーマベースラインで再確認すること）
 
--- 20260714000005_orders_history_prereqs.sql が consumable_orders/loan_orders/loan_returns の
--- (facility_id, created_at)複合インデックスを追加済みだが、case_ordersが欠落している（本migrationで補う）
-CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
-  ON case_orders (facility_id, created_at DESC);
+-- 【SPEC訂正（実装時に判明）】case_ordersの(facility_id, created_at)複合インデックスは
+-- 20260626000000_fix_fk_and_indexes.sql で既に作成済みだった（本ドラフト作成時は
+-- 「欠落している」と誤認していた）。追加のCREATE INDEXは不要。
 ```
 
 **注意点**: `unit_price`はNUMERIC(12,2)（円未満は扱わないが、将来の消費税等端数対応に備え小数2桁を確保）。既存行はNULLのまま（遡及なし、未解決事項7）。
@@ -118,41 +121,52 @@ CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
   - `loan_order_items`: `case_order_items`と同型
   - 同一JANが複数`distributor_products`に紐づく場合は`MIN(purchase_price)`を採用（未解決事項3）
   - 単価解決に失敗した場合（該当行なし・`consumables.jan`がNULL等）は`unit_price = NULL`のまま挿入し、例外を投げない（best-effort、RPCはロールバックしない）
+  - **重複実装指摘対応（important）**: `case_order_items`と`loan_order_items`は`jan → products → distributor_products → hospital_prices`という全く同一の単価解決クエリを使う。これを共通のSQL関数`resolve_jan_unit_price(p_jan TEXT, p_facility_id UUID) RETURNS NUMERIC`（`LANGUAGE sql STABLE`）に切り出し、3つのRPCすべてがこの関数を呼び出す形にする（`consumable_order_items`は`consumables.jan`を求めたうえで同じ関数を呼ぶ）。各RPC内にインラインで同一クエリを重複実装しない
+  - **GRANT EXECUTE必須（important指摘対応）**: `resolve_jan_unit_price`に`GRANT EXECUTE ON FUNCTION resolve_jan_unit_price(TEXT, UUID) TO authenticated;`を明示的に付与する。暗黙のPUBLIC権限に依存すると、将来`REVOKE EXECUTE FROM PUBLIC`相当の防御的変更が入った際に`create_*_order_atomic`からの呼び出しが失敗し、発注作成自体が壊れる退行リスクがある（`is_facility_member()`の既存対応 `20260711000001_grant_execute_is_facility_member.sql` と同じ理由）
 - **テスト観点**:
   - 正常な単価解決で`unit_price`が正しく保存される
   - 該当する`hospital_prices`がない場合、`unit_price=NULL`で挿入が成功する（例外にならない）
   - 同一JANが複数distributor_productsに紐づく場合、`MIN(purchase_price)`が採用される
+  - `resolve_jan_unit_price`に`GRANT EXECUTE TO authenticated`が明示的に付与されている
 
 #### Set B: 集計RPC
 
 - **触るファイル**: `supabase/migrations/<実装日>_add_order_amount_report_rpc.sql`
 - RPC名: `get_order_amount_report(p_date_from TIMESTAMPTZ, p_date_to TIMESTAMPTZ)`
-- 戻り値型:
+- 戻り値型（コードレビュー指摘・critical対応: `*_total_count`列を追加。理由は下記参照）:
   ```sql
   TABLE(
     facility_id UUID,
     facility_name TEXT,
     case_order_amount NUMERIC,
     case_order_count INTEGER,
+    case_order_total_count INTEGER,
     consumable_order_amount NUMERIC,
     consumable_order_count INTEGER,
+    consumable_order_total_count INTEGER,
     loan_order_amount NUMERIC,
-    loan_order_count INTEGER
+    loan_order_count INTEGER,
+    loan_order_total_count INTEGER
   )
   ```
-  - `*_count`は「単価データがある明細の件数」。0件と「発注はあるが単価データなし」をUI側で区別するために必要（未解決事項4）
+  - `*_count`は「単価データがある明細の件数」（amount集計に使われた件数）。
+  - `*_total_count`は「価格の有無を問わない全明細件数」。**critical指摘対応**: 当初案は`*_count`のみで
+    「発注0件」と「発注はあるが単価データなし」を区別しようとしていたが、両者とも`amount=NULL・count=0`で
+    返るため区別不能だった。`*_total_count = 0`なら「発注自体が0件」、`*_total_count > 0`かつ`amount IS NULL`
+    なら「発注はあるが単価データなし」とUI側で判定する（未解決事項4）。
 - 実装方針:
   - `SECURITY DEFINER` + `SET search_path = public` + 関数冒頭で`is_admin()`チェック（false なら`RAISE EXCEPTION 'permission denied'`）
   - `GRANT EXECUTE ON FUNCTION get_order_amount_report TO authenticated, service_role`（`anon`除外。実行時の最終ガードは関数内`is_admin()`）
   - `facilities`テーブルを起点にLEFT JOINし、全施設が必ず出力される
   - 各発注種別は`WHERE (p_date_from IS NULL OR created_at >= p_date_from) AND (p_date_to IS NULL OR created_at <= p_date_to)`（ステータス条件なし、未解決事項2）
-  - `SUM(unit_price * quantity) FILTER (WHERE unit_price IS NOT NULL)`で集計、NULLはNULLのまま返す（COALESCEしない。UI側で判定）
+  - `SUM(unit_price * quantity) FILTER (WHERE unit_price IS NOT NULL)`と`COUNT(*) FILTER (WHERE unit_price IS NOT NULL)`で
+    `amount`/`count`を集計しつつ、フィルタなしの`COUNT(*)`を`total_count`として同時に集計する。`amount`はNULLのまま返す（COALESCEしない。UI側で判定）
 - **テスト観点**:
   - adminユーザーで実行できる
   - 非adminユーザーでpermission deniedが返る
   - 期間フィルタが正しく適用される（境界値含む）
-  - 発注0件の施設はNULL・countも0で返る
-  - 発注はあるが単価データなしの施設はNULL・count=0で返る
+  - 発注0件の施設は`amount=NULL`・`count=0`・`total_count=0`で返る
+  - 発注はあるが単価データなしの施設は`amount=NULL`・`count=0`・`total_count>0`で返る（`total_count`で発注0件の施設と区別できることを検証する）
 
 #### Set C: 型定義・Repository
 
@@ -160,17 +174,20 @@ CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
   - `src/types/report.ts`（新規）
   - `src/lib/reports/repository.ts`（新規）
   - `src/lib/reports/__tests__/repository.test.ts`（新規）
-- 型定義:
+- 型定義（`*_total_count`はcritical指摘対応。上記Set Bの`*_total_count`列に対応）:
   ```typescript
   export type OrderAmountReportRow = {
     facilityId: string
     facilityName: string
     caseOrderAmount: number | null
     caseOrderCount: number
+    caseOrderTotalCount: number
     consumableOrderAmount: number | null
     consumableOrderCount: number
+    consumableOrderTotalCount: number
     loanOrderAmount: number | null
     loanOrderCount: number
+    loanOrderTotalCount: number
   }
   export type OrderAmountReportFilter = {
     dateFrom?: string  // YYYY-MM-DD
@@ -188,7 +205,7 @@ CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
   - `src/app/api/admin/reports/route.ts`（新規）
   - `src/app/api/admin/reports/__tests__/route.test.ts`（新規）
 - `GET /api/admin/reports?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD`
-- 認可: `requireAdmin()`（`createServerSupabase()`経由、`createAdminSupabase()`は不要）→ 403
+- 認可: 【SPEC訂正（実装時に判明）】`requireAdmin()`（`src/lib/admin-auth.ts`）は未認証/非adminをどちらもnullで返し401/403を区別できないため、`requireAuth(db)`で認証チェック（失敗時401）→ `resolveIsAdmin(db, user)`で個別にadmin判定（false時403）というパターンを採用する（`createAdminSupabase()`は不要）
 - バリデーション:
   - `date_from`/`date_to`は省略可。指定時は`isValidDateString()`でYYYY-MM-DD形式チェック（不正形式は400）
   - `date_from > date_to`の場合は400
@@ -200,7 +217,7 @@ CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
 
 - **触るファイル**:
   - `src/components/reports/ReportFilters.tsx`（新規）: 期間フィルタUI。バリデーションエラー表示含む
-  - `src/components/reports/ReportTable.tsx`（新規）: 集計テーブル。`caseOrderCount === 0 && caseOrderAmount === null`なら「-（金額データなし）」、行自体の全種別が発注0件なら「-」、集計値0円は「¥0」と判定して表示（未解決事項4のルールを実装）
+  - `src/components/reports/ReportTable.tsx`（新規）: 集計テーブル。種別ごとに`*_total_count === 0`なら「-」（発注0件）、`*_total_count > 0 && amount === null`なら「-（金額データなし）」、集計値0円は「¥0」と判定して表示（未解決事項4のルールを実装。**critical/important指摘対応**: 種別単位の判定に`*_total_count`を使うことで、「発注0件」と「発注はあるが単価データなし」を混同しない。合計列は「全種別が`total_count===0`（=真に発注0件）」の場合のみ「-」とし、それ以外はNULLを0とみなして加算する。以前は`count===0 && amount===null`のみで判定していたため、一部種別だけ単価データなしの行を誤って「全種別発注0件」と判定してしまう境界条件の欠落があった。**important指摘対応・追加分**: 加えて「全種別に発注はあるが、いずれの種別にも金額データが一切ない（全`amount===null`）」場合は、合計を「NULLを0とみなして加算」した結果の「¥0」ではなく「-（金額データなし）」と表示する。この判定は「全種別発注0件」判定より優先し、一部種別のみ金額データがある場合は従来どおりNULLを0とみなして加算する）
   - `src/components/reports/__tests__/ReportFilters.test.tsx`（新規）
   - `src/components/reports/__tests__/ReportTable.test.tsx`（新規）
 - **テスト観点**: NULL/0/「-（金額データなし）」の3パターンが正しく出し分けられること、金額がカンマ区切り円表示されること、日付バリデーションが機能すること

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,20 +1,24 @@
-# 機能仕様書: コンパチ（互換品）ページの実体化（issue #21）
+# 機能仕様書: 分析・レポートページの新設（issue #23）
 
-作成日: 2026-07-14
-ステータス: ドラフト（人間レビュー承認済み。Adversarial Verify 35件中35件生存＋Judge Panel統合案を反映済み）
+作成日: 2026-07-15
+ステータス: ドラフト（人間レビュー待ち。Adversarial Verify 55件＋Judge Panel統合案を反映済み）
 
 ---
 
-## 人間レビューでの決定事項（2026-07-14）
+## ⚠️ 人間が判断すべき未解決事項（レビュー時に必ず確認）
 
-1. **施設スコープ**: 単一共有マスタで進める（決定）。互換性は「製品仕様上の客観的事実」であり施設ごとの運用判断ではないため。「施設ごとに採用可否を分けたい」という運用は、確認の結果**現時点ではあり得ない**と判断されたため、施設スコープ・採用可否フラグはいずれも今回は導入しない。
-2. **CASCADE削除**: 許容で進める（決定）。他マスタ（products/categories/distributor_products）と同じ物理削除+CASCADEパターンに揃える。論理削除化は全体アーキテクチャの話として別途検討。
-3. **migration タイムスタンプ**: 実装着手日に確定（レビュー時点では判断不要、ドラフトの `20260715000001` は仮置きのまま）。
-4. **UPDATE（備考編集）**: RLSは `FOR ALL` のまま進める（決定）。備考の入力ミス訂正需要があり、admin限定で既に保護されているため `INSERT/DELETE` に絞る実益は薄い。
-5. **ページネーション閾値**: **500件**を閾値として仕様に明記する（Set C 実装セクション参照）。初期実装はページネーションなしで進め、`product_compatibilities` の総件数が500件を超えたらページネーション導入を別issueで検討する。
-6. **既存の技術的負債の別issue化**: 承認。以下2件をissue化キューに追加済み（本issueとは独立して対応）。
-   - `products`/`categories`/`distributor-products`/`facilities` の PUT/DELETE に `requireAdmin()` 呼び出しが欠落
-   - `src/app/login/page.tsx:110` の `<Suspense>` に `fallback` が未設定
+以下はAI側で仮決定しているが、承認前に確認をお願いします（1・2は既に人間確認済み）。
+
+1. **【確認済み】単価の取得方法**: 発注**作成時**（`create_*_order_atomic` RPC内）に単価をスナップショット保存する方式で進める。過去の発注（本機能実装日より前）は単価データがなく、集計上「-」表示になる。
+2. **【確認済み】集計対象ステータス**: `draft`/`submitted`を問わず全発注を集計対象にする（現状submitフロー自体が存在しないため）。将来submitフローが実装されたら、WHERE句一行で絞り込める設計にしておく。
+3. **複数`distributor_products`が同一JANに紐づく場合の単価選択ルール**: 本ドラフトは`MIN(purchase_price)`（最安値・決定論的）を採用と仮決定。曖昧な場合にNULL（保存しない）にする案もある。金額の正確性に関わるため確認を推奨。
+4. **NULL/¥0/「-」の表示区分**: 本ドラフトは以下の3区分で仮決定。表示文言は要確認。
+   - 発注0件 → 「-」
+   - 発注はあるが全明細のunit_price=NULL（金額データなし）→ 「-（金額データなし）」
+   - 金額集計値が0円（数量0等）→ 「¥0」
+5. **ページ初回表示**: 性能懸念のため、初回アクセス時は自動集計せず「期間未指定＝空状態（フィルタ入力待ち）」とする仮決定。全期間自動集計にすべきかは要確認。
+6. **監査ログ**: admin による全施設金額閲覧の監査ログは今回スコープ外（コンプライアンス要件があれば別途検討）。
+7. **過去データの遡及計算**: 行わない（実装日以前の発注は永続的に「-」）。遡及必要なら別issue。
 
 ---
 
@@ -22,304 +26,229 @@
 
 ### 何ができるようになるか（利用者目線）
 
-「コンパチ」ページ（`/compat`）で、同一カテゴリ内の複数製品（JAN単位）が互いに代替品として使用可能かどうかを登録・検索できる。例えば「縫合糸カテゴリ」で A社製品と B社製品が互換であることを管理者が登録すると、一般ユーザーも検索して確認できる。現在 `src/app/compat/page.tsx` は「Coming Soon」のプレースホルダのままであり、これを**全面的に置き換える**。
+admin ユーザーのみが `/admin/reports` にアクセスし、任意の期間を指定して「施設別 × 発注種別（症例発注 / 消耗品発注 / 短貸発注）の発注金額集計テーブル」を閲覧できる。一般ユーザーはこのページへのリンク・ナビゲーションが表示されず、URLを直打ちしても`/login`にリダイレクトされる（`/admin/*`の既存adminガードをそのまま利用するため、ページを`/admin/reports`に配置する）。
 
-- **一般ユーザー（施設メンバー）**: カテゴリで絞り込み、互換ペアを一覧表示・検索できる
-- **管理者**: 上記に加え、互換ペアの新規登録・削除ができる
+価格推移グラフは今回のスコープ外（別issueで検討）。
 
 ### 操作の流れ
 
-#### 検索フロー
-1. `/compat` を開く
-2. カテゴリドロップダウンで絞り込む（未選択時は全件表示、初期ソートは登録日時 `created_at` 降順）
-3. キーワード入力欄で製品名・JAN・メーカー名を部分一致で絞り込む
-4. 結果テーブルに「カテゴリ名 / 製品A（名称・JAN・メーカー）/ 製品B（名称・JAN・メーカー）/ 備考 / 登録日」が表示される
-
-#### 登録フロー（管理者のみ表示）
-1. 「互換品を追加」ボタンをクリック
-2. カテゴリを選択する（未選択の間は製品A・B の選択欄は disabled、プレースホルダー「先にカテゴリを選択してください」を表示）
-3. 製品Aを選択（カテゴリ内の `distributor_products` に紐づく `products` に限定。選択肢ラベルは `{name}（JAN: {jan}、メーカー: {maker ?? '不明'}）` の形式で一覧テーブルと統一表記にする）
-4. 製品Bを選択（製品Aと同じ制約。製品Aで選択済みの製品は選択肢から除外し、自己参照を未然に防ぐ。送信時にも再検証する）
-5. 備考（任意、最大500文字）を入力して登録
-6. 送信成功後、フォームをクリアする（モーダル使用時は閉じる）。一覧は即時再取得される
-7. 重複ペア（順序問わず同一組み合わせ）は登録できず、「すでに登録済みです。【製品A名】と【製品B名】は既に互換登録されています」とエラー表示する
-
-#### 削除フロー（管理者のみ）
-- 一覧の各行に「削除」ボタン → 確認ダイアログ（「【製品A名（JAN xxx / メーカーyyy）】と【製品B名（JAN zzz / メーカーwww）】の互換登録を削除しますか？」の具体的な文言）→ DELETE API
-- 既に削除済み（他管理者が先に削除した等）の場合は404を受けて「すでに削除されています」を表示し、一覧を自動再取得する
-
----
+1. adminユーザーが `/admin/reports` にアクセスする
+2. ページ上部に期間フィルタ（開始日・終了日、任意入力）が表示される
+3. 「集計する」ボタン押下、またはURLパラメータ変更で集計テーブルが更新される
+4. テーブルは「施設名」行 × 「症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」列の形式で表示される（全施設が行として表示され、発注0件の施設も表示する）
+5. 金額はすべて円表示（カンマ区切り整数）
+6. 該当データがない場合は「-」、金額データなしの場合は「-（金額データなし）」、集計値0円は「¥0」と表示を区別する（未解決事項4）
 
 ### 受け入れ条件チェックリスト
 
-**機能**
-- [ ] 未ログイン状態でアクセスすると `/login` にリダイレクトされる
-- [ ] ログイン済みで `/compat` にアクセスすると互換品一覧が表示される（Coming Soon でなくなる）
-- [ ] カテゴリ未選択で全互換ペアが `created_at` 降順で表示される
-- [ ] カテゴリを選択すると同カテゴリの互換ペアのみに絞り込まれる
-- [ ] キーワード入力で製品A・製品Bの名称・JAN・メーカー名を部分一致（OR条件）で絞り込める
-- [ ] 管理者は「互換品を追加」フォームが表示される（一般ユーザーには表示されない）
-- [ ] 登録フォームはカテゴリ未選択時、製品A・B の選択が無効化されている
-- [ ] 管理者が有効なペアを登録すると一覧に即時反映され、フォームがクリアされる
-- [ ] 同じペア（順序問わず）を再登録しようとすると、対象製品名を含む重複エラーになる
-- [ ] 自己参照（製品A = 製品B）は、製品Bの選択肢から製品Aを除外することで防止される（送信時にも400で再検証）
-- [ ] 管理者が削除ボタンを押すと、削除対象の製品名・JAN・メーカーを含む確認ダイアログの後に行が消える
-- [ ] 削除対象が既に存在しない場合（404）、「すでに削除されています」と表示され一覧が再取得される
+**アクセス制御**
+- [ ] adminユーザーが `/admin/reports` にアクセスできる
+- [ ] 未認証ユーザーが `/admin/reports` にアクセスすると `/login` にリダイレクトされる
+- [ ] 一般ユーザーが `/admin/reports` にアクセスすると `/login` にリダイレクトされる（middlewareのadminガードで弾かれる。middleware自体の改修は不要）
+- [ ] `DashboardShortcuts` に「レポート」リンクがadminユーザーのみに表示される（一般ユーザーには非表示）
+- [ ] 一般ユーザーが `GET /api/admin/reports` に直接リクエストすると403が返る
+- [ ] 未認証リクエストは401が返る
 
-**セキュリティ**
-- [ ] 一般ユーザーが POST /api/compat に直接リクエストすると 403 が返る
-- [ ] 一般ユーザーが DELETE /api/compat/[id] に直接リクエストすると 403 が返る
-- [ ] 未認証リクエストは 401 が返る
-- [ ] GET /api/compat/products も認証必須（未認証は401）。カテゴリに属さない製品情報の推測はカテゴリ内提示に限定されるため追加の施設スコープ制御は不要（本機能はテナント非分離。上記「未解決事項1」参照）
+**期間フィルタ**
+- [ ] 開始日・終了日をYYYY-MM-DD形式で任意指定できる（両方省略時は全期間）
+- [ ] 開始日のみ指定時は「指定日(JST 00:00:00)以降」、終了日のみ指定時は「指定日(JST 23:59:59)以前」として集計される（`src/lib/jst-date-range.ts`の`jstDayStart`/`jstDayEnd`/`isValidDateString`を再利用する。独自実装しない）
+- [ ] 開始日 > 終了日の場合はバリデーションエラーを表示し、APIは呼ばない
+- [ ] 不正な日付形式は400エラーになる
 
-**DB**
-- [ ] `product_compatibilities` テーブルが migration で作成される
-- [ ] `(category_id, product_id_1, product_id_2)` に UNIQUE 制約がある
-- [ ] `product_id_1 < product_id_2` の CHECK 制約で順序正規化がある（(a,b)と(b,a)の二重登録防止）
-- [ ] RLS: SELECT は全認証ユーザー、CUD は `is_admin()` のみ
-- [ ] migration末尾で `refresh_schema_baseline_snapshot()` を呼んでいる（issue #305要件）
+**集計テーブル**
+- [ ] 全施設が行として表示される（発注が0件の施設も表示する）
+- [ ] 列は「施設名 / 症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」の5列
+- [ ] 各金額セルは該当期間・施設・発注種別の `unit_price × quantity` のSUM（ステータスは問わず全件対象。未解決事項2）
+- [ ] 発注0件の施設は「-」、発注はあるが単価データが一切ない場合は「-（金額データなし）」、集計値が0円の場合は「¥0」と表示が区別される（未解決事項4）
+- [ ] 合計列は各種別のNULLを0とみなして加算する。ただし全種別が「発注0件」の場合は合計も「-」
+- [ ] ページ下部に「YYYY-MM-DD以前の発注は金額データがありません」旨の注釈を表示する
+- [ ] 集計中はテーブル領域にローディング表示をする
 
-**UI**
-- [ ] 本ページは `useSearchParams()` を使わない設計のため `<Suspense>` ラップは不要（URL連動フィルタは今回スコープ外）
-- [ ] 一覧が0件のとき、状況に応じて空状態メッセージが出し分けられる:
-  - 全体0件かつ管理者:「互換品が登録されていません」＋「＋互換品を追加」への導線
-  - 全体0件かつ一般ユーザー:「互換品はまだ登録されていません」
-  - フィルタ結果0件（登録は存在）:「条件に一致する互換品がありません」
-- [ ] 一覧初回表示・再取得中はテーブル領域にスケルトンまたはスピナーを表示する
-- [ ] カテゴリ変更時、製品候補取得中は製品Select近傍にインラインスピナーを表示し、Selectを一時disabledにする
-- [ ] 削除・製品候補取得・一覧再取得のいずれかでネットワークエラーが発生した場合、画面上部にエラーメッセージを表示する（既存 `products` ページと同一パターン）
+**データ精度**
+- [ ] 発注作成時（`create_*_order_atomic` RPC内）に単価スナップショットが保存されている
+- [ ] 単価解決に失敗した場合（該当する`hospital_prices`が存在しない等）は`unit_price=NULL`として保存し、発注作成自体は失敗させない（best-effort）
 
 ---
 
 ## Part 2 — 実装計画（AI用）
 
-### 設計方針の確定事項（Judge Panel採用: 保守的設計アプローチ、スコア78）
+### 設計方針の確定事項（Judge Panel採用: 保守的設計アプローチ、スコア77）
 
 | 論点 | 採用 | 理由 |
 |---|---|---|
-| ページ構成 | 純 `'use client'` + `useReducer(refreshKey)` + `useEffect(fetch)` | Server/Client混在は本プロジェクト初の構成でrefreshKeyがServer再実行に繋がらないリスクがある。既存 `products/page.tsx` と同型にして実装差異を排除する |
-| Admin認可 | `requireAuth(db)` + `resolveIsAdmin(db, user)` を直接呼ぶ | `requireAdmin()`（`src/lib/admin-auth.ts`）は内部で `createServerSupabase()` を二重生成するため使わない。`facilities` API と同型でテストモックも整合する |
-| 製品候補取得 | `/api/compat/products` を新設 | 既存 `/api/products` のGET仕様変更によるクライアント影響を避け、責務を`/compat`ドメインに閉じる |
-| キーワード検索 | サーバサイド `.ilike`（Supabaseパラメータバインド） | raw SQL禁止でSQLiリスクを排除。GIN/pg_trgmは初期実装では不要（マスタ件数が少ない前提。件数増大時は別issueで検討） |
-| ON DELETE CASCADE | 許容 | 他マスタと同じ物理削除パターンに揃える（人間レビューで決定）。論理削除化は全体アーキ検討として別途 |
-| ページネーション | 初期実装では対応せず、初期ソートのみ `created_at DESC` を明記 | 500件超過で別issue検討（人間レビューで決定した閾値） |
+| ページ配置 | `/admin/reports` | `src/middleware.ts`の`isAdminPath`は`/admin/*`のみ対応。middleware改修なしでadminガードを効かせるため |
+| 単価保存タイミング | 発注**作成時**（`create_*_order_atomic` RPC内） | 現状submitフローが存在しないため（未解決事項2で確定） |
+| 集計対象ステータス | 問わず全件 | 同上。将来submitフロー実装時にWHERE句一行で絞れる設計にしておく |
+| JST日付変換 | `src/lib/jst-date-range.ts`を再利用 | 既存の`jstDayStart`/`jstDayEnd`/`isValidDateString`と重複実装しない |
+| 単価解決パス | `case_order_items.jan → products(jan) → distributor_products(product_id) → hospital_prices(distributor_product_id, facility_id)` | 実際のスキーマに基づく正しいJOINパス（`hospital_prices`は`distributor_product_id`+`facility_id`で一意） |
+| 認可 | API層`requireAdmin()`（403）+ RPC層`is_admin()`（permission denied→403変換） | 既存`admin-auth.ts`パターンを踏襲。`createAdminSupabase()`は不要 |
 
-不採用（検討したが見送り）: **互換グループモデル**（`compat_groups` + `compat_group_members` の2テーブル方式）。N対N表現には優れるが、ペア追加時のグループ検索・マージ・孤立グループ自動削除のロジックが大幅に増え、issue #21 の要求（ペア登録・検索）に対し過剰設計と判断。将来「3製品以上の互換群」要件が出た場合の再検討候補として記録する。
+不採用（検討したが見送り）: クエリ時に現在の`hospital_prices`をJOINして計算する方式（未解決事項1で確定）。過去発注の履歴的単価精度が失われるため。
 
 ---
 
-### DB設計（テーブル定義）
+### DB設計
+
+#### Set A: 既存order_itemsテーブルへの単価カラム追加
 
 ```sql
--- migration: <実装日に合わせて確定>_create_product_compatibilities.sql
--- (ドラフトでは 20260715000001 を仮置き。未解決事項3を参照し実装日で確定すること)
+-- migration: <実装日>_add_unit_price_to_order_items.sql
+ALTER TABLE case_order_items       ADD COLUMN unit_price NUMERIC(12,2);
+ALTER TABLE consumable_order_items ADD COLUMN unit_price NUMERIC(12,2);
+ALTER TABLE loan_order_items       ADD COLUMN unit_price NUMERIC(12,2);
 
-CREATE TABLE product_compatibilities (
-  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
-  category_id uuid        NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
-  product_id_1 uuid       NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-  product_id_2 uuid       NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-  note        text,
-  created_at  timestamptz NOT NULL DEFAULT now(),
-  updated_at  timestamptz NOT NULL DEFAULT now(),
-  -- 自己参照禁止
-  CONSTRAINT no_self_compat CHECK (product_id_1 <> product_id_2),
-  -- UUID文字列の辞書順で小さい方を必ず product_id_1 に入れる → (a,b)と(b,a)を同一視
-  CONSTRAINT ordered_pair  CHECK (product_id_1 < product_id_2),
-  -- 同カテゴリ内でのペア重複禁止
-  UNIQUE (category_id, product_id_1, product_id_2)
-);
+-- 既存データはNULL（過去発注は金額データなし）。カラム追加のみでテーブル新設/削除ではないため
+-- refresh_schema_baseline_snapshot は不要（issue #305要件の対象外。実装時に最新スキーマベースラインで再確認すること）
 
--- インデックス戦略（category_id・product_id_1/2 に対するFK/絞り込み用。
--- keyword検索は products.name/jan/maker に対するJOIN後の.ilikeであり、
--- このインデックスでは加速されない。マスタ件数が少ない前提のためGIN/pg_trgmは初期実装では未導入）
-CREATE INDEX idx_compat_category_id  ON product_compatibilities (category_id);
-CREATE INDEX idx_compat_product_id_1 ON product_compatibilities (product_id_1);
-CREATE INDEX idx_compat_product_id_2 ON product_compatibilities (product_id_2);
-
--- RLS（products/categories/distributor_products と同じマスタテーブルパターン。
--- 本機能はテナント非分離＝施設スコープなし。未解決事項1を参照）
-ALTER TABLE product_compatibilities ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "compat_select" ON product_compatibilities FOR SELECT TO authenticated USING (true);
-CREATE POLICY "compat_write"  ON product_compatibilities FOR ALL    TO authenticated
-  USING (is_admin()) WITH CHECK (is_admin());
-  -- 未解決事項4: UPDATE(備考編集)を提供しないなら FOR ALL ではなく
-  -- FOR INSERT / FOR DELETE の2ポリシーに分割し最小権限にする選択肢もある
-
--- refresh_schema_baseline_snapshot 呼び出し（issue #305要件・テーブル新設のため必須）
-SELECT refresh_schema_baseline_snapshot('<実際のmigrationタイムスタンプ>');
+-- 20260714000005_orders_history_prereqs.sql が consumable_orders/loan_orders/loan_returns の
+-- (facility_id, created_at)複合インデックスを追加済みだが、case_ordersが欠落している（本migrationで補う）
+CREATE INDEX IF NOT EXISTS idx_case_orders_facility_created_at
+  ON case_orders (facility_id, created_at DESC);
 ```
 
-**注意点（調査で判明した設計上の落とし穴）**
-- `products` テーブルに `category_id` は存在しない。カテゴリは `distributor_products.category_id` 経由で判定する。
-  → 「このカテゴリで有効な product 一覧」を取得するクエリは `distributor_products` を経由する必要がある。
-- DB制約では「両製品が当該カテゴリ内に存在するか」を強制できない。アプリケーション層（API route）でバリデーションとして実装する。
-- `product_id_1 < product_id_2` の CHECK により、リポジトリ層でペア挿入前に UUID を比較して小さい方を `product_id_1` に入れる正規化処理が必要。
-- `product_compatibilities` は `distributor_products` への直接FKを持たない。`distributor_products` が削除されても行は残存しうるが、表示時のカテゴリ有効性判定はアプリ層フィルタ（`listProductsInCategory`）で担保する。恒久対応は別issue化する。
+**注意点**: `unit_price`はNUMERIC(12,2)（円未満は扱わないが、将来の消費税等端数対応に備え小数2桁を確保）。既存行はNULLのまま（遡及なし、未解決事項7）。
 
----
+#### Set A-2: 既存の発注作成RPC改修（単価スナップショット保存）
 
-### 実装セット一覧（依存順）
-
-#### Set A: DBマイグレーション（他セットのブロッカー）
-- **ファイル**: `supabase/migrations/<実装日>_create_product_compatibilities.sql`
-- **内容**: テーブル作成・インデックス・RLS・`refresh_schema_baseline_snapshot`
+- **触るファイル**: `supabase/migrations/<実装日>_add_unit_price_snapshot_to_order_rpcs.sql`（新規。既存migrationファイルは追記・修正禁止のため`CREATE OR REPLACE FUNCTION`で対応）
+- 対象: `create_case_order_atomic` / `create_consumable_order_atomic` / `create_loan_order_atomic`（`supabase/migrations/20260626002000_add_order_rpc_functions.sql` 等で定義済み）
+- 各RPC内で、各明細行の挿入前に単価を解決してINSERTする:
+  - `case_order_items`: `jan → products(jan) → distributor_products(product_id) → hospital_prices(distributor_product_id, p_facility_id)` で`purchase_price`を取得
+  - `consumable_order_items`: `consumable_id → consumables(jan) → products(jan) → distributor_products(product_id) → hospital_prices(...)`
+  - `loan_order_items`: `case_order_items`と同型
+  - 同一JANが複数`distributor_products`に紐づく場合は`MIN(purchase_price)`を採用（未解決事項3）
+  - 単価解決に失敗した場合（該当行なし・`consumables.jan`がNULL等）は`unit_price = NULL`のまま挿入し、例外を投げない（best-effort、RPCはロールバックしない）
 - **テスト観点**:
-  - migration が clean apply できること（`supabase db reset` でエラーなし）
-  - `product_id_1 > product_id_2` で直接INSERTすると CHECK制約違反になること
-  - 自己参照（`product_id_1 = product_id_2`）で直接INSERTすると CHECK制約違反になること
+  - 正常な単価解決で`unit_price`が正しく保存される
+  - 該当する`hospital_prices`がない場合、`unit_price=NULL`で挿入が成功する（例外にならない）
+  - 同一JANが複数distributor_productsに紐づく場合、`MIN(purchase_price)`が採用される
 
-#### Set B: 型定義（Set A完了後）
-- **ファイル**: `src/types/compatibility.ts`
+#### Set B: 集計RPC
+
+- **触るファイル**: `supabase/migrations/<実装日>_add_order_amount_report_rpc.sql`
+- RPC名: `get_order_amount_report(p_date_from TIMESTAMPTZ, p_date_to TIMESTAMPTZ)`
+- 戻り値型:
+  ```sql
+  TABLE(
+    facility_id UUID,
+    facility_name TEXT,
+    case_order_amount NUMERIC,
+    case_order_count INTEGER,
+    consumable_order_amount NUMERIC,
+    consumable_order_count INTEGER,
+    loan_order_amount NUMERIC,
+    loan_order_count INTEGER
+  )
+  ```
+  - `*_count`は「単価データがある明細の件数」。0件と「発注はあるが単価データなし」をUI側で区別するために必要（未解決事項4）
+- 実装方針:
+  - `SECURITY DEFINER` + `SET search_path = public` + 関数冒頭で`is_admin()`チェック（false なら`RAISE EXCEPTION 'permission denied'`）
+  - `GRANT EXECUTE ON FUNCTION get_order_amount_report TO authenticated, service_role`（`anon`除外。実行時の最終ガードは関数内`is_admin()`）
+  - `facilities`テーブルを起点にLEFT JOINし、全施設が必ず出力される
+  - 各発注種別は`WHERE (p_date_from IS NULL OR created_at >= p_date_from) AND (p_date_to IS NULL OR created_at <= p_date_to)`（ステータス条件なし、未解決事項2）
+  - `SUM(unit_price * quantity) FILTER (WHERE unit_price IS NOT NULL)`で集計、NULLはNULLのまま返す（COALESCEしない。UI側で判定）
+- **テスト観点**:
+  - adminユーザーで実行できる
+  - 非adminユーザーでpermission deniedが返る
+  - 期間フィルタが正しく適用される（境界値含む）
+  - 発注0件の施設はNULL・countも0で返る
+  - 発注はあるが単価データなしの施設はNULL・count=0で返る
+
+#### Set C: 型定義・Repository
+
+- **触るファイル**:
+  - `src/types/report.ts`（新規）
+  - `src/lib/reports/repository.ts`（新規）
+  - `src/lib/reports/__tests__/repository.test.ts`（新規）
+- 型定義:
   ```typescript
-  export type ProductCompatibility = {
-    id: string
-    categoryId: string
-    categoryName: string
-    productId1: string
-    product1: { jan: string; name: string; maker: string | null }
-    productId2: string
-    product2: { jan: string; name: string; maker: string | null }
-    note: string | null
-    createdAt: string
-    updatedAt: string
+  export type OrderAmountReportRow = {
+    facilityId: string
+    facilityName: string
+    caseOrderAmount: number | null
+    caseOrderCount: number
+    consumableOrderAmount: number | null
+    consumableOrderCount: number
+    loanOrderAmount: number | null
+    loanOrderCount: number
   }
-  export type ProductCompatibilityInput = {
-    categoryId: string
-    productId1: string
-    productId2: string
-    note: string | null
+  export type OrderAmountReportFilter = {
+    dateFrom?: string  // YYYY-MM-DD
+    dateTo?: string    // YYYY-MM-DD
   }
   ```
-- **テスト観点**: 型定義のみ（`tsc --noEmit` でコンパイルエラーなし）
+- `fetchOrderAmountReport(db: SupabaseClient, filter: OrderAmountReportFilter): Promise<OrderAmountReportRow[]>`
+  - `filter.dateFrom`/`dateTo`は`jstDayStart`/`jstDayEnd`でTIMESTAMPTZに変換してから`db.rpc('get_order_amount_report', {...})`を呼ぶ
+  - スネークケース→キャメルケースへの全フィールドマッピングをテストでアサートする（マッピング漏れ防止）
+- **テスト観点**: RPC呼び出しが正しい引数で呼ばれること、レスポンス全フィールドのマッピングが正しいこと
 
-#### Set C: リポジトリ層（Set B完了後）
-- **ファイル**: `src/lib/compatibilities/repository.ts`
-- **内容**:
-  - `listCompatibilities(db, { categoryId?: string, keyword?: string }): Promise<ProductCompatibility[]>`
-    → `product_compatibilities` を JOIN（categories, products as p1, products as p2）して取得。`created_at DESC` でソート。keyword は product1/product2 の name/jan/maker を `.ilike` の OR検索（パラメータバインド、raw SQL禁止）。
-  - `createCompatibility(db, input: ProductCompatibilityInput): Promise<ProductCompatibility>`
-    → 挿入前に `product_id_1 < product_id_2` の正規化処理（文字列比較で小さい方を `product_id_1` に入れる）。
-  - `deleteCompatibility(db, id: string): Promise<void>`
-    → 対象が存在しない場合は呼び出し元（API route）で404判定できるよう、削除件数0件をハンドリング可能な形で返す。
-  - `listProductsInCategory(db, categoryId: string): Promise<Product[]>`
-    → `SELECT DISTINCT p.* FROM products p JOIN distributor_products dp ON dp.product_id = p.id WHERE dp.category_id = ?` で、フォームの製品選択肢取得に使用。
-- **ページネーション閾値（人間レビューで決定）**: 初期実装はページネーションなし（全件取得）。`product_compatibilities` の総件数が**500件**を超えたら、ページネーション（LIMIT/OFFSET）導入を別issueで検討する。閾値到達の監視方法は本issueのスコープ外（別issueで検討）。
-- **テスト観点**:
-  - `createCompatibility` で同じペアを2回挿入すると 23505 エラー
-  - `createCompatibility` で `productId1 > productId2` を渡した場合に正規化されること（`product_id_1 < product_id_2` になること）
-  - `listCompatibilities` で `categoryId` 指定時に他カテゴリの行が含まれないこと
-  - `listCompatibilities` の keyword検索が product1/product2 双方の name/jan/maker に対して機能すること
-  - `deleteCompatibility` で存在しないIDを渡した場合の挙動（0件削除として判定可能なこと）
+#### Set D: APIエンドポイント
 
-#### Set D: APIルート（Set C完了後）
+- **触るファイル**:
+  - `src/app/api/admin/reports/route.ts`（新規）
+  - `src/app/api/admin/reports/__tests__/route.test.ts`（新規）
+- `GET /api/admin/reports?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD`
+- 認可: `requireAdmin()`（`createServerSupabase()`経由、`createAdminSupabase()`は不要）→ 403
+- バリデーション:
+  - `date_from`/`date_to`は省略可。指定時は`isValidDateString()`でYYYY-MM-DD形式チェック（不正形式は400）
+  - `date_from > date_to`の場合は400
+  - RPCからの`permission denied`はAPIが403に変換する（500で隠さない）
+- レスポンス: `{ rows: OrderAmountReportRow[] }`
+- **テスト観点**: 未認証401・非admin403・不正日付400・正常系
 
-**GET/POST: `src/app/api/compat/route.ts`**
-- GET: `requireAuth` のみ（全認証ユーザーが読める）。クエリパラメータ: `categoryId?`, `keyword?`（最大100文字、超過は400）
-- POST: `requireAuth` → `resolveIsAdmin(db, user)` → isAdmin でなければ 403
-  - body: `ProductCompatibilityInput`
-  - バリデーション:
-    - `categoryId` / `productId1` / `productId2` は null・undefined・空文字列いずれも400
-    - `categoryId` / `productId1` / `productId2` はUUID形式チェック（不正形式は400、FK到達前に弾く）
-    - 自己参照チェック: 正規化前の生の値で `productId1 === productId2` を判定 → 400
-    - `listProductsInCategory(db, categoryId)` の結果集合に両IDが含まれるか検証 → 含まれなければ400
-    - 存在しない `categoryId` はFK違反を捕捉し「カテゴリが見つかりません」400
-    - `note` は最大500文字（超過は400）
-  - 重複: DB 23505 → 409「すでに登録済みです（順序問わず）。【製品A名】と【製品B名】は既に互換登録されています」（具体的なペア名を含める）
-  - TOCTOU（カテゴリ検証後に対象製品がカテゴリから外れる競合）はDBのUNIQUE/FK制約を最終防壁として割り切る
+#### Set E: UIコンポーネント
 
-**DELETE: `src/app/api/compat/[id]/route.ts`**
-- `requireAuth` → `resolveIsAdmin(db, user)` → isAdmin でなければ 403
-- `deleteCompatibility`、対象が存在しなければ 404
+- **触るファイル**:
+  - `src/components/reports/ReportFilters.tsx`（新規）: 期間フィルタUI。バリデーションエラー表示含む
+  - `src/components/reports/ReportTable.tsx`（新規）: 集計テーブル。`caseOrderCount === 0 && caseOrderAmount === null`なら「-（金額データなし）」、行自体の全種別が発注0件なら「-」、集計値0円は「¥0」と判定して表示（未解決事項4のルールを実装）
+  - `src/components/reports/__tests__/ReportFilters.test.tsx`（新規）
+  - `src/components/reports/__tests__/ReportTable.test.tsx`（新規）
+- **テスト観点**: NULL/0/「-（金額データなし）」の3パターンが正しく出し分けられること、金額がカンマ区切り円表示されること、日付バリデーションが機能すること
 
-**GET: `src/app/api/compat/products/route.ts`**（フォームの製品候補取得用）
-- `requireAuth`、クエリパラメータ `categoryId` 必須（UUID形式チェック、不正・欠落は400）
-- `listProductsInCategory` 呼び出し
-- レスポンス: `{ products: Product[] }`
-- 新設理由: 既存 `/api/products` のGET仕様変更によるクライアント影響を避け、製品候補取得の責務を`/compat`ドメインに閉じるため
+#### Set F: ページ・ナビ統合
 
-**テスト観点**:
-- POST 一般ユーザー → 403
-- DELETE 一般ユーザー → 403
-- POST/DELETE/GET(products) 未認証 → 401
-- POST 自己参照 → 400
-- POST カテゴリ外製品 → 400
-- POST 不正UUID形式（categoryId/productId1/productId2）→ 400
-- POST note 501文字 → 400
-- POST 重複 → 409（レスポンスに製品A名・製品B名を含む）
-- DELETE 存在しないID → 404
-- GET /api/compat/products の categoryId 欠落・不正UUID → 400
-
-#### Set E: UIコンポーネント（Set D完了後）
-
-**並列グループ宣言（E-1 と E-2 は互いに独立、並列実装可）**
-
-**E-1: `src/components/compat/CompatList.tsx`**
-- props: `{ items: ProductCompatibility[]; isAdmin: boolean; onDelete: (id: string) => void; hasFilter: boolean }`
-- 表示カラム: カテゴリ名 / 製品A（名称・JAN・メーカー）/ 製品B（名称・JAN・メーカー）/ 備考 / 登録日
-- 0件時の空状態メッセージを3パターンで出し分け（`items.length === 0` かつ `hasFilter` で判定）:
-  - `!hasFilter && isAdmin`: 「互換品が登録されていません」＋「＋互換品を追加」導線
-  - `!hasFilter && !isAdmin`: 「互換品はまだ登録されていません」
-  - `hasFilter`: 「条件に一致する互換品がありません」
-- `isAdmin=true` 時のみ削除ボタン表示。削除ボタン押下で確認ダイアログ（対象製品名・JAN・メーカーを含む具体的文言）を表示
-- 既存 `ProductList` のテーブルスタイルを踏襲
-- 一覧再取得中はスケルトンまたはスピナーを表示
-
-**E-2: `src/components/compat/CompatForm.tsx`**
-- props: `{ categories: Category[]; isAdmin: boolean; onSuccess: () => void }`
-- 内部 state: `categoryId`, `productId1`, `productId2`, `note`, `productsInCategory`, `isLoadingProducts`
-- `categoryId` 変更時に `/api/compat/products?categoryId=xxx` を呼び `productsInCategory` を更新。取得中は製品Select近傍にインラインスピナーを表示し、Selectを一時disabledにする
-- カテゴリ未選択時は製品A・B の Select を disabled にし、プレースホルダー「先にカテゴリを選択してください」を表示
-- 選択肢ラベル: `{name}（JAN: {jan}、メーカー: {maker ?? '不明'}）` 形式（一覧テーブルと表記統一）
-- 製品Bの選択肢からは製品Aで選択済みの製品を除外（自己参照防止）。送信時にも `productId1 === productId2` を再検証
-- 送信成功後、フォームをクリアする（モーダル使用時は閉じる）。`onSuccess()` を呼んで一覧を再取得
-- 重複エラー（409）・ネットワークエラー時は画面上部にエラーメッセージを表示
-
-#### Set F: ページ統合（Set E完了後）
-
-**`src/app/compat/page.tsx`**（既存の Coming Soon プレースホルダを全面上書き）
-- 純 `'use client'` + `useReducer(refreshKey)` + `useEffect(fetch)` 構成（`products/page.tsx` と同型。Server Component併用はしない）
-- カテゴリ一覧は `useEffect` で `/api/categories` から取得
-- Admin判定: `requireAuth(db)` + `resolveIsAdmin(db, user)`（クライアント側で判定が必要な場合は、既存の管理者判定を返すAPI/propの取得パターンを既存コードから確認して踏襲する）
-- `categoryId`・`keyword` のフィルタ状態はコンポーネント内 state で保持（URL searchParams 連動・`useSearchParams()` は使わないため `<Suspense>` ラップは不要）
-- `CompatForm`（`isAdmin=true` の場合のみ表示）と `CompatList` を配置
-- ネットワークエラー時は `setError` で画面上部にエラーメッセージ表示（`products` ページと同一パターン）
-
-**テスト観点（Set E・F共通）**:
-- 一般ユーザーには「互換品を追加」フォームが表示されない
-- 管理者の登録フロー一連が動作する（カテゴリ選択→製品A/B選択→登録→一覧反映→フォームクリア）
-- 重複エラー時に具体的なペア名を含むメッセージが表示される
-- 削除確認ダイアログに対象製品名・JAN・メーカーが含まれる
-- 空状態メッセージが管理者/一般ユーザー/フィルタ結果で出し分けられる
-- ネットワークエラー時に画面が壊れずエラーメッセージが表示される
-
-#### Set G: E2Eテスト（Set F完了後）
-- **ファイル**: `e2e/compat.spec.ts`（新規、既存 `e2e/products.spec.ts` を踏襲）
-- 最低3シナリオ: ①一般ユーザーに「互換品を追加」ボタンが表示されない ②管理者の登録フロー ③重複登録時のエラー表示
-- ダミー施設・ダミー製品のみ使用（`docs/agents/common.md` のデータ衛生ルール準拠）
+- **触るファイル**:
+  - `src/app/admin/reports/page.tsx`（新規）
+  - `src/app/admin/reports/__tests__/page.test.tsx`（新規）
+  - `src/components/dashboard/DashboardShortcuts.tsx`（既存・改修）
+- `page.tsx`実装方針:
+  - `useSearchParams()`を使う場合は`<Suspense>`必須ラップ（`src/app/orders/page.tsx`パターン参照）
+  - 初回アクセス時（`date_from`/`date_to`ともURLパラメータなし）は自動集計せず空状態（フィルタ入力待ち）を表示する（未解決事項5）
+  - `/api/admin/reports`をfetchして`ReportTable`に渡す
+- `DashboardShortcuts.tsx`改修（重要な既存コード注意点）:
+  - 現行は`const ADMIN_SHORTCUT = { href:'/admin/users', label:'管理ユーザー' }`という**単一オブジェクト**を`[...BASE_SHORTCUTS, ADMIN_SHORTCUT]`でスプレッドしている
+  - `ADMIN_SHORTCUTS`という**配列**（`[{ href:'/admin/users', ... }, { href:'/admin/reports', label:'レポート' }]`）に定義し直し、呼び出し側を`[...BASE_SHORTCUTS, ...ADMIN_SHORTCUTS]`（二重スプレッド）に変更する。単純に配列へ差し替えるだけだと`[...BASE, [...]]`になり型が壊れるため注意
+- **テスト観点**: adminユーザーには「レポート」リンクが表示される、一般ユーザーには非表示であること、ページのローディング/エラー状態が機能すること
 
 ---
 
-### 並列グループ宣言（Phase 3 実装時の参考）
+### 並列グループ宣言
 
 | グループ | セット | 触るファイル |
 |---|---|---|
-| G1（直列ブロッカー）| A | `supabase/migrations/<実装日>_create_product_compatibilities.sql` |
-| G2（G1後）| B | `src/types/compatibility.ts` |
-| G3（G2後）| C | `src/lib/compatibilities/repository.ts` |
-| G4（G3後）| D | `src/app/api/compat/route.ts`, `src/app/api/compat/[id]/route.ts`, `src/app/api/compat/products/route.ts` |
-| G5（G4後、E-1とE-2は並列）| E-1 | `src/components/compat/CompatList.tsx` |
-| G5（G4後、E-1とE-2は並列）| E-2 | `src/components/compat/CompatForm.tsx` |
-| G6（G5後）| F | `src/app/compat/page.tsx` |
-| G7（G6後）| G | `e2e/compat.spec.ts` |
+| G1（並列可）| A | `supabase/migrations/<実装日>_add_unit_price_to_order_items.sql` |
+| G1（並列可）| A-2 | `supabase/migrations/<実装日>_add_unit_price_snapshot_to_order_rpcs.sql` |
+| G2（G1後）| B | `supabase/migrations/<実装日>_add_order_amount_report_rpc.sql` |
+| G3（G2後）| C | `src/types/report.ts`, `src/lib/reports/repository.ts` |
+| G4（G3後、DとEは並列可）| D | `src/app/api/admin/reports/route.ts` |
+| G4（G3後、DとEは並列可）| E | `src/components/reports/ReportFilters.tsx`, `src/components/reports/ReportTable.tsx` |
+| G5（G4後）| F | `src/app/admin/reports/page.tsx`, `src/components/dashboard/DashboardShortcuts.tsx` |
+
+---
+
+### 触れないファイル（実装者は変更禁止）
+
+- `src/middleware.ts`（`/admin/reports`配置により既存adminガードで対応済み。改修不要）
+- `src/types/order.ts`（既存の`OrderListItem`等は変更しない）
+- 既存のマイグレーションファイル（追記・修正禁止。RPC改修は`CREATE OR REPLACE FUNCTION`による新規migrationで対応）
 
 ---
 
 ### スコープ外（今回あえて対応しない）
 
-- 既存 API の `requireAdmin` 欠落修正（`products`/`categories`/`distributor-products`/`facilities` の PUT/DELETE）— 別issue化済み（人間レビューで決定）
-- `login/page.tsx` の Suspense fallback 欠落 — 別issue化済み（人間レビューで決定）
-- 互換品の閲覧権限を施設スコープにすること — 人間レビューで「不要」と決定済み。今回はテナント非分離の前提で進める
-- ページネーション（LIMIT/OFFSET・cursor・無限スクロール） — 500件超過時に別issueで検討（人間レビューで決定した閾値）
-- `distributor_products` 削除時の `product_compatibilities` 孤立レコード対策（直接FKなし） — 表示はアプリ層フィルタで担保し、DB整合性上の孤立は許容。恒久対応は別issue
-- キーワード検索の `pg_trgm`/GIN インデックス導入 — マスタ件数が少ない前提のため初期実装では未導入。件数増大時に別issueで検討
+- 価格推移グラフ（issue本文にも明記。別issueで検討）
+- CSVエクスポート
+- submitフロー自体の実装（未解決事項2で「不要」と決定）
+- 過去データの遡及計算（未解決事項7）
+- 監査ログ（未解決事項6）
+- ページネーション（施設数が少ない前提。増大時は別issueで検討）

--- a/src/app/admin/reports/__tests__/page.test.tsx
+++ b/src/app/admin/reports/__tests__/page.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const pushMock = vi.fn()
+let searchParamsValue = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => searchParamsValue,
+}))
+
+import ReportsPage from '../page'
+
+describe('ReportsPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    pushMock.mockClear()
+    searchParamsValue = new URLSearchParams()
+  })
+
+  it('初回アクセス時（URLパラメータなし）は自動集計せず空状態を表示する', () => {
+    const fetchMock = vi.spyOn(global, 'fetch')
+    render(<ReportsPage />)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.getByText(/期間を指定して/)).toBeInTheDocument()
+  })
+
+  it('「集計する」押下でURLが更新される', async () => {
+    render(<ReportsPage />)
+
+    await userEvent.type(screen.getByLabelText('開始日'), '2026-01-01')
+    await userEvent.type(screen.getByLabelText('終了日'), '2026-01-31')
+    await userEvent.click(screen.getByRole('button', { name: '集計する' }))
+
+    expect(pushMock).toHaveBeenCalledWith('/admin/reports?date_from=2026-01-01&date_to=2026-01-31')
+  })
+
+  it('URLパラメータがある場合は集計APIを呼びテーブルを表示する', async () => {
+    searchParamsValue = new URLSearchParams('date_from=2026-01-01&date_to=2026-01-31')
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        rows: [
+          {
+            facilityId: 'f1',
+            facilityName: '施設A',
+            caseOrderAmount: 1000,
+            caseOrderCount: 1,
+            caseOrderTotalCount: 1,
+            consumableOrderAmount: null,
+            consumableOrderCount: 0,
+            consumableOrderTotalCount: 0,
+            loanOrderAmount: null,
+            loanOrderCount: 0,
+            loanOrderTotalCount: 0,
+          },
+        ],
+      }),
+    } as Response)
+
+    render(<ReportsPage />)
+
+    expect(await screen.findByText('施設A')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/reports?date_from=2026-01-01&date_to=2026-01-31')
+  })
+
+  it('集計中はローディング表示になる', async () => {
+    searchParamsValue = new URLSearchParams('date_from=2026-01-01&date_to=2026-01-31')
+    let resolveFetch!: (value: Response) => void
+    vi.spyOn(global, 'fetch').mockReturnValue(
+      new Promise<Response>((resolve) => { resolveFetch = resolve })
+    )
+
+    render(<ReportsPage />)
+
+    expect(await screen.findByText('集計中...')).toBeInTheDocument()
+
+    resolveFetch({ ok: true, json: async () => ({ rows: [] }) } as Response)
+    await waitFor(() => expect(screen.queryByText('集計中...')).not.toBeInTheDocument())
+  })
+
+  it('集計APIが失敗した場合はエラーメッセージを表示する', async () => {
+    searchParamsValue = new URLSearchParams('date_from=2026-01-01&date_to=2026-01-31')
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, json: async () => ({}) } as Response)
+
+    render(<ReportsPage />)
+
+    expect(await screen.findByText('集計データの取得に失敗しました')).toBeInTheDocument()
+  })
+})

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { OrderAmountReportRow } from '@/types/report'
+import { ReportFilters } from '@/components/reports/ReportFilters'
+import { ReportTable } from '@/components/reports/ReportTable'
+
+// WHY: issue #23 Part2 Set F。useSearchParams()を使うためSuspense必須ラップ
+// （src/app/orders/page.tsxパターン踏襲）。
+
+function ReportsPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const dateFrom = searchParams.get('date_from') ?? ''
+  const dateTo = searchParams.get('date_to') ?? ''
+  // WHY: 未解決事項5「ページ初回表示は自動集計せず空状態」を、URLに期間パラメータが
+  //      1つも無いかどうかで判定する。
+  const hasFilter = Boolean(dateFrom || dateTo)
+
+  const [rows, setRows] = useState<OrderAmountReportRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      if (!hasFilter) return
+      setLoading(true)
+      setError(null)
+      try {
+        const params = new URLSearchParams()
+        if (dateFrom) params.set('date_from', dateFrom)
+        if (dateTo) params.set('date_to', dateTo)
+        const res = await fetch(`/api/admin/reports?${params.toString()}`)
+        if (!res.ok) throw new Error()
+        const data = await res.json()
+        if (cancelled) return
+        setRows(data.rows ?? [])
+      } catch {
+        if (!cancelled) setError('集計データの取得に失敗しました')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [hasFilter, dateFrom, dateTo])
+
+  function handleSubmit(filter: { dateFrom: string; dateTo: string }) {
+    const params = new URLSearchParams()
+    if (filter.dateFrom) params.set('date_from', filter.dateFrom)
+    if (filter.dateTo) params.set('date_to', filter.dateTo)
+    const query = params.toString()
+    router.push(query ? `/admin/reports?${query}` : '/admin/reports')
+  }
+
+  return (
+    <div>
+      <div className="mb-8 border-b pb-4" style={{ borderColor: '#072C2C33' }}>
+        <p
+          className="text-xs font-semibold uppercase tracking-widest mb-1"
+          style={{ color: '#FF5F03', fontFamily: 'var(--font-oswald), sans-serif' }}
+        >
+          Reports
+        </p>
+        <h1
+          className="text-3xl font-bold"
+          style={{ color: '#072C2C', fontFamily: 'var(--font-oswald), sans-serif', letterSpacing: '0.04em' }}
+        >
+          分析・レポート
+        </h1>
+      </div>
+
+      {/* WHY: ブラウザの戻る/進むやURL直打ちでdateFrom/dateToが変わった場合、ReportFiltersの入力欄が
+          マウント時点の値のまま固定されてしまう（内部stateの初期値はpropsの変化に追従しない）バグを防ぐ。
+          key にURL由来の値を含めることでReactの推奨パターン(propsが変わったらstateをリセットする)通りに
+          コンポーネントを作り直し、setState-in-effectを避けつつ入力欄をURLと同期させる。 */}
+      <ReportFilters key={`${dateFrom}|${dateTo}`} dateFrom={dateFrom} dateTo={dateTo} onSubmit={handleSubmit} />
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded text-sm text-white" style={{ backgroundColor: '#DC2626' }}>
+          {error}
+        </div>
+      )}
+
+      {!error && !hasFilter && (
+        <p className="text-sm" style={{ color: '#6B7280' }}>
+          期間を指定して「集計する」を押してください
+        </p>
+      )}
+
+      {!error && hasFilter && loading && (
+        <p className="text-sm" style={{ color: '#6B7280' }}>集計中...</p>
+      )}
+
+      {!error && hasFilter && !loading && <ReportTable rows={rows} />}
+    </div>
+  )
+}
+
+export default function ReportsPage() {
+  return (
+    <Suspense fallback={<p className="text-sm" style={{ color: '#6B7280' }}>読み込み中...</p>}>
+      <ReportsPageInner />
+    </Suspense>
+  )
+}

--- a/src/app/api/admin/reports/__tests__/route.test.ts
+++ b/src/app/api/admin/reports/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockFetchOrderAmountReport = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/reports/repository', () => ({
+  fetchOrderAmountReport: (...args: unknown[]) => mockFetchOrderAmountReport(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+
+const ROW = {
+  facilityId: 'f1',
+  facilityName: '施設A',
+  caseOrderAmount: 1000,
+  caseOrderCount: 2,
+  caseOrderTotalCount: 2,
+  consumableOrderAmount: null,
+  consumableOrderCount: 0,
+  consumableOrderTotalCount: 0,
+  loanOrderAmount: 0,
+  loanOrderCount: 1,
+  loanOrderTotalCount: 1,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/admin/reports', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports'))
+    expect(res.status).toBe(401)
+    expect(mockFetchOrderAmountReport).not.toHaveBeenCalled()
+  })
+
+  it('一般ユーザー(非admin)の場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports'))
+    expect(res.status).toBe(403)
+    expect(mockFetchOrderAmountReport).not.toHaveBeenCalled()
+  })
+
+  it('date_fromが不正な形式の場合は400を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports?date_from=not-a-date'))
+    expect(res.status).toBe(400)
+    expect(mockFetchOrderAmountReport).not.toHaveBeenCalled()
+  })
+
+  it('date_toが不正な形式の場合は400を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports?date_to=2026-13-40'))
+    expect(res.status).toBe(400)
+    expect(mockFetchOrderAmountReport).not.toHaveBeenCalled()
+  })
+
+  it('date_from > date_to の場合は400を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports?date_from=2026-07-10&date_to=2026-07-01'))
+    expect(res.status).toBe(400)
+    expect(mockFetchOrderAmountReport).not.toHaveBeenCalled()
+  })
+
+  it('adminユーザーで正常にレポートを取得できる', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    mockFetchOrderAmountReport.mockResolvedValue([ROW])
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports?date_from=2026-07-01&date_to=2026-07-10'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.rows).toEqual([ROW])
+    expect(mockFetchOrderAmountReport).toHaveBeenCalledWith(
+      expect.anything(),
+      { dateFrom: '2026-07-01', dateTo: '2026-07-10' },
+    )
+  })
+
+  it('date_from/date_to省略時はfilterが空オブジェクトで呼ばれる', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    mockFetchOrderAmountReport.mockResolvedValue([])
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports'))
+    expect(res.status).toBe(200)
+    expect(mockFetchOrderAmountReport).toHaveBeenCalledWith(expect.anything(), {})
+  })
+
+  it('repositoryがpermission deniedを投げた場合は403に変換する', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    mockFetchOrderAmountReport.mockRejectedValue(new Error('permission denied'))
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports'))
+    expect(res.status).toBe(403)
+  })
+
+  it('repositoryがその他のエラーを投げた場合は500を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    mockFetchOrderAmountReport.mockRejectedValue(new Error('db error'))
+    const res = await GET(new NextRequest('http://localhost/api/admin/reports'))
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
+import { apiError } from '@/lib/api-error'
+import { isValidDateString } from '@/lib/jst-date-range'
+import { fetchOrderAmountReport } from '@/lib/reports/repository'
+import type {
+  OrderAmountReportApiErrorResponse,
+  OrderAmountReportApiQuery,
+  OrderAmountReportApiResponse,
+} from '@/types/report'
+
+// WHY: apiError は共通の { error: string } 形式を返すが、OrderAmountReportApiErrorResponse型と
+//      一致していることをコンパイル時に保証するため、戻り値をこの型でラップして返す
+function reportsApiError(message: string, status = 500): NextResponse<OrderAmountReportApiErrorResponse> {
+  return apiError(message, status)
+}
+
+// GET /api/admin/reports?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD
+// 施設別 × 発注種別（症例発注/消耗品発注/短貸発注）の発注金額集計をadminのみ閲覧できるAPI（issue #23 Part2 Set D）
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<OrderAmountReportApiResponse> | NextResponse<OrderAmountReportApiErrorResponse>> {
+  const db = await createServerSupabase()
+
+  let user
+  try {
+    user = await requireAuth(db)
+  } catch {
+    return reportsApiError('認証が必要です', 401)
+  }
+
+  // WHY: requireAdmin()(admin-auth.ts)は未認証/非adminをどちらもnullで返し401/403を区別できない。
+  //      本APIは受け入れ条件で401(未認証)と403(非admin)を明確に分けることが求められているため、
+  //      requireAuth()で認証チェック済みのユーザーに対してresolveIsAdmin()で個別にadmin判定する
+  const isAdmin = await resolveIsAdmin(db, user)
+  if (!isAdmin) return reportsApiError('権限がありません', 403)
+
+  const params = request.nextUrl.searchParams
+  const dateFrom = params.get('date_from')
+  const dateTo = params.get('date_to')
+
+  if (dateFrom && !isValidDateString(dateFrom)) {
+    return reportsApiError('date_from は YYYY-MM-DD 形式で指定してください', 400)
+  }
+  if (dateTo && !isValidDateString(dateTo)) {
+    return reportsApiError('date_to は YYYY-MM-DD 形式で指定してください', 400)
+  }
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    return reportsApiError('date_from は date_to 以前の日付を指定してください', 400)
+  }
+
+  const query: OrderAmountReportApiQuery = {
+    ...(dateFrom ? { dateFrom } : {}),
+    ...(dateTo ? { dateTo } : {}),
+  }
+
+  try {
+    const rows = await fetchOrderAmountReport(db, query)
+    const body: OrderAmountReportApiResponse = { rows }
+    return NextResponse.json(body)
+  } catch (error) {
+    // WHY: RPC(get_order_amount_report)内のis_admin()チェックはservice_roleを経由しない
+    //      SECURITY DEFINER関数だが、二重防御として万一permission deniedが漏れてきた場合も
+    //      500で隠さず403に変換する（Part2 Set D仕様）
+    const message = error instanceof Error ? error.message : ''
+    if (message.includes('permission denied')) {
+      return reportsApiError('権限がありません', 403)
+    }
+    return reportsApiError(message || '発注金額レポートの取得に失敗しました')
+  }
+}

--- a/src/components/dashboard/DashboardShortcuts.tsx
+++ b/src/components/dashboard/DashboardShortcuts.tsx
@@ -14,10 +14,16 @@ const BASE_SHORTCUTS = [
   { href: '/categories', label: 'カテゴリ一覧' },
 ]
 
-const ADMIN_SHORTCUT = { href: '/admin/users', label: '管理ユーザー' }
+// WHY: issue #23 Part2 Set F。admin向けショートカットが「管理ユーザー」の1件から2件になったため、
+//      単一オブジェクトではなく配列で保持する。呼び出し側は二重スプレッド([...BASE, ...ADMIN])で結合する
+//      （単純に配列へ差し替えるだけだと[...BASE, [...]]になり型が壊れるため注意）。
+const ADMIN_SHORTCUTS = [
+  { href: '/admin/users', label: '管理ユーザー' },
+  { href: '/admin/reports', label: 'レポート' },
+]
 
 export function DashboardShortcuts({ isAdmin }: DashboardShortcutsProps) {
-  const shortcuts = isAdmin ? [...BASE_SHORTCUTS, ADMIN_SHORTCUT] : BASE_SHORTCUTS
+  const shortcuts = isAdmin ? [...BASE_SHORTCUTS, ...ADMIN_SHORTCUTS] : BASE_SHORTCUTS
 
   return (
     <div className="flex flex-wrap gap-3">

--- a/src/components/dashboard/__tests__/DashboardShortcuts.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardShortcuts.test.tsx
@@ -21,4 +21,15 @@ describe('DashboardShortcuts', () => {
     render(<DashboardShortcuts isAdmin={true} />)
     expect(screen.getByRole('link', { name: /管理ユーザー/ })).toHaveAttribute('href', '/admin/users')
   })
+
+  // issue #23: adminのみ「レポート」ショートカットが表示される
+  it('admin権限がない場合はレポートページへのリンクが表示されない', () => {
+    render(<DashboardShortcuts isAdmin={false} />)
+    expect(screen.queryByRole('link', { name: /レポート/ })).not.toBeInTheDocument()
+  })
+
+  it('admin権限がある場合はレポートページへのリンクが表示される', () => {
+    render(<DashboardShortcuts isAdmin={true} />)
+    expect(screen.getByRole('link', { name: /レポート/ })).toHaveAttribute('href', '/admin/reports')
+  })
 })

--- a/src/components/reports/ReportFilters.tsx
+++ b/src/components/reports/ReportFilters.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+
+// WHY: issue #23 Part2 Set E。期間フィルタUI。「集計する」ボタン押下時のみonSubmitを呼び、
+//      開始日>終了日のバリデーションはAPIを呼ぶ前にここで弾く（受け入れ条件チェックリスト「期間フィルタ」）。
+
+type Props = {
+  dateFrom: string
+  dateTo: string
+  onSubmit: (filter: { dateFrom: string; dateTo: string }) => void
+}
+
+const labelClass = 'text-xs font-semibold uppercase tracking-widest mb-1 block'
+const labelStyle = { color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }
+const inputClass = 'rounded border px-3 py-2 text-sm'
+const inputStyle = { borderColor: '#072C2C33', color: '#072C2C' }
+
+export function ReportFilters({ dateFrom, dateTo, onSubmit }: Props) {
+  // WHY: URLパラメータ変更でも集計テーブルが更新される仕様(SPEC Part1「操作の流れ」3)のため、
+  //      入力欄自体はローカルstateで持ちつつ、propsのdateFrom/dateToを初期値として使う。
+  const [dateFromInput, setDateFromInput] = useState(dateFrom)
+  const [dateToInput, setDateToInput] = useState(dateTo)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSubmit() {
+    if (dateFromInput && dateToInput && dateFromInput > dateToInput) {
+      setError('開始日は終了日より前の日付を指定してください')
+      return
+    }
+    setError(null)
+    onSubmit({ dateFrom: dateFromInput, dateTo: dateToInput })
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <label htmlFor="report-date-from" className={labelClass} style={labelStyle}>開始日</label>
+          <input
+            id="report-date-from"
+            type="date"
+            value={dateFromInput}
+            onChange={(e) => setDateFromInput(e.target.value)}
+            className={inputClass}
+            style={inputStyle}
+          />
+        </div>
+        <div>
+          <label htmlFor="report-date-to" className={labelClass} style={labelStyle}>終了日</label>
+          <input
+            id="report-date-to"
+            type="date"
+            value={dateToInput}
+            onChange={(e) => setDateToInput(e.target.value)}
+            className={inputClass}
+            style={inputStyle}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="px-4 py-2 text-sm font-semibold text-white rounded"
+          style={{ backgroundColor: '#FF5F03' }}
+        >
+          集計する
+        </button>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm" style={{ color: '#DC2626' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/ReportTable.tsx
+++ b/src/components/reports/ReportTable.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import type { OrderAmountReportRow } from '@/types/report'
+
+// WHY: issue #23 Part2 Set E。未解決事項4のNULL/¥0/「-」表示区分ルールを実装する。
+//      当初は「発注0件」と「発注はあるが単価データなし」をamount=NULL・count=0のみで
+//      判定しており、種別単位で両者を区別できず、行全体がNULLのときも「本当に発注が0件」と
+//      誤判定する不具合があった（コードレビュー指摘: critical）。
+//      `get_order_amount_report`RPCが返す*_totalCount（価格の有無を問わない全明細件数）を使い、
+//      種別ごとに totalCount === 0 なら「発注0件」、totalCount > 0 かつ amount === null なら
+//      「発注はあるが単価データなし」と判定する（SPEC.md Part2 Set B参照）。
+
+const labelStyle = { color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }
+
+// WHY: 単価スナップショットはこの日付以降に作成された発注にのみ存在する
+// （supabase/migrations/20260715000001_add_unit_price_to_order_items.sql 適用日）。
+const UNIT_PRICE_SNAPSHOT_START_DATE = '2026-07-15'
+
+function formatYen(amount: number): string {
+  return `¥${amount.toLocaleString('ja-JP')}`
+}
+
+// WHY: 種別ごとの「発注0件」判定は totalCount(価格の有無を問わない全明細件数)のみで行う。
+//      count(単価データがある明細の件数)はamount集計に使われた件数であり、
+//      「発注はあるが単価データなし」の場合も0になるため、この判定には使えない。
+function hasNoOrdersInCategory(totalCount: number): boolean {
+  return totalCount === 0
+}
+
+function hasNoOrdersAtAll(row: OrderAmountReportRow): boolean {
+  return (
+    hasNoOrdersInCategory(row.caseOrderTotalCount) &&
+    hasNoOrdersInCategory(row.consumableOrderTotalCount) &&
+    hasNoOrdersInCategory(row.loanOrderTotalCount)
+  )
+}
+
+// WHY(important指摘対応・追加分): 「発注はあるが単価データが一切ない」施設が
+//      全種別に及ぶ場合（=いずれの種別も amount===null）、hasNoOrdersAtAll は
+//      false になるため合計を¥0として計算してしまうが、これは「確定0円」ではなく
+//      「金額が不明」であり誤解を招く。少なくとも1種別に発注があり(totalCount>0)、
+//      かつどの種別にも金額データが一切ない(全amountがnull)場合は合計も
+//      「-（金額データなし）」と表示する。
+function hasNoAmountDataAtAll(row: OrderAmountReportRow): boolean {
+  return (
+    row.caseOrderAmount === null &&
+    row.consumableOrderAmount === null &&
+    row.loanOrderAmount === null
+  )
+}
+
+function formatCell(amount: number | null, totalCount: number): string {
+  if (hasNoOrdersInCategory(totalCount)) return '-'
+  if (amount === null) return '-（金額データなし）'
+  return formatYen(amount)
+}
+
+// WHY(important指摘対応): 合計は「全種別が発注0件」の場合のみ「-」とし、それ以外は
+//      各種別のNULL（発注はあるが単価データなし、または発注0件で結果的にamount=null）を
+//      0とみなして加算する（SPEC.md Part2「集計テーブル」受け入れ条件のとおり）。
+//      hasNoOrdersAtAllをtotalCountベースに修正したことで、「一部の種別だけ単価データなし」の
+//      行を誤って「全種別発注0件」と判定してしまう境界条件の欠落も併せて解消している。
+//      さらに、発注はあるが全種別で単価データが一切ない場合（hasNoAmountDataAtAll）は
+//      「-（金額データなし）」を優先し、確定0円である「¥0」と誤表示しない。
+function formatTotal(row: OrderAmountReportRow): string {
+  if (hasNoOrdersAtAll(row)) return '-'
+  if (hasNoAmountDataAtAll(row)) return '-（金額データなし）'
+  const total = (row.caseOrderAmount ?? 0) + (row.consumableOrderAmount ?? 0) + (row.loanOrderAmount ?? 0)
+  return formatYen(total)
+}
+
+type Props = {
+  rows: OrderAmountReportRow[]
+}
+
+export function ReportTable({ rows }: Props) {
+  return (
+    <div>
+      <div className="rounded bg-white shadow-sm overflow-hidden" style={{ border: '1px solid #E5E7EB' }}>
+        <div className="overflow-x-auto">
+          <table className="min-w-full">
+            <thead>
+              <tr style={{ borderBottom: '1px solid #E5E7EB', backgroundColor: '#F9FAFB' }}>
+                <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-widest whitespace-nowrap" style={labelStyle}>施設名</th>
+                <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest whitespace-nowrap" style={labelStyle}>症例発注金額</th>
+                <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest whitespace-nowrap" style={labelStyle}>消耗品発注金額</th>
+                <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest whitespace-nowrap" style={labelStyle}>短貸発注金額</th>
+                <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-widest whitespace-nowrap" style={labelStyle}>合計</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                return (
+                  <tr key={row.facilityId} style={{ borderBottom: '1px solid #E5E7EB' }}>
+                    <td className="px-6 py-4 text-sm font-medium whitespace-nowrap" style={{ color: '#111827' }}>{row.facilityName}</td>
+                    <td className="px-6 py-4 text-sm text-right whitespace-nowrap" style={{ color: '#072C2C' }}>
+                      {formatCell(row.caseOrderAmount, row.caseOrderTotalCount)}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-right whitespace-nowrap" style={{ color: '#072C2C' }}>
+                      {formatCell(row.consumableOrderAmount, row.consumableOrderTotalCount)}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-right whitespace-nowrap" style={{ color: '#072C2C' }}>
+                      {formatCell(row.loanOrderAmount, row.loanOrderTotalCount)}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-right font-semibold whitespace-nowrap" style={{ color: '#072C2C' }}>
+                      {formatTotal(row)}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <p className="mt-3 text-xs" style={{ color: '#6B7280' }}>
+        {UNIT_PRICE_SNAPSHOT_START_DATE}以前の発注は金額データがありません
+      </p>
+    </div>
+  )
+}

--- a/src/components/reports/__tests__/ReportFilters.test.tsx
+++ b/src/components/reports/__tests__/ReportFilters.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReportFilters } from '../ReportFilters'
+
+describe('ReportFilters', () => {
+  it('開始日・終了日の初期値が表示される', () => {
+    render(<ReportFilters dateFrom="2026-01-01" dateTo="2026-01-31" onSubmit={vi.fn()} />)
+    expect(screen.getByLabelText('開始日')).toHaveValue('2026-01-01')
+    expect(screen.getByLabelText('終了日')).toHaveValue('2026-01-31')
+  })
+
+  it('「集計する」押下で入力値がonSubmitに渡される', async () => {
+    const onSubmit = vi.fn()
+    render(<ReportFilters dateFrom="" dateTo="" onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByLabelText('開始日'), '2026-01-01')
+    await userEvent.type(screen.getByLabelText('終了日'), '2026-01-31')
+    await userEvent.click(screen.getByRole('button', { name: '集計する' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({ dateFrom: '2026-01-01', dateTo: '2026-01-31' })
+  })
+
+  it('開始日が終了日より後の場合はバリデーションエラーを表示しonSubmitを呼ばない', async () => {
+    const onSubmit = vi.fn()
+    render(<ReportFilters dateFrom="" dateTo="" onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByLabelText('開始日'), '2026-02-01')
+    await userEvent.type(screen.getByLabelText('終了日'), '2026-01-01')
+    await userEvent.click(screen.getByRole('button', { name: '集計する' }))
+
+    expect(await screen.findByText('開始日は終了日より前の日付を指定してください')).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('開始日・終了日とも未入力でも集計できる（全期間扱い）', async () => {
+    const onSubmit = vi.fn()
+    render(<ReportFilters dateFrom="" dateTo="" onSubmit={onSubmit} />)
+
+    await userEvent.click(screen.getByRole('button', { name: '集計する' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({ dateFrom: '', dateTo: '' })
+  })
+})

--- a/src/components/reports/__tests__/ReportTable.test.tsx
+++ b/src/components/reports/__tests__/ReportTable.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { OrderAmountReportRow } from '@/types/report'
+import { ReportTable } from '../ReportTable'
+
+function makeRow(overrides: Partial<OrderAmountReportRow> = {}): OrderAmountReportRow {
+  return {
+    facilityId: 'f1',
+    facilityName: '施設A',
+    caseOrderAmount: null,
+    caseOrderCount: 0,
+    caseOrderTotalCount: 0,
+    consumableOrderAmount: null,
+    consumableOrderCount: 0,
+    consumableOrderTotalCount: 0,
+    loanOrderAmount: null,
+    loanOrderCount: 0,
+    loanOrderTotalCount: 0,
+    ...overrides,
+  }
+}
+
+describe('ReportTable', () => {
+  it('列見出しが「施設名 / 症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」の5列', () => {
+    render(<ReportTable rows={[]} />)
+    expect(screen.getByRole('columnheader', { name: '施設名' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: '症例発注金額' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: '消耗品発注金額' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: '短貸発注金額' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: '合計' })).toBeInTheDocument()
+  })
+
+  it('発注0件（全種別NULL・count=0）の施設は各セル・合計とも「-」と表示される', () => {
+    render(<ReportTable rows={[makeRow()]} />)
+    const row = screen.getByText('施設A').closest('tr')!
+    // 施設名以外の4セル(症例/消耗品/短貸/合計)すべて「-」
+    expect(row.textContent?.match(/-/g)?.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('発注はあるが単価データが一切ない場合は「-（金額データなし）」と表示される', () => {
+    const row = makeRow({
+      caseOrderAmount: null,
+      caseOrderCount: 0,
+      caseOrderTotalCount: 2,
+      consumableOrderAmount: 12000,
+      consumableOrderCount: 3,
+      consumableOrderTotalCount: 3,
+    })
+    render(<ReportTable rows={[row]} />)
+    expect(screen.getAllByText('-（金額データなし）').length).toBeGreaterThan(0)
+  })
+
+  it('集計値が0円の場合は「¥0」と表示される（金額データなしとは区別）', () => {
+    const row = makeRow({
+      caseOrderAmount: 0,
+      caseOrderCount: 1,
+      caseOrderTotalCount: 1,
+      consumableOrderAmount: 5000,
+      consumableOrderCount: 1,
+      consumableOrderTotalCount: 1,
+    })
+    render(<ReportTable rows={[row]} />)
+    expect(screen.getByText('¥0')).toBeInTheDocument()
+  })
+
+  it('金額はカンマ区切りの円表示になる', () => {
+    const row = makeRow({
+      caseOrderAmount: 1234567,
+      caseOrderCount: 10,
+      caseOrderTotalCount: 10,
+    })
+    render(<ReportTable rows={[row]} />)
+    expect(screen.getAllByText('¥1,234,567').length).toBeGreaterThan(0)
+  })
+
+  it('（critical指摘の回帰）種別ごとに「発注0件」と「発注はあるが単価データなし」を正しく区別する', () => {
+    // 症例発注: 本当に0件（caseOrderTotalCount=0）
+    // 消耗品発注: 発注はあるが単価データなし（totalCount>0だがamount=null・count=0）
+    // 短貸発注: 金額データあり（他種別に引きずられて「発注0件」と誤判定されないことを確認する行）
+    const row = makeRow({
+      caseOrderAmount: null,
+      caseOrderCount: 0,
+      caseOrderTotalCount: 0,
+      consumableOrderAmount: null,
+      consumableOrderCount: 0,
+      consumableOrderTotalCount: 4,
+      loanOrderAmount: 3000,
+      loanOrderCount: 1,
+      loanOrderTotalCount: 1,
+    })
+    render(<ReportTable rows={[row]} />)
+    const tr = screen.getByText('施設A').closest('tr')!
+    const cells = Array.from(tr.querySelectorAll('td')).map((td) => td.textContent)
+    // 施設名, 症例(発注0件→'-'), 消耗品(単価データなし), 短貸(金額), 合計
+    expect(cells[1]).toBe('-')
+    expect(cells[2]).toBe('-（金額データなし）')
+    expect(cells[3]).toBe('¥3,000')
+    // 合計は「全種別が発注0件」ではない（短貸に金額あり）ため、NULLを0とみなして加算した値になる
+    expect(cells[4]).toBe('¥3,000')
+  })
+
+  it('合計列は各種別のNULLを0とみなして加算する', () => {
+    const row = makeRow({
+      caseOrderAmount: 1000,
+      caseOrderCount: 1,
+      caseOrderTotalCount: 1,
+      consumableOrderAmount: null,
+      consumableOrderCount: 0,
+      consumableOrderTotalCount: 0,
+      loanOrderAmount: 2000,
+      loanOrderCount: 1,
+      loanOrderTotalCount: 1,
+    })
+    render(<ReportTable rows={[row]} />)
+    expect(screen.getByText('¥3,000')).toBeInTheDocument()
+  })
+
+  it('（important指摘対応: 全種別に発注はあるが単価データが一切ない場合、合計は「¥0」ではなく「-（金額データなし）」と表示される', () => {
+    // 3種別すべて totalCount>0（発注はある）だが amount=null（単価データなし）。
+    // 「全種別発注0件」ではないため従来ロジックだと合計は¥0になってしまうが、
+    // 実際には金額が不明なだけで確定0円ではないため区別が必要。
+    const row = makeRow({
+      caseOrderAmount: null,
+      caseOrderCount: 0,
+      caseOrderTotalCount: 2,
+      consumableOrderAmount: null,
+      consumableOrderCount: 0,
+      consumableOrderTotalCount: 3,
+      loanOrderAmount: null,
+      loanOrderCount: 0,
+      loanOrderTotalCount: 1,
+    })
+    render(<ReportTable rows={[row]} />)
+    const tr = screen.getByText('施設A').closest('tr')!
+    const cells = Array.from(tr.querySelectorAll('td')).map((td) => td.textContent)
+    expect(cells[4]).toBe('-（金額データなし）')
+  })
+
+  it('ページ下部に単価データ開始日の注釈が表示される', () => {
+    render(<ReportTable rows={[]} />)
+    expect(screen.getByText(/以前の発注は金額データがありません/)).toBeInTheDocument()
+  })
+})

--- a/src/lib/reports/__tests__/repository.test.ts
+++ b/src/lib/reports/__tests__/repository.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { fetchOrderAmountReport } from '@/lib/reports/repository'
+
+function makeMockRpcDb(rpcResult: { data: unknown; error: unknown }): { db: SupabaseClient; rpc: ReturnType<typeof vi.fn> } {
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+  const db = { rpc } as unknown as SupabaseClient
+  return { db, rpc }
+}
+
+describe('fetchOrderAmountReport', () => {
+  it('RPCを正しい引数(JST日境界のTIMESTAMPTZ)で呼び出す', async () => {
+    const { db, rpc } = makeMockRpcDb({ data: [], error: null })
+
+    await fetchOrderAmountReport(db, { dateFrom: '2026-07-01', dateTo: '2026-07-31' })
+
+    expect(rpc).toHaveBeenCalledWith('get_order_amount_report', {
+      p_date_from: '2026-07-01T00:00:00+09:00',
+      p_date_to: '2026-07-31T23:59:59+09:00',
+    })
+  })
+
+  it('dateFrom/dateTo省略時はnullを渡す', async () => {
+    const { db, rpc } = makeMockRpcDb({ data: [], error: null })
+
+    await fetchOrderAmountReport(db, {})
+
+    expect(rpc).toHaveBeenCalledWith('get_order_amount_report', {
+      p_date_from: null,
+      p_date_to: null,
+    })
+  })
+
+  it('全フィールドをスネークケースからキャメルケースへマッピングする（*_total_countも含む）', async () => {
+    const rpcRow = {
+      facility_id: 'f-1',
+      facility_name: 'テスト施設A',
+      case_order_amount: 12345,
+      case_order_count: 3,
+      case_order_total_count: 3,
+      consumable_order_amount: null,
+      consumable_order_count: 0,
+      consumable_order_total_count: 5,
+      loan_order_amount: 0,
+      loan_order_count: 2,
+      loan_order_total_count: 2,
+    }
+    const { db } = makeMockRpcDb({ data: [rpcRow], error: null })
+
+    const result = await fetchOrderAmountReport(db, {})
+
+    expect(result).toEqual([
+      {
+        facilityId: 'f-1',
+        facilityName: 'テスト施設A',
+        caseOrderAmount: 12345,
+        caseOrderCount: 3,
+        caseOrderTotalCount: 3,
+        consumableOrderAmount: null,
+        consumableOrderCount: 0,
+        consumableOrderTotalCount: 5,
+        loanOrderAmount: 0,
+        loanOrderCount: 2,
+        loanOrderTotalCount: 2,
+      },
+    ])
+  })
+
+  it('data=nullの場合は空配列を返す', async () => {
+    const { db } = makeMockRpcDb({ data: null, error: null })
+
+    const result = await fetchOrderAmountReport(db, {})
+
+    expect(result).toEqual([])
+  })
+
+  it('RPCがエラーを返した場合はthrowする', async () => {
+    const { db } = makeMockRpcDb({ data: null, error: { message: 'permission denied' } })
+
+    await expect(fetchOrderAmountReport(db, {})).rejects.toThrow('permission denied')
+  })
+})

--- a/src/lib/reports/repository.ts
+++ b/src/lib/reports/repository.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { asString, asNullableNumber, asNumber } from '@/lib/mapping'
+import { jstDayStart, jstDayEnd } from '@/lib/jst-date-range'
+import type { OrderAmountReportRow, OrderAmountReportFilter } from '@/types/report'
+
+interface OrderAmountReportRpcRow {
+  facility_id?: unknown
+  facility_name?: unknown
+  case_order_amount?: unknown
+  case_order_count?: unknown
+  case_order_total_count?: unknown
+  consumable_order_amount?: unknown
+  consumable_order_count?: unknown
+  consumable_order_total_count?: unknown
+  loan_order_amount?: unknown
+  loan_order_count?: unknown
+  loan_order_total_count?: unknown
+}
+
+function mapRow(row: OrderAmountReportRpcRow): OrderAmountReportRow {
+  return {
+    facilityId: asString(row.facility_id),
+    facilityName: asString(row.facility_name),
+    caseOrderAmount: asNullableNumber(row.case_order_amount),
+    caseOrderCount: asNumber(row.case_order_count),
+    caseOrderTotalCount: asNumber(row.case_order_total_count),
+    consumableOrderAmount: asNullableNumber(row.consumable_order_amount),
+    consumableOrderCount: asNumber(row.consumable_order_count),
+    consumableOrderTotalCount: asNumber(row.consumable_order_total_count),
+    loanOrderAmount: asNullableNumber(row.loan_order_amount),
+    loanOrderCount: asNumber(row.loan_order_count),
+    loanOrderTotalCount: asNumber(row.loan_order_total_count),
+  }
+}
+
+/**
+ * 施設別×発注種別の発注金額集計を取得する（issue #23 分析・レポートページ）。
+ * dateFrom/dateTo（YYYY-MM-DD）は jstDayStart/jstDayEnd でJST日境界のTIMESTAMPTZに変換してから
+ * RPC(get_order_amount_report)へ渡す。RPC側でis_admin()チェックがあり、非adminの場合は
+ * permission deniedエラーになる（API層(route.ts)で403に変換する想定。ここではそのままthrowする）。
+ */
+export async function fetchOrderAmountReport(
+  db: SupabaseClient,
+  filter: OrderAmountReportFilter
+): Promise<OrderAmountReportRow[]> {
+  const { data, error } = await db.rpc('get_order_amount_report', {
+    p_date_from: filter.dateFrom ? jstDayStart(filter.dateFrom) : null,
+    p_date_to: filter.dateTo ? jstDayEnd(filter.dateTo) : null,
+  })
+  if (error) throw new Error(error.message)
+
+  return ((data ?? []) as OrderAmountReportRpcRow[]).map(mapRow)
+}

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,57 @@
+/**
+ * 分析・レポートページ（issue #23）
+ * Set C: `get_order_amount_report` RPC の戻り値をキャメルケース化した型
+ */
+export type OrderAmountReportRow = {
+  facilityId: string
+  facilityName: string
+  /** NULL: 発注はあるが単価データなし（未解決事項4）。0円は number の 0 として区別される */
+  caseOrderAmount: number | null
+  /** 単価データがある明細の件数（金額集計に使われた件数。0件だけでは「発注0件」と区別できないため caseOrderTotalCount と併用する） */
+  caseOrderCount: number
+  /**
+   * 価格の有無を問わない全明細件数。0 なら「発注自体が0件」、0より大きく caseOrderAmount が
+   * null なら「発注はあるが単価データなし」と判定できる（レビュー指摘: critical
+   * 「発注0件と単価データなしの区別ができない」への対応。SPEC.md Part2 Set B参照）
+   */
+  caseOrderTotalCount: number
+  consumableOrderAmount: number | null
+  consumableOrderCount: number
+  consumableOrderTotalCount: number
+  loanOrderAmount: number | null
+  loanOrderCount: number
+  loanOrderTotalCount: number
+}
+
+/**
+ * Set C: fetchOrderAmountReport の filter 引数 / Set D: APIクエリパラメータの由来
+ * dateFrom/dateTo は YYYY-MM-DD（JST日境界への変換は repository 側の責務。
+ * `src/lib/jst-date-range.ts` の jstDayStart/jstDayEnd を再利用する）
+ */
+export type OrderAmountReportFilter = {
+  dateFrom?: string
+  dateTo?: string
+}
+
+/**
+ * GET /api/admin/reports のクエリパラメータ（パース・バリデーション後の型）
+ * Set D: date_from/date_to は isValidDateString() でYYYY-MM-DD形式チェック済み、
+ * dateFrom > dateTo でないことを route 側で検証済みとする
+ */
+export type OrderAmountReportApiQuery = OrderAmountReportFilter
+
+/**
+ * GET /api/admin/reports のレスポンス型（成功時）
+ * Set D: route.ts が返すペイロード
+ */
+export type OrderAmountReportApiResponse = {
+  rows: OrderAmountReportRow[]
+}
+
+/**
+ * GET /api/admin/reports のエラーレスポンス型
+ * 400: date_from/date_to 形式不正・dateFrom > dateTo, 401: 未認証, 403: 非admin, 500: サーバーエラー
+ */
+export type OrderAmountReportApiErrorResponse = {
+  error: string
+}

--- a/supabase/migrations/20260715000001_add_unit_price_to_order_items.sql
+++ b/supabase/migrations/20260715000001_add_unit_price_to_order_items.sql
@@ -1,0 +1,22 @@
+-- supabase/migrations/20260715000001_add_unit_price_to_order_items.sql
+-- issue #23 Part2 Set A: 発注明細に単価スナップショット用カラムを追加する。
+-- WHY: 過去発注の金額を「発注時点の単価」で再現できるようにするため
+--      （現在のhospital_pricesをJOINして計算する方式は履歴精度が失われるため不採用）。
+
+ALTER TABLE case_order_items       ADD COLUMN unit_price NUMERIC(12,2);
+ALTER TABLE consumable_order_items ADD COLUMN unit_price NUMERIC(12,2);
+ALTER TABLE loan_order_items       ADD COLUMN unit_price NUMERIC(12,2);
+
+-- 既存データはNULL（過去発注は金額データなし、未解決事項7で確定）。カラム追加のみで
+-- テーブル新設/削除ではないため refresh_schema_baseline_snapshot は不要（issue #305要件の対象外）。
+
+-- WHY(重複・過剰実装指摘対応): 当初SPEC.mdは「20260714000005_orders_history_prereqs.sqlが
+-- consumable_orders/loan_orders/loan_returnsの(facility_id, created_at)複合インデックスを
+-- 追加済みだが、case_ordersが欠落している」という前提でCREATE INDEXを追加していたが、この前提は
+-- 誤りだった。case_ordersには20260626000000_fix_fk_and_indexes.sqlで既に
+-- idx_case_orders_facility_created_at ON case_orders (facility_id, created_at) が作成済みであり、
+-- 同名インデックスをCREATE INDEX IF NOT EXISTSで再作成しようとしても既存インデックス名と衝突して
+-- 静かにno-opになる（DESC指定が実際には反映されない死んだ文になっていた）。
+-- btreeインデックスは昇順・降順どちらの範囲検索・ORDER BYにも双方向で使えるため、DESC無しの
+-- 既存インデックスで本レポート機能（WHERE created_at範囲 + GROUP BY facility_id）の要件は
+-- 満たされる。よって本migrationでは重複するインデックス作成を行わない。

--- a/supabase/migrations/20260715000002_add_unit_price_snapshot_to_order_rpcs.sql
+++ b/supabase/migrations/20260715000002_add_unit_price_snapshot_to_order_rpcs.sql
@@ -1,0 +1,177 @@
+-- supabase/migrations/20260715000002_add_unit_price_snapshot_to_order_rpcs.sql
+-- issue #23 Part2 Set A-2: 発注作成RPC内で単価スナップショットを保存する。
+-- WHY: 既存migrationは追記・修正禁止のため、CREATE OR REPLACE FUNCTIONで既存RPCを更新する。
+--      単価解決に失敗しても発注作成自体は失敗させない（best-effort、未解決事項1・2・3・
+--      受け入れ条件「データ精度」に対応）。
+
+-- WHY(重複実装指摘対応): create_case_order_atomicとcreate_loan_order_atomicは
+--      jan→products→distributor_products→hospital_pricesという全く同一の単価解決クエリを
+--      使用していた（レビュー指摘: important「重複実装」）。共通のSQL関数
+--      resolve_jan_unit_price(p_jan, p_facility_id)に集約し、両RPCから呼び出す形にする。
+--      consumable_order側はconsumable_id→consumables(jan)というjan解決の前段が異なるため、
+--      consumables.janを求めたうえで同じresolve_jan_unit_priceを呼び出す。
+CREATE OR REPLACE FUNCTION resolve_jan_unit_price(
+  p_jan TEXT,
+  p_facility_id UUID
+)
+RETURNS NUMERIC
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT MIN(hp.purchase_price)
+  FROM products p
+  JOIN distributor_products dp ON dp.product_id = p.id
+  JOIN hospital_prices hp
+    ON hp.distributor_product_id = dp.id
+   AND hp.facility_id = p_facility_id
+  WHERE p.jan = p_jan
+$$;
+
+-- WHY(コードレビュー指摘対応・important): 本関数にGRANT EXECUTEが無いまま暗黙のPUBLIC権限に
+-- 依存していた。is_facility_member()に対して20260711000001_grant_execute_is_facility_member.sql
+-- が明示的GRANTを追加した既存実績と同じ理由で、明示的に付与する（将来PUBLICへの自動権限付与が
+-- revokeされた場合でも、create_*_order_atomicからの呼び出しがbest-effort原則を保てるように）。
+GRANT EXECUTE ON FUNCTION resolve_jan_unit_price(TEXT, UUID) TO authenticated;
+
+-- 症例発注
+CREATE OR REPLACE FUNCTION create_case_order_atomic(
+  p_facility_id UUID,
+  p_case_datetime TIMESTAMPTZ,
+  p_procedure_name TEXT,
+  p_patient_id TEXT,
+  p_patient_initials TEXT,
+  p_gender TEXT,
+  p_doctor_name TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order case_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO case_orders (
+    facility_id, case_datetime, procedure_name,
+    patient_id, patient_initials, gender, doctor_name
+  ) VALUES (
+    p_facility_id, p_case_datetime, p_procedure_name,
+    p_patient_id, p_patient_initials, p_gender, p_doctor_name
+  )
+  RETURNING * INTO v_order;
+
+  -- 単価解決はresolve_jan_unit_price()に委譲する（未解決事項3: MIN(purchase_price)採用）。
+  -- 該当行なしの場合はNULLのまま挿入する（best-effort、例外を投げない）。
+  INSERT INTO case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM case_order_items i
+  WHERE i.case_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+-- 短貸発注
+CREATE OR REPLACE FUNCTION create_loan_order_atomic(
+  p_facility_id UUID,
+  p_procedure_name TEXT,
+  p_maker TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order loan_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO loan_orders (facility_id, procedure_name, maker)
+  VALUES (p_facility_id, p_procedure_name, p_maker)
+  RETURNING * INTO v_order;
+
+  -- case_order_itemsと同型の単価解決パス（jan起点）。resolve_jan_unit_price()に委譲する。
+  INSERT INTO loan_order_items (loan_order_id, jan, name, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'name',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM loan_order_items i
+  WHERE i.loan_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+-- 消耗品発注
+CREATE OR REPLACE FUNCTION create_consumable_order_atomic(
+  p_facility_id UUID,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order consumable_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO consumable_orders (facility_id)
+  VALUES (p_facility_id)
+  RETURNING * INTO v_order;
+
+  -- 単価解決: consumable_id → consumables(jan) を経てから resolve_jan_unit_price() に委譲する。
+  -- consumables.janがNULL、または該当行なしの場合はNULLのまま挿入する（best-effort）。
+  INSERT INTO consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)
+  SELECT
+    v_order.id,
+    (elem->>'consumable_id')::UUID,
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    (
+      SELECT resolve_jan_unit_price(c.jan, p_facility_id)
+      FROM consumables c
+      WHERE c.id = (elem->>'consumable_id')::UUID
+    )
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM consumable_order_items i
+  WHERE i.consumable_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;

--- a/supabase/migrations/20260715000003_add_order_amount_report_rpc.sql
+++ b/supabase/migrations/20260715000003_add_order_amount_report_rpc.sql
@@ -1,0 +1,97 @@
+-- supabase/migrations/20260715000003_add_order_amount_report_rpc.sql
+-- issue #23 Part2 Set B: 施設別×発注種別の発注金額集計RPC。
+-- WHY: adminのみが全施設の金額を横断集計できるようにするため、SECURITY DEFINER +
+--      is_admin()チェックで実装する（既存admin-auth.tsパターンを踏襲）。
+--
+-- WHY(*_total_count列): 当初案では*_count(単価データがある明細の件数)がゼロの場合、
+--   「発注自体が0件」なのか「発注はあるが全明細のunit_priceがNULL(金額データなし)」なのかを
+--   区別できず、UI側で両者を誤って同一視してしまうcriticalなバグがあった(コードレビュー指摘)。
+--   *_total_count(価格の有無を問わない全明細件数)を追加で返し、
+--     total_count = 0            → 発注自体が0件
+--     total_count > 0 かつ amount IS NULL → 発注はあるが金額データなし
+--   をUI側(ReportTable)で区別できるようにする。
+
+CREATE OR REPLACE FUNCTION get_order_amount_report(
+  p_date_from TIMESTAMPTZ,
+  p_date_to TIMESTAMPTZ
+)
+RETURNS TABLE(
+  facility_id UUID,
+  facility_name TEXT,
+  case_order_amount NUMERIC,
+  case_order_count INTEGER,
+  case_order_total_count INTEGER,
+  consumable_order_amount NUMERIC,
+  consumable_order_count INTEGER,
+  consumable_order_total_count INTEGER,
+  loan_order_amount NUMERIC,
+  loan_order_count INTEGER,
+  loan_order_total_count INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'permission denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    f.id AS facility_id,
+    f.name AS facility_name,
+    co_agg.amount AS case_order_amount,
+    COALESCE(co_agg.cnt, 0)::INTEGER AS case_order_count,
+    COALESCE(co_agg.total_cnt, 0)::INTEGER AS case_order_total_count,
+    cons_agg.amount AS consumable_order_amount,
+    COALESCE(cons_agg.cnt, 0)::INTEGER AS consumable_order_count,
+    COALESCE(cons_agg.total_cnt, 0)::INTEGER AS consumable_order_total_count,
+    loan_agg.amount AS loan_order_amount,
+    COALESCE(loan_agg.cnt, 0)::INTEGER AS loan_order_count,
+    COALESCE(loan_agg.total_cnt, 0)::INTEGER AS loan_order_total_count
+  FROM facilities f
+  LEFT JOIN (
+    SELECT
+      co.facility_id,
+      SUM(coi.unit_price * coi.quantity) FILTER (WHERE coi.unit_price IS NOT NULL) AS amount,
+      COUNT(*) FILTER (WHERE coi.unit_price IS NOT NULL) AS cnt,
+      COUNT(*) AS total_cnt
+    FROM case_orders co
+    JOIN case_order_items coi ON coi.case_order_id = co.id
+    WHERE (p_date_from IS NULL OR co.created_at >= p_date_from)
+      AND (p_date_to IS NULL OR co.created_at <= p_date_to)
+    GROUP BY co.facility_id
+  ) co_agg ON co_agg.facility_id = f.id
+  LEFT JOIN (
+    SELECT
+      cons.facility_id,
+      SUM(coi.unit_price * coi.quantity) FILTER (WHERE coi.unit_price IS NOT NULL) AS amount,
+      COUNT(*) FILTER (WHERE coi.unit_price IS NOT NULL) AS cnt,
+      COUNT(*) AS total_cnt
+    FROM consumable_orders cons
+    JOIN consumable_order_items coi ON coi.consumable_order_id = cons.id
+    WHERE (p_date_from IS NULL OR cons.created_at >= p_date_from)
+      AND (p_date_to IS NULL OR cons.created_at <= p_date_to)
+    GROUP BY cons.facility_id
+  ) cons_agg ON cons_agg.facility_id = f.id
+  LEFT JOIN (
+    SELECT
+      lo.facility_id,
+      SUM(loi.unit_price * loi.quantity) FILTER (WHERE loi.unit_price IS NOT NULL) AS amount,
+      COUNT(*) FILTER (WHERE loi.unit_price IS NOT NULL) AS cnt,
+      COUNT(*) AS total_cnt
+    FROM loan_orders lo
+    JOIN loan_order_items loi ON loi.loan_order_id = lo.id
+    WHERE (p_date_from IS NULL OR lo.created_at >= p_date_from)
+      AND (p_date_to IS NULL OR lo.created_at <= p_date_to)
+    GROUP BY lo.facility_id
+  ) loan_agg ON loan_agg.facility_id = f.id
+  ORDER BY f.name;
+END;
+$$;
+
+-- anonは除外し、実行時の最終ガードは関数内is_admin()に委ねる。
+GRANT EXECUTE ON FUNCTION get_order_amount_report(TIMESTAMPTZ, TIMESTAMPTZ) TO authenticated, service_role;
+
+-- 新規テーブルの追加/削除を伴わない（RPC新設のみ）ため refresh_schema_baseline_snapshot は不要。

--- a/supabase/migrations/__tests__/add_order_amount_report_rpc.test.ts
+++ b/supabase/migrations/__tests__/add_order_amount_report_rpc.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(SPEC.md Part2 Set B)を
+//      満たすかを静的に検証することで、回帰テストとして固定する。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_order_amount_report_rpc.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_order_amount_report_rpc.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('get_order_amount_report(p_date_from TIMESTAMPTZ, p_date_to TIMESTAMPTZ)を定義する', () => {
+    expect(n).toContain('create or replace function get_order_amount_report( p_date_from timestamptz, p_date_to timestamptz )'.replace(/ +/g, ' '))
+  })
+
+  it('戻り値の11列すべてを定義する（*_total_countは発注0件と金額データなしを区別するための列）', () => {
+    for (const col of [
+      'facility_id uuid',
+      'facility_name text',
+      'case_order_amount numeric',
+      'case_order_count integer',
+      'case_order_total_count integer',
+      'consumable_order_amount numeric',
+      'consumable_order_count integer',
+      'consumable_order_total_count integer',
+      'loan_order_amount numeric',
+      'loan_order_count integer',
+      'loan_order_total_count integer',
+    ]) {
+      expect(n).toContain(col)
+    }
+  })
+
+  it('*_total_countは単価の有無を問わない全明細件数(COUNT(*))として定義される', () => {
+    expect((n.match(/count\(\*\) as total_cnt/g) ?? []).length).toBe(3)
+  })
+
+  it('SECURITY DEFINERかつSET search_path = publicで、is_admin()チェックを持つ', () => {
+    expect(n).toContain('security definer')
+    expect(n).toContain('set search_path = public')
+    expect(n).toContain('if not is_admin() then')
+    expect(n).toContain("raise exception 'permission denied'")
+  })
+
+  it('facilitiesを起点にLEFT JOINし全施設が出力される設計になっている', () => {
+    expect(n).toContain('from facilities f')
+    expect(n).toContain('left join')
+  })
+
+  it('各発注種別のWHERE句が期間フィルタ(NULL許容)になっている', () => {
+    const occurrences = n.match(/\(p_date_from is null or .*?>= p_date_from\)/g) ?? []
+    expect(occurrences.length).toBe(3)
+  })
+
+  it('unit_priceがNULLの明細を除外してSUM/COUNTし、結果をCOALESCEしない(UI側で判定するためNULLのまま返す)', () => {
+    expect(n).toContain('filter (where coi.unit_price is not null)')
+    expect(n).toContain('filter (where loi.unit_price is not null)')
+    // amountカラム自体はCOALESCEしない(NULLのまま返す)。count側のみCOALESCE(..., 0)する。
+    expect(n).not.toMatch(/coalesce\(co_agg\.amount/)
+    expect(n).not.toMatch(/coalesce\(cons_agg\.amount/)
+    expect(n).not.toMatch(/coalesce\(loan_agg\.amount/)
+  })
+
+  it('GRANT EXECUTEはauthenticated/service_roleのみでanonを含まない', () => {
+    expect(n).toContain('grant execute on function get_order_amount_report(timestamptz, timestamptz) to authenticated, service_role')
+    expect(n).not.toMatch(/grant execute on function get_order_amount_report[^;]*anon/)
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})

--- a/supabase/migrations/__tests__/add_unit_price_snapshot_to_order_rpcs.test.ts
+++ b/supabase/migrations/__tests__/add_unit_price_snapshot_to_order_rpcs.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(SPEC.md Part2 Set A-2)を
+//      満たすかを静的に検証することで、回帰テストとして固定する。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_unit_price_snapshot_to_order_rpcs.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_unit_price_snapshot_to_order_rpcs.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('既存migrationを追記せず、CREATE OR REPLACE FUNCTIONで3つのRPCを再定義する', () => {
+    expect(n).toContain('create or replace function create_case_order_atomic(')
+    expect(n).toContain('create or replace function create_loan_order_atomic(')
+    expect(n).toContain('create or replace function create_consumable_order_atomic(')
+  })
+
+  it('is_facility_memberチェックを維持している（施設境界チェックの退行防止）', () => {
+    const occurrences = n.match(/if not is_facility_member\(p_facility_id\) then/g) ?? []
+    expect(occurrences.length).toBe(3)
+  })
+
+  it('resolve_jan_unit_priceにGRANT EXECUTEが明示的に付与されている（暗黙のPUBLIC権限に依存しない）', () => {
+    expect(n).toContain('grant execute on function resolve_jan_unit_price(text, uuid) to authenticated')
+  })
+
+  it('resolve_jan_unit_price内でjan→products→distributor_products→hospital_pricesの経路でunit_priceを解決する', () => {
+    expect(n).toContain('from products p')
+    expect(n).toContain('join distributor_products dp on dp.product_id = p.id')
+    expect(n).toContain('join hospital_prices hp')
+    expect(n).toContain('hp.distributor_product_id = dp.id')
+    expect(n).toContain('hp.facility_id = p_facility_id')
+  })
+
+  it('case_order_itemsとloan_order_itemsはそれぞれresolve_jan_unit_price(elem->>\'jan\', p_facility_id)を呼び出す', () => {
+    expect(n).toContain("insert into case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price) select v_order.id, elem->>'jan', elem->>'lot', elem->>'ubd', coalesce((elem->>'quantity')::integer, 1), resolve_jan_unit_price(elem->>'jan', p_facility_id)")
+    expect(n).toContain("insert into loan_order_items (loan_order_id, jan, name, quantity, unit_price) select v_order.id, elem->>'jan', elem->>'name', coalesce((elem->>'quantity')::integer, 1), resolve_jan_unit_price(elem->>'jan', p_facility_id)")
+  })
+
+  it('consumable_order_itemsはconsumable_id→consumables(jan)の経路でjanを求め、resolve_jan_unit_price(products→distributor_products→hospital_prices経路)に委譲する', () => {
+    expect(n).toContain('from consumables c')
+    expect(n).toContain('resolve_jan_unit_price(c.jan, p_facility_id)')
+  })
+
+  // WHY(重複実装指摘対応): case_order_itemsとloan_order_itemsは全く同一の単価解決クエリ
+  //     (jan→products→distributor_products→hospital_prices, MIN(purchase_price))を使うため、
+  //     共通のSQL関数resolve_jan_unit_priceに切り出して重複を排除する。
+  //     consumable側はconsumables経由の別経路のため、同関数を呼び出しつつ最終的なjan解決だけ
+  //     独自に行う（呼び出し1回として数える）。
+  it('共通ヘルパー関数resolve_jan_unit_priceに単価解決ロジックを集約し、重複実装しない', () => {
+    expect(n).toContain('create or replace function resolve_jan_unit_price(')
+    // MIN(purchase_price)による単価解決の実クエリは resolve_jan_unit_price 内の1箇所のみに
+    // 存在すること（case/loan/consumableそれぞれに同じクエリをインラインで重複実装しない）。
+    const definitionOccurrences = n.match(/select min\(hp\.purchase_price\)/g) ?? []
+    expect(definitionOccurrences.length).toBe(1)
+    // case/loan/consumableの3箇所それぞれが実際にresolve_jan_unit_price(...)を呼び出すこと。
+    expect(n).toContain("resolve_jan_unit_price(elem->>'jan', p_facility_id)")
+    expect(n).toContain('resolve_jan_unit_price(c.jan, p_facility_id)')
+  })
+
+  it('case_order_items/loan_order_items/consumable_order_itemsのINSERT文にunit_price列を含む', () => {
+    expect(n).toContain('insert into case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)')
+    expect(n).toContain('insert into loan_order_items (loan_order_id, jan, name, quantity, unit_price)')
+    expect(n).toContain(
+      'insert into consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)'
+    )
+  })
+
+  it('単価解決に失敗してもRAISE EXCEPTIONせずNULLのまま挿入する(best-effort、例外はforbiddenメッセージのみ)', () => {
+    const raiseCount = (n.match(/raise exception/g) ?? []).length
+    expect(raiseCount).toBe(3)
+    expect(n).toContain("raise exception 'forbidden: not a member of this facility'")
+    expect(n).not.toMatch(/raise exception.{0,120}unit_price/i)
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})

--- a/supabase/migrations/__tests__/add_unit_price_to_order_items.test.ts
+++ b/supabase/migrations/__tests__/add_unit_price_to_order_items.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(SPEC.md Part2 Set A)を
+//      満たすかを静的に検証することで、回帰テストとして固定する。
+//      (supabase/migrations/__tests__/orders_history_prereqs.test.ts と同じ方針)
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_unit_price_to_order_items.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_unit_price_to_order_items.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  const expectedColumns = [
+    'alter table case_order_items add column unit_price numeric(12,2)',
+    'alter table consumable_order_items add column unit_price numeric(12,2)',
+    'alter table loan_order_items add column unit_price numeric(12,2)',
+  ]
+
+  it.each(expectedColumns)('%s を含む', (stmt) => {
+    expect(n).toContain(stmt)
+  })
+
+  // WHY(重複・過剰実装指摘対応): case_ordersのidx_case_orders_facility_created_atは
+  // 20260626000000_fix_fk_and_indexes.sqlで既に作成済み。同名でCREATE INDEX IF NOT EXISTSを
+  // 再度書くと既存インデックス名と衝突して静かにno-opになる（死んだ文）ため、本migrationでは
+  // 重複するインデックス作成を行わないことを回帰テストで固定する。
+  it('case_ordersのインデックスを重複作成しない（既存のidx_case_orders_facility_created_atと衝突するため）', () => {
+    expect(n).not.toContain('create index if not exists idx_case_orders_facility_created_at')
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## Summary
- admin限定の「分析・レポートページ」（`/admin/reports`）を新設。施設別×発注種別（症例発注/消耗品発注/短貸発注）の発注金額集計を、任意の期間で閲覧できる
- 発注金額の元データ（単価）がどこにも保存されていなかったという構造的課題を、発注作成時のスナップショット保存方式で解決（`create_*_order_atomic` RPC改修）
- 人間レビューでの決定事項をSPEC.mdに記録: 単価は発注作成時にスナップショット保存、集計対象はstatusを問わず全発注
- 統合ゲート後の4観点レビュー（3回の自動差し戻し後、残った指摘）を手動修正: SPEC.md合計列ロジックの自己矛盾解消、`resolve_jan_unit_price()`のGRANT EXECUTE漏れ修正、ローディング表示テスト追加、SPEC記述と実装の乖離訂正

Closes #23

## Test plan
- [x] `npx vitest run` 995件全通過
- [x] `npx tsc --noEmit` エラーなし
- [x] `npm run lint` エラーなし
- [x] 構造化レビュー実施（CRUD網羅性・過剰実装/重複/抜け漏れ・ドメイン整合性）、指摘なし
- [ ] CI（e2e含む）の実行結果を確認

## 既知の制約
- ローカルSupabase(docker)が開発環境になく、マイグレーション・RPCの実DB検証は静的検証テストのみ
- 過去発注（本機能実装日より前）は単価データがなく、集計上「-」表示になる（仕様として決定済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)