### PR TITLE
fix: .skip消費時にSTATE_FILEをリセットし指摘の復活を防ぐ(issue #372)

### DIFF
--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -76,12 +76,6 @@ block_with_retry_check() {
   fi
 }
 
-# --- エスケープハッチ: .skipマーカーがあれば無条件pass（消費して削除） ---
-if [ -f "$SKIP_MARKER" ]; then
-  rm -f "$SKIP_MARKER"
-  emit_pass "verify-claims: 手動オーバーライド(.skipマーカー)が使用されたため、今回の検証をスキップしました。"
-fi
-
 # --- diffハッシュ計算 ---
 # WHY(issue #352): `git diff HEAD` はtrackedファイルの差分のみを含み、`git status --porcelain`は
 # untrackedファイルを `?? path` の1行としか出さず中身を含まない。そのため新規(untracked)ファイルの
@@ -97,6 +91,17 @@ UNTRACKED_CONTENT="$(
   done < <(git ls-files --others --exclude-standard -z 2>/dev/null || true)
 )"
 CURRENT_HASH="$(printf '%s%s' "$DIFF_CONTENT" "$UNTRACKED_CONTENT" | shasum -a 256 | awk '{print $1}')"
+
+# --- エスケープハッチ: .skipマーカーがあれば無条件pass（消費して削除） ---
+# WHY(issue #372): write_stateを呼ばずにexitすると、STATE_FILEのlast_verdictが直前のblockedのまま
+# 残り、次のStopイベントでdiffハッシュが変化していない場合に「ケース1/2」分岐でblockedが復活してしまう。
+# .skipは「そのStopイベント1回だけ」のはずなので、消費時点のCURRENT_HASHとpass判定を書き込んで
+# 以降のStopイベントに影響を残さないようにする。
+if [ -f "$SKIP_MARKER" ]; then
+  rm -f "$SKIP_MARKER"
+  write_state "$CURRENT_HASH" "pass" 0 ""
+  emit_pass "verify-claims: 手動オーバーライド(.skipマーカー)が使用されたため、今回の検証をスキップしました。"
+fi
 
 PREV_HASH=""
 PREV_VERDICT=""

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -227,6 +227,21 @@ assert_eq "$EXIT_CODE" "0" "untrackedファイルの中身を書き換えてもp
 assert_eq "$(call_count)" "2" "untrackedファイルの中身の変更だけでも再検証される(ハッシュが変わる)"
 rm -f "$REPO/new-file.txt"
 
+echo "=== scenario 11: .skip消費後、同一diffで再度Stopしてもblockedが復活しない(issue #372) ==="
+rm -f "$MOCK_CALL_LOG"
+echo "line11" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "critical", "description": "解消されない指摘", "evidence": "x:1"}]}' > "$MOCK_FINDINGS_FILE"
+run_hook "s11"
+assert_eq "$EXIT_CODE" "2" "1回目(新規diff・critical)はブロック"
+touch "$STATE_DIR/s11.skip"
+run_hook "s11"
+assert_eq "$EXIT_CODE" "0" ".skipマーカー使用時はpass"
+VERDICT_AFTER_SKIP="$(jq -r '.last_verdict' "$STATE_DIR/s11.json")"
+assert_eq "$VERDICT_AFTER_SKIP" "pass" ".skip消費時に状態ファイルのlast_verdictがpassにリセットされる"
+run_hook "s11"
+assert_eq "$EXIT_CODE" "0" ".skip消費後、diffが変化していない3回目もblockedが復活せずpass"
+assert_eq "$(call_count)" "1" ".skip消費後の3回目は検証エージェントを再度呼ばない(diffハッシュ一致・pass再利用)"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- `.skip`マーカー消費時に`write_state`を呼んでいなかったため、`last_verdict`が直前の`blocked`のまま残り、次のStopイベントでdiffハッシュが変化していない場合に同一指摘が復活するバグを修正 (closes #372)
- diffハッシュ計算をスキップ判定より前に移動し、`.skip`消費時点で`pass`/`retry_count=0`として状態を書き込むようにした

## Test plan
- [x] `bash scripts/verify-claims.test.sh` — 全11シナリオ（新規追加のscenario 11含む）が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)