### PR TITLE
fix: products/categories/distributor-products/facilitiesのPUT/DELETEにrequireAdmin相当のチェックを追加(issue #346)

### DIFF
--- a/src/__tests__/api-categories.test.ts
+++ b/src/__tests__/api-categories.test.ts
@@ -3,8 +3,10 @@ import { NextRequest } from 'next/server'
 
 vi.mock('@/lib/supabase/server', () => ({ createServerSupabase: vi.fn().mockResolvedValue({}) }))
 vi.mock('@/lib/supabase/require-auth', () => ({ requireAuth: vi.fn().mockResolvedValue({ id: 'u-1', email: 'user@example.com' }) }))
+vi.mock('@/lib/admin-status', () => ({ resolveIsAdmin: vi.fn() }))
 vi.mock('@/lib/categories/repository')
 
+import { resolveIsAdmin } from '@/lib/admin-status'
 import {
   listCategories,
   createCategory,
@@ -35,7 +37,10 @@ function makeParams(id: string) {
   return { params: Promise.resolve({ id }) }
 }
 
-beforeEach(() => vi.resetAllMocks())
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(resolveIsAdmin).mockResolvedValue(true)
+})
 
 describe('GET /api/categories', () => {
   it('カテゴリ一覧を返す', async () => {
@@ -99,6 +104,18 @@ describe('POST /api/categories', () => {
     const res = await POST(req)
     expect(res.status).toBe(401)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/categories', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'カテゴリA', description: null }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(403)
+    expect(createCategory).not.toHaveBeenCalled()
+  })
 })
 
 describe('GET /api/categories/[id]', () => {
@@ -160,6 +177,18 @@ describe('PUT /api/categories/[id]', () => {
     const res = await PUT(req, makeParams('test-id'))
     expect(res.status).toBe(409)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/categories/test-id', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'カテゴリB', description: null }),
+    })
+    const res = await PUT(req, makeParams('test-id'))
+    expect(res.status).toBe(403)
+    expect(updateCategory).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/categories/[id]', () => {
@@ -186,5 +215,14 @@ describe('DELETE /api/categories/[id]', () => {
     expect(res.status).toBe(409)
     const body = await res.json()
     expect(body.error).toBe('使用中のため削除できません')
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/categories/test-id', { method: 'DELETE' })
+    const res = await DELETE(req, makeParams('test-id'))
+    expect(res.status).toBe(403)
+    expect(deleteCategory).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/api-products.test.ts
+++ b/src/__tests__/api-products.test.ts
@@ -3,8 +3,10 @@ import { NextRequest } from 'next/server'
 
 vi.mock('@/lib/supabase/server', () => ({ createServerSupabase: vi.fn().mockResolvedValue({}) }))
 vi.mock('@/lib/supabase/require-auth', () => ({ requireAuth: vi.fn().mockResolvedValue({ id: 'u-1', email: 'user@example.com' }) }))
+vi.mock('@/lib/admin-status', () => ({ resolveIsAdmin: vi.fn() }))
 vi.mock('@/lib/products/repository')
 
+import { resolveIsAdmin } from '@/lib/admin-status'
 import {
   listProducts,
   createProduct,
@@ -37,7 +39,10 @@ function makeParams(id: string) {
   return { params: Promise.resolve({ id }) }
 }
 
-beforeEach(() => vi.resetAllMocks())
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(resolveIsAdmin).mockResolvedValue(true)
+})
 
 describe('GET /api/products', () => {
   it('製品一覧を返す', async () => {
@@ -110,6 +115,18 @@ describe('POST /api/products', () => {
     const res = await POST(req)
     expect(res.status).toBe(401)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/products', {
+      method: 'POST',
+      body: JSON.stringify({ jan: '4901234567890', ref: 'REF-001', name: '製品A' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(403)
+    expect(createProduct).not.toHaveBeenCalled()
+  })
 })
 
 describe('GET /api/products/[id]', () => {
@@ -170,6 +187,18 @@ describe('PUT /api/products/[id]', () => {
     const res = await PUT(req, makeParams('test-id'))
     expect(res.status).toBe(400)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/products/test-id', {
+      method: 'PUT',
+      body: JSON.stringify({ jan: '4901234567890', ref: 'REF-001', name: '製品A' }),
+    })
+    const res = await PUT(req, makeParams('test-id'))
+    expect(res.status).toBe(403)
+    expect(updateProduct).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/products/[id]', () => {
@@ -189,5 +218,14 @@ describe('DELETE /api/products/[id]', () => {
     expect(res.status).toBe(404)
     const body = await res.json()
     expect(body.error).toBe('製品が見つかりません')
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    const { resolveIsAdmin } = await import('@/lib/admin-status')
+    vi.mocked(resolveIsAdmin).mockResolvedValueOnce(false)
+    const req = makeRequest('/api/products/test-id', { method: 'DELETE' })
+    const res = await DELETE(req, makeParams('test-id'))
+    expect(res.status).toBe(403)
+    expect(deleteProduct).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/categories/[id]/__tests__/route.test.ts
+++ b/src/app/api/categories/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PUT, DELETE } from '../route'
 
 const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
 const mockGetCategory = vi.fn()
 const mockUpdateCategory = vi.fn()
 const mockDeleteCategory = vi.fn()
@@ -10,6 +11,10 @@ vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: async () => ({
     auth: { getUser: mockGetUser },
   }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
 }))
 
 vi.mock('@/lib/categories/repository', () => ({
@@ -24,6 +29,7 @@ const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
 })
 
 describe('GET /api/categories/[id]', () => {
@@ -58,6 +64,15 @@ describe('PUT /api/categories/[id]', () => {
     const res = await PUT(req as never, context)
     expect(res.status).toBe(200)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'PUT', body: JSON.stringify({ name: 'x' }) })
+    const res = await PUT(req as never, context)
+    expect(res.status).toBe(403)
+    expect(mockUpdateCategory).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/categories/[id]', () => {
@@ -73,5 +88,13 @@ describe('DELETE /api/categories/[id]', () => {
     mockDeleteCategory.mockResolvedValue(undefined)
     const res = await DELETE(new Request('http://localhost') as never, context)
     expect(res.status).toBe(200)
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const res = await DELETE(new Request('http://localhost') as never, context)
+    expect(res.status).toBe(403)
+    expect(mockDeleteCategory).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { getCategory, updateCategory, deleteCategory } from '@/lib/categories/repository'
 import { apiError } from '@/lib/api-error'
 import type { CategoryInput } from '@/types/category'
@@ -32,7 +33,10 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const category = await updateCategory(db, id, input)
     return NextResponse.json({ category })
   } catch (error) {
@@ -52,7 +56,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const { id } = await context.params
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     await deleteCategory(db, id)
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/app/api/categories/__tests__/route.test.ts
+++ b/src/app/api/categories/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockCreateCategory = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/categories/repository', () => ({
+  listCategories: vi.fn(),
+  createCategory: (...args: unknown[]) => mockCreateCategory(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+const validInput = { name: 'カテゴリA' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
+})
+
+describe('POST /api/categories', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+    expect(mockCreateCategory).not.toHaveBeenCalled()
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(403)
+    expect(mockCreateCategory).not.toHaveBeenCalled()
+  })
+
+  it('管理者は正常に作成できる', async () => {
+    authenticated()
+    mockCreateCategory.mockResolvedValue({ id: 'c1', ...validInput })
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(201)
+  })
+})

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { listCategories, createCategory } from '@/lib/categories/repository'
 import { apiError } from '@/lib/api-error'
 import type { CategoryInput } from '@/types/category'
@@ -30,7 +31,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const category = await createCategory(db, input)
     return NextResponse.json({ category }, { status: 201 })
   } catch (error) {

--- a/src/app/api/distributor-products/[id]/__tests__/route.test.ts
+++ b/src/app/api/distributor-products/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PUT, DELETE } from '../route'
 
 const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
 const mockGetDistributorProduct = vi.fn()
 const mockUpdateDistributorProduct = vi.fn()
 const mockDeleteDistributorProduct = vi.fn()
@@ -10,6 +11,10 @@ vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: async () => ({
     auth: { getUser: mockGetUser },
   }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
 }))
 
 vi.mock('@/lib/distributor-products/repository', () => ({
@@ -26,6 +31,7 @@ const validInput = { productId: 'p1', maker: 'maker', supplier: 'supplier', name
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
 })
 
 describe('GET /api/distributor-products/[id]', () => {
@@ -60,6 +66,15 @@ describe('PUT /api/distributor-products/[id]', () => {
     const res = await PUT(req as never, context)
     expect(res.status).toBe(200)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'PUT', body: JSON.stringify(validInput) })
+    const res = await PUT(req as never, context)
+    expect(res.status).toBe(403)
+    expect(mockUpdateDistributorProduct).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/distributor-products/[id]', () => {
@@ -75,5 +90,13 @@ describe('DELETE /api/distributor-products/[id]', () => {
     mockDeleteDistributorProduct.mockResolvedValue(undefined)
     const res = await DELETE(new Request('http://localhost') as never, context)
     expect(res.status).toBe(200)
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const res = await DELETE(new Request('http://localhost') as never, context)
+    expect(res.status).toBe(403)
+    expect(mockDeleteDistributorProduct).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/distributor-products/[id]/route.ts
+++ b/src/app/api/distributor-products/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { getDistributorProduct, updateDistributorProduct, deleteDistributorProduct } from '@/lib/distributor-products/repository'
 import { apiError } from '@/lib/api-error'
 import type { DistributorProductInput } from '@/types/distributorProduct'
@@ -32,7 +33,10 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const item = await updateDistributorProduct(db, id, input)
     return NextResponse.json({ item })
   } catch (error) {
@@ -52,7 +56,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const { id } = await context.params
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     await deleteDistributorProduct(db, id)
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/app/api/distributor-products/__tests__/route.test.ts
+++ b/src/app/api/distributor-products/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockCreateDistributorProduct = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/distributor-products/repository', () => ({
+  listDistributorProducts: vi.fn(),
+  createDistributorProduct: (...args: unknown[]) => mockCreateDistributorProduct(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+const validInput = { productId: 'p1', maker: 'maker', supplier: 'supplier', name: 'name', categoryId: 'cat1' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
+})
+
+describe('POST /api/distributor-products', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+    expect(mockCreateDistributorProduct).not.toHaveBeenCalled()
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(403)
+    expect(mockCreateDistributorProduct).not.toHaveBeenCalled()
+  })
+
+  it('管理者は正常に作成できる', async () => {
+    authenticated()
+    mockCreateDistributorProduct.mockResolvedValue({ id: 'dp1', ...validInput })
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(201)
+  })
+})

--- a/src/app/api/distributor-products/route.ts
+++ b/src/app/api/distributor-products/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { listDistributorProducts, createDistributorProduct } from '@/lib/distributor-products/repository'
 import { apiError } from '@/lib/api-error'
 import type { DistributorProductInput } from '@/types/distributorProduct'
@@ -30,7 +31,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const item = await createDistributorProduct(db, input)
     return NextResponse.json({ item }, { status: 201 })
   } catch (error) {

--- a/src/app/api/facilities/[id]/__tests__/route.test.ts
+++ b/src/app/api/facilities/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PUT, DELETE } from '../route'
 
 const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
 const mockGetFacility = vi.fn()
 const mockUpdateFacility = vi.fn()
 const mockDeleteFacility = vi.fn()
@@ -10,6 +11,10 @@ vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: async () => ({
     auth: { getUser: mockGetUser },
   }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
 }))
 
 vi.mock('@/lib/facilities/repository', () => ({
@@ -24,6 +29,7 @@ const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
 })
 
 describe('GET /api/facilities/[id]', () => {
@@ -58,6 +64,15 @@ describe('PUT /api/facilities/[id]', () => {
     const res = await PUT(req as never, context)
     expect(res.status).toBe(200)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'PUT', body: JSON.stringify({ name: 'x' }) })
+    const res = await PUT(req as never, context)
+    expect(res.status).toBe(403)
+    expect(mockUpdateFacility).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/facilities/[id]', () => {
@@ -73,5 +88,13 @@ describe('DELETE /api/facilities/[id]', () => {
     mockDeleteFacility.mockResolvedValue(undefined)
     const res = await DELETE(new Request('http://localhost') as never, context)
     expect(res.status).toBe(200)
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const res = await DELETE(new Request('http://localhost') as never, context)
+    expect(res.status).toBe(403)
+    expect(mockDeleteFacility).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/facilities/[id]/route.ts
+++ b/src/app/api/facilities/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { getFacility, updateFacility, deleteFacility } from '@/lib/facilities/repository'
 import { apiError } from '@/lib/api-error'
 import type { FacilityInput } from '@/types/facility'
@@ -32,7 +33,10 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const facility = await updateFacility(db, id, input)
     return NextResponse.json({ facility })
   } catch (error) {
@@ -52,7 +56,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const { id } = await context.params
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     await deleteFacility(db, id)
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/app/api/facilities/__tests__/route.test.ts
+++ b/src/app/api/facilities/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockCreateFacility = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/facilities/repository', () => ({
+  listFacilities: vi.fn(),
+  createFacility: (...args: unknown[]) => mockCreateFacility(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+const validInput = { name: '施設A' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
+})
+
+describe('POST /api/facilities', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+    expect(mockCreateFacility).not.toHaveBeenCalled()
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(403)
+    expect(mockCreateFacility).not.toHaveBeenCalled()
+  })
+
+  it('管理者は正常に作成できる', async () => {
+    authenticated()
+    mockCreateFacility.mockResolvedValue({ id: 'f1', ...validInput })
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(201)
+  })
+})

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -36,7 +36,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const facility = await createFacility(db, input)
     return NextResponse.json({ facility }, { status: 201 })
   } catch (error) {

--- a/src/app/api/products/[id]/__tests__/route.test.ts
+++ b/src/app/api/products/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PUT, DELETE } from '../route'
 
 const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
 const mockGetProduct = vi.fn()
 const mockUpdateProduct = vi.fn()
 const mockDeleteProduct = vi.fn()
@@ -10,6 +11,10 @@ vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: async () => ({
     auth: { getUser: mockGetUser },
   }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
 }))
 
 vi.mock('@/lib/products/repository', () => ({
@@ -24,6 +29,7 @@ const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
 })
 
 describe('GET /api/products/[id]', () => {
@@ -58,6 +64,15 @@ describe('PUT /api/products/[id]', () => {
     const res = await PUT(req as never, context)
     expect(res.status).toBe(200)
   })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'PUT', body: JSON.stringify({ jan: '1', ref: 'r', name: '製品A' }) })
+    const res = await PUT(req as never, context)
+    expect(res.status).toBe(403)
+    expect(mockUpdateProduct).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/products/[id]', () => {
@@ -73,5 +88,13 @@ describe('DELETE /api/products/[id]', () => {
     mockDeleteProduct.mockResolvedValue(undefined)
     const res = await DELETE(new Request('http://localhost') as never, context)
     expect(res.status).toBe(200)
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const res = await DELETE(new Request('http://localhost') as never, context)
+    expect(res.status).toBe(403)
+    expect(mockDeleteProduct).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { getProduct, updateProduct, deleteProduct } from '@/lib/products/repository'
 import { apiError } from '@/lib/api-error'
 import type { ProductInput } from '@/types/product'
@@ -36,7 +37,10 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const product = await updateProduct(db, id, input)
     return NextResponse.json({ product })
   } catch (error) {
@@ -56,7 +60,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const { id } = await context.params
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     await deleteProduct(db, id)
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/app/api/products/__tests__/route.test.ts
+++ b/src/app/api/products/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockCreateProduct = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/products/repository', () => ({
+  listProducts: vi.fn(),
+  createProduct: (...args: unknown[]) => mockCreateProduct(...args),
+}))
+
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+const validInput = { jan: '1234567890123', ref: 'ref1', name: '製品A' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(true)
+})
+
+describe('POST /api/products', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(401)
+    expect(mockCreateProduct).not.toHaveBeenCalled()
+  })
+
+  it('一般ユーザーの場合は403を返す', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(403)
+    expect(mockCreateProduct).not.toHaveBeenCalled()
+  })
+
+  it('管理者は正常に作成できる', async () => {
+    authenticated()
+    mockCreateProduct.mockResolvedValue({ id: 'p1', ...validInput })
+    const req = new Request('http://localhost', { method: 'POST', body: JSON.stringify(validInput) })
+    const res = await POST(req as never)
+    expect(res.status).toBe(201)
+  })
+})

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
 import { listProducts, createProduct } from '@/lib/products/repository'
 import { apiError } from '@/lib/api-error'
 import type { ProductInput } from '@/types/product'
@@ -34,7 +35,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = await createServerSupabase()
-    try { await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    let user
+    try { user = await requireAuth(db) } catch { return apiError('認証が必要です', 401) }
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (!isAdmin) return apiError('権限がありません', 403)
     const product = await createProduct(db, input)
     return NextResponse.json({ product }, { status: 201 })
   } catch (error) {


### PR DESCRIPTION
## Summary
- RLS層では`is_admin()`によりCUD操作がadmin限定になっていたが、API層（route.ts）では`requireAuth()`のみでadmin判定が行われておらず、多層防御（[known-failure-patterns.md](docs/agents/known-failure-patterns.md) issue #24再発防止）の観点で欠落していた (closes #346)
- issue #21のCompat API（`requireAuth()` + `resolveIsAdmin()`のパターン）に実装方針を揃え、以下8箇所のPOST/PUT/DELETEに「一般ユーザーなら403」のチェックを追加
  - `src/app/api/products/route.ts`（POST）, `src/app/api/products/[id]/route.ts`（PUT/DELETE）
  - `src/app/api/categories/route.ts`（POST）, `src/app/api/categories/[id]/route.ts`（PUT/DELETE）
  - `src/app/api/distributor-products/route.ts`（POST）, `src/app/api/distributor-products/[id]/route.ts`（PUT/DELETE）
  - `src/app/api/facilities/route.ts`（POST）, `src/app/api/facilities/[id]/route.ts`（PUT/DELETE）
- 既存テスト（`src/__tests__/api-products.test.ts` / `api-categories.test.ts`等）はadmin判定を通す前提だったため、`resolveIsAdmin`をデフォルトadmin=trueでモックし直し、一般ユーザー(403)のケースを追加
- POSTのみのroute.ts（products/categories/distributor-products/facilities）には元々テストが無かったため、最小限のテストを新規追加

## Test plan
- [x] `npm test` — 全1042テスト成功（新規追加の403ケース・既存テストの調整含む）
- [x] `npm run lint` — エラーなし
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `supabase/migrations/__tests__/admin_rls.test.ts`（RLS層の非admin書き込み拒否、32テスト）が既に通っていることを確認 — DB層・API層の両方で多層防御が効いていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)