### PR TITLE
docs: verify-claims設計書にissue #360(グローバルhookの通知抑制)実装済みの旨を追記

### DIFF
--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -220,7 +220,16 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
 - この判定ロジックはグローバルスクリプト側(`~/claude_stop_notify.sh`、`~/claude_auto_issue.sh`)
   に実装する必要がある。`verify-claims.sh`が存在しない/未実行のプロジェクトでは状態ファイルも
   存在しないため、従来通りの挙動になる(後方互換)
-- 実装(グローバルスクリプトの変更)は本ドキュメントのスコープ外とし、別issueとして切り出す
+- **実装済み(issue #360)**: 上記2ファイルはこのリポジトリ外(`$HOME`直下)にあり、
+  medical-inventory-vkumai以外の全プロジェクトで共通して使われるグローバル設定のため、
+  このリポジトリのgit管理・PRレビューの対象外。判定ロジック本体は共通ヘルパー
+  `~/claude_verify_suppress_check.sh`(diffハッシュ計算を`verify-claims.sh`と同じ方法で
+  行う。将来この計算方法がズレても常に非抑制側に倒れるだけで安全)に切り出し、
+  `claude_stop_notify.sh`/`claude_auto_issue.sh`はセッションIDを渡して呼ぶだけにした。
+  リポジトリ外ファイルのためこのリポジトリのテストスイートには含められないが、サンドボックス
+  (偽の`$HOME`・`osascript`/`gh`のスタブコマンド)で「抑制されるケース(実際の通知・
+  issue作成が発生しないこと)」「状態ファイルが無いセッションでは従来通り実行されること
+  (後方互換)」の両方を確認済み
 
 ## テスト方針
 


### PR DESCRIPTION
## Summary
- issue #360の実装内容(グローバルhookでのブロックループ中の通知・issue自動作成の抑制)を設計書に記録
- 実装本体(`~/claude_verify_suppress_check.sh`新規作成、`~/claude_stop_notify.sh`/`~/claude_auto_issue.sh`への抑制チェック追加)はこのリポジトリ外(`$HOME`直下、全プロジェクト共通のグローバルスクリプト)のため、コード変更自体はこのリポジトリのgit管理・PR対象外

## Why
`docs/agents/common.md`のissue #339棚卸しレビュー指摘(9/9)、および設計書「ブロックループ中の他hookとの相互作用」節で「別issueとして切り出す」としていた実装が完了したため、ドキュメント側を実装済み状態に更新する。

## 検証(このリポジトリ外での実施内容)
- 共通ヘルパー`~/claude_verify_suppress_check.sh`単体: 5シナリオ(状態ファイル無し／pass／ハッシュ不一致／ハッシュ一致+blocked／session_id未指定)全PASS
- グローバルhook統合: 偽の`$HOME`と`osascript`/`gh`のスタブコマンドを使ったサンドボックスで、「抑制時は実際の通知・issue作成が発生しない」「状態ファイルが無いセッションでは従来通り動く(後方互換)」の両方を確認(実際のMac通知やGitHub issue作成は発生させていない)

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)