### PR TITLE
feat: verify-claimsに効果測定ログ(fail-open率・ブロック回数・誤検知率)を追加(issue #355)

### DIFF
--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -125,6 +125,38 @@ hook側で機械チェックする。検証サブエージェント自身がLLM�
 
 理由: 「severityが不明」は検証した上での判断の曖昧さだが、「検証エージェントが動かなかった」のはツール自体の不備であり、これを理由にブロックし続けるのは開発を止めるだけで安全性に寄与しない。`systemMessage` に「検証エージェントの実行に失敗したため今回はスキップしました」と明記し、可視化はする。
 
+### 効果測定(Effectiveness Measurement)(issue #355)
+
+このリポジトリ自身の運用ルール「新しい運用ルールは検知手段を先に決める」(issue #339、
+[`docs/agents/common.md`](../../agents/common.md)参照)に照らすと、この検証サブエージェント自体にも
+「役に立っているかを機械的に知る手段」が無ければ、fail-open(検証未実施)が静かに常態化しても
+気づけない「動いていない検証装置」になり得る。これに対応するため、判定の種類ごとに
+`logs/verify-claims-effectiveness.jsonl` へ1行JSONを追記する(実装: `scripts/verify-claims.sh`の
+`log_effectiveness`)。
+
+- 記録するevent種別:
+  - `skip_used` - `.skip`マーカーが使われた(誤検知シグナル。issue #348がこのマーカー自体の
+    エスケープハッチ設計を別途扱う)
+  - `pass` - 指摘なしでpass(`cached`: 前回と同一diffの再利用によるものか、新規検証によるものか)
+  - `blocked` - critical/important指摘でブロック(`retry_count`、`cached`: LLM呼び出し無しでretry
+    だけ消費したケースか否か)
+  - `resolved` - 直前が`blocked`だった状態が、次の検証で指摘なしに変わった。**「指摘が修正に
+    つながった」ことを示す唯一のシグナル**であり、単なる`pass`(初回・元々問題なし)とは区別する
+  - `fail_open` - 検証未実施でfail-open。`reason`で`verifier_failed`(サブプロセス自体の失敗)・
+    `parse_failed`(出力がJSONとして解析不能)・`circuit_breaker`(同時実行数上限)を区別する
+- ログ書き込みはベストエフォート(`|| true`)とし、書き込み失敗が本来の検証フロー自体をブロック
+  しないようにする
+- **閾値検知**: 直近N件(既定5件、`VERIFY_CLAIMS_FAIL_OPEN_STREAK_THRESHOLD`で変更可)が連続して
+  `fail_open`の場合、「検証サブエージェント自体が機能していない可能性がある」旨の警告を
+  `systemMessage`に追記する。fail-open自体は単発では正常な安全策(インフラ障害時に開発を止めない)
+  だが、連続する場合は検証が実質的に機能していないシグナルであるため区別する
+- **自己参照バグへの注意**: このログファイル自身がリポジトリ配下の未追跡(untracked)ファイルに
+  なるため、diffハッシュ計算(「発火の仕組み」節、issue #352)にログの中身が混入すると、
+  ログ追記のたびにハッシュが変化し続け、キャッシュ機構(スキップ・再判定ロジックのケース1/2)が
+  機能しなくなる自己参照バグになる。`STATE_DIR`・`LOCK_DIR`・`EFFECTIVENESS_LOG`の配置先ディレクトリは
+  untrackedファイルのハッシュ計算対象から明示的に除外する(`/logs/`がgitignore対象であることに
+  暗黙依存しない)
+
 ## データフロー(概要)
 
 ```
@@ -240,6 +272,9 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
   10. **(issue #354)** evidenceが実在しないファイルを指すcritical finding → minorへ格下げされブロックされない(exit 0)
   11. **(issue #354)** evidenceのファイルは実在するが行番号がファイルの行数を超えるcritical finding → minorへ格下げされブロックされない(exit 0)
   12. **(issue #354)** evidenceが空/ファイルパスらしきトークンを含まないcritical finding → minorへ格下げされブロックされない(exit 0)
+  13. **(issue #355)** blockedからpassへ遷移した場合、効果測定ログに`resolved`イベントが記録される。blockedイベント自体にも`retry_count`・`cached`が記録される
+  14. **(issue #355)** `.skip`マーカー使用時に効果測定ログへ`skip_used`イベントが記録される
+  15. **(issue #355)** 直近N件(閾値)連続でfail_openが発生した場合、`systemMessage`に「検証サブエージェントが機能していない可能性」の警告が追記される
 - `claude -p` 呼び出し部分は実行コストがかかるため、テストではモック(固定のfindings JSONを返すダミースクリプト)に差し替えて検証する
 
 ## 対象範囲外(YAGNI)

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -17,6 +17,20 @@ set -euo pipefail
 #                                 プロンプトを受け取り、findings JSONを標準出力に返すこと）
 #   VERIFY_CLAIMS_LOCK_DIR      - サーキットブレーカー用ロック置き場（省略時は .claude/.verify-lock）
 #   VERIFY_CLAIMS_MAX_CONCURRENT - 同時実行を許す検証プロセス数の上限（省略時は4）
+#   VERIFY_CLAIMS_EFFECTIVENESS_LOG - 効果測定ログの出力先（省略時は logs/verify-claims-effectiveness.jsonl）
+#   VERIFY_CLAIMS_FAIL_OPEN_STREAK_THRESHOLD - 連続fail-open警告の閾値（省略時は5）
+#
+# 効果測定ログ（issue #355）: 「新しい運用ルールは検知手段を先に決める」(issue #339)の原則に照らし、
+# fail-open（検証未実施）が静かに常態化しても気づけない状態を防ぐため、判定の種類ごとに
+# logs/verify-claims-effectiveness.jsonl へ1行JSONを追記する。event種別:
+#   skip_used  - .skipマーカーが使われた（誤検知シグナル）
+#   pass       - 指摘なしでpass（cached: 前回と同一diffの再利用か否か）
+#   blocked    - critical/important指摘でブロック（cached: LLM呼び出し無しでretry消費したか否か）
+#   resolved   - 前回blockedだった状態が、次の検証でfindings無しに変わった（指摘が修正につながった）
+#   fail_open  - 検証未実施でfail-open（reason: verifier_failed | parse_failed | circuit_breaker）
+# 直近N件（既定5件）が連続してfail_openの場合、「検証サブエージェントが機能していない可能性」の
+# 警告をsystemMessageに追記する。設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+# の「効果測定（Effectiveness Measurement）」節
 #
 # サーキットブレーカー（issue #359）: --setting-sources ""等の個別修正が正しくても、
 # それが適用され忘れる・マージされ忘れることで同種の再帰暴走が繰り返された実績がある
@@ -33,8 +47,10 @@ TIMEOUT_SECONDS="${VERIFY_CLAIMS_TIMEOUT_SECONDS:-60}"
 MODEL="${VERIFY_CLAIMS_MODEL:-claude-haiku-4-5-20251001}"
 LOCK_DIR="${VERIFY_CLAIMS_LOCK_DIR:-.claude/.verify-lock}"
 MAX_CONCURRENT="${VERIFY_CLAIMS_MAX_CONCURRENT:-4}"
+EFFECTIVENESS_LOG="${VERIFY_CLAIMS_EFFECTIVENESS_LOG:-logs/verify-claims-effectiveness.jsonl}"
+FAIL_OPEN_STREAK_THRESHOLD="${VERIFY_CLAIMS_FAIL_OPEN_STREAK_THRESHOLD:-5}"
 
-mkdir -p "$STATE_DIR" "$LOCK_DIR"
+mkdir -p "$STATE_DIR" "$LOCK_DIR" "$(dirname "$EFFECTIVENESS_LOG")"
 
 INPUT="$(cat)"
 SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
@@ -58,6 +74,46 @@ emit_block() {
   exit 2
 }
 
+# WHY(issue #355): 効果測定ログはあくまで補助であり、書き込み失敗（ディスクフル等）で
+# 本来の検証フロー自体を止めてはならないため、すべて`|| true`でベストエフォートにする。
+log_effectiveness() {
+  local event="$1"
+  local extra_json="${2:-}"
+  [ -n "$extra_json" ] || extra_json="{}"
+  local ts
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
+  jq -nc --arg ts "$ts" --arg session "$SESSION_ID" --arg event "$event" --argjson extra "$extra_json" \
+    '{timestamp: $ts, session_id: $session, event: $event} + $extra' \
+    >> "$EFFECTIVENESS_LOG" 2>/dev/null || true
+}
+
+# 直近FAIL_OPEN_STREAK_THRESHOLD件が全てfail_openなら警告文を返す(無ければ空文字)。
+# WHY: fail-openは単発では正常な安全策(インフラ障害時に開発を止めない)だが、連続して
+# 発生し続ける場合は「検証サブエージェント自体が機能していない」シグナルであり、
+# 気づく手段が無いと静かに劣化する(issue #339の原則)。
+check_fail_open_streak() {
+  [ -f "$EFFECTIVENESS_LOG" ] || return 0
+  local recent total fail_open_count
+  recent="$(tail -n "$FAIL_OPEN_STREAK_THRESHOLD" "$EFFECTIVENESS_LOG" 2>/dev/null | jq -s '[.[].event]' 2>/dev/null || echo '[]')"
+  total="$(printf '%s' "$recent" | jq 'length' 2>/dev/null || echo 0)"
+  fail_open_count="$(printf '%s' "$recent" | jq '[.[] | select(. == "fail_open")] | length' 2>/dev/null || echo 0)"
+  if [ "$total" -ge "$FAIL_OPEN_STREAK_THRESHOLD" ] && [ "$fail_open_count" -eq "$total" ]; then
+    printf 'verify-claims: 警告: 直近%d件の検証が連続してfail-open(検証未実施)です。検証サブエージェント自体が機能していない可能性があります。%s を確認してください。' \
+      "$FAIL_OPEN_STREAK_THRESHOLD" "$EFFECTIVENESS_LOG"
+  fi
+}
+
+emit_pass_fail_open() {
+  local reason="$1" msg="$2"
+  log_effectiveness "fail_open" "$(jq -n --arg r "$reason" '{reason: $r}')"
+  local streak_warning
+  streak_warning="$(check_fail_open_streak)"
+  if [ -n "$streak_warning" ]; then
+    msg="$(printf '%s\n%s' "$msg" "$streak_warning")"
+  fi
+  emit_pass "$msg"
+}
+
 write_state() {
   local hash="$1" verdict="$2" retry="$3" findings_msg="$4" fingerprint="${5:-}"
   jq -n --arg h "$hash" --arg v "$verdict" --argjson r "$retry" --arg m "$findings_msg" --arg fp "$fingerprint" \
@@ -72,7 +128,7 @@ write_state() {
 # 指摘の中身が変わった場合は1から数え直す(diffハッシュを変えるだけで同じ問題を放置する
 # ズルは、diffハッシュ不一致→再検証のたびに同一findingが再検出される限り引き続き累積されるため防げる)。
 block_with_retry_check() {
-  local hash="$1" findings_msg="$2" fingerprint="${3:-}"
+  local hash="$1" findings_msg="$2" fingerprint="${3:-}" cached="${4:-false}"
   local new_retry
   if [ "$PREV_VERDICT" = "blocked" ] && [ -n "$fingerprint" ] && [ "$fingerprint" = "$PREV_BLOCKING_FINGERPRINT" ]; then
     new_retry=$((PREV_RETRY_COUNT + 1))
@@ -80,6 +136,7 @@ block_with_retry_check() {
     new_retry=1
   fi
   write_state "$hash" "blocked" "$new_retry" "$findings_msg" "$fingerprint"
+  log_effectiveness "blocked" "$(jq -n --argjson retry "$new_retry" --argjson cached "$cached" '{retry_count: $retry, cached: $cached}')"
   if [ "$new_retry" -le "$MAX_RETRIES" ]; then
     emit_block "$(printf 'verify-claims: 未解消の指摘を検出しました(試行%d/%d):\n%s' "$new_retry" "$MAX_RETRIES" "$findings_msg")"
   else
@@ -95,8 +152,17 @@ block_with_retry_check() {
 # 依存する暗黙のカップリングだったため、ここではuntrackedファイルの中身を直接読んでハッシュ対象に含める
 # (indexは変更しない = git add -N等でこのスクリプトが副作用的にリポジトリ状態を書き換えない)。
 DIFF_CONTENT="$( { git diff HEAD; git status --porcelain; } 2>/dev/null || true)"
+# WHY(issue #355): このスクリプト自身が書き込む状態ファイル(STATE_DIR)・ロック(LOCK_DIR)・
+# 効果測定ログ(EFFECTIVENESS_LOG)がuntrackedのままだと、ログ追記のたびに中身が変化し、
+# それ自体がdiffハッシュに混入して「何もソースを直していないのにハッシュが変わり続ける」
+# 自己参照バグになる(このプロジェクトでは/logs/がgitignore対象のため実害はないが、
+# .gitignoreの存在に暗黙依存させず、スクリプト自身でも明示的に除外する)。
+EFFECTIVENESS_LOG_DIR="$(dirname "$EFFECTIVENESS_LOG")"
 UNTRACKED_CONTENT="$(
   while IFS= read -r -d '' f; do
+    if [[ "$f" == "$STATE_DIR"/* || "$f" == "$LOCK_DIR"/* || "$f" == "$EFFECTIVENESS_LOG_DIR"/* ]]; then
+      continue
+    fi
     printf '%s\0' "$f"
     cat -- "$f" 2>/dev/null
   done < <(git ls-files --others --exclude-standard -z 2>/dev/null || true)
@@ -111,6 +177,7 @@ CURRENT_HASH="$(printf '%s%s' "$DIFF_CONTENT" "$UNTRACKED_CONTENT" | shasum -a 2
 if [ -f "$SKIP_MARKER" ]; then
   rm -f "$SKIP_MARKER"
   write_state "$CURRENT_HASH" "pass" 0 ""
+  log_effectiveness "skip_used"
   emit_pass "verify-claims: 手動オーバーライド(.skipマーカー)が使用されたため、今回の検証をスキップしました。"
 fi
 
@@ -130,12 +197,13 @@ fi
 # --- ケース1/2: diffハッシュ一致（前回状態あり） ---
 if [ -n "$PREV_HASH" ] && [ "$CURRENT_HASH" = "$PREV_HASH" ]; then
   if [ "$PREV_VERDICT" = "pass" ]; then
+    log_effectiveness "pass" '{"cached": true}'
     emit_pass ""
   fi
   if [ "$PREV_VERDICT" = "blocked" ]; then
     # 何も直さずに再Stopしようとした場合。LLM呼び出しはせずretry_countだけ消費する。
     # フィンガープリントは前回と同一のものをそのまま渡す(同一findingとして必ず累積させる)。
-    block_with_retry_check "$CURRENT_HASH" "$PREV_FINDINGS_MSG" "$PREV_BLOCKING_FINGERPRINT"
+    block_with_retry_check "$CURRENT_HASH" "$PREV_FINDINGS_MSG" "$PREV_BLOCKING_FINGERPRINT" "true"
   fi
 fi
 
@@ -239,7 +307,7 @@ done
 
 CURRENT_CONCURRENT="$(find "$LOCK_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
 if [ "$CURRENT_CONCURRENT" -ge "$MAX_CONCURRENT" ]; then
-  emit_pass "$(printf 'verify-claims: 検証プロセスの同時実行数が上限(%d)に達しているため、サーキットブレーカーが働き今回の検証をスキップしました(暴走防止のfail-open)。' "$MAX_CONCURRENT")"
+  emit_pass_fail_open "circuit_breaker" "$(printf 'verify-claims: 検証プロセスの同時実行数が上限(%d)に達しているため、サーキットブレーカーが働き今回の検証をスキップしました(暴走防止のfail-open)。' "$MAX_CONCURRENT")"
 fi
 
 LOCK_ENTRY="$LOCK_DIR/$$"
@@ -251,13 +319,13 @@ VERIFIER_OUTPUT="$(run_verifier_with_timeout)" || VERIFIER_EXIT=$?
 
 if [ "$VERIFIER_EXIT" -ne 0 ]; then
   # インフラ障害時のfail-open: 検証プロセス自体の失敗はdeny-by-defaultの対象外とする
-  emit_pass "verify-claims: 検証エージェントの実行に失敗したため(exit=${VERIFIER_EXIT})、今回はスキップしました。"
+  emit_pass_fail_open "verifier_failed" "verify-claims: 検証エージェントの実行に失敗したため(exit=${VERIFIER_EXIT})、今回はスキップしました。"
 fi
 
 FINDINGS_JSON="$(printf '%s' "$VERIFIER_OUTPUT" | jq -c '.findings' 2>/dev/null || echo "")"
 if [ -z "$FINDINGS_JSON" ] || [ "$FINDINGS_JSON" = "null" ]; then
   # 出力自体が壊れている場合も検証プロセスの不備として扱い、fail-open
-  emit_pass "verify-claims: 検証エージェントの出力を解析できなかったため、今回はスキップしました。"
+  emit_pass_fail_open "parse_failed" "verify-claims: 検証エージェントの出力を解析できなかったため、今回はスキップしました。"
 fi
 
 # deny-by-default: severity欠損・不明値はcriticalとして扱う
@@ -323,10 +391,17 @@ if [ "$HAS_BLOCKING" = "true" ]; then
     [.[] | select(.severity == "critical" or .severity == "important")
        | {severity, description, evidence: (.evidence // "")}] | sort
   ' | shasum -a 256 | awk '{print $1}')"
-  block_with_retry_check "$CURRENT_HASH" "$FINDINGS_TEXT" "$BLOCKING_FINGERPRINT"
+  block_with_retry_check "$CURRENT_HASH" "$FINDINGS_TEXT" "$BLOCKING_FINGERPRINT" "false"
 fi
 
 write_state "$CURRENT_HASH" "pass" 0 ""
+# WHY(issue #355): 直前がblockedからのpassへの遷移は「指摘が修正につながった」ことを意味する
+# ため、単なるpass(初回・元々問題なし)とは区別してresolvedとして記録する。
+if [ "$PREV_VERDICT" = "blocked" ]; then
+  log_effectiveness "resolved"
+else
+  log_effectiveness "pass" '{"cached": false}'
+fi
 if [ -n "$MINOR_TEXT" ]; then
   emit_pass "$(printf 'verify-claims: 軽微な指摘があります(ブロックはしません):\n%s' "$MINOR_TEXT")"
 fi

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -29,6 +29,7 @@ STATE_DIR="$WORKDIR/state"
 MOCK_VERIFIER="$WORKDIR/mock-verifier.sh"
 MOCK_CALL_LOG="$WORKDIR/call.log"
 MOCK_FINDINGS_FILE="$WORKDIR/findings.json"
+EFFECTIVENESS_LOG="$WORKDIR/effectiveness.jsonl"
 
 cat > "$MOCK_VERIFIER" <<'MOCK_EOF'
 #!/usr/bin/env bash
@@ -80,6 +81,8 @@ run_hook() {
       VERIFY_CLAIMS_STATE_DIR="$STATE_DIR" \
       VERIFY_CLAIMS_MAX_RETRIES=3 \
       VERIFY_CLAIMS_VERIFIER_CMD="$MOCK_VERIFIER" \
+      VERIFY_CLAIMS_EFFECTIVENESS_LOG="$EFFECTIVENESS_LOG" \
+      VERIFY_CLAIMS_FAIL_OPEN_STREAK_THRESHOLD="${MOCK_FAIL_OPEN_STREAK_THRESHOLD:-5}" \
       MOCK_CALL_LOG="$MOCK_CALL_LOG" \
       MOCK_FINDINGS_FILE="$MOCK_FINDINGS_FILE" \
       MOCK_SHOULD_FAIL="${MOCK_SHOULD_FAIL:-0}" \
@@ -307,6 +310,59 @@ echo '{"findings": [{"severity": "critical", "description": "根拠不明の指�
 run_hook "s17"
 assert_eq "$EXIT_CODE" "0" "evidenceが空の場合はminor格下げでブロックされない"
 assert_contains "$STDOUT_OUT" "evidence未検証" "格下げの旨がsystemMessageに含まれる"
+
+echo "=== scenario 18: 効果測定ログにblocked/resolvedイベントが記録される(issue #355) ==="
+rm -f "$MOCK_CALL_LOG"
+: > "$EFFECTIVENESS_LOG"
+echo "line18a" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "critical", "description": "指摘", "evidence": "file.txt:1"}]}' > "$MOCK_FINDINGS_FILE"
+run_hook "s18"
+assert_eq "$EXIT_CODE" "2" "1回目はブロック"
+BLOCKED_EVENT="$(jq -c 'select(.session_id == "s18" and .event == "blocked")' "$EFFECTIVENESS_LOG" | tail -n1)"
+assert_contains "$BLOCKED_EVENT" '"retry_count":1' "blockedイベントにretry_countが記録される"
+assert_contains "$BLOCKED_EVENT" '"cached":false' "blockedイベントにcached:falseが記録される(LLM呼び出しあり)"
+
+echo "line18b" >> "$REPO/file.txt"
+echo '{"findings": []}' > "$MOCK_FINDINGS_FILE"
+run_hook "s18"
+assert_eq "$EXIT_CODE" "0" "2回目(指摘解消)はpass"
+RESOLVED_EVENT="$(jq -c 'select(.session_id == "s18" and .event == "resolved")' "$EFFECTIVENESS_LOG")"
+assert_contains "$RESOLVED_EVENT" '"event":"resolved"' "blockedからpassへの遷移がresolvedイベントとして記録される(=指摘が修正につながった)"
+
+echo "=== scenario 19: 効果測定ログにskip_usedイベントが記録される(issue #355) ==="
+rm -f "$MOCK_CALL_LOG"
+: > "$EFFECTIVENESS_LOG"
+touch "$STATE_DIR/s19.skip"
+run_hook "s19"
+assert_eq "$EXIT_CODE" "0" ".skip使用時はpass"
+SKIP_EVENT="$(jq -c 'select(.session_id == "s19" and .event == "skip_used")' "$EFFECTIVENESS_LOG")"
+assert_contains "$SKIP_EVENT" '"event":"skip_used"' "skip_usedイベント(誤検知シグナル)が記録される"
+
+echo "=== scenario 20: fail-openが連続するとsystemMessageに警告が追記される(issue #355) ==="
+rm -f "$MOCK_CALL_LOG"
+: > "$EFFECTIVENESS_LOG"
+MOCK_FAIL_OPEN_STREAK_THRESHOLD=3
+MOCK_SHOULD_FAIL=1
+echo "line20a" >> "$REPO/file.txt"
+run_hook "s20a"
+assert_eq "$EXIT_CODE" "0" "1回目のfail-openはpass"
+if printf '%s' "$STDOUT_OUT" | grep -qF "警告"; then
+  echo "  NG: 1回目から警告が出てはいけない(閾値未満)"
+  fail=1
+else
+  echo "  OK: 1回目は警告なし(閾値未満)"
+fi
+echo "line20b" >> "$REPO/file.txt"
+run_hook "s20b"
+echo "line20c" >> "$REPO/file.txt"
+run_hook "s20c"
+assert_eq "$EXIT_CODE" "0" "3回目もfail-openでpass"
+assert_contains "$STDOUT_OUT" "警告" "連続3回(閾値)のfail-openで警告が追記される"
+assert_contains "$STDOUT_OUT" "機能していない可能性" "警告文言に検証サブエージェント機能不全の旨が含まれる"
+FAIL_OPEN_COUNT="$(jq -c 'select(.event == "fail_open" and .reason == "verifier_failed")' "$EFFECTIVENESS_LOG" | wc -l | tr -d ' ')"
+assert_eq "$FAIL_OPEN_COUNT" "3" "fail_openイベントが3件記録される(reason: verifier_failed)"
+MOCK_SHOULD_FAIL=0
+MOCK_FAIL_OPEN_STREAK_THRESHOLD=5
 
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"


### PR DESCRIPTION
## Summary
- 「新しい運用ルールは検知手段を先に決める」(issue #339)の原則に照らし、この検証サブエージェントには効果を機械的に知る手段が無かった (closes #355)
- `logs/verify-claims-effectiveness.jsonl` に判定種別ごとのイベントを記録:
  - `skip_used` - `.skip`マーカー使用(誤検知シグナル)
  - `pass` - 指摘なしでpass(`cached`で再利用か新規検証かを区別)
  - `blocked` - critical/important指摘でブロック(`retry_count`・`cached`を記録)
  - `resolved` - blockedからpassへの遷移(=指摘が修正につながった)。単なるpassとは区別
  - `fail_open` - 検証未実施(`reason`: verifier_failed/parse_failed/circuit_breaker)
- 直近N件(既定5件、`VERIFY_CLAIMS_FAIL_OPEN_STREAK_THRESHOLD`で変更可)が連続してfail_openの場合、systemMessageに「検証サブエージェントが機能していない可能性」の警告を追記
- 設計書に「効果測定(Effectiveness Measurement)」節を追加

## 副次的に発見・修正したバグ
- 効果測定ログ自身がリポジトリ内のuntrackedファイルとしてdiffハッシュ計算(issue #352)に混入し、ログ追記のたびにハッシュが変化し続けてキャッシュ機構(スキップ・再判定ロジック)が機能しなくなる自己参照バグを発見。`STATE_DIR`/`LOCK_DIR`/`EFFECTIVENESS_LOG`の配置先を明示的にハッシュ計算対象から除外することで修正(`/logs/`がgitignore対象であることに暗黙依存しない)
- 実装中、bash 3.2(macOS既定)で「同一`local`行の2つ目以降の変数に`${N:-{}}`形式のデフォルト値を使うと余分な閉じ括弧が混入する」パーサ既知問題を踏んだため、if文による明示的なデフォルト値設定に置き換え

## Test plan
- [x] `bash scripts/verify-claims.test.sh` — 全20シナリオ成功(新規追加のscenario 18-20でblocked/resolved/skip_usedイベント記録・fail-open連続警告を確認)
- [x] `bash -n scripts/verify-claims.sh` — 構文エラーなし
- [x] `npm run lint` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)