### PR TITLE
fix: verify-claimsの効果測定ログが診断用ハッシュに混入する自己参照バグをスクリプト側で防ぐ

### DIFF
--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -161,16 +161,26 @@ fail-open(検証プロセス自体の失敗によるexit 0)が静かに常態化
 - **`was_previously_blocked`**: `pass`イベント限定。直前状態が`blocked`だった場合は`true`。
   これが「指摘が修正につながった」ことの直接シグナルになる(=誤検知でなければ、指摘後に
   正しく直されてpassに転じたということ)
-- **WHY untrackedファイルとして扱われない場所に書く必要がある**: `/logs/`は`.gitignore`済み
-  (既存の`loop-observability.jsonl`と同じ扱い)。これは単なる衛生上の配慮ではなく**必須**:
-  もし`/logs/`がgitignoreされていない場合、このログファイル自身がuntrackedファイルとして
-  「スキップ・再判定ロジック」のdiffハッシュ計算(issue #352で既にuntrackedファイルの中身を
-  含める方式に変更済み)に取り込まれ、判定のたびにログファイルが増えて中身が変わる
-  →ハッシュが常に変わる→ケース1(即pass)が二度と成立しなくなり、Stopのたびに必ず
-  `claude -p`を呼び続ける自己参照バグになる。テスト(`verify-claims.test.sh`)ではテスト用
-  gitリポジトリに`.gitignore`が無いため、`VERIFY_CLAIMS_OBSERVABILITY_LOG`を明示的に
-  リポジトリ外(`$WORKDIR`配下)へ向けて回避している(既存の`VERIFY_CLAIMS_STATE_DIR`/
-  `VERIFY_CLAIMS_LOCK_DIR`と同じパターン)
+- **untrackedファイルとしてdiffハッシュに混入しないようにする(自己参照バグ対策)**: `/logs/`・
+  `.claude/.verify-state/`は`.gitignore`済み(既存の`loop-observability.jsonl`と同じ扱い)だが、
+  **`.gitignore`の存在に暗黙依存させず、スクリプト自身でも明示的に除外する**。もし除外していない
+  場合、このログファイル自身がuntrackedファイルとして「スキップ・再判定ロジック」のdiffハッシュ
+  計算(issue #352で既にuntrackedファイルの中身を含める方式に変更済み)に取り込まれ、判定のたびに
+  ログファイルが増えて中身が変わる→ハッシュが常に変わる→ケース1/2(キャッシュ経路)が二度と
+  成立しなくなり、Stopのたびに必ず`claude -p`を呼び続ける、または`retry_count`の累積・リセット
+  判定が壊れる自己参照バグになる。
+  - 実装: `STATE_DIR`/`LOCK_DIR`/`OBS_LOG_FILE`の配置先ディレクトリを、`git diff HEAD` +
+    `git status --porcelain`の`?? path`行 + `git ls-files --others --exclude-standard`の
+    いずれからも明示的に除外する(`scripts/verify-claims.sh`の`is_excluded_path`)
+  - これら3つのパスは環境変数で絶対パスに上書きされる可能性があるため、比較前に絶対パスへ
+    正規化する(相対パスのまま前方一致比較すると、絶対パスで上書きされた場合に除外が効かない)
+  - 正規化後の除外ディレクトリがリポジトリ配下(`REPO_DIR`配下)に無い場合は除外対象に加えない:
+    除外ディレクトリがリポジトリの祖先ディレクトリだと、「`$ancestor/*`」というglobがリポジトリ
+    配下の全ファイルに誤って一致してしまうため
+  - テスト(`verify-claims.test.sh`)の大半のシナリオは`VERIFY_CLAIMS_OBSERVABILITY_LOG`を
+    リポジトリ外(`$WORKDIR`配下)へ向けて自己参照バグ自体を回避しているが、この除外ロジック
+    自体の回帰テストとして、ログをリポジトリ内(`$REPO/logs/...`)に明示的に置いた上で
+    キャッシュ経路(ケース2)が正しく機能することを検証するシナリオを別途用意している
 
 ### 計算できる指標(事後集計、本ドキュメントのスコープでは集計スクリプトは実装しない)
 

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -140,9 +140,60 @@ block_with_retry_check() {
 # claude_stop_notify.sh側のgit add -Aが先に走っていれば偶然trackedになり救われるが、hookの実行順序に
 # 依存する暗黙のカップリングだったため、ここではuntrackedファイルの中身を直接読んでハッシュ対象に含める
 # (indexは変更しない = git add -N等でこのスクリプトが副作用的にリポジトリ状態を書き換えない)。
-DIFF_CONTENT="$( { git diff HEAD; git status --porcelain; } 2>/dev/null || true)"
+#
+# WHY(自己参照バグ対策): このスクリプト自身が書き込む状態ファイル(STATE_DIR)・ロック(LOCK_DIR)・
+# 効果測定ログ(OBS_LOG_FILEの配置先ディレクトリ)がuntrackedのままだと、ログ追記のたびに中身が
+# 変化し、それ自体がdiffハッシュに混入して「何もソースを直していないのにハッシュが変わり続ける」
+# 自己参照バグになる(このプロジェクトでは/logs/・.claude/.verify-state/がgitignore対象のため
+# 実害はないが、.gitignoreの存在に暗黙依存させず、スクリプト自身でも明示的に除外する)。
+# `git status --porcelain`の`?? path`行(パスのみ・中身は含まない)にも同じ除外を適用する必要が
+# ある。UNTRACKED_CONTENTのループだけ除外しても、この`?? path`行自体が新規追加/削除されると
+# それだけでDIFF_CONTENTが変化してしまうため。
+# `git ls-files`/`git status --porcelain`はリポジトリルート相対のパスを返す一方、
+# STATE_DIR/LOCK_DIR/OBS_LOG_FILEは環境変数で絶対パスに上書きされる可能性があるため、
+# 比較前に両者を絶対パスへ正規化する(相対パスのまま前方一致比較すると、絶対パスで上書き
+# された場合に除外が効かなくなる)。さらに、正規化後の除外ディレクトリがリポジトリ配下
+# (REPO_DIR_ABS配下)に無い場合は除外対象に加えない: 除外ディレクトリがリポジトリの祖先
+# ディレクトリだと、「$ancestor/*」というglobがリポジトリ配下の全ファイルに一致してしまい、
+# 本来除外すべきでないファイルまで丸ごとハッシュ対象から消えてしまう。
+REPO_DIR_ABS="$(pwd)"
+to_abs_path() {
+  case "$1" in
+    /*) printf '%s' "$1" ;;
+    *) printf '%s/%s' "$REPO_DIR_ABS" "$1" ;;
+  esac
+}
+is_within_repo() {
+  [[ "$1" == "$REPO_DIR_ABS" || "$1" == "$REPO_DIR_ABS"/* ]]
+}
+is_excluded_path() {
+  local abs
+  abs="$(to_abs_path "$1")"
+  [[ ( -n "$STATE_DIR_ABS" && "$abs" == "$STATE_DIR_ABS"/* ) || ( -n "$LOCK_DIR_ABS" && "$abs" == "$LOCK_DIR_ABS"/* ) || ( -n "$OBS_LOG_DIR_ABS" && "$abs" == "$OBS_LOG_DIR_ABS"/* ) ]]
+}
+STATE_DIR_ABS="$(to_abs_path "$STATE_DIR")"
+is_within_repo "$STATE_DIR_ABS" || STATE_DIR_ABS=""
+LOCK_DIR_ABS="$(to_abs_path "$LOCK_DIR")"
+is_within_repo "$LOCK_DIR_ABS" || LOCK_DIR_ABS=""
+OBS_LOG_DIR_ABS="$(to_abs_path "$(dirname "$OBS_LOG_FILE")")"
+is_within_repo "$OBS_LOG_DIR_ABS" || OBS_LOG_DIR_ABS=""
+
+STATUS_PORCELAIN="$(git status --porcelain 2>/dev/null || true)"
+FILTERED_STATUS=""
+while IFS= read -r status_line; do
+  [ -n "$status_line" ] || continue
+  if [[ "$status_line" == '?? '* ]] && is_excluded_path "${status_line#\?\? }"; then
+    continue
+  fi
+  FILTERED_STATUS="$(printf '%s\n%s' "$FILTERED_STATUS" "$status_line")"
+done <<< "$STATUS_PORCELAIN"
+
+DIFF_CONTENT="$( { git diff HEAD 2>/dev/null || true; printf '%s' "$FILTERED_STATUS"; } )"
 UNTRACKED_CONTENT="$(
   while IFS= read -r -d '' f; do
+    if is_excluded_path "$f"; then
+      continue
+    fi
     printf '%s\0' "$f"
     cat -- "$f" 2>/dev/null
   done < <(git ls-files --others --exclude-standard -z 2>/dev/null || true)

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -373,6 +373,55 @@ echo "=== scenario 26: .skipマーカー使用がskip_usedイベントとして�
 SKIP_COUNT="$(jq -rs --arg sid "s6" '[.[] | select(.session_id == $sid and .event == "skip_used")] | length' "$OBS_LOG")"
 assert_eq "$SKIP_COUNT" "1" "skip_usedイベントが1件記録される"
 
+echo "=== scenario 27: 効果測定ログをリポジトリ内(untracked)に置いても診断用ハッシュに混入せずキャッシュが機能する ==="
+# WHY: OBS_LOG_FILEの既定値はREPO_DIR相対の"logs/..."であり、リポジトリ配下のuntrackedファイルになる。
+# もしdiffハッシュ計算からこのログファイル自身を除外していないと、ログ追記のたびにハッシュが
+# 変化し続け、「ハッシュ一致・前回blocked」のキャッシュ経路(LLM再呼び出し無しでretry消費)が
+# 機能しなくなる自己参照バグになる(このテストスイート内では他シナリオがOBS_LOG_FILEを
+# $REPO外に置いて回避しているため、他シナリオではこのバグを検知できない)。
+IN_REPO_OBS_LOG="$REPO/logs/verify-claims-observability.jsonl"
+rm -f "$MOCK_CALL_LOG"
+echo "line27" >> "$REPO/file.txt"
+echo '{"findings": [{"severity": "critical", "description": "解消されない指摘", "evidence": "file.txt:1"}]}' > "$MOCK_FINDINGS_FILE"
+set +e
+STDOUT_OUT="$(
+  cd "$REPO"
+  input="$(jq -n --arg sid "s27" --arg tp "$WORKDIR/no-transcript.jsonl" '{session_id: $sid, transcript_path: $tp}')"
+  printf '%s' "$input" | \
+    VERIFY_CLAIMS_REPO_DIR="$REPO" \
+    VERIFY_CLAIMS_STATE_DIR="$STATE_DIR" \
+    VERIFY_CLAIMS_OBSERVABILITY_LOG="$IN_REPO_OBS_LOG" \
+    VERIFY_CLAIMS_MAX_RETRIES=3 \
+    VERIFY_CLAIMS_VERIFIER_CMD="$MOCK_VERIFIER" \
+    MOCK_CALL_LOG="$MOCK_CALL_LOG" \
+    MOCK_FINDINGS_FILE="$MOCK_FINDINGS_FILE" \
+    bash "$SCRIPT"
+)"
+EXIT_CODE=$?
+set -e
+assert_eq "$EXIT_CODE" "2" "1回目(新規diff・critical)はブロック"
+assert_eq "$(call_count)" "1" "1回目は検証エージェントが1回呼ばれる"
+set +e
+STDOUT_OUT="$(
+  cd "$REPO"
+  input="$(jq -n --arg sid "s27" --arg tp "$WORKDIR/no-transcript.jsonl" '{session_id: $sid, transcript_path: $tp}')"
+  printf '%s' "$input" | \
+    VERIFY_CLAIMS_REPO_DIR="$REPO" \
+    VERIFY_CLAIMS_STATE_DIR="$STATE_DIR" \
+    VERIFY_CLAIMS_OBSERVABILITY_LOG="$IN_REPO_OBS_LOG" \
+    VERIFY_CLAIMS_MAX_RETRIES=3 \
+    VERIFY_CLAIMS_VERIFIER_CMD="$MOCK_VERIFIER" \
+    MOCK_CALL_LOG="$MOCK_CALL_LOG" \
+    MOCK_FINDINGS_FILE="$MOCK_FINDINGS_FILE" \
+    bash "$SCRIPT"
+)"
+EXIT_CODE=$?
+set -e
+assert_eq "$EXIT_CODE" "2" "2回目(同一diff、ログ追記後)も再ブロック"
+assert_eq "$(call_count)" "1" "2回目は検証エージェントを再度呼ばない(ログ追記でハッシュが変わっていないため、キャッシュ経路が機能する)"
+RETRY_COUNT_S27="$(jq -r '.retry_count' "$STATE_DIR/s27.json")"
+assert_eq "$RETRY_COUNT_S27" "2" "retry_countが2まで進む(キャッシュ経路でも正しくretryが消費される)"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- issue #355の効果測定ログ実装(PR #380、`logs/verify-claims-observability.jsonl`)は`/logs/`が`.gitignore`対象であることに暗黙依存しており、ログファイル自身がuntrackedファイルとしてdiffハッシュ計算(issue #352)に混入すると、ログ追記のたびにハッシュが変化し続けてキャッシュ機構(スキップ・再判定ロジックのケース1/2)が機能しなくなる自己参照バグを抱えていた
- `STATE_DIR`/`LOCK_DIR`/`OBS_LOG_FILE`の配置先を、`git diff HEAD`・`git status --porcelain`の`?? path`行・`git ls-files --others`のいずれからも明示的に除外することで、`.gitignore`の存在に依存せず防ぐようにした
- 設計書「効果測定」節にハードニングの内容を反映

## 実装中に見つけた追加バグ(自己テストで検出)
1. 除外先パスが環境変数で絶対パスに上書きされるケース: `git ls-files`は相対パスを返すため、相対パスのまま前方一致比較すると絶対パス上書き時に除外が効かない → 両者を絶対パスへ正規化して比較
2. 除外ディレクトリがリポジトリの祖先ディレクトリになるケース: 正規化後の除外ディレクトリがリポジトリの外(親ディレクトリ等)だと、`$ancestor/*`というglobがリポジトリ配下の全ファイルに誤って一致し、本来除外すべきでないファイルまで丸ごとハッシュ対象から消えてしまう → 除外ディレクトリがリポジトリ配下にある場合のみ適用するようにした

## Test plan
- [x] `bash scripts/verify-claims.test.sh` — 全27シナリオ成功
  - 既存scenario 1-26(PR #380由来)は引き続き成功
  - 新規scenario 27: 効果測定ログをリポジトリ内(`$REPO/logs/...`)に明示的に置いた上で、キャッシュ経路(ケース2、LLM再呼び出し無しでretry消費)が正しく機能することを確認
- [x] `bash -n scripts/verify-claims.sh` — 構文エラーなし
- [x] `npm run lint` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)