### PR TITLE
fix: verify-claimsのエスケープハッチを人間専用に限定(issue #348)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,8 @@
       "Bash(scripts/ai-check-suggest.sh *)",
       "Bash(scripts/verify-claims.sh *)",
       "Bash(bash scripts/verify-claims.test.sh*)",
+      "Bash(scripts/check-skip-marker-write.sh *)",
+      "Bash(bash scripts/check-skip-marker-write.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -122,6 +124,14 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "scripts/check-skip-marker-write.sh", "timeout": 5 }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,271 +1,135 @@
-# 機能仕様書: 分析・レポートページの新設（issue #23）
+# SPEC: 検証サブエージェントのエスケープハッチを人間専用に限定する(issue #348)
 
-作成日: 2026-07-15
-ステータス: ドラフト（人間レビュー待ち。Adversarial Verify 55件＋Judge Panel統合案を反映済み）
+## Part 1 — 仕様（★人間がレビューする部分）
 
----
+### 何ができるようになるか
 
-## ⚠️ 人間が判断すべき未解決事項（レビュー時に必ず確認）
+Stop hook(`verify-claims.sh`)が「未解消の指摘あり」として3回連続でブロックし続けた場合、現状は「誤検知なら `touch <パス>` でスキップできます」という案内をブロックされた本人(VS Code側のエージェント)自身に見せてしまっています。これだと、指摘を直す代わりに自分でそのファイルを作ってすり抜ける、という抜け道が成立してしまいます。
 
-以下はAI側で仮決定しているが、承認前に確認をお願いします（1・2は既に人間確認済み）。
-
-1. **【確認済み】単価の取得方法**: 発注**作成時**（`create_*_order_atomic` RPC内）に単価をスナップショット保存する方式で進める。過去の発注（本機能実装日より前）は単価データがなく、集計上「-」表示になる。
-2. **【確認済み】集計対象ステータス**: `draft`/`submitted`を問わず全発注を集計対象にする（現状submitフロー自体が存在しないため）。将来submitフローが実装されたら、WHERE句一行で絞り込める設計にしておく。
-3. **複数`distributor_products`が同一JANに紐づく場合の単価選択ルール**: 本ドラフトは`MIN(purchase_price)`（最安値・決定論的）を採用と仮決定。曖昧な場合にNULL（保存しない）にする案もある。金額の正確性に関わるため確認を推奨。
-4. **NULL/¥0/「-」の表示区分**: 本ドラフトは以下の3区分で仮決定。表示文言は要確認。
-   - 発注0件 → 「-」
-   - 発注はあるが全明細のunit_price=NULL（金額データなし）→ 「-（金額データなし）」
-   - 金額集計値が0円（数量0等）→ 「¥0」
-5. **ページ初回表示**: 性能懸念のため、初回アクセス時は自動集計せず「期間未指定＝空状態（フィルタ入力待ち）」とする仮決定。全期間自動集計にすべきかは要確認。
-6. **監査ログ**: admin による全施設金額閲覧の監査ログは今回スコープ外（コンプライアンス要件があれば別途検討）。
-7. **過去データの遡及計算**: 行わない（実装日以前の発注は永続的に「-」）。遡及必要なら別issue。
-
----
-
-## Part 1 — 仕様（人間レビュー用）
-
-### 何ができるようになるか（利用者目線）
-
-admin ユーザーのみが `/admin/reports` にアクセスし、任意の期間を指定して「施設別 × 発注種別（症例発注 / 消耗品発注 / 短貸発注）の発注金額集計テーブル」を閲覧できる。一般ユーザーはこのページへのリンク・ナビゲーションが表示されず、URLを直打ちしても`/login`にリダイレクトされる（`/admin/*`の既存adminガードをそのまま利用するため、ページを`/admin/reports`に配置する）。
-
-価格推移グラフは今回のスコープ外（別issueで検討）。
+この修正後は:
+- ブロックメッセージから具体的なコマンド案内を消し、「人間に相談してください」だけを表示するようにします。
+- スキップ用ファイル(`.claude/.verify-state/<session_id>.skip`)を作成する行為そのものに、手段(touch・echo・python等)を問わず人間の確認プロンプトが挟まるようにします。エージェントが黙って作成しようとしても、人間が実際にその場で「はい」と答えない限り作成できません。
+- 人間がその場で承認すれば、従来通りスキップは機能します。
 
 ### 操作の流れ
 
-1. adminユーザーが `/admin/reports` にアクセスする
-2. ページ上部に期間フィルタ（開始日・終了日、任意入力）が表示される
-3. 「集計する」ボタン押下、またはURLパラメータ変更で集計テーブルが更新される
-4. テーブルは「施設名」行 × 「症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」列の形式で表示される（全施設が行として表示され、発注0件の施設も表示する）
-5. 金額はすべて円表示（カンマ区切り整数）
-6. 該当データがない場合は「-」、金額データなしの場合は「-（金額データなし）」、集計値0円は「¥0」と表示を区別する（未解決事項4）
+1. エージェントが同じ指摘で3回ブロックされる
+2. stderrに「3回試みたが解消されなかった。人間に相談してください」とだけ表示される(具体的なコマンドは出ない)
+3a. 人間が状況を見て誤検知と判断し、スキップ用ファイルの作成をエージェントに指示(またはエージェントが自発的に提案)した場合 → 作成しようとした瞬間に確認ダイアログが表示される → 人間が承認 → 次のStopで通過
+3b. エージェントが人間に断りなく黙ってスキップ用ファイルを作成しようとした場合 → 同じ確認ダイアログが表示される(見えている画面の前に人間がいなければ、ここで待機したまま先に進まない)
 
-### 受け入れ条件チェックリスト
+📸 スクリーンショット対象外(CLIのStop hook・権限ダイアログのため通常の画面キャプチャ対象ではありません)
 
-**アクセス制御**
-- [ ] adminユーザーが `/admin/reports` にアクセスできる
-- [ ] 未認証ユーザーが `/admin/reports` にアクセスすると `/login` にリダイレクトされる
-- [ ] 一般ユーザーが `/admin/reports` にアクセスすると `/login` にリダイレクトされる（middlewareのadminガードで弾かれる。middleware自体の改修は不要）
-- [ ] `DashboardShortcuts` に「レポート」リンクがadminユーザーのみに表示される（一般ユーザーには非表示）
-- [ ] 一般ユーザーが `GET /api/admin/reports` に直接リクエストすると403が返る
-- [ ] 未認証リクエストは401が返る
+### 受け入れ条件
 
-**期間フィルタ**
-- [ ] 開始日・終了日をYYYY-MM-DD形式で任意指定できる（両方省略時は全期間）
-- [ ] 開始日のみ指定時は「指定日(JST 00:00:00)以降」、終了日のみ指定時は「指定日(JST 23:59:59)以前」として集計される（`src/lib/jst-date-range.ts`の`jstDayStart`/`jstDayEnd`/`isValidDateString`を再利用する。独自実装しない）
-  - **既知のリスク（minor、本機能スコープ外）**: `jstDayEnd`は秒精度（`23:59:59`）までしか表現できず、`created_at`（TIMESTAMPTZ、マイクロ秒精度）が`23:59:59.xxxxxx`の場合に`<=`比較で終了日当日の最後の1秒未満の発注が期間集計から漏れる可能性がある。これは`jstDayEnd`が既存の複数機能（case-orders/consumable-orders/loan-orders/loan-returns/orders）で共有されている既存実装（issue #20由来）であり、本機能はそれを再利用する方針のため本SPECの対応範囲外とする。修正するなら`jstDayEnd`自体を`23:59:59.999999`等に改める必要があり、影響範囲が本機能を超えるため別issueで検討する。
-- [ ] 開始日 > 終了日の場合はバリデーションエラーを表示し、APIは呼ばない
-- [ ] 不正な日付形式は400エラーになる
+- [ ] ブロックメッセージに具体的なコマンド(ファイルパスの作り方)が含まれない
+- [ ] `touch`・`echo`・`python3`・`node`など手段を問わず、`.claude/.verify-state/*.skip`への書き込みを試みると人間の確認プロンプトが表示される
+- [ ] 確認プロンプトで人間が承認した場合のみスキップが機能する(黙って通過することはない)
+- [ ] 既存のテスト(3回超過後のブロック継続、.skip使用時のpass、.skip消費後の状態リセット)が引き続き通る
+- [ ] 設計ドキュメント(`docs/superpowers/specs/2026-07-14-verification-subagent-design.md`)のエスケープハッチ節・ブロックロジック節・エラーハンドリング表が新しい挙動に更新されている
 
-**集計テーブル**
-- [ ] 全施設が行として表示される（発注が0件の施設も表示する）
-- [ ] 列は「施設名 / 症例発注金額 / 消耗品発注金額 / 短貸発注金額 / 合計」の5列
-- [ ] 各金額セルは該当期間・施設・発注種別の `unit_price × quantity` のSUM（ステータスは問わず全件対象。未解決事項2）
-- [ ] 発注0件の施設は「-」、発注はあるが単価データが一切ない場合は「-（金額データなし）」、集計値が0円の場合は「¥0」と表示が区別される（未解決事項4）。この区別は種別（症例/消耗品/短貸）単位で行われ、他種別の状態に引きずられない（critical指摘対応: `*_total_count`で「発注0件」と「単価データなし」を種別ごとに判定する）
-- [ ] 合計列は以下の優先順位で判定する（コードレビューでSPEC文言の自己矛盾＝critical指摘を修正済み。`src/components/reports/ReportTable.tsx`の`formatTotal`実装が正）:
-  1. **3種別すべての`*_total_count === 0`**（=施設に発注が1件もない）→ 合計は「-」
-  2. 上記に該当せず、かつ**3種別すべての`amount === null`**（=発注はあるが、どの種別にも金額データがない）→ 合計は「-（金額データなし）」
-  3. 上記いずれにも該当しない（=少なくとも1種別に確定金額がある）→ 各種別の`amount`のNULLを0とみなして合計し「¥N,NNN」で表示（他種別が「発注0件」または「金額データなし」でも、確定金額がある種別が1つでもあれば合計は算出できる）
-- [ ] ページ下部に「YYYY-MM-DD以前の発注は金額データがありません」旨の注釈を表示する
-- [ ] 集計中はテーブル領域にローディング表示をする
+### 設計上の限界(正直な注意点)
 
-**データ精度**
-- [ ] 発注作成時（`create_*_order_atomic` RPC内）に単価スナップショットが保存されている
-- [ ] 単価解決に失敗した場合（該当する`hospital_prices`が存在しない等）は`unit_price=NULL`として保存し、発注作成自体は失敗させない（best-effort）
+- コマンド文字列に直接パスを書かず、変数展開・base64エンコード等で難読化された場合は正規表現マッチをすり抜けうる。完全な保証ではなく、典型的な迂回手段(touch/echo/cp/python -c/node -e等)を塞ぐもの
+- 確認プロンプトはVS Code側セッションを実際に見ている人間が応答することが前提。誰も見ていない完全放置の自律実行中は、確認待ちのまま止まる(=通過しない側に倒れる。これはブロック継続と同じ安全側の挙動)
 
 ---
 
-## Part 2 — 実装計画（AI用）
+## Part 2 — 実装計画（AI用・レビュー不要）
 
-### 設計方針の確定事項（Judge Panel採用: 保守的設計アプローチ、スコア77）
+### 実装セット(単一セット、依存関係があるため並列化しない)
 
-| 論点 | 採用 | 理由 |
-|---|---|---|
-| ページ配置 | `/admin/reports` | `src/middleware.ts`の`isAdminPath`は`/admin/*`のみ対応。middleware改修なしでadminガードを効かせるため |
-| 単価保存タイミング | 発注**作成時**（`create_*_order_atomic` RPC内） | 現状submitフローが存在しないため（未解決事項2で確定） |
-| 集計対象ステータス | 問わず全件 | 同上。将来submitフロー実装時にWHERE句一行で絞れる設計にしておく |
-| JST日付変換 | `src/lib/jst-date-range.ts`を再利用 | 既存の`jstDayStart`/`jstDayEnd`/`isValidDateString`と重複実装しない |
-| 単価解決パス | `case_order_items.jan → products(jan) → distributor_products(product_id) → hospital_prices(distributor_product_id, facility_id)` | 実際のスキーマに基づく正しいJOINパス（`hospital_prices`は`distributor_product_id`+`facility_id`で一意） |
-| 認可 | API層`requireAuth()`（401）+`resolveIsAdmin()`（403）+ RPC層`is_admin()`（permission denied→403変換） | `requireAdmin()`は401/403を区別できないため個別判定パターンを採用。`createAdminSupabase()`は不要 |
+対象ファイル:
+- `scripts/verify-claims.sh`
+- `scripts/verify-claims.test.sh`
+- `docs/superpowers/specs/2026-07-14-verification-subagent-design.md`
 
-不採用（検討したが見送り）: クエリ時に現在の`hospital_prices`をJOINして計算する方式（未解決事項1で確定）。過去発注の履歴的単価精度が失われるため。
+いずれも同じロジック変更に対する実装/テスト/ドキュメントの三点セットであり、共有ファイルというより「1つの変更を3ファイルに反映する」性質のため、統合ゲート無しの単一実装セットとして扱う。
 
----
+### 変更内容
 
-### DB設計
+#### 1. `scripts/verify-claims.sh`
 
-#### Set A: 既存order_itemsテーブルへの単価カラム追加
+**a. ブロックメッセージから具体案内を削除(86行目)**
 
-```sql
--- migration: <実装日>_add_unit_price_to_order_items.sql
-ALTER TABLE case_order_items       ADD COLUMN unit_price NUMERIC(12,2);
-ALTER TABLE consumable_order_items ADD COLUMN unit_price NUMERIC(12,2);
-ALTER TABLE loan_order_items       ADD COLUMN unit_price NUMERIC(12,2);
-
--- 既存データはNULL（過去発注は金額データなし）。カラム追加のみでテーブル新設/削除ではないため
--- refresh_schema_baseline_snapshot は不要（issue #305要件の対象外。実装時に最新スキーマベースラインで再確認すること）
-
--- 【SPEC訂正（実装時に判明）】case_ordersの(facility_id, created_at)複合インデックスは
--- 20260626000000_fix_fk_and_indexes.sql で既に作成済みだった（本ドラフト作成時は
--- 「欠落している」と誤認していた）。追加のCREATE INDEXは不要。
+現状:
+```bash
+emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが指摘が解消されませんでした。人間の介入待ちです。誤検知の場合は `touch %s` でスキップできます。\n%s' "$MAX_RETRIES" "$SKIP_MARKER" "$findings_msg")"
 ```
 
-**注意点**: `unit_price`はNUMERIC(12,2)（円未満は扱わないが、将来の消費税等端数対応に備え小数2桁を確保）。既存行はNULLのまま（遡及なし、未解決事項7）。
+変更後: `touch %s` 部分を削除し、「人間に相談してください」のみにする。`SKIP_MARKER`変数自体は変更不要(既存のまま維持)。
 
-#### Set A-2: 既存の発注作成RPC改修（単価スナップショット保存）
+**この修正のみで、`.skip`検知・pass判定ロジック(既存106-115行目)自体は一切変更しない。** エスケープハッチの安全性は後述のPreToolUse hookで「作成行為そのもの」をゲートする方式に一本化するため、Stop hook側に検知ロジックを持たせる必要がなくなる。
 
-- **触るファイル**: `supabase/migrations/<実装日>_add_unit_price_snapshot_to_order_rpcs.sql`（新規。既存migrationファイルは追記・修正禁止のため`CREATE OR REPLACE FUNCTION`で対応）
-- 対象: `create_case_order_atomic` / `create_consumable_order_atomic` / `create_loan_order_atomic`（`supabase/migrations/20260626002000_add_order_rpc_functions.sql` 等で定義済み）
-- 各RPC内で、各明細行の挿入前に単価を解決してINSERTする:
-  - `case_order_items`: `jan → products(jan) → distributor_products(product_id) → hospital_prices(distributor_product_id, p_facility_id)` で`purchase_price`を取得
-  - `consumable_order_items`: `consumable_id → consumables(jan) → products(jan) → distributor_products(product_id) → hospital_prices(...)`
-  - `loan_order_items`: `case_order_items`と同型
-  - 同一JANが複数`distributor_products`に紐づく場合は`MIN(purchase_price)`を採用（未解決事項3）
-  - 単価解決に失敗した場合（該当行なし・`consumables.jan`がNULL等）は`unit_price = NULL`のまま挿入し、例外を投げない（best-effort、RPCはロールバックしない）
-  - **重複実装指摘対応（important）**: `case_order_items`と`loan_order_items`は`jan → products → distributor_products → hospital_prices`という全く同一の単価解決クエリを使う。これを共通のSQL関数`resolve_jan_unit_price(p_jan TEXT, p_facility_id UUID) RETURNS NUMERIC`（`LANGUAGE sql STABLE`）に切り出し、3つのRPCすべてがこの関数を呼び出す形にする（`consumable_order_items`は`consumables.jan`を求めたうえで同じ関数を呼ぶ）。各RPC内にインラインで同一クエリを重複実装しない
-  - **GRANT EXECUTE必須（important指摘対応）**: `resolve_jan_unit_price`に`GRANT EXECUTE ON FUNCTION resolve_jan_unit_price(TEXT, UUID) TO authenticated;`を明示的に付与する。暗黙のPUBLIC権限に依存すると、将来`REVOKE EXECUTE FROM PUBLIC`相当の防御的変更が入った際に`create_*_order_atomic`からの呼び出しが失敗し、発注作成自体が壊れる退行リスクがある（`is_facility_member()`の既存対応 `20260711000001_grant_execute_is_facility_member.sql` と同じ理由）
-- **テスト観点**:
-  - 正常な単価解決で`unit_price`が正しく保存される
-  - 該当する`hospital_prices`がない場合、`unit_price=NULL`で挿入が成功する（例外にならない）
-  - 同一JANが複数distributor_productsに紐づく場合、`MIN(purchase_price)`が採用される
-  - `resolve_jan_unit_price`に`GRANT EXECUTE TO authenticated`が明示的に付与されている
+#### 2. 新規: `scripts/check-skip-marker-write.sh` (PreToolUse hook)
 
-#### Set B: 集計RPC
+`.claude/.verify-state/<session_id>.skip`というパスへの書き込みを試みるツール呼び出し(Bash/Write/Edit)を検知し、手段を問わず人間の確認プロンプト(ask)に強制的に切り替える。
 
-- **触るファイル**: `supabase/migrations/<実装日>_add_order_amount_report_rpc.sql`
-- RPC名: `get_order_amount_report(p_date_from TIMESTAMPTZ, p_date_to TIMESTAMPTZ)`
-- 戻り値型（コードレビュー指摘・critical対応: `*_total_count`列を追加。理由は下記参照）:
-  ```sql
-  TABLE(
-    facility_id UUID,
-    facility_name TEXT,
-    case_order_amount NUMERIC,
-    case_order_count INTEGER,
-    case_order_total_count INTEGER,
-    consumable_order_amount NUMERIC,
-    consumable_order_count INTEGER,
-    consumable_order_total_count INTEGER,
-    loan_order_amount NUMERIC,
-    loan_order_count INTEGER,
-    loan_order_total_count INTEGER
-  )
+- 標準入力でPreToolUseのhook入力JSON(`tool_name`, `tool_input`)を受け取る
+- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
+- マッチした場合、以下を標準出力してexit 0:
+  ```json
+  {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "verify-claimsのエスケープハッチ(.skipマーカー)への書き込みです。人間の確認が必要です。"}}
   ```
-  - `*_count`は「単価データがある明細の件数」（amount集計に使われた件数）。
-  - `*_total_count`は「価格の有無を問わない全明細件数」。**critical指摘対応**: 当初案は`*_count`のみで
-    「発注0件」と「発注はあるが単価データなし」を区別しようとしていたが、両者とも`amount=NULL・count=0`で
-    返るため区別不能だった。`*_total_count = 0`なら「発注自体が0件」、`*_total_count > 0`かつ`amount IS NULL`
-    なら「発注はあるが単価データなし」とUI側で判定する（未解決事項4）。
-- 実装方針:
-  - `SECURITY DEFINER` + `SET search_path = public` + 関数冒頭で`is_admin()`チェック（false なら`RAISE EXCEPTION 'permission denied'`）
-  - `GRANT EXECUTE ON FUNCTION get_order_amount_report TO authenticated, service_role`（`anon`除外。実行時の最終ガードは関数内`is_admin()`）
-  - `facilities`テーブルを起点にLEFT JOINし、全施設が必ず出力される
-  - 各発注種別は`WHERE (p_date_from IS NULL OR created_at >= p_date_from) AND (p_date_to IS NULL OR created_at <= p_date_to)`（ステータス条件なし、未解決事項2）
-  - `SUM(unit_price * quantity) FILTER (WHERE unit_price IS NOT NULL)`と`COUNT(*) FILTER (WHERE unit_price IS NOT NULL)`で
-    `amount`/`count`を集計しつつ、フィルタなしの`COUNT(*)`を`total_count`として同時に集計する。`amount`はNULLのまま返す（COALESCEしない。UI側で判定）
-- **テスト観点**:
-  - adminユーザーで実行できる
-  - 非adminユーザーでpermission deniedが返る
-  - 期間フィルタが正しく適用される（境界値含む）
-  - 発注0件の施設は`amount=NULL`・`count=0`・`total_count=0`で返る
-  - 発注はあるが単価データなしの施設は`amount=NULL`・`count=0`・`total_count>0`で返る（`total_count`で発注0件の施設と区別できることを検証する）
+- マッチしない場合は何も出力せずexit 0(通常の許可フローに委ねる。allowでもdenyでもなく無関与)
 
-#### Set C: 型定義・Repository
+判定基準:
 
-- **触るファイル**:
-  - `src/types/report.ts`（新規）
-  - `src/lib/reports/repository.ts`（新規）
-  - `src/lib/reports/__tests__/repository.test.ts`（新規）
-- 型定義（`*_total_count`はcritical指摘対応。上記Set Bの`*_total_count`列に対応）:
-  ```typescript
-  export type OrderAmountReportRow = {
-    facilityId: string
-    facilityName: string
-    caseOrderAmount: number | null
-    caseOrderCount: number
-    caseOrderTotalCount: number
-    consumableOrderAmount: number | null
-    consumableOrderCount: number
-    consumableOrderTotalCount: number
-    loanOrderAmount: number | null
-    loanOrderCount: number
-    loanOrderTotalCount: number
+| ケース | 挙動 |
+|---|---|
+| Bashコマンド文字列またはWrite/Edit file_pathが`.claude/.verify-state/*.skip`にマッチしない | このhookは関与しない(通常の権限フローのまま) |
+| マッチする | `permissionDecision: "ask"`を返し、通常の確認ダイアログが表示される。人間が承認すれば実行され、拒否すれば実行されない |
+
+既知の限界(設計ドキュメントに明記する):
+- 正規表現によるコマンド文字列マッチのため、変数展開・base64エンコード等で意図的に難読化されたコマンドは検知をすり抜けうる。典型的な手段(touch/echo/cp/mv/python -c/node -e等、コマンド文字列に直接パスが現れるもの)を塞ぐのが目的であり、完全な保証ではない
+- 確認プロンプトはVS Code側で実際にセッションを見ている人間が応答することが前提。誰も見ていない間は応答待ちのまま進まない(=通過しない側に倒れるため安全)
+
+#### 3. `.claude/settings.json`
+
+`PreToolUse` hookエントリを新規追加する:
+```json
+"PreToolUse": [
+  {
+    "matcher": "Bash|Write|Edit",
+    "hooks": [
+      { "type": "command", "command": "scripts/check-skip-marker-write.sh", "timeout": 5 }
+    ]
   }
-  export type OrderAmountReportFilter = {
-    dateFrom?: string  // YYYY-MM-DD
-    dateTo?: string    // YYYY-MM-DD
-  }
-  ```
-- `fetchOrderAmountReport(db: SupabaseClient, filter: OrderAmountReportFilter): Promise<OrderAmountReportRow[]>`
-  - `filter.dateFrom`/`dateTo`は`jstDayStart`/`jstDayEnd`でTIMESTAMPTZに変換してから`db.rpc('get_order_amount_report', {...})`を呼ぶ
-  - スネークケース→キャメルケースへの全フィールドマッピングをテストでアサートする（マッピング漏れ防止）
-- **テスト観点**: RPC呼び出しが正しい引数で呼ばれること、レスポンス全フィールドのマッピングが正しいこと
+]
+```
+既存の`Stop`フックエントリ(doc-suggest-check.sh / ai-check-suggest.sh / verify-claims.sh)はそのまま変更しない。
 
-#### Set D: APIエンドポイント
+#### 4. `scripts/verify-claims.sh`のテスト、`scripts/verify-claims.test.sh`
 
-- **触るファイル**:
-  - `src/app/api/admin/reports/route.ts`（新規）
-  - `src/app/api/admin/reports/__tests__/route.test.ts`（新規）
-- `GET /api/admin/reports?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD`
-- 認可: 【SPEC訂正（実装時に判明）】`requireAdmin()`（`src/lib/admin-auth.ts`）は未認証/非adminをどちらもnullで返し401/403を区別できないため、`requireAuth(db)`で認証チェック（失敗時401）→ `resolveIsAdmin(db, user)`で個別にadmin判定（false時403）というパターンを採用する（`createAdminSupabase()`は不要）
-- バリデーション:
-  - `date_from`/`date_to`は省略可。指定時は`isValidDateString()`でYYYY-MM-DD形式チェック（不正形式は400）
-  - `date_from > date_to`の場合は400
-  - RPCからの`permission denied`はAPIが403に変換する（500で隠さない）
-- レスポンス: `{ rows: OrderAmountReportRow[] }`
-- **テスト観点**: 未認証401・非admin403・不正日付400・正常系
+- 既存シナリオ5(「touch」「s5.skip」を含むことをアサート)は、コマンド案内を消す変更と矛盾するため、アサーション内容を「`touch`という語を含まないこと」「`人間に相談`という文言を含むこと」に更新する
+- 既存シナリオ6・11(`.skip`マーカーでpass、消費後のリセット)は無変更で維持する(Stop hook側のロジックは変えていないため)
 
-#### Set E: UIコンポーネント
+#### 5. 新規: `scripts/check-skip-marker-write.test.sh`
 
-- **触るファイル**:
-  - `src/components/reports/ReportFilters.tsx`（新規）: 期間フィルタUI。バリデーションエラー表示含む
-  - `src/components/reports/ReportTable.tsx`（新規）: 集計テーブル。種別ごとに`*_total_count === 0`なら「-」（発注0件）、`*_total_count > 0 && amount === null`なら「-（金額データなし）」、集計値0円は「¥0」と判定して表示（未解決事項4のルールを実装。**critical/important指摘対応**: 種別単位の判定に`*_total_count`を使うことで、「発注0件」と「発注はあるが単価データなし」を混同しない。合計列は「全種別が`total_count===0`（=真に発注0件）」の場合のみ「-」とし、それ以外はNULLを0とみなして加算する。以前は`count===0 && amount===null`のみで判定していたため、一部種別だけ単価データなしの行を誤って「全種別発注0件」と判定してしまう境界条件の欠落があった。**important指摘対応・追加分**: 加えて「全種別に発注はあるが、いずれの種別にも金額データが一切ない（全`amount===null`）」場合は、合計を「NULLを0とみなして加算」した結果の「¥0」ではなく「-（金額データなし）」と表示する。この判定は「全種別発注0件」判定より優先し、一部種別のみ金額データがある場合は従来どおりNULLを0とみなして加算する）
-  - `src/components/reports/__tests__/ReportFilters.test.tsx`（新規）
-  - `src/components/reports/__tests__/ReportTable.test.tsx`（新規）
-- **テスト観点**: NULL/0/「-（金額データなし）」の3パターンが正しく出し分けられること、金額がカンマ区切り円表示されること、日付バリデーションが機能すること
+PreToolUse hook単体の回帰テスト。合成した`tool_name`/`tool_input`のJSONを標準入力で渡し、以下を確認する:
+- シナリオ1: `Bash`で`command`が`touch .claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る
+- シナリオ2: `Bash`で`command`が`echo x > .claude/.verify-state/abc.skip`の場合(リダイレクト経由) → `permissionDecision: "ask"`が返る
+- シナリオ3: `Write`で`file_path`が`.claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る
+- シナリオ4: `Bash`で`command`が`.claude/.verify-state/`と無関係な通常コマンド(例: `npm test`)の場合 → 何も出力されない(exit 0、空出力)
+- シナリオ5: `Bash`で`command`が`.claude/.verify-state/`配下だが`.skip`拡張子ではないファイル(例: `cat .claude/.verify-state/abc.json`)への操作の場合 → 何も出力されない(状態ファイル自体の閲覧・既存ロジックの正常動作を妨げない)
 
-#### Set F: ページ・ナビ統合
+#### 6. 設計ドキュメント更新
 
-- **触るファイル**:
-  - `src/app/admin/reports/page.tsx`（新規）
-  - `src/app/admin/reports/__tests__/page.test.tsx`（新規）
-  - `src/components/dashboard/DashboardShortcuts.tsx`（既存・改修）
-- `page.tsx`実装方針:
-  - `useSearchParams()`を使う場合は`<Suspense>`必須ラップ（`src/app/orders/page.tsx`パターン参照）
-  - 初回アクセス時（`date_from`/`date_to`ともURLパラメータなし）は自動集計せず空状態（フィルタ入力待ち）を表示する（未解決事項5）
-  - `/api/admin/reports`をfetchして`ReportTable`に渡す
-- `DashboardShortcuts.tsx`改修（重要な既存コード注意点）:
-  - 現行は`const ADMIN_SHORTCUT = { href:'/admin/users', label:'管理ユーザー' }`という**単一オブジェクト**を`[...BASE_SHORTCUTS, ADMIN_SHORTCUT]`でスプレッドしている
-  - `ADMIN_SHORTCUTS`という**配列**（`[{ href:'/admin/users', ... }, { href:'/admin/reports', label:'レポート' }]`）に定義し直し、呼び出し側を`[...BASE_SHORTCUTS, ...ADMIN_SHORTCUTS]`（二重スプレッド）に変更する。単純に配列へ差し替えるだけだと`[...BASE, [...]]`になり型が壊れるため注意
-- **テスト観点**: adminユーザーには「レポート」リンクが表示される、一般ユーザーには非表示であること、ページのローディング/エラー状態が機能すること
+`docs/superpowers/specs/2026-07-14-verification-subagent-design.md`の以下を更新:
+- 「エスケープハッチ(誤検知対策)」節(115-120行目): 「VS Code側セッションに依頼してtouchする形でも可」という記述を削除し、PreToolUse hookによるask強制の仕組みに差し替える
+- 「判定・ブロックロジック」節(108-109行目): ブロックメッセージからコマンド案内を削除する旨を反映
+- 「エラーハンドリングまとめ」表(143-153行目): `.skip`マーカーの行はStop hook側の挙動として変更なし(pass)のまま維持しつつ、「ただしマーカー作成自体はPreToolUse hookでask」の注記を追加
+- テスト方針の一覧(225-243行目)にシナリオ5のアサーション更新内容と、新規`check-skip-marker-write.test.sh`への参照を追記
+
+### 型・データアクセス層の方針
+
+該当なし(bashスクリプトとMarkdownドキュメントのみの変更。DB/型定義/UIへの変更なし)。
 
 ---
 
-### 並列グループ宣言
+## Part 3 — 仕様レビュー前セルフチェック（AI用・レビュー不要）
 
-| グループ | セット | 触るファイル |
-|---|---|---|
-| G1（並列可）| A | `supabase/migrations/<実装日>_add_unit_price_to_order_items.sql` |
-| G1（並列可）| A-2 | `supabase/migrations/<実装日>_add_unit_price_snapshot_to_order_rpcs.sql` |
-| G2（G1後）| B | `supabase/migrations/<実装日>_add_order_amount_report_rpc.sql` |
-| G3（G2後）| C | `src/types/report.ts`, `src/lib/reports/repository.ts` |
-| G4（G3後、DとEは並列可）| D | `src/app/api/admin/reports/route.ts` |
-| G4（G3後、DとEは並列可）| E | `src/components/reports/ReportFilters.tsx`, `src/components/reports/ReportTable.tsx` |
-| G5（G4後）| F | `src/app/admin/reports/page.tsx`, `src/components/dashboard/DashboardShortcuts.tsx` |
-
----
-
-### 触れないファイル（実装者は変更禁止）
-
-- `src/middleware.ts`（`/admin/reports`配置により既存adminガードで対応済み。改修不要）
-- `src/types/order.ts`（既存の`OrderListItem`等は変更しない）
-- 既存のマイグレーションファイル（追記・修正禁止。RPC改修は`CREATE OR REPLACE FUNCTION`による新規migrationで対応）
-
----
-
-### スコープ外（今回あえて対応しない）
-
-- 価格推移グラフ（issue本文にも明記。別issueで検討）
-- CSVエクスポート
-- submitフロー自体の実装（未解決事項2で「不要」と決定）
-- 過去データの遡及計算（未解決事項7）
-- 監査ログ（未解決事項6）
-- ページネーション（施設数が少ない前提。増大時は別issueで検討）
+- **判定基準の欠落**: PreToolUse hookの判定は「`.claude/.verify-state/*.skip`にマッチする/しない」の2値のみであり、それぞれの挙動をPart2の表に明記済み。`permissionDecision`という既存のClaude Code側enum(allow/deny/ask)の値をそのまま使い、新しいstatusフィールドは追加していない。
+- **下流の反応の欠落**: マッチしない場合はhookが完全に無関与(通常の権限フローに委ねる)、マッチする場合はask確認ダイアログが表示される。いずれの場合もStop hook(`verify-claims.sh`)側の`.skip`検知・pass判定ロジックには一切手を入れないため、既存の分岐(ケース1/2、fail-open、evidence検証等)への影響はない。
+- **列挙の自己矛盾**: 対象/対象外のような包含・除外リストは今回無し(該当なし)。
+- **信号の意味変更**: 既存の`permissionDecision`(Claude Code組み込みの権限判定シグナル)の意味は変えていない。今回はこのシグナルを新しい判定元(PreToolUse hookスクリプト)から発行するだけであり、下流(Claude Code本体の権限ダイアログ表示ロジック)が受け取る値の意味は従来通り。

--- a/docs/sessions/2026-07-15-verify-claims-escape-hatch.md
+++ b/docs/sessions/2026-07-15-verify-claims-escape-hatch.md
@@ -1,0 +1,28 @@
+# 2026-07-15 verify-claims-escape-hatch
+
+## フロー実行時間
+- Phase 1（調査）:    10秒
+- Phase 2〜5（実装）: —
+- AI稼働合計:         10秒
+- セッション総時間:   1分18秒（人間レビュー待ち含む）
+
+## フロー実行統計
+
+### Phase 1 調査
+- Sweeper: 4台 × 1ラウンド
+- 指摘あり軸数: 3 / 4
+
+### Phase 2〜5 実装・検証
+- implementer: 2台（直列。初回実装 → レビュー指摘の修正差し戻し。aidd-phase2ワークフロー本体のContract+DBフェーズ相当分は別途2台）
+- integrator: 0台（単一実装セットのため統合ゲート不要。npm test/lint/tscも対象ファイル変更なしのため未実行）
+- reviewer: 4台（並列。正しさ/仕様カバレッジ/重複・過剰実装/型安全の4観点）
+- 合計エージェント: 8台（implementer 2 + reviewer 4 + aidd-phase2ワークフロー内contract-writer/db-impl 2）+ 調査用claude-code-guide 3台・aidd-phase1-router内sweep 4台
+- 実装成功: 1 / 1グループ（レビューでcritical 1件・important 4件の指摘を受け、修正ループ1回で解消）
+
+## Loop Observability要約
+`aidd-phase1-router`・`aidd-phase2`ワークフロー経由の実行分は`logs/loop-observability.jsonl`に10件記録された。**既知の未対応**: 今回はdb-implの誤判定(task_c35e4bfb参照)によりワークフロー本体を最後まで使えず、Phase3実装・Phase5レビューを直接Agentツールでのサブエージェント呼び出しに切り替えた。そのうちimplementerへの指示には`log-agent-progress.sh`呼び出しを含めたが、reviewer(4観点、4台)への指示にはloop-observability/agent-progress双方の記録指示を含め忘れており、この4台分は両ログに記録されていない。ワークフローを介さない直接Agent呼び出しでは記録漏れ検知の仕組み(`check-loop-observability-gap.sh`等)自体が機能しないため、機械的な検知にも掛かっていない。
+
+## 結果
+- うまくいったこと: PreToolUse hookでの`ask`強制方式が、アダバーサリアルなレビュー(事後検知案の弱点指摘 → `bypassPermissions`実機検証 → 4観点レビューでのcritical指摘発見)を経て、最終的に堅牢な形に仕上がった。具体的には、コマンド文字列への直接一致だけでなく、`cd`によるディレクトリ移動後の相対パス操作(単一コマンド内の`cd && touch`、および事前の`cd`済みcwdからの単独コマンド)の2パターンも検知できるようになった。
+- 問題・気になった点: 当初のcwd非考慮の正規表現では、`cd .claude/.verify-state && touch abc.skip`のような**難読化ですらない通常の操作**で検知をすり抜けられてしまっていた(修正1で対応済み)。また、`aidd-phase2`ワークフロー自体に「DB変更不要なタスクをblocked誤判定する」設計バグが見つかり、別タスク(task_c35e4bfb)として切り出した。
+- 次の課題: 停止②(構造化レビュー)は人間が`/structured-review`で起動するまで実行しないこと。正規表現マッチによる検知は変数展開・base64エンコード等の難読化コマンドまでは防げない既知の限界が残っている。

--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -106,7 +106,7 @@ hook側で機械チェックする。検証サブエージェント自身がLLM�
       (スキップ・再判定ロジックの(2)、LLM呼び出し無し)は前回と同一のフィンガープリントを
       そのまま引き継ぐため、常に累積される(この経路の挙動は変えない)
   - `retry_count <= 3`(既存の `MAX_REVIEW_RETRIES` と同じ上限): 該当箇所の指摘内容を `stderr` に出力して `exit 2`(Stopをブロックし、VS Code側セッションに指摘を伝えて修正を促す)
-  - `retry_count > 3`: ブロックしたまま人間の介入を待つ状態にする。`stderr` に「3回自動修正を試みたが解消されなかった」旨と、下記エスケープハッチの使い方を明記する
+  - `retry_count > 3`: ブロックしたまま人間の介入を待つ状態にする。`stderr` に「3回自動修正を試みたが解消されなかった」旨と「人間に相談してください」とだけ表示する。**issue #348以降、具体的なコマンド案内(`touch <パス>`等)はブロックメッセージから削除した。** これは、指摘を直す代わりにブロックされた本人(エージェント自身)がその案内通りにスキップ用ファイルを作成してすり抜けられてしまう抜け道だったため。エスケープハッチ自体の使い方は下記「エスケープハッチ(誤検知対策)」節を参照
   - 状態ファイルを `{ diff_hash, verdict: "blocked", retry_count, last_blocking_fingerprint }` で更新
 - **findingsが無い、またはminorのみの場合**:
   - `exit 0`。minor findingsがあれば `systemMessage` として警告のみ添える(ブロックはしない)
@@ -116,8 +116,21 @@ hook側で機械チェックする。検証サブエージェント自身がLLM�
 
 検証サブエージェント自身がLLMである以上、誤って `critical` と判定する可能性がある。3回のリトライを使い切って完全ブロックされた場合に人間が詰まないよう、以下を用意する:
 
-- 人間(またはVS Code側セッション)が `.claude/.verify-state/<session_id>.skip` というマーカーファイルを作成できるようにする(小さいヘルパースクリプト、またはVS Code側セッションに依頼して touch する形でも可)
-- hookはこのファイルの存在を検知したら、それを消費(削除)した上で無条件に `exit 0` とする。ログに「手動オーバーライドが使用された」旨を残す
+- 人間が `.claude/.verify-state/<session_id>.skip` というマーカーファイルを作成できるようにする
+- hookはこのファイルの存在を検知したら、それを消費(削除)した上で無条件に `exit 0` とする。ログに「手動オーバーライドが使用された」旨を残す(このpass判定ロジック自体はissue #348の変更でも一切変えていない)
+
+**issue #348: マーカー作成行為そのものを人間確認(ask)で強制する。** 当初の設計では「VS Code側セッションに依頼してtouchする形でも可」としていたが、これだとブロックされた本人(エージェント自身)が人間に断りなく黙ってスキップ用ファイルを作成し、指摘を直さずすり抜けられてしまう抜け道になっていた。これを塞ぐため、PreToolUse hook `scripts/check-skip-marker-write.sh` を追加した:
+
+- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
+- マッチした場合、`permissionDecision: "ask"` を返す(`hookSpecificOutput.hookEventName: "PreToolUse"`)。これにより、touch・echo・python等の手段を問わず、`.skip`ファイルへの書き込みを試みた瞬間に通常の権限確認ダイアログが表示される。人間がその場で承認しない限り作成されない
+- マッチしない場合は何も出力せずexit 0(allow/denyには関与せず、通常の権限フローに委ねる)
+- `.claude/settings.json`の`hooks.PreToolUse`に`matcher: "Bash|Write|Edit"`で登録している。**この`matcher`はツール名の完全一致(exact match)のリストであり、`"MultiEdit"`のような別名ツールには一致しない。**将来Claude Code側に別名の書き込み系ツールが追加された場合は、`matcher`と`scripts/check-skip-marker-write.sh`内の`case`文の両方を更新する必要がある(片方だけ直しても検知が効かない)
+- **cwd変更後の相対パス操作への対策(issue #348追加修正)**: 当初の実装は正規表現によるコマンド文字列の直接一致のみだったため、`cd .claude/.verify-state && touch abc.skip`という単一コマンド、または事前に`cd .claude/.verify-state`を実行済みの状態で別のBash呼び出しとして`touch abc.skip`のみを実行する、という**難読化ですらない通常の操作**で検知をすり抜けられることが4観点レビューで実証された。これに対し、(1)コマンド文字列中に`.claude/.verify-state`というディレクトリ参照と相対パスの`.skip`トークンの両方が含まれる場合、(2)hook入力の`cwd`フィールド(セッション間で持続する現在の作業ディレクトリ)が`.claude/.verify-state`配下を指しており、かつ対象文字列に相対パスの`.skip`トークンが含まれる場合、の2つを追加で検知するようにした
+
+**実機検証で確認した安全側への倒れ方**: `--permission-mode bypassPermissions`かつheadlessモード(人間が確認に応答できない自律実行環境)で実際に検証したところ、hookが返す`permissionDecision: "ask"`は無視されず、確認相手が存在しない場合はツール実行が拒否される側に倒れることを確認済み。つまり「誰も見ていない完全放置の自律実行中に黙って`.skip`が作成されてしまう」ケースは発生しない(応答待ちのまま進まない=ブロック継続と同じ安全側の挙動)。**この検証は本実装時点のセッション内で一度実施したものであり、自動回帰テストとしては存在しない。**再現可能な形でリポジトリに残っているのは正規表現マッチ部分の`scripts/check-skip-marker-write.test.sh`のみで、`bypassPermissions`環境での実際のask強制の挙動そのものは手動一回検証にとどまる。
+
+既知の限界:
+- 正規表現によるコマンド文字列マッチのため、変数展開・base64エンコード等で意図的に難読化されたコマンドは検知をすり抜けうる。典型的な手段(touch/echo/cp/mv/python -c/node -e等、コマンド文字列に直接パスが現れるもの)を塞ぐのが目的であり、完全な保証ではない
 
 ### インフラ障害時の扱い(fail-open例外)
 
@@ -150,7 +163,7 @@ Stop event
 | critical/important、retry > 3 | ブロック継続、人間の介入待ち。エスケープハッチ案内 |
 | minorのみ/findingsなし | pass(exit 0)、retry_countリセット |
 | 検証プロセス自体の失敗(タイムアウト等)、または出力JSONの解析失敗 | fail-open(exit 0、警告のみ) |
-| `.skip`マーカーあり | 無条件pass、マーカー消費 |
+| `.skip`マーカーあり | 無条件pass、マーカー消費(Stop hook側のロジックはissue #348で変更なし)。**ただしマーカー作成自体はPreToolUse hook(`scripts/check-skip-marker-write.sh`)でask強制(issue #348)** |
 
 ## 運用インシデント(postmortem)
 
@@ -232,7 +245,7 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
   2. diff一致・前回pass → 即pass(LLM呼び出しが発生しないこと)
   3. diff一致・前回blocked → LLM呼び出し無しでretry_count+1、再ブロック
   4. diff不一致・critical finding → ブロック、状態ファイルにblocked+retry_count記録
-  5. retry_countが3を超える → ブロック継続、エスケープハッチ案内が出力に含まれる
+  5. retry_countが3を超える → ブロック継続。**(issue #348)** ブロックメッセージに`touch`という語を含まないこと・「人間に相談」という文言を含むことをアサートする(具体的なコマンド案内を削除したため)
   6. `.skip`マーカーあり → 無条件pass、マーカーファイルが削除される
   7. 検証プロセス自体が失敗(モック) → fail-openでpass
   8. 同時実行数が上限に達している → サーキットブレーカーでfail-open(LLM呼び出し無し)
@@ -242,9 +255,26 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
   12. **(issue #354)** evidenceが空/ファイルパスらしきトークンを含まないcritical finding → minorへ格下げされブロックされない(exit 0)
 - `claude -p` 呼び出し部分は実行コストがかかるため、テストではモック(固定のfindings JSONを返すダミースクリプト)に差し替えて検証する
 
+**(issue #348)** PreToolUse hook `scripts/check-skip-marker-write.sh` 単体の回帰テストは
+`scripts/check-skip-marker-write.test.sh` に分離した(Stop hook本体とは別プロセス・別入力形式の
+ため)。合成した`tool_name`/`tool_input`のhook入力JSONを標準入力で渡し、以下を確認する:
+  1. `Bash`で`command`が`touch .claude/.verify-state/abc.skip` → `permissionDecision: "ask"`が出力される
+  2. `Bash`で`command`が`echo x > .claude/.verify-state/abc.skip`(リダイレクト経由) → 同様に`ask`
+  3. `Write`で`file_path`が`.claude/.verify-state/abc.skip` → 同様に`ask`
+  4. `Bash`で`command`が無関係な通常コマンド(例: `npm test`) → 何も出力されない(exit 0、空出力)
+  5. `Bash`で`command`が`.claude/.verify-state/`配下だが`.skip`拡張子ではないファイル(例: `cat *.json`)への操作 → 何も出力されない
+  6. **(issue #348追加修正)** `command`が`cd .claude/.verify-state && touch abc.skip`という単一コマンド(cwdフィールド併用) → `ask`
+  7. **(issue #348追加修正)** 事前に`cd .claude/.verify-state`済みのcwdから`command`が`touch abc.skip`のみ → `ask`
+  8. `command`が`python3 -c "open('.claude/.verify-state/abc.skip','w').close()"`のようなpython3経由の書き込み → `ask`
+  9. `command`が`node -e "require('fs').writeFileSync('.claude/.verify-state/abc.skip','')"`のようなnode経由の書き込み → `ask`
+  10. `Edit`で`file_path`が`.claude/.verify-state/abc.skip` → `ask`
+
 ## 対象範囲外(YAGNI)
 
-- Stop以外のhookイベント(PreToolUse等)への拡張は今回のスコープ外
+- Stop以外のhookイベントへの拡張は今回のスコープ外。**ただし例外として、issue #348のエスケープ
+  ハッチ濫用対策(`.skip`マーカー作成行為そのものへのask強制)のみPreToolUse hookを追加した。**
+  これはStop hook本体の判定ロジック拡張ではなく、Stop hookとは独立した別の権限制御であり、
+  上記「エスケープハッチ(誤検知対策)」節を参照
 - CLIセッション(Claude Code CLI)側への同様の仕組みの導入は行わない(CLIはアドバイスのみの方針を維持)
 - severity分類自体のチューニング(閾値の精度向上等)は運用開始後の継続課題とする
 

--- a/scripts/check-skip-marker-write.sh
+++ b/scripts/check-skip-marker-write.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse hook。issue #348: verify-claims.shのエスケープハッチ
+# (.claude/.verify-state/<session_id>.skip の作成)を、touch/echo/python等の手段を問わず
+# 人間の確認プロンプト(ask)に強制する。
+# 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md 「エスケープハッチ(誤検知対策)」節
+#
+# 標準入力でPreToolUseのhook入力JSON({tool_name, tool_input, cwd, ...})を受け取り、
+# 書き込み対象が .claude/.verify-state/*.skip にマッチする場合のみ、
+# permissionDecision: "ask" のJSONを標準出力してexit 0する。
+# マッチしない場合は何も出力せずexit 0(通常の権限フローに委ねる。allow/denyには関与しない)。
+#
+# 検知は3系統:
+# 1. フルパス一致: command/file_path に ".claude/.verify-state/<name>.skip" という
+#    連続した文字列が現れる場合(絶対/相対どちらの書き方でも、途中に何らかの引用符・括弧が
+#    前後にあっても部分文字列として一致すればよい)
+# 2. コマンド内cd + 相対パス一致(issue #348追加修正): `cd .claude/.verify-state && touch abc.skip`
+#    のように、同一コマンド文字列内でディレクトリへ移動してから相対パスで.skipファイルに触る場合。
+#    hook実行時点のtool_input.commandはまだ実行前(cdは走っていない)ため、cwdフィールドではなく
+#    command文字列自体から「.claude/.verify-state というディレクトリ参照」と「相対パスの.skip
+#    トークン」の両方が同じコマンド文字列中に含まれるかを見る。
+# 3. cwd起点の相対パス一致(issue #348追加修正): Bashツールはセッション間でcwdが持続するため、
+#    事前のBash呼び出しで既に`cd .claude/.verify-state`を実行済みの状態で、別呼び出しとして
+#    `touch abc.skip`のみを実行する、といった操作で1系統目の文字列一致をすり抜けられることが
+#    実証された。hook入力の`cwd`フィールド(現在の作業ディレクトリの絶対パス)が
+#    ".claude/.verify-state" ディレクトリそのもの/配下を指しており、かつcommand/file_pathに
+#    スラッシュを含まない(=相対パスらしい)".skip"トークンが含まれる場合も対象とする。
+#
+# 既知の限界(設計ドキュメントに明記済み):
+# - 正規表現によるコマンド文字列マッチのため、変数展開・base64エンコード等で意図的に
+#   難読化されたコマンドはすり抜けうる。典型的な手段(touch/echo/cp/mv/python -c/node -e等、
+#   コマンド文字列に直接パスが現れるもの)を塞ぐのが目的であり、完全な保証ではない。
+
+FULL_PATH_PATTERN='\.claude/\.verify-state/[^/]+\.skip'
+# ディレクトリ参照の後にスラッシュ・空白・&・;・文字列末尾のいずれかが続く(cdの引数として
+# 使われる書き方も含めて拾うため、直後に必ずスラッシュが来るとは限らない)。
+DIR_REFERENCE_PATTERN='\.claude/\.verify-state([/[:space:]&;]|$)'
+CWD_PATTERN='(^|/)\.claude/\.verify-state($|/)'
+RELATIVE_SKIP_TOKEN_PATTERN='[^/[:space:]]+\.skip'
+
+INPUT="$(cat)"
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')"
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // ""')"
+
+TARGET=""
+case "$TOOL_NAME" in
+  Bash)
+    TARGET="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+    ;;
+  Write|Edit)
+    TARGET="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+MATCHED=0
+if [[ "$TARGET" =~ $FULL_PATH_PATTERN ]]; then
+  MATCHED=1
+fi
+if [[ "$MATCHED" -eq 0 ]] && [[ "$TARGET" =~ $DIR_REFERENCE_PATTERN ]] && [[ "$TARGET" =~ $RELATIVE_SKIP_TOKEN_PATTERN ]]; then
+  MATCHED=1
+fi
+if [[ "$MATCHED" -eq 0 ]] && [[ "$CWD" =~ $CWD_PATTERN ]] && [[ "$TARGET" =~ $RELATIVE_SKIP_TOKEN_PATTERN ]]; then
+  MATCHED=1
+fi
+
+if [[ "$MATCHED" -eq 1 ]]; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "verify-claimsのエスケープハッチ(.skipマーカー)への書き込みです。人間の確認が必要です。"}}'
+fi
+
+exit 0

--- a/scripts/check-skip-marker-write.test.sh
+++ b/scripts/check-skip-marker-write.test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# WHY: issue #348向けのPreToolUse hook(scripts/check-skip-marker-write.sh)の回帰テスト。
+# 合成したtool_name/tool_inputのhook入力JSONを標準入力で渡し、
+# .claude/.verify-state/*.skipへの書き込みを検知した場合にpermissionDecision: "ask"を
+# 返すこと・それ以外は何も出力しないことを確認する。
+# 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+#
+# 実行: bash scripts/check-skip-marker-write.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-skip-marker-write.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+run_hook() {
+  local input="$1"
+  set +e
+  OUT="$(printf '%s' "$input" | bash "$SCRIPT")"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: Bash + touch .skip → ask ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "touch .claude/.verify-state/abc.skip"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 2: Bash + echo x > .skip(リダイレクト経由) → ask ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "echo x > .claude/.verify-state/abc.skip"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 3: Write file_path=.skip → ask ==="
+input="$(jq -n '{tool_name: "Write", tool_input: {file_path: ".claude/.verify-state/abc.skip", content: "x"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 4: Bashで無関係な通常コマンド(npm test) → 何も出力しない ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "npm test"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 5: .verify-state配下だが.skip拡張子ではないファイル(cat *.json) → 何も出力しない ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "cat .claude/.verify-state/abc.json"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 6: cdで.verify-state配下に移動後、単一コマンドで相対touch → ask(issue #348回帰) ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "cd .claude/.verify-state && touch abc.skip"}, cwd: "/repo"}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 7: 事前にcd済みのcwdから相対touchのみを実行 → ask(issue #348回帰) ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "touch abc.skip"}, cwd: "/repo/.claude/.verify-state"}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 8: python3経由でフルパス書き込み → ask ==="
+python3_cmd='python3 -c "open('"'"'.claude/.verify-state/abc.skip'"'"',\"w\").close()"'
+input="$(jq -n --arg cmd "$python3_cmd" '{tool_name: "Bash", tool_input: {command: $cmd}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 9: node経由でフルパス書き込み → ask ==="
+node_cmd='node -e "require('"'"'fs'"'"').writeFileSync('"'"'.claude/.verify-state/abc.skip'"'"',\"\")"'
+input="$(jq -n --arg cmd "$node_cmd" '{tool_name: "Bash", tool_input: {command: $cmd}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 10: Editツールでfile_pathが.skip → ask ==="
+input="$(jq -n '{tool_name: "Edit", tool_input: {file_path: ".claude/.verify-state/abc.skip", old_string: "x", new_string: "y"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -83,7 +83,7 @@ block_with_retry_check() {
   if [ "$new_retry" -le "$MAX_RETRIES" ]; then
     emit_block "$(printf 'verify-claims: 未解消の指摘を検出しました(試行%d/%d):\n%s' "$new_retry" "$MAX_RETRIES" "$findings_msg")"
   else
-    emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが指摘が解消されませんでした。人間の介入待ちです。誤検知の場合は `touch %s` でスキップできます。\n%s' "$MAX_RETRIES" "$SKIP_MARKER" "$findings_msg")"
+    emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが指摘が解消されませんでした。人間の介入待ちです。人間に相談してください。\n%s' "$MAX_RETRIES" "$findings_msg")"
   fi
 }
 

--- a/scripts/verify-claims.test.sh
+++ b/scripts/verify-claims.test.sh
@@ -143,8 +143,13 @@ run_hook "s5"   # retry 2 (diff不変)
 run_hook "s5"   # retry 3 (diff不変)
 run_hook "s5"   # retry 4 → 上限超過
 assert_eq "$EXIT_CODE" "2" "上限超過後もブロック継続"
-assert_contains "$STDERR_OUT" "touch" "エスケープハッチ(.skipマーカー作成方法)の案内が出力される"
-assert_contains "$STDERR_OUT" "s5.skip" "案内にセッション固有のskipマーカーパスが含まれる"
+if printf '%s' "$STDERR_OUT" | grep -qF -- "touch"; then
+  echo "  NG: ブロックメッセージにtouchという語を含まないこと"
+  fail=1
+else
+  echo "  OK: ブロックメッセージにtouchという語を含まないこと"
+fi
+assert_contains "$STDERR_OUT" "人間に相談" "ブロックメッセージに人間に相談してくださいという文言が含まれる"
 
 echo "=== scenario 6: .skipマーカーあり → 無条件pass、マーカー削除 ==="
 rm -f "$MOCK_CALL_LOG"


### PR DESCRIPTION
## Summary
- Stop hook `scripts/verify-claims.sh` が3回連続ブロック後に出していた具体的な `touch <パス>` 案内を削除し、「人間に相談してください」のみに変更
- `.claude/.verify-state/<session_id>.skip` マーカーの作成行為自体を、新規PreToolUse hook `scripts/check-skip-marker-write.sh` で検知し、手段(touch/echo/python3/node等)を問わず人間の確認プロンプト(ask)に強制。`cd`によるディレクトリ移動後の相対パス操作も含めて3系統で検知
- `bypassPermissions`モード・headless実行下でも、hookの`ask`は無視されず安全側(実行拒否)に倒れることを実機検証済み

## Test plan
- [x] `bash scripts/verify-claims.test.sh` 全17シナリオPASS
- [x] `bash scripts/check-skip-marker-write.test.sh` 全10シナリオPASS(cd回避・python3・node・Edit経由を含む)
- [x] `jq . .claude/settings.json` で妥当性確認
- [x] 4観点並列レビュー(正しさ/仕様カバレッジ/重複・過剰実装/型安全)を実施し、指摘をすべて反映

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)