### PR TITLE
fix: aidd-phase2のdb-implがDB変更不要ケースを一律blocked判定する問題を修正

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -216,10 +216,10 @@ const [contractResult, dbResult] = await parallel([
     { label: 'contract-writer', phase: 'Contract + DB', agentType: 'contract-writer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。${guide(
-      'マイグレーション実装が完了した',
+    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。\nPart 2にDBスキーマ変更が不要と明記されている場合（例:「該当なし」「DB変更なし」）は、何も実装せずstatus: passでdetailにその旨（不要と判断した根拠）を書いて報告すること。これはblocked（着手不能）ではない。${guide(
+      'マイグレーション実装が完了した、またはPart2にDBスキーマ変更が不要と明記されており対応不要と判断した',
       'マイグレーションを試みたがエラー・矛盾がある',
-      'SPEC.mdが存在しない、またはPart2にマイグレーション情報が無く着手不能'
+      'SPEC.mdが存在しない、またはPart2にDB変更の要否自体を判断できる記載が無い'
     )}`,
     { label: 'db-impl', phase: 'Contract + DB', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),


### PR DESCRIPTION
## Summary
- issue #348対応中に実際に発生したバグを修正。`.claude/workflows/aidd-phase2.js`のdb-implエージェント（Contract + DBフェーズ）が、SPEC.md Part2に「DBスキーマ変更は不要」と明記されているだけの正常ケースまで、「SPEC.mdが存在しない」と同じ`blocked`判定にしてしまっていた
- guide()文言を変更し、DB変更不要は明示的に`status: pass`（detailに不要と判断した根拠を記載）として報告するよう指示を変更した。`blocked`はSPEC.md自体が無い・要否を判断できる記載が無いケースに限定
- contract-writer側にも同様のギャップが無いか確認済み（無し：contract-writerのblocked条件は「SPEC.mdが存在しない/読めない」のみで、型定義は常に必要なため該当しない）

Closes #389

## Test plan
- [x] `node --check .claude/workflows/aidd-phase2.js` で構文エラーが無いことを確認
- [ ] 次回実際のAIDDフロー実行で、DBスキーマ変更が不要な機能実装においてdb-implが`pass`を返しPhase 3が止まらないことを目視確認する（このプロンプト文言はWorkflow DSL内の自然言語ガイダンスであり、`shouldBlock`等の純粋関数と違いユニットテスト不可のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)