### PR TITLE
feat: ブランチ運用ルール(マージ済みブランチ再利用)の機械検知を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,6 +74,8 @@
       "Bash(scripts/show-agent-status.sh *)",
       "Bash(scripts/verify-agent-progress-transcript.sh *)",
       "Bash(scripts/doc-suggest-check.sh *)",
+      "Bash(scripts/check-branch-pr-status.sh*)",
+      "Bash(bash scripts/check-branch-pr-status.test.sh*)",
       "Bash(scripts/ai-check-suggest.sh *)",
       "Bash(scripts/verify-claims.sh *)",
       "Bash(bash scripts/verify-claims.test.sh*)",
@@ -128,6 +130,17 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/check-branch-pr-status.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash|Write|Edit",

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -54,6 +54,10 @@ any code. Heed deprecation notices.
 - **新しいissue・機能の作業を始める前に、現在のブランチが別issue用の未マージPRの対象になっていないか確認する**（`git branch --show-current` → `gh pr list --head <branch>`）。
   なっていた場合は、着手前に `git checkout -b <new-branch> main` で新しいブランチを切ってから進める。
   1つのPRに無関係なissueのコミットが混ざると、レビュアーが混乱し、片方だけ却下・差し戻しになった際に切り分けられなくなる
+  - **このルールのうち「現在のブランチに既にマージ済みのPRが乗っている」ケースは、SessionStart hook（`scripts/check-branch-pr-status.sh`）が機械的に警告する。**
+    `git branch --show-current` → `gh pr list --head <branch> --state merged` の結果が空でなければ、セッション開始時に警告メッセージを出す（block不可・warningのみ）。
+    実際にissue-20-orders-list-page等、マージ済みブランチ上で気づかず並行作業が続き、重複・陳腐化したworktreeが複数残った実害があったため導入した。
+    **「別issueの未マージPRが乗っている」ケース（マージ前の分岐）はこのhookの検知対象外**で、引き続き人手の確認に依存する。
 - **`git checkout -b <new-branch> main` の前に、必ず `git fetch origin main` してから最新の `origin/main` を起点にする**（`git checkout -b <new-branch> origin/main`、または直前に`git merge origin/main`でローカルmainを追従させる）。
   ローカルの`main`ブランチ参照は自動更新されない（`gh pr merge`はリモートを更新するだけで、ローカルの別ブランチにいる間はローカル`main`が古いまま）。古いローカル`main`から新しいブランチを切ると、直近でマージされたPRの変更が丸ごと欠落した状態で作業が進んでしまい、後から気づいて`origin/main`をマージし直す手戻りが発生する
 
@@ -176,7 +180,7 @@ any code. Heed deprecation notices.
 |---|---|---|
 | `aidd-phase1-router`を入口に使うこと自体（TRI/RISK判定の実施） | 本ファイル「TRI/RISK 機械判定基準」 | 判定ロジック自体は機械的だが、routerを経由せず直接実装に入れば判定がまるごとスキップされる（優先度2候補） |
 | 引き継ぎフォーマットの実施 | 本ファイル「引き継ぎフォーマット」 | 既存Stop hook（`doc-suggest-check.sh`等）の拡張候補（優先度3候補） |
-| ブランチ運用ルール（着手前PR確認・`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり |
+| ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースのみ`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。「別issueの未マージPRが乗っている」ケースと`origin/main`起点確認自体は未検知のまま |
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
 | AIDD stats書き出し（各フェーズでの`write_aidd_stats.sh`呼び出し） | ルートの`CLAUDE.md` | 呼び忘れても気づく手段がない |

--- a/scripts/check-branch-pr-status.sh
+++ b/scripts/check-branch-pr-status.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: docs/agents/common.md「ブランチ運用ルール」（新しいissue・機能の作業を始める前に、
+# 現在のブランチが別issue用の未マージPRの対象になっていないか確認する）には、これまで
+# 検知手段がなかった（自然言語指示のみ）。実際にissue-20-orders-list-page等、既にPRが
+# マージ済みのブランチ上で並行して重複作業が発生し、無駄なworktreeが複数残る実害が
+# 発生したため、SessionStart hookで機械的に警告する。
+# block（session開始そのものの停止）はできない前提のためwarningのみ。
+#
+# 設計: docs/agents/common.md「検知手段のないルールの棚卸し（issue #339）」表の
+# 「ブランチ運用ルール」行を参照。
+
+cd "$(dirname "$0")/.."
+
+BRANCH="$(git branch --show-current 2>/dev/null || true)"
+
+if [ -z "$BRANCH" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+MERGED_PRS="$(gh pr list --head "$BRANCH" --state merged --json number,title,url --limit 3 2>/dev/null || echo '[]')"
+
+if [ -z "$MERGED_PRS" ]; then
+  MERGED_PRS='[]'
+fi
+
+COUNT="$(printf '%s' "$MERGED_PRS" | jq 'length' 2>/dev/null || echo 0)"
+
+if [ "$COUNT" = "0" ] || [ -z "$COUNT" ]; then
+  exit 0
+fi
+
+SUMMARY="$(printf '%s' "$MERGED_PRS" | jq -r '.[] | "- #\(.number) \(.title) (\(.url))"')"
+
+MSG="現在のブランチ「${BRANCH}」は既に以下のPRでマージ済みです。このまま新しいissue・機能の作業を続けると、レビュー時に既マージ分の差分が混在したり、既に他の作業で解決済みの内容を重複実装する恐れがあります。着手前に \`git fetch origin main\` → \`git checkout -b <new-branch> origin/main\` で新しいブランチを作成することを検討してください（docs/agents/common.md「ブランチ運用ルール」参照）。
+${SUMMARY}"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-branch-pr-status.test.sh
+++ b/scripts/check-branch-pr-status.test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# WHY: scripts/check-branch-pr-status.sh(SessionStart hook)の回帰テスト。
+# 実物のgit/ghに依存させず、テスト用のフェイクgit/ghスクリプトをPATHの先頭に注入して
+# 決定的に検証する。
+#
+# 実行: bash scripts/check-branch-pr-status.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-branch-pr-status.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+FAKE_BIN="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN"' EXIT
+BASH_BIN="$(command -v bash)"
+
+setup_fakes() {
+  local branch="$1" gh_output="$2" gh_available="${3:-1}"
+
+  cat > "$FAKE_BIN/git" <<EOF
+#!/bin/bash
+if [ "\$1" = "branch" ] && [ "\$2" = "--show-current" ]; then
+  echo "$branch"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$FAKE_BIN/git"
+
+  if [ "$gh_available" = "1" ]; then
+    cat > "$FAKE_BIN/gh" <<EOF
+#!/bin/bash
+echo '$gh_output'
+EOF
+    chmod +x "$FAKE_BIN/gh"
+  else
+    rm -f "$FAKE_BIN/gh"
+  fi
+}
+
+run_hook() {
+  set +e
+  OUT="$(PATH="$FAKE_BIN:$PATH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+# gh不在ケース専用: 実PATH上のghディレクトリだけを取り除く
+# (dirname/jq等の他coreutilsは実PATH由来のまま使わせる)
+REAL_GH="$(command -v gh || true)"
+GH_DIR="$(dirname "$REAL_GH" 2>/dev/null || true)"
+PATH_WITHOUT_GH="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vF "$GH_DIR" | tr '\n' ':')"
+
+run_hook_no_gh_on_path() {
+  set +e
+  OUT="$(PATH="$FAKE_BIN:$PATH_WITHOUT_GH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: mainブランチ → 何も出力しない ==="
+setup_fakes "main" '[]'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: featureブランチだがマージ済みPRなし → 何も出力しない ==="
+setup_fakes "feature/foo" '[]'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 3: featureブランチにマージ済みPRあり → 警告を出す ==="
+setup_fakes "issue-20-orders-list-page" '[{"number":336,"title":"feat: 発注履歴ページ","url":"https://github.com/example/repo/pull/336"}]'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "#336" "PR番号が含まれる"
+assert_contains "$OUT" "additionalContext" "additionalContextフィールドがある"
+
+echo "=== scenario 4: ghコマンドが無い環境 → 何も出力しない ==="
+setup_fakes "feature/foo" '[]' "0"
+run_hook_no_gh_on_path
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- `docs/agents/common.md`の「新しいissue着手前にブランチのPR状況を確認する」ルールは自然言語指示のみで検知手段がなく、実際にマージ済みブランチ上で気づかず並行作業が続き、重複・陳腐化したworktreeが複数残る実害があった
- SessionStart hook（`scripts/check-branch-pr-status.sh`）で `git branch --show-current` → `gh pr list --head <branch> --state merged` を機械チェックし、該当時にwarningを出す（block不可のため警告のみ）
- `docs/agents/common.md`の「ブランチ運用ルール」節・「検知手段のないルールの棚卸し」表を更新

## Scope
- docsとスクリプトのみ。アプリコード・DBスキーマには一切触れていない

## Known limitation
- 「別issueの未マージPRが乗っている」ケースと`origin/main`起点確認自体は今回のスコープ外（common.mdに明記済み）
- `gh pr list`はネットワーク呼び出しのため、featureブランチでのセッション開始のたびにGitHub APIへの往復が発生する（`--limit 3`で応答は絞っているため致命的ではない）

## Test plan
- [x] `bash scripts/check-branch-pr-status.test.sh` — フェイクgit/ghによる4シナリオ（main／マージ済みPRなし／マージ済みPRあり／gh不在）全てpass
- [x] `bash -n` で両スクリプトの構文チェック
- [x] `jq empty .claude/settings.json` でJSON妥当性確認
- [x] 現在のブランチ（未マージ）で実行し、無警告であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)