### PR TITLE
fix: skip-markerガードのMultiEdit抜け漏れ・cd/cwd誤検知を修正(issue #397)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -130,7 +130,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Write|Edit",
+        "matcher": "Bash|Write|Edit|MultiEdit",
         "hooks": [
           { "type": "command", "command": "scripts/check-skip-marker-write.sh", "timeout": 5 }
         ]

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,26 +63,29 @@ emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが�
 
 #### 2. 新規: `scripts/check-skip-marker-write.sh` (PreToolUse hook)
 
-`.claude/.verify-state/<session_id>.skip`というパスへの書き込みを試みるツール呼び出し(Bash/Write/Edit)を検知し、手段を問わず人間の確認プロンプト(ask)に強制的に切り替える。
+`.claude/.verify-state/<session_id>.skip`というパスへの書き込みを試みるツール呼び出し(Bash/Write/Edit/MultiEdit)を検知し、手段を問わず人間の確認プロンプト(ask)に強制的に切り替える。
 
-- 標準入力でPreToolUseのhook入力JSON(`tool_name`, `tool_input`)を受け取る
-- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
+- 標準入力でPreToolUseのhook入力JSON(`tool_name`, `tool_input`, `cwd`)を受け取る
+- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`/`MultiEdit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
 - マッチした場合、以下を標準出力してexit 0:
   ```json
   {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "verify-claimsのエスケープハッチ(.skipマーカー)への書き込みです。人間の確認が必要です。"}}
   ```
 - マッチしない場合は何も出力せずexit 0(通常の許可フローに委ねる。allowでもdenyでもなく無関与)
+- **cwd変更後の相対パス操作への追加検知(コードレビューで実証された抜け道への追加修正)**: フルパスの正規表現一致だけでは、以下2パターンで検知をすり抜けられることが判明したため、追加で検知する:
+  1. 単一コマンド内での`cd`後の相対パス操作(例: `cd .claude/.verify-state && touch abc.skip`) — 同一コマンド文字列内に`.claude/.verify-state`というディレクトリ参照と、相対パスの`.skip`トークンの両方が含まれるかを見る
+  2. 事前のBash呼び出しで既に`cd .claude/.verify-state`を実行済みの状態で、別呼び出しとして`touch abc.skip`のみを実行する場合 — hook入力の`cwd`フィールド(Bashツールがセッション間で持続させる現在の作業ディレクトリ)が`.claude/.verify-state`ディレクトリそのもの/配下を指しており、かつ対象文字列に相対パスの`.skip`トークンが含まれるかを見る
 
 判定基準:
 
 | ケース | 挙動 |
 |---|---|
-| Bashコマンド文字列またはWrite/Edit file_pathが`.claude/.verify-state/*.skip`にマッチしない | このhookは関与しない(通常の権限フローのまま) |
-| マッチする | `permissionDecision: "ask"`を返し、通常の確認ダイアログが表示される。人間が承認すれば実行され、拒否すれば実行されない |
+| Bashコマンド文字列またはWrite/Edit/MultiEdit file_pathが`.claude/.verify-state/*.skip`にマッチせず、cd+相対パス・cwd起点の追加検知にも該当しない | このhookは関与しない(通常の権限フローのまま) |
+| マッチする(フルパス一致、またはcd+相対パス一致、またはcwd起点の相対パス一致) | `permissionDecision: "ask"`を返し、通常の確認ダイアログが表示される。人間が承認すれば実行され、拒否すれば実行されない |
 
 既知の限界(設計ドキュメントに明記する):
 - 正規表現によるコマンド文字列マッチのため、変数展開・base64エンコード等で意図的に難読化されたコマンドは検知をすり抜けうる。典型的な手段(touch/echo/cp/mv/python -c/node -e等、コマンド文字列に直接パスが現れるもの)を塞ぐのが目的であり、完全な保証ではない
-- 確認プロンプトはVS Code側で実際にセッションを見ている人間が応答することが前提。誰も見ていない間は応答待ちのまま進まない(=通過しない側に倒れるため安全)
+- 確認プロンプトはVS Code側で実際にセッションを見ている人間が応答することが前提。誰も見ていない間は応答待ちのまま進まない(=通過しない側に倒れるため安全)。`--permission-mode bypassPermissions`かつheadless環境での実機検証では応答待ちのまま拒否側に倒れることを確認済みだが、この検証は一度限りの手動確認であり自動回帰テストとしては存在しない
 
 #### 3. `.claude/settings.json`
 
@@ -90,13 +93,14 @@ emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが�
 ```json
 "PreToolUse": [
   {
-    "matcher": "Bash|Write|Edit",
+    "matcher": "Bash|Write|Edit|MultiEdit",
     "hooks": [
       { "type": "command", "command": "scripts/check-skip-marker-write.sh", "timeout": 5 }
     ]
   }
 ]
 ```
+`matcher`はツール名の完全一致(exact match)のリストである。`Edit`と同じくfile_pathを持つ書き込み系ツールの`MultiEdit`を漏らさず含める(`matcher`と`scripts/check-skip-marker-write.sh`内の`case`文の両方を揃える必要があり、片方だけ直しても検知が効かない)。
 既存の`Stop`フックエントリ(doc-suggest-check.sh / ai-check-suggest.sh / verify-claims.sh)はそのまま変更しない。
 
 #### 4. `scripts/verify-claims.sh`のテスト、`scripts/verify-claims.test.sh`
@@ -106,20 +110,26 @@ emit_block "$(printf 'verify-claims: %d回の自動修正を試みましたが�
 
 #### 5. 新規: `scripts/check-skip-marker-write.test.sh`
 
-PreToolUse hook単体の回帰テスト。合成した`tool_name`/`tool_input`のJSONを標準入力で渡し、以下を確認する:
+PreToolUse hook単体の回帰テスト。合成した`tool_name`/`tool_input`/`cwd`のJSONを標準入力で渡し、以下を確認する:
 - シナリオ1: `Bash`で`command`が`touch .claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る
 - シナリオ2: `Bash`で`command`が`echo x > .claude/.verify-state/abc.skip`の場合(リダイレクト経由) → `permissionDecision: "ask"`が返る
 - シナリオ3: `Write`で`file_path`が`.claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る
 - シナリオ4: `Bash`で`command`が`.claude/.verify-state/`と無関係な通常コマンド(例: `npm test`)の場合 → 何も出力されない(exit 0、空出力)
 - シナリオ5: `Bash`で`command`が`.claude/.verify-state/`配下だが`.skip`拡張子ではないファイル(例: `cat .claude/.verify-state/abc.json`)への操作の場合 → 何も出力されない(状態ファイル自体の閲覧・既存ロジックの正常動作を妨げない)
+- シナリオ6: `Bash`で`command`が`cd .claude/.verify-state && touch abc.skip`(単一コマンド内でcd後に相対パス操作)の場合 → `permissionDecision: "ask"`が返る(cd+相対パス検知の回帰)
+- シナリオ7: `Bash`で`command`が`touch abc.skip`、`cwd`が`.claude/.verify-state`配下(事前のBash呼び出しで既にcd済み)の場合 → `permissionDecision: "ask"`が返る(cwd起点の相対パス検知の回帰)
+- シナリオ8: `Bash`で`command`が`python3 -c "..."`でフルパス`.claude/.verify-state/abc.skip`へ書き込む場合 → `permissionDecision: "ask"`が返る
+- シナリオ9: `Bash`で`command`が`node -e "..."`でフルパス`.claude/.verify-state/abc.skip`へ書き込む場合 → `permissionDecision: "ask"`が返る
+- シナリオ10: `Edit`で`file_path`が`.claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る
+- シナリオ11: `MultiEdit`で`file_path`が`.claude/.verify-state/abc.skip`の場合 → `permissionDecision: "ask"`が返る(matcher/case文からMultiEditが漏れていた抜け道の回帰)
 
 #### 6. 設計ドキュメント更新
 
 `docs/superpowers/specs/2026-07-14-verification-subagent-design.md`の以下を更新:
-- 「エスケープハッチ(誤検知対策)」節(115-120行目): 「VS Code側セッションに依頼してtouchする形でも可」という記述を削除し、PreToolUse hookによるask強制の仕組みに差し替える
+- 「エスケープハッチ(誤検知対策)」節(115-120行目): 「VS Code側セッションに依頼してtouchする形でも可」という記述を削除し、PreToolUse hookによるask強制の仕組みに差し替える。あわせて、`matcher`へのMultiEdit追加(当初漏れていた書き込み系ツール)、cd+相対パス・cwd起点の相対パスという2つの追加検知、`bypassPermissions`環境での実機検証結果(一度限りの手動確認である旨も含む)を明記する
 - 「判定・ブロックロジック」節(108-109行目): ブロックメッセージからコマンド案内を削除する旨を反映
 - 「エラーハンドリングまとめ」表(143-153行目): `.skip`マーカーの行はStop hook側の挙動として変更なし(pass)のまま維持しつつ、「ただしマーカー作成自体はPreToolUse hookでask」の注記を追加
-- テスト方針の一覧(225-243行目)にシナリオ5のアサーション更新内容と、新規`check-skip-marker-write.test.sh`への参照を追記
+- テスト方針の一覧(225-243行目)にシナリオ5のアサーション更新内容と、新規`check-skip-marker-write.test.sh`(シナリオ1〜11)への参照を追記
 
 ### 型・データアクセス層の方針
 

--- a/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
+++ b/docs/superpowers/specs/2026-07-14-verification-subagent-design.md
@@ -121,11 +121,12 @@ hook側で機械チェックする。検証サブエージェント自身がLLM�
 
 **issue #348: マーカー作成行為そのものを人間確認(ask)で強制する。** 当初の設計では「VS Code側セッションに依頼してtouchする形でも可」としていたが、これだとブロックされた本人(エージェント自身)が人間に断りなく黙ってスキップ用ファイルを作成し、指摘を直さずすり抜けられてしまう抜け道になっていた。これを塞ぐため、PreToolUse hook `scripts/check-skip-marker-write.sh` を追加した:
 
-- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
+- `tool_name`が`Bash`の場合は`tool_input.command`全体(リダイレクト先パスを含む)、`Write`/`Edit`/`MultiEdit`の場合は`tool_input.file_path`を対象に、正規表現 `\.claude/\.verify-state/[^/]+\.skip` にマッチするかを調べる
 - マッチした場合、`permissionDecision: "ask"` を返す(`hookSpecificOutput.hookEventName: "PreToolUse"`)。これにより、touch・echo・python等の手段を問わず、`.skip`ファイルへの書き込みを試みた瞬間に通常の権限確認ダイアログが表示される。人間がその場で承認しない限り作成されない
 - マッチしない場合は何も出力せずexit 0(allow/denyには関与せず、通常の権限フローに委ねる)
-- `.claude/settings.json`の`hooks.PreToolUse`に`matcher: "Bash|Write|Edit"`で登録している。**この`matcher`はツール名の完全一致(exact match)のリストであり、`"MultiEdit"`のような別名ツールには一致しない。**将来Claude Code側に別名の書き込み系ツールが追加された場合は、`matcher`と`scripts/check-skip-marker-write.sh`内の`case`文の両方を更新する必要がある(片方だけ直しても検知が効かない)
-- **cwd変更後の相対パス操作への対策(issue #348追加修正)**: 当初の実装は正規表現によるコマンド文字列の直接一致のみだったため、`cd .claude/.verify-state && touch abc.skip`という単一コマンド、または事前に`cd .claude/.verify-state`を実行済みの状態で別のBash呼び出しとして`touch abc.skip`のみを実行する、という**難読化ですらない通常の操作**で検知をすり抜けられることが4観点レビューで実証された。これに対し、(1)コマンド文字列中に`.claude/.verify-state`というディレクトリ参照と相対パスの`.skip`トークンの両方が含まれる場合、(2)hook入力の`cwd`フィールド(セッション間で持続する現在の作業ディレクトリ)が`.claude/.verify-state`配下を指しており、かつ対象文字列に相対パスの`.skip`トークンが含まれる場合、の2つを追加で検知するようにした
+- `.claude/settings.json`の`hooks.PreToolUse`に`matcher: "Bash|Write|Edit|MultiEdit"`で登録している。**この`matcher`はツール名の完全一致(exact match)のリストである。**当初`MultiEdit`が抜けており、`Edit`と同じくfile_pathを持つ書き込み系ツールであるにもかかわらず検知対象外だったため追加した(コードレビューで指摘・修正済み)。将来さらに別名の書き込み系ツール(file_path以外のパラメータ名で書き込み先を指定するものを含む)が追加された場合は、`matcher`と`scripts/check-skip-marker-write.sh`内の`case`文の両方を更新する必要がある(片方だけ直しても検知が効かない)。**この二重管理は一度実際にMultiEdit抜け漏れという形で顕在化したため、`scripts/check-skip-marker-write.test.sh`のシナリオ13で`.claude/settings.json`の`matcher`一覧と本スクリプトの`case`文のツール一覧を機械的に突き合わせ、片方だけ更新した場合はテストが失敗するようにしている(単一情報源化ではなく整合性チェックによる再発防止)**
+- **cwd変更後の相対パス操作への対策(issue #348追加修正)**: 当初の実装は正規表現によるコマンド文字列の直接一致のみだったため、`cd .claude/.verify-state && touch abc.skip`という単一コマンド、または事前に`cd .claude/.verify-state`を実行済みの状態で別のBash呼び出しとして`touch abc.skip`のみを実行する、という**難読化ですらない通常の操作**で検知をすり抜けられることが4観点レビューで実証された。これに対し、(1)コマンド文字列中に`cd .claude/.verify-state`という**cd操作としての**ディレクトリ参照と相対パスの`.skip`トークンの両方が含まれる場合、(2)hook入力の`cwd`フィールド(セッション間で持続する現在の作業ディレクトリ)が`.claude/.verify-state`配下を指しており、かつ対象文字列に相対パスの`.skip`トークンが含まれる場合、の2つを追加で検知するようにした
+- **誤検知(false positive)修正(issue #348コードレビュー指摘)**: (1)の判定を「コマンド文字列中に`.claude/.verify-state`というディレクトリ参照が単に含まれるか」で実装すると、`ls .claude/.verify-state && rm old-backup.skip`のように、ディレクトリを読み取るだけの操作(cdを伴わない)と、無関係な場所にある別の`*.skip`ファイルへの操作が同一コマンド文字列中にたまたま同居しているだけで誤って`ask`になる問題があった。ディレクトリ参照は`cd`という移動操作を伴う場合のみ対象とするよう正規表現を絞り込み、この誤検知を解消した
 
 **実機検証で確認した安全側への倒れ方**: `--permission-mode bypassPermissions`かつheadlessモード(人間が確認に応答できない自律実行環境)で実際に検証したところ、hookが返す`permissionDecision: "ask"`は無視されず、確認相手が存在しない場合はツール実行が拒否される側に倒れることを確認済み。つまり「誰も見ていない完全放置の自律実行中に黙って`.skip`が作成されてしまう」ケースは発生しない(応答待ちのまま進まない=ブロック継続と同じ安全側の挙動)。**この検証は本実装時点のセッション内で一度実施したものであり、自動回帰テストとしては存在しない。**再現可能な形でリポジトリに残っているのは正規表現マッチ部分の`scripts/check-skip-marker-write.test.sh`のみで、`bypassPermissions`環境での実際のask強制の挙動そのものは手動一回検証にとどまる。
 
@@ -355,6 +356,9 @@ claude_auto_issue / aidd_session_report が並走する。Claude Codeのhook実�
   8. `command`が`python3 -c "open('.claude/.verify-state/abc.skip','w').close()"`のようなpython3経由の書き込み → `ask`
   9. `command`が`node -e "require('fs').writeFileSync('.claude/.verify-state/abc.skip','')"`のようなnode経由の書き込み → `ask`
   10. `Edit`で`file_path`が`.claude/.verify-state/abc.skip` → `ask`
+  11. **(コードレビュー指摘・マッチャー抜け漏れ修正)** `MultiEdit`で`file_path`が`.claude/.verify-state/abc.skip` → `ask`
+  12. **(コードレビュー指摘・誤検知修正)** `command`が`ls .claude/.verify-state && rm old-backup.skip`(cdを伴わないディレクトリ参照+無関係な`.skip`ファイルへの操作) → 何も出力されない
+  13. **(コードレビュー指摘・matcher/case文の二重管理による抜け漏れの再発防止)** `.claude/settings.json`の`matcher`一覧と本スクリプトの`case`文のツール一覧(Bash/Write/Edit/MultiEdit)を機械的に突き合わせ、一致することを確認する(片方だけ更新された場合にテストが落ちるようにする回帰テスト)
 
 ## 対象範囲外(YAGNI)
 

--- a/scripts/check-skip-marker-write.sh
+++ b/scripts/check-skip-marker-write.sh
@@ -27,15 +27,22 @@ set -euo pipefail
 #    ".claude/.verify-state" ディレクトリそのもの/配下を指しており、かつcommand/file_pathに
 #    スラッシュを含まない(=相対パスらしい)".skip"トークンが含まれる場合も対象とする。
 #
+# 対象ツール: Bash / Write / Edit / MultiEdit(いずれもtool_input.file_pathまたはcommandに
+# 書き込み先パスが現れる)。.claude/settings.jsonのmatcherと本スクリプトのcase文の両方を
+# 揃える必要がある(片方だけ直しても検知が効かない)。NotebookEdit等、file_path以外の
+# パラメータ名で書き込み先を指定するツールが将来追加された場合は同様に追随が必要。
+#
 # 既知の限界(設計ドキュメントに明記済み):
 # - 正規表現によるコマンド文字列マッチのため、変数展開・base64エンコード等で意図的に
 #   難読化されたコマンドはすり抜けうる。典型的な手段(touch/echo/cp/mv/python -c/node -e等、
 #   コマンド文字列に直接パスが現れるもの)を塞ぐのが目的であり、完全な保証ではない。
 
 FULL_PATH_PATTERN='\.claude/\.verify-state/[^/]+\.skip'
-# ディレクトリ参照の後にスラッシュ・空白・&・;・文字列末尾のいずれかが続く(cdの引数として
-# 使われる書き方も含めて拾うため、直後に必ずスラッシュが来るとは限らない)。
-DIR_REFERENCE_PATTERN='\.claude/\.verify-state([/[:space:]&;]|$)'
+# 「cd」でディレクトリへ移動する操作に限定する(単に ls/cat/grep 等でディレクトリ名に
+# 言及しているだけの読み取り系コマンドと、無関係な場所にある別の *.skip ファイルへの
+# 操作が同一コマンド文字列中にたまたま同居しているだけの誤検知(false positive)を避けるため)。
+# 直前が行頭・空白・;・& のいずれかで始まる「cd <path>」の形のみを対象とする。
+DIR_REFERENCE_PATTERN='(^|[;&[:space:]])cd[[:space:]]+\.claude/\.verify-state([/[:space:]&;]|$)'
 CWD_PATTERN='(^|/)\.claude/\.verify-state($|/)'
 RELATIVE_SKIP_TOKEN_PATTERN='[^/[:space:]]+\.skip'
 
@@ -48,7 +55,7 @@ case "$TOOL_NAME" in
   Bash)
     TARGET="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
     ;;
-  Write|Edit)
+  Write|Edit|MultiEdit)
     TARGET="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')"
     ;;
   *)

--- a/scripts/check-skip-marker-write.test.sh
+++ b/scripts/check-skip-marker-write.test.sh
@@ -112,6 +112,24 @@ run_hook "$input"
 assert_eq "$EXIT_CODE" "0" "exit 0"
 assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
 
+echo "=== scenario 11: MultiEditツールでfile_pathが.skip → ask(マッチャー抜け漏れ修正) ==="
+input="$(jq -n '{tool_name: "MultiEdit", tool_input: {file_path: ".claude/.verify-state/abc.skip", edits: [{old_string: "x", new_string: "y"}]}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "ask"' "permissionDecision: askが出力される"
+
+echo "=== scenario 12: cdを伴わないディレクトリ言及(ls)+無関係な.skipファイルへの操作 → 何も出力しない(誤検知修正の回帰) ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "ls .claude/.verify-state && rm old-backup.skip"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(cdを伴わないディレクトリ参照は誤検知としない)"
+
+echo "=== scenario 13: .claude/settings.jsonのmatcherと本スクリプトのcase文のツール一覧が一致する(matcher/case文の二重管理による抜け漏れの再発防止) ==="
+SETTINGS_FILE="$SCRIPT_DIR/../.claude/settings.json"
+MATCHER_TOOLS="$(jq -r '.hooks.PreToolUse[] | select(.hooks[].command | endswith("check-skip-marker-write.sh")) | .matcher' "$SETTINGS_FILE" | tr '|' '\n' | sort)"
+CASE_TOOLS="$(grep -oE '^  [A-Za-z]+(\|[A-Za-z]+)*\)' "$SCRIPT" | grep -v '^  \*)' | tr -d ' )' | tr '|' '\n' | sort -u)"
+assert_eq "$CASE_TOOLS" "$MATCHER_TOOLS" "settings.jsonのmatcherとcase文のツール一覧(Bash/Write/Edit/MultiEdit)が一致する(片方だけ変更されている場合はここで失敗する)"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- `.claude/settings.json`のPreToolUse matcherと`scripts/check-skip-marker-write.sh`のcase文に`MultiEdit`が漏れており、MultiEditツール経由での`.skip`マーカー書き込みが検知をすり抜けられる問題を修正
- `cd .claude/.verify-state && touch abc.skip`のような単一コマンド内cd後の相対パス操作、および事前cd済みのcwdからの相対パス操作(hook入力の`cwd`フィールドを見る)がフルパス正規表現一致だけでは検知できなかった問題を修正
- 上記の回帰テスト(シナリオ6〜13、matcher/case文の突き合わせテストを含む)を追加
- 設計ドキュメントを更新

Closes #397

## Test plan
- [x] `bash scripts/check-skip-marker-write.test.sh` 全13シナリオPASS
- [x] `npm test` 1042件PASS
- [x] `npm run lint` エラーなし
