### PR TITLE
fix: Spec Checkが指定specPath以外のファイルを読んでpass誤判定する問題への回避策(issue #399)

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -126,12 +126,13 @@ const SPEC_CHECK_SCHEMA = {
   properties: {
     status: { type: 'string', enum: ['pass', 'blocked'] },
     detail: { type: 'string' },
+    actualPath: { type: 'string' },
   },
-  required: ['status', 'detail'],
+  required: ['status', 'detail', 'actualPath'],
 }
 
 const specCheck = await agent(
-  `Readツールで ${specPath} が存在し読み込めるか確認してください。それ以外は何もしないでください。${guide(
+  `Readツールで ${specPath} が存在し読み込めるか確認してください。指定されたパス以外のファイル（例: リポジトリルート直下の別のSPEC.md）が見つかっても、それは無視して絶対に読まないでください。それ以外は何もしないでください。\n\n完了報告のactualPathフィールドに、実際にReadツールへ渡した絶対パスを（今回指定された ${specPath} をそのまま解決したもので）必ず記載してください。${guide(
     `${specPath}が存在し読み込めた`,
     '（未使用: このエージェントはpass/blockedの2値のみ返す）',
     `${specPath}が存在しない、または読み込めない`
@@ -141,7 +142,29 @@ const specCheck = await agent(
 
 countLoggable('reviewer')
 countProgressLoggable('reviewer')
-log(`Spec Check完了: status=${specCheck?.status ?? 'なし'}`)
+log(`Spec Check完了: status=${specCheck?.status ?? 'なし'}, actualPath=${specCheck?.actualPath ?? 'なし'}`)
+
+// issue #399: Workflowツール側の非対称バグにより、最初のagent()呼び出し（Spec Check）だけが
+// 指定specPathを無視しデフォルト値'SPEC.md'を対象にしてしまう事象が実測で確認されている。
+// 根本原因はWorkflowツール側にある可能性が高く本スクリプトでは修正できないため、当面の防御として
+// 「実際にReadした絶対パス」を自己申告させ、指定specPathとの文字列一致をここで機械検証する。
+// 判定ロジックの正本・テストは .claude/workflows/lib/spec-check.js の isSpecCheckPathMismatch。
+// Workflow DSLはrequire不可のためインライン複製している（プロンプト文言を変更した場合は
+// spec-check.js側も手動で追従させること。自動では同期されない）。
+const specCheckPathMismatch = specCheck?.status === 'pass'
+  && typeof specCheck?.actualPath === 'string'
+  && !specCheck.actualPath.endsWith(specPath)
+
+if (specCheckPathMismatch) {
+  log(`品質ゲート: Spec Checkが指定specPath(${specPath})ではなく別ファイル(${specCheck.actualPath})を読んだため中断（issue #399）`)
+  return {
+    done: false,
+    specCheck,
+    blocked: true,
+    blockedAt: 'Spec Check',
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: 'Spec Check', expectedLoopObservabilityRecords: loggableAgentCount, expectedAgentProgressRecords: progressLoggableAgentCount },
+  }
+}
 
 if (shouldBlock([specCheck])) {
   log(`品質ゲート: ${specPath}が存在しないため中断（Manifest Check以降のエージェントは起動しません）`)

--- a/.claude/workflows/lib/__tests__/spec-check.test.js
+++ b/.claude/workflows/lib/__tests__/spec-check.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { isSpecCheckPathMismatch } from '../spec-check.js'
+
+describe('isSpecCheckPathMismatch', () => {
+  it('statusがpassでactualPathが指定specPathで終わっていればfalse（一致・不一致なし）', () => {
+    const specCheck = { status: 'pass', detail: 'ok', actualPath: '/repo/SPEC.md' }
+    expect(isSpecCheckPathMismatch(specCheck, 'SPEC.md')).toBe(false)
+  })
+
+  it('statusがpassでactualPathが指定specPath（サブディレクトリ）で終わっていればfalse', () => {
+    const specCheck = {
+      status: 'pass',
+      detail: 'ok',
+      actualPath: '/repo/.claude/workflows/__fixtures__/fault-injection/missing-spec/SPEC.md',
+    }
+    expect(isSpecCheckPathMismatch(specCheck, '.claude/workflows/__fixtures__/fault-injection/missing-spec/SPEC.md')).toBe(false)
+  })
+
+  it('statusがpassでactualPathが指定specPathと異なるファイルを指していればtrue（issue #399の再現ケース）', () => {
+    const specCheck = {
+      status: 'pass',
+      detail: 'SPEC.mdが存在し読み込めた',
+      actualPath: '/repo/SPEC.md',
+    }
+    expect(isSpecCheckPathMismatch(specCheck, '.claude/workflows/__fixtures__/fault-injection/missing-spec/SPEC.md')).toBe(true)
+  })
+
+  it('statusがblockedならactualPathが不一致でもfalse（既存のblocked判定に委ねる）', () => {
+    const specCheck = { status: 'blocked', detail: '存在しない', actualPath: '/repo/SPEC.md' }
+    expect(isSpecCheckPathMismatch(specCheck, 'SPEC.md')).toBe(false)
+  })
+
+  it('actualPathが欠落していればfalse（従来のstatusベース判定に委ねる）', () => {
+    const specCheck = { status: 'pass', detail: 'ok' }
+    expect(isSpecCheckPathMismatch(specCheck, 'SPEC.md')).toBe(false)
+  })
+})

--- a/.claude/workflows/lib/spec-check.js
+++ b/.claude/workflows/lib/spec-check.js
@@ -1,0 +1,21 @@
+// aidd-phase2.js の Spec Check フェーズが行っている「指定specPath以外のファイルを
+// 誤って読んでいないか」の機械検証ロジックを、Node側の純粋関数として切り出したもの（issue #399）。
+//
+// 背景: Spec Checkエージェントに指定specPathとは異なるパス（例: リポジトリルート直下の
+// 慣習的なSPEC.md）を読ませ、それをpassの根拠にしてしまう非対称バグが実測で確認された
+// （根本原因はWorkflowツール側の可能性が高く、このリポジトリ側では修正できない）。
+// 当面の防御として、エージェントに「実際にReadした絶対パス」を自己申告させ、
+// 指定specPathとの一致をここで機械検証する。
+//
+// 注意（構造的な制約）: Workflow DSL（aidd-phase2.js）自体はrequire不可のため、
+// このファイルの判定ロジックはaidd-phase2.js内にインライン複製されている。
+// プロンプト文言・判定条件を変更した場合、このファイルとテストも手動で追従させること
+// （自動では同期されない）。
+
+// specCheck: Spec Checkエージェントの返り値 { status, detail, actualPath }
+// specPath: 今回のAIDD実行に指定されたSPEC.mdのパス
+export function isSpecCheckPathMismatch(specCheck, specPath) {
+  if (specCheck?.status !== 'pass') return false
+  if (typeof specCheck?.actualPath !== 'string') return false
+  return !specCheck.actualPath.endsWith(specPath)
+}


### PR DESCRIPTION
## Summary
- issue #399の実測で確定した問題(aidd-phase2.jsの最初のagent()呼び出し=Spec Checkだけが、指定specPathを無視してデフォルト値'SPEC.md'を対象にしてしまう非対称バグ)への当面の防御策
- Spec Checkエージェントに「実際にReadツールへ渡した絶対パス」の申告(`actualPath`)を必須化し、指定specPathとの一致をスクリプト側で機械検証。不一致ならpass自己申告でも強制blocked
- 判定ロジックを`.claude/workflows/lib/spec-check.js`に切り出し、`manifest-check.js`と同じパターンでユニットテスト化

## Not in scope
- 根本原因はWorkflowツール側にある可能性が高く、このリポジトリでは修正不可(issue本文が推奨するClaude Code本体への報告は未実施)
- リポジトリルート直下に慣習的な`SPEC.md`を常時置く運用自体の見直しは未着手(影響範囲が大きく別途判断が必要)

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/spec-check.test.js` (5 tests pass)
- [x] `npx vitest run .claude/workflows/lib/__tests__/` (全85件 pass、既存テストの回帰なし)
- [ ] 実際にfault-injectionシナリオ(`missing-spec`)でSpec Checkがblocked判定になることを再実行して確認(次回セッションで実施推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)