### PR TITLE
docs: ツール制約回避のload-bearing workaround棚卸しと解除条件を追加(issue #413)

### DIFF
--- a/.claude/workflows/aidd-phase1-router.js
+++ b/.claude/workflows/aidd-phase1-router.js
@@ -47,6 +47,8 @@ function isHighRiskPath(filePath) {
 
 // Workflowツール実行系のargsがverbatimでなく文字列化されて渡ってくる既知の不具合への回避策。
 // argsが文字列で届いた場合はJSONとしてパースしてから使う。
+// 正本・単体テストは .claude/workflows/lib/resolve-workflow-args.js を参照（issue #413）。
+// Workflow DSL自体はrequire不可のためインライン複製している（1行のみのためsync testは設けていない）。
 const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
 
 const taskDescription = parsedArgs?.taskDescription ?? '現在のコードベース全体の調査'

--- a/.claude/workflows/lib/__tests__/resolve-workflow-args.test.js
+++ b/.claude/workflows/lib/__tests__/resolve-workflow-args.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWorkflowArgs } from '../resolve-workflow-args.js'
+
+describe('resolveWorkflowArgs', () => {
+  it('argsがobjectで渡ってきた場合はそのまま返す', () => {
+    const args = { taskDescription: '在庫一覧の並び替え', changedFiles: ['src/app/page.tsx'] }
+    expect(resolveWorkflowArgs(args)).toBe(args)
+  })
+
+  it('argsがJSON文字列で渡ってきた場合はparseして返す（Workflowツール既知の不具合への回避策）', () => {
+    const args = JSON.stringify({ taskDescription: '在庫一覧の並び替え', maxRounds: 2 })
+    expect(resolveWorkflowArgs(args)).toEqual({ taskDescription: '在庫一覧の並び替え', maxRounds: 2 })
+  })
+
+  it('argsがundefinedの場合はundefinedをそのまま返す', () => {
+    expect(resolveWorkflowArgs(undefined)).toBeUndefined()
+  })
+})

--- a/.claude/workflows/lib/resolve-workflow-args.js
+++ b/.claude/workflows/lib/resolve-workflow-args.js
@@ -1,0 +1,16 @@
+// Workflowツール実行系のargsがverbatimでなく文字列化されて渡ってくる既知の不具合への
+// 回避策（`.claude/workflows/aidd-phase1-router.js`）を、Node側の純粋関数として切り出した
+// もの（issue #413のload-bearing workaround棚卸し対象）。
+//
+// 背景: Workflowツールに`args: {"taskDescription": "..."}`をオブジェクトとして渡しても、
+// スクリプト内で受け取ったargsが`typeof args === 'string'`になる（JSON文字列化された状態で
+// 渡ってくる）ことを診断用スクリプトで確認した（docs/agents/decisions.md「なぜ
+// aidd-phase1-router.jsでargsをJSON.parseする防御コードを入れたか」参照）。
+//
+// 注意（構造的な制約）: Workflow DSL（aidd-phase1-router.js）自体はrequire不可のため、
+// この関数の判定ロジックはaidd-phase1-router.js内にインライン複製されている
+// （1行のみのため、他の複製箇所のようなsync testは設けていない。ロジックを変更する場合は
+// 両方を手動で追従させること）。
+export function resolveWorkflowArgs(args) {
+  return typeof args === 'string' ? JSON.parse(args) : args
+}

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -222,6 +222,30 @@ any code. Heed deprecation notices.
 自動追従しない（issue #348で発覚した回避穴と同種のギャップ）。単体テストのgreenだけでは
 「実行パスの本体が本当にblockedを返すこと」は証明されないため、実測訓練で埋める。
 
+## ツール制約回避のload-bearing workaround棚卸し（issue #413）
+
+2026-07-16のmentor設計レビューで、AIDDフレームワークの相当部分がツール（Workflow DSL /
+`claude -p`）の制約・不具合への回避策でできていることが確認された。各回避策はdecisions.md等に
+「なぜ」が記録されガードも付いているが、**Claude Code側の更新で回避策の前提が壊れると、検知網
+自体が静かに全滅しうる**（回避策 = 検知網の土台、というメタ構造のため）。ツール本体を更新した
+とき、またはeval/ワークフロー実行が理由不明に失敗し始めたときは、まずこの表を確認すること。
+
+| 回避策 | 場所 | 前提とするツール挙動 | 解除条件／破損条件 | smoke test |
+|---|---|---|---|---|
+| args `typeof === 'string'` → `JSON.parse`防御 | `.claude/workflows/aidd-phase1-router.js`（正本: `.claude/workflows/lib/resolve-workflow-args.js`） | Workflowツールがargsをobjectで渡してもstringで届く不具合（[`decisions.md`](./decisions.md#なぜaidd-phase1-routerjsでargsをjsonparseする防御コードを入れたか)） | **解除**: ツール側がargsを常にobjectで渡すよう修正されれば、この分岐に到達しなくなるだけで副作用なし（前方互換設計のため削除は任意）。**破損**: このガード自体が壊れることは想定しにくい（`typeof`判定のみのため） | `resolve-workflow-args.test.js`（npm test内） |
+| `--setting-sources ""` + `--agents`フラグでのagent定義注入 | `scripts/lib/build-eval-agent-json.mjs` | `--setting-sources ""`が`.claude/agents/*.md`探索も無効化する挙動 | **解除**: `--setting-sources`が`.claude/agents/`探索のみを無効化しないよう修正されれば不要。**破損**: `--agents`フラグのJSON構造・優先順位が変更されると`--agent implementer`解決自体が失敗し、evalの実エージェント呼び出しが全滅する（common.md「AIDDワークフロープロンプトのeval」に既述のload-bearing箇所） | JSON出力形式は`build-eval-agent-json.test.mjs`（npm test内）で検証済み。**ただし実際に`claude -p --agents ... --agent <type>`でagent解決できるかどうかの専用smoke testは無い**（`claude -p`の実呼び出しが必要でCI化見送り済みのため、issue #391と同じ判断。`npm run eval:workflows db-impl`を手動実行した際に暗黙的に再検証されるのみ） |
+| プロンプト正本の切り出し＋インライン複製＋sync test | `.claude/workflows/lib/prompts/db-impl.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/spec-check.js` / `manifest-check.js` ⇔ `aidd-phase2.js` | Workflow DSLがfilesystem API不可でローカルモジュールをrequire/importできない制約 | **解除**: Workflow DSLがローカルモジュールをimportできるようになれば、インライン複製自体が不要になり正本を直接importする形に変えられる。**破損**: プロンプト文言変更時にインライン複製側を追従させ忘れると乖離する（これを検知するのがsync testの目的そのもの） | `workflow-prompt-sync.test.js`（npm test内） |
+| eval fixture manifestとaidd-phase2.js内スキーマ定義の同期 | `scripts/eval-fixtures/db-impl/manifest.json` ⇔ `aidd-phase2.js`内のスキーマ定義 | 同上（Workflow DSL importの制約） | **解除**: 同上。**破損**: スキーマ定義がドリフトすると、evalが実際のプロンプトと異なるスキーマでテストしてしまい気づかれない | `eval-fixture-manifest-schema-sync.test.js`（npm test内） |
+| 進捗・観測ログの自然言語指示依存 | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`呼び出し | Workflow DSLがfilesystem API不可で、ワークフロー本体から機械的にログを書き込めない制約 | **解除**: 同上（importまたは直接fs書き込みが可能になれば、本体側から機械的に記録できる設計に変更可能）。**破損**: 元々「壊れる」ものではなく「そもそも書かれない」リスクが常態（自然言語指示依存のため） | 記録漏れの事後検知（`check-loop-observability-gap.sh` / `check-agent-progress-gap.sh`）はあるが、その実行自体が人起動であり第3層ルールとして上表に残っている（issue #411） |
+
+**Claude Code更新時の確認手順**: (1) 上表の「smoke test」列にnpm test内のテストがある項目は
+`npm test`を実行して確認する。(2) smoke testが「無い」と明記されている項目（現状は
+`--setting-sources`+`--agents`の組み合わせのみ）は`npm run eval:workflows db-impl`を一度手動実行し、
+4ケース中`case-1`〜`case-4`がエージェント呼び出し自体（`NG: エージェント実行が失敗しました`
+以外の結果）に到達しているかを確認する。(3) 新しいload-bearing workaroundを追加した場合は、
+この表に行を追加すること（issue #411の原則どおり、smoke testを機械トリガーに載せられないなら
+その旨をこの表に明記し、prose追加だけで済ませない）。
+
 ## 重要ファイルへのパス
 
 | ファイル | 目的 |


### PR DESCRIPTION
## Summary
- `docs/agents/common.md`に「ツール制約回避のload-bearing workaround棚卸し」表を新設。現時点で判明している5件（argsのJSON.parse防御・`--setting-sources`+`--agents`combo・プロンプト正本+インライン複製+sync test・eval fixture manifestとのスキーマ同期・進捗ログの自然言語指示依存）それぞれに、解除条件（ツール側がこう直ったら不要になる）・破損条件（こう変わると壊れる）・smoke testの有無を明記した
- Claude Code更新時、またはeval/ワークフロー実行が理由不明に失敗し始めたときにまず確認する手順も追記
- 未テストだった`aidd-phase1-router.js`のargs `JSON.parse`防御を`.claude/workflows/lib/resolve-workflow-args.js`に切り出し、単体テストを追加（issueの「可能なものにはsmoke testを付ける」に対応）

## Background
2026-07-16のmentor設計レビューで、AIDDフレームワークの相当部分がWorkflow DSL/`claude -p`の制約・不具合への回避策で成り立っていることが確認された。各回避策は分散して記録されており全体像を持つ場所が無く、ツール更新で前提が壊れても気づけないリスクがあった。

## Not in scope
- `--setting-sources ""` + `--agents`の組み合わせが実際に機能するかのsmoke test化（`claude -p`の実呼び出しが必要でCI化見送り。表にその旨明記）
- 進捗・観測ログの記録自体の機械化（issue #339スコープ、別途）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/` (17ファイル・101件 pass、既存テストの回帰なし)

Ref #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)