### PR TITLE
品質ゲートのpass/fail実績をStop hookで月次自動サマリ(issue #412)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -172,6 +172,12 @@
             "command": "scripts/verify-claims.sh",
             "timeout": 90,
             "statusMessage": "直前ターンの主張を裏取り中..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/gate-effectiveness-monthly-check.sh",
+            "timeout": 15,
+            "statusMessage": "品質ゲート月次サマリを確認中..."
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ e2e/.auth/*.json
 /.claude/.doc-suggest-state/
 /.claude/.ai-check-suggest-state/
 /.claude/.verify-state/
+/.claude/.gate-effectiveness-state/
 
 # AIDD Run Manifest（フロー実行ごとに生成される一時状態。スキーマはdocs/agents/run-manifest.md参照）
 /.aidd/

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -206,6 +206,39 @@ common.mdの分量は増え続けており、prose追加1件ごとに他ルー�
 実測件数」パターンを再利用）として実装済み。残る2件（router非経由でのTRI/RISK対象変更検知、
 引き継ぎフォーマット実施検知）は優先度順に別途実装する（未着手、issue #339）。
 
+## なぜ品質ゲートの効果測定をpass/fail集計のみに絞り、blocked実績は対象外にしたか（issue #412）
+
+2026-07-16のmentor設計レビューで、AIDD品質ゲート群（Spec Check / Manifest Check / Adversarial
+Verify / Judge Panel等）が「実際に何件の欠陥を止めたか」を示すデータが構造的に存在しないことが
+指摘された。効果測定の本格版（issue #394）は集中維持のためnot plannedクローズ済みのため、
+`logs/loop-observability.jsonl`の集計のみで済む最小構成として着手した。
+
+**実装前に判明した前提の誤り:** issue #412の起票時点では「ゲートのblocked/fail実績は
+loop-observability.jsonlに記録されている」という前提だったが、実装着手時に検証したところ誤り
+だった。`scripts/log-loop-observability.sh`の`--result`は`pass|fail`の2値のみを受け付け
+（`.claude/agents/reviewer.md`の呼び出し例も`pass`/`fail`のみ）、`blocked`は
+`aidd-phase2.js`のAGENT_RESULT_SCHEMAが返す独立した値（Spec Check/Manifest Check/Contract+DB/
+Implement/Integrate/Reviewの各ゲート）で、Workflowの戻り値（`stats.blockedAt`等）としてその場に
+出るだけであり、リポジトリ内のどのファイルにも永続化されていない。
+
+このため今回のスコープは、loop-observability.jsonlに実在するreviewer/implementer/judge-panelの
+pass/fail実績（試行回数・fail率のagent別集計）に絞った。ゲート本体（Spec Check等）のblocked
+実績を可視化するには、`aidd-phase2.js`側にblocked判定時のログ永続化を追加する別スコープの作業が
+必要であり、今回は着手していない。
+
+**なぜ機械トリガーをGitHub Actions cronではなくStop hookにしたか:** schema-drift-check.yml
+（issue #305）と同じ「月次cron + 既存ログの集計」パターンを検討したが、`logs/`は
+`.gitignore`で除外されておりリポジトリにコミットされない（ローカル専用ログ）。GitHub Actions
+はfresh checkoutで動くためローカルの`logs/loop-observability.jsonl`を参照できず、この方式は
+不採用にした。代わりに、セッション終了ごとに必ず発火する既存のStop hook機構
+（`scripts/doc-suggest-check.sh`等と同じパターン）を使い、`.claude/.gate-effectiveness-state/
+last-summary-at`のmtimeで前回出力から30日経過したかを判定して間引く方式にした。これにより
+「起動トリガーは機械」という原則（issue #411のレビューで確認した観点）を保ちながら、GitHub
+Secretsやリモートのステータス源を新設せずに済む。
+
+**関連**: #394（クローズ済みの本格版効果測定）、#411（「起動トリガーは機械か人か」の原則）、
+#305（同型パターンだが本件では不採用にした理由の比較対象）
+
 **追記の原則（issue #411）:** 新しい検知・検証メカニズムを足すときは、「その起動トリガーは
 機械か人か」を先に確認する。人起動（フロー実行の前後でエージェントが手順として実行する形）
 なら、それは第3層ルールの削減ではなく追加であり、下記の棚卸し表に行が1つ増えるだけである。

--- a/scripts/gate-effectiveness-monthly-check.sh
+++ b/scripts/gate-effectiveness-monthly-check.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hookから呼ばれる。issue #412: 品質ゲート（reviewer/implementer/judge-panel）の
+# pass/fail実績を、人が思い出して実行する運用にせず機械トリガー（Stop hook）で月次集計する。
+#
+# 起動はセッション終了のたびだが、実際にsystemMessageを出すのは前回出力から30日以上
+# 経過した場合のみ（状態は.claude/.gate-effectiveness-state/last-summary-atのmtimeで判定）。
+# これにより「Stop hookは毎回発火する（機械トリガー）が、通知は月次に間引く」を両立する。
+#
+# 対象外: aidd-phase2.jsのSpec Check/Manifest Check等が返すblocked状態は
+# logs/loop-observability.jsonlに記録されないため、この集計には現れない
+# （scripts/log-loop-observability.shの--resultはpass|failのみ受け付ける。issue #412コメント参照）。
+
+cd "$(dirname "$0")/.."
+
+LOG_FILE="logs/loop-observability.jsonl"
+if [ ! -f "$LOG_FILE" ]; then
+  echo '{"systemMessage": ""}'
+  exit 0
+fi
+
+STATE_DIR=".claude/.gate-effectiveness-state"
+STATE_FILE="$STATE_DIR/last-summary-at"
+mkdir -p "$STATE_DIR"
+
+INTERVAL_DAYS=30
+
+if [ -f "$STATE_FILE" ]; then
+  # find -mtime +N は「N日より古い」判定。該当すればstdoutに1行出る
+  STALE="$(find "$STATE_FILE" -mtime "+${INTERVAL_DAYS}" 2>/dev/null || true)"
+  if [ -z "$STALE" ]; then
+    echo '{"systemMessage": ""}'
+    exit 0
+  fi
+fi
+
+SUMMARY="$(bash scripts/summarize-loop-observability.sh --log-file "$LOG_FILE" 2>/dev/null || true)"
+touch "$STATE_FILE"
+
+if [ -z "$SUMMARY" ]; then
+  echo '{"systemMessage": ""}'
+  exit 0
+fi
+
+MSG="品質ゲート月次サマリ（issue #412。blocked状態は対象外、reviewer/implementer/judge-panelのpass/failのみ）:
+
+${SUMMARY}"
+
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'

--- a/scripts/gate-effectiveness-monthly-check.test.sh
+++ b/scripts/gate-effectiveness-monthly-check.test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# WHY: scripts/gate-effectiveness-monthly-check.sh(Stop hook)の回帰テスト。
+# 実物のlogs/.claude/.gate-effectiveness-stateに依存させず、サンドボックスディレクトリに
+# scripts/一式をコピーして決定的に検証する（issue #412）。
+#
+# 実行: bash scripts/gate-effectiveness-monthly-check.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty_system_message() {
+  local actual="$1" label="$2"
+  local msg
+  msg="$(printf '%s' "$actual" | jq -r '.systemMessage')"
+  if [ -z "$msg" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (systemMessage=$msg)"
+    fail=1
+  fi
+}
+assert_file_exists() {
+  local path="$1" label="$2"
+  if [ -f "$path" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (not found: $path)"
+    fail=1
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/scripts" "$SANDBOX/logs" "$SANDBOX/.claude"
+cp "$SCRIPT_DIR/gate-effectiveness-monthly-check.sh" "$SANDBOX/scripts/"
+cp "$SCRIPT_DIR/summarize-loop-observability.sh" "$SANDBOX/scripts/"
+
+STATE_FILE="$SANDBOX/.claude/.gate-effectiveness-state/last-summary-at"
+LOG_FILE="$SANDBOX/logs/loop-observability.jsonl"
+
+run_hook() {
+  set +e
+  OUT="$(cd "$SANDBOX" && bash scripts/gate-effectiveness-monthly-check.sh < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+write_sample_log() {
+  cat > "$LOG_FILE" <<'EOF'
+{"timestamp":"2026-07-01T00:00:00Z","loop":"developer","agent":"reviewer","feature":"orders-list","attempt":1,"model":"sonnet","tokens":1000,"costUsd":0.1,"intent":"check","scenario":"quality","result":"pass","reason":"ok"}
+{"timestamp":"2026-07-02T00:00:00Z","loop":"developer","agent":"implementer","feature":"orders-list","attempt":1,"model":"sonnet","tokens":2000,"costUsd":0.2,"intent":"tdd","scenario":"red-green","result":"fail","reason":"test failed"}
+EOF
+}
+
+echo "=== scenario 1: logs/loop-observability.jsonlが無い → 何も出力せず状態ファイルも作らない ==="
+run_hook
+assert_empty_system_message "$OUT" "systemMessageが空である"
+if [ -f "$STATE_FILE" ]; then
+  echo "  NG: 状態ファイルが作られていないこと (unexpectedly found: $STATE_FILE)"
+  fail=1
+else
+  echo "  OK: 状態ファイルが作られていないこと"
+fi
+
+echo "=== scenario 2: ログはあるが状態ファイルが無い(初回) → サマリを出力し状態ファイルを作る ==="
+write_sample_log
+run_hook
+assert_contains "$OUT" "品質ゲート月次サマリ" "systemMessageにサマリ見出しが含まれる"
+assert_contains "$OUT" "reviewer" "systemMessageにagent別内訳が含まれる"
+assert_file_exists "$STATE_FILE" "状態ファイルが作られている"
+
+echo "=== scenario 3: 状態ファイルが新しい(直前に更新) → 何も出力しない ==="
+run_hook
+assert_empty_system_message "$OUT" "systemMessageが空である(間引かれる)"
+
+echo "=== scenario 4: 状態ファイルが31日以上前 → 再度サマリを出力する ==="
+touch -t "$(date -v-31d +%Y%m%d%H%M 2>/dev/null || date -d '31 days ago' +%Y%m%d%H%M)" "$STATE_FILE"
+run_hook
+assert_contains "$OUT" "品質ゲート月次サマリ" "31日経過後は再びsystemMessageが出る"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/summarize-loop-observability.sh
+++ b/scripts/summarize-loop-observability.sh
@@ -39,6 +39,28 @@ SUMMARY="$(jq -s -r '
     "- loop別: agentic=\($agentic), developer=\($developer), external=\($external)",
     "- 結果: pass=\($pass), fail=\($fail), other=\($other)",
     "",
+    "## Agent別（品質ゲートの発火実績。blocked状態はこのログに記録されないため対象外。issue #412）",
+    (
+      if $total == 0 then empty
+      else
+        ($all | group_by(.agent)[] |
+          . as $g |
+          ($g[0].agent) as $agent |
+          ($g | length) as $attempts |
+          ($g | map(select(.result == "pass")) | length) as $p |
+          ($g | map(select(.result == "fail")) | length) as $f |
+          "- \($agent): 試行\($attempts)件 / pass=\($p) / fail=\($f)"
+        ),
+        (
+          ($all | group_by(.agent) | map(select(any(.[]; .result == "fail")) | .[0].agent)) as $everFailed
+          | ($all | group_by(.agent) | map(.[0].agent) - $everFailed) as $neverFailed
+          | if ($neverFailed | length) > 0 then
+              "- 一度もfailを返していないagent: \($neverFailed | sort | join(", "))"
+            else empty end
+        ),
+        ""
+      end
+    ),
     "## Feature別",
     (
       if $total == 0 then empty

--- a/src/__tests__/summarize-loop-observability.test.ts
+++ b/src/__tests__/summarize-loop-observability.test.ts
@@ -58,6 +58,23 @@ describe('summarize-loop-observability.sh', () => {
     expect(output).toContain(
       '- [2026-07-02T01:00:00Z] loop=agentic agent=implementer feature=admin-role attempt=1 scenario="unit test" reason="型エラー"'
     )
+    expect(output).toContain('- implementer: 試行2件 / pass=1 / fail=1')
+    expect(output).toContain('- reviewer: 試行1件 / pass=1 / fail=0')
+    expect(output).toContain('- 一度もfailを返していないagent: reviewer')
+  })
+
+  it('omits the never-failed callout when every agent has failed at least once (issue #412)', () => {
+    writeRecords([
+      {
+        timestamp: '2026-07-02T01:00:00Z', loop: 'developer', agent: 'implementer',
+        feature: 'admin-role', attempt: 1, model: 'sonnet', tokens: null, costUsd: null,
+        intent: 'add role field', scenario: 'unit test', result: 'fail', reason: '型エラー',
+      },
+    ])
+
+    const output = run(['--log-file', logFile])
+
+    expect(output).not.toContain('一度もfailを返していないagent')
   })
 
   it('reports no failures when every record passed', () => {


### PR DESCRIPTION
## Summary
- `summarize-loop-observability.sh` にagent別（reviewer/implementer/judge-panel）のpass/fail集計を追加し、「一度もfailを返していないagent」を一覧できるようにした
- `gate-effectiveness-monthly-check.sh`（Stop hook）でセッション終了ごとに自動発火し、前回出力から30日経過していればサマリをsystemMessageとして表示する。人が思い出して実行する運用は避けた
- `logs/`はgitignore対象でGitHub Actions cronから読めないため、schema-drift-check.ymlと同型のcronパターンは不採用にし、既存Stop hook機構に載せた

## 実装前に判明したissue #412の前提誤り
起票時点では「blocked/fail実績はloop-observability.jsonlに記録されている」という前提だったが、実装着手時に検証したところ`--result`は`pass|fail`の2値のみで、`blocked`（Spec Check/Manifest Check等のゲート判定）はこのログに一切記録されないことが判明した。ユーザーと相談の上、今回はpass/fail集計のみに絞り（[docs/agents/decisions.md](../blob/main/docs/agents/decisions.md)に記録）、blocked可視化は別スコープとした。

## Test plan
- [x] `npx vitest run src/__tests__/summarize-loop-observability.test.ts`（新規2ケース含め全6件pass）
- [x] `bash scripts/gate-effectiveness-monthly-check.test.sh`（4シナリオ全pass）
- [x] `npm run typecheck` / `npm run lint`（既存の無関係な警告1件のみ、エラー0）
- [x] `npm test`（144ファイル・1066テスト全pass）

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
