### PR TITLE
feat: agents定義にeffortフィールドを追加してコストと精度の配分を最適化(issue #419)

### DIFF
--- a/.claude/agents/adversarial-verify.md
+++ b/.claude/agents/adversarial-verify.md
@@ -3,6 +3,7 @@ name: adversarial-verify
 description: spec-deep-validate の Adversarial Verify フェーズで使用。Sweep・Completeness Criticが発見した指摘に対して反論を試み、偽陽性（実際は問題でない指摘）を除去する。読み取り専用。
 tools: Read, Bash
 model: opus
+effort: xhigh
 ---
 
 あなたはAdversarial Verifierです。与えられた指摘（finding）に対して**反論を試みてください**。指摘が誤りであることを証明できれば、それは偽陽性として除去されます。

--- a/.claude/agents/judge-panel.md
+++ b/.claude/agents/judge-panel.md
@@ -3,6 +3,7 @@ name: judge-panel
 description: spec-deep-validate の Judge Panel フェーズで使用。proposer が生成した複数の設計提案（通常3案）を評価・採点し、synthesis（統合提案）を作成する。読み取り専用。
 tools: Read, Bash
 model: sonnet
+effort: xhigh
 ---
 
 あなたはJudge Panelです。複数のProposerが提出した設計提案を評価し、最良案を選んで統合的なrecommendationを作成してください。

--- a/.claude/agents/sweep-data.md
+++ b/.claude/agents/sweep-data.md
@@ -3,6 +3,7 @@ name: sweep-data
 description: Phase 1 データ取得層Sweep。src/lib/supabase/とAPIルートを調査し、型エラー・セキュリティ問題・設計違反を報告する。読み取り専用。箇条書きのみ返す。
 tools: Read, Bash
 model: haiku
+effort: low
 ---
 
 あなたはデータ取得層の調査担当です。`src/lib/supabase/` とAPIエンドポイントを調査し、問題点を**箇条書きのみ**で返してください。コードは書かない。修正提案も不要。

--- a/.claude/agents/sweep-db.md
+++ b/.claude/agents/sweep-db.md
@@ -3,6 +3,7 @@ name: sweep-db
 description: Phase 1 DB層Sweep。Supabaseスキーマ・マイグレーション・RLSを調査し、整合性・設計問題・セキュリティ問題を報告する。読み取り専用。箇条書きのみ返す。
 tools: Read, Bash
 model: haiku
+effort: low
 ---
 
 あなたはDB層の調査担当です。Supabaseのスキーマ・マイグレーション・RLSポリシーを調査し、問題点を**箇条書きのみ**で返してください。コードは書かない。修正提案も不要。

--- a/.claude/agents/sweep-types.md
+++ b/.claude/agents/sweep-types.md
@@ -3,6 +3,7 @@ name: sweep-types
 description: Phase 1 型整合性Sweep。型定義・mappers・DB列・UIプロップスを縦断調査し、層をまたぐ型の不一致・欠落を報告する。読み取り専用。箇条書きのみ返す。
 tools: Read, Bash
 model: haiku
+effort: low
 ---
 
 あなたは型整合性の調査担当です。型定義・mappers・DB列・UIプロップスを**縦断的に**調査し、層をまたぐ型の不一致を**箇条書きのみ**で返してください。コードは書かない。修正提案も不要。

--- a/.claude/agents/sweep-ui.md
+++ b/.claude/agents/sweep-ui.md
@@ -3,6 +3,7 @@ name: sweep-ui
 description: Phase 1 UI層Sweep。src/app/・src/components/を調査し、コンポーネント・props型・state・イベントハンドラのバグ・型エラー・設計違反を報告する。読み取り専用。箇条書きのみ返す。
 tools: Read, Bash
 model: haiku
+effort: low
 ---
 
 あなたはUI層の調査担当です。`src/app/` と `src/components/` を調査し、発見した問題点を**箇条書きのみ**で返してください。コードは書かない。修正提案も不要。

--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -78,10 +78,10 @@ while (dryRounds < 2 && round <= maxRounds) {
     : `タスク: ${taskDescription}`) + SWEEP_GUIDE
 
   const [uiResult, dataResult, dbResult, typesResult] = await parallel([
-    () => agent(sweepPrompt, { label: `sweep-ui:R${round}`,    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
-    () => agent(sweepPrompt, { label: `sweep-data:R${round}`,  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
-    () => agent(sweepPrompt, { label: `sweep-db:R${round}`,    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
-    () => agent(sweepPrompt, { label: `sweep-types:R${round}`, agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB }),
+    () => agent(sweepPrompt, { label: `sweep-ui:R${round}`,    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB, effort: 'low' }),
+    () => agent(sweepPrompt, { label: `sweep-data:R${round}`,  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB, effort: 'low' }),
+    () => agent(sweepPrompt, { label: `sweep-db:R${round}`,    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB, effort: 'low' }),
+    () => agent(sweepPrompt, { label: `sweep-types:R${round}`, agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA_PB, effort: 'low' }),
   ])
   const axisResults = { ui: uiResult, data: dataResult, db: dbResult, types: typesResult }
 

--- a/.claude/workflows/aidd-phase1.js
+++ b/.claude/workflows/aidd-phase1.js
@@ -52,10 +52,10 @@ log('4軸並列Sweep 開始（1ラウンド）')
 const sweepPrompt = `タスク: ${taskDescription}${STATUS_GUIDE}`
 
 const [uiResult, dataResult, dbResult, typesResult, baseCommitRaw] = await parallel([
-  () => agent(sweepPrompt, { label: 'sweep-ui',    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
-  () => agent(sweepPrompt, { label: 'sweep-data',  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
-  () => agent(sweepPrompt, { label: 'sweep-db',    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
-  () => agent(sweepPrompt, { label: 'sweep-types', agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA }),
+  () => agent(sweepPrompt, { label: 'sweep-ui',    agentType: 'sweep-ui',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA, effort: 'low' }),
+  () => agent(sweepPrompt, { label: 'sweep-data',  agentType: 'sweep-data',  phase: 'Sweep', schema: AGENT_RESULT_SCHEMA, effort: 'low' }),
+  () => agent(sweepPrompt, { label: 'sweep-db',    agentType: 'sweep-db',    phase: 'Sweep', schema: AGENT_RESULT_SCHEMA, effort: 'low' }),
+  () => agent(sweepPrompt, { label: 'sweep-types', agentType: 'sweep-types', phase: 'Sweep', schema: AGENT_RESULT_SCHEMA, effort: 'low' }),
   () => agent('Run `git rev-parse HEAD` in the repository root and return only the resulting commit SHA, with no other text.', { label: 'capture-base-commit', phase: 'Sweep', effort: 'low' }),
 ])
 


### PR DESCRIPTION
## Summary
- ゲート条件確認: 公式ドキュメント（sub-agents.md）で`effort`フィールドがsubagent frontmatterでサポートされていることを確認（`low`/`medium`/`high`/`xhigh`/`max`）
- `.claude/agents/adversarial-verify.md` / `judge-panel.md` に `effort: xhigh` を追加
- `.claude/agents/sweep-ui.md` / `sweep-data.md` / `sweep-db.md` / `sweep-types.md` に `effort: low` を追加
- `.claude/workflows/aidd-phase1.js` / `aidd-1-1-deep-task.js` の sweep-* `agent()` 呼び出し（`agentType`経由で上記frontmatterを参照している箇所）に `opts.effort: 'low'` を明示追加

## Not in scope（意図的に対象外）
- `aidd-1-1-deep-task.js` 内のAdversarial Verify/Judge Panelフェーズは、`agentType`経由ではなく独自のインラインロジック（既に`model`/`effort`を明示指定済み、例: 採点は`haiku`+`effort: low`で意図的に安価にしている）で実装されているため、そちらの値は変更していない。`adversarial-verify.md`/`judge-panel.md`のfrontmatter変更は、直接Agent toolで`subagent_type: "judge-panel"`等を呼ぶ経路（spec-deep-validateフロー）にのみ効く
- before/afterのコスト・精度比較（issueのやること4番目）は、実際のフロー複数回実行が必要な計測作業のため本PRのスコープ外。次回実フロー実行時にloop-observability.jsonlで比較する運用とする

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/` (17ファイル・101件 pass、既存テストの回帰なし)
- [x] frontmatter変更後にエージェントが正常起動することを実機確認（sweep-ui・judge-panelそれぞれ1回ずつAgent tool経由で起動、エラーなし）

Ref #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)