### PR TITLE
feat: SubagentStart/Stop hookでサブエージェント骨格記録を機械強制(issue #423)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -152,6 +152,20 @@
         ]
       }
     ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "scripts/log-subagent-hook-skeleton.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "scripts/log-subagent-hook-skeleton.sh", "timeout": 5 }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -137,6 +137,43 @@ any code. Heed deprecation notices.
     （hooks非継承・セッション非永続化・同時実行数上限）を初回コミットから組み込んだ上でのみ
     着手する。issue本文に理由を明記済み。
 
+## サブエージェント骨格記録の機械強制（issue #423）
+
+上記の`agent-progress.jsonl` / `loop-observability.jsonl`は、いずれもエージェントへの
+自然言語指示（「◯◯のタイミングで呼ぶこと」）に依存しており、呼び忘れると記録が丸ごと
+欠落する構造的弱点を持つ（2026-07-07以降、実際に5日分欠落した実績がある）。これに対し、
+`SubagentStart`/`SubagentStop` hookは「LLMが実行を選ぶことに頼らず決定論的に実行される」
+ため、呼び忘れという故障モード自体を構造的に解消できる。
+
+**保証レベル3層（新旧の役割分担）:**
+
+| 層 | 内容 | 記録手段 | 保証レベル |
+|---|---|---|---|
+| ① 骨格 | agent_id・agent_type・開始/終了・timestamp | `scripts/log-subagent-hook-skeleton.sh`（`SubagentStart`/`SubagentStop` hook） | 機械強制（呼び忘れ得ない） |
+| ② feature/attempt | どの機能・何回目の試行か | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`（自然言語指示） | ベストエフォート（label規約化は未着手、issue #423ステップ3） |
+| ③ 自由記述intent/scenario | 何をしようとしていたかの説明 | 同上 | ベストエフォート（欠落許容） |
+
+`logs/subagent-skeleton.jsonl`に、通常のAgent tool経由・Workflowの`agent()`呼び出し経由の
+両方のサブエージェント起動が、`{timestamp, hookEvent, sessionId, agentId, agentType,
+agentTranscriptPath?, lastAssistantMessage?}`形式で自動記録される。フィールド名はissue #423
+ステップ1の実験で実際に観測したhookペイロード（`agent_id`・`agent_type`・
+`agent_transcript_path`・`last_assistant_message`等）に基づく。
+
+**既知の限界:**
+- ペイロードに`status`（pass/fail/blocked）フィールドは含まれない。`SubagentStop`が発火した
+  という事実は「エージェントが完了処理まで到達した」ことの証拠にしかならず、pass/fail/blocked
+  の意味判定は引き続き自己申告・transcript突合（`scripts/verify-agent-progress-transcript.sh`）
+  に委ねる
+- このログは**セッション全体で共通**であり、1つのAIDDフロー実行にスコープされない。並行して
+  他の作業（別のAgent tool呼び出し等）が走っていると、そのイベントも同じファイルに混在する。
+  特定のフロー実行に絞り込みたい場合は、`agentTranscriptPath`が
+  `subagents/workflows/wf_<runId>/`配下かどうかで判別する
+- ②feature/attemptを「モデルの善意の報告」から「コードが決定的に埋め込む構造化データ」に
+  変えるlabel規約化（issue #423ステップ3、例: `agent()`呼び出しの`label`に
+  `implementer:${feature}:attempt${n}`規約を導入する）は未着手のまま残っている
+- 既存の`log-agent-progress.sh` / `log-loop-observability.sh` / gap check群は削除しておらず、
+  新方式と併存させている（新方式が安定稼働することを確認してから、廃止を別issueで検討する）
+
 ## AIDDワークフロープロンプトのeval（issue #391）
 
 `.claude/workflows/*.js` 内の自然言語プロンプト（例: db-implの「DBスキーマ変更不要ならblockedではなくpass」という判定基準）は、ユニットテストが効かず、修正の妥当性が「次回実フローでの目視確認」頼みになりがちだった（issue #389のフォローアップ）。fixture SPEC.mdを実際のエージェント（`claude -p --agent <agentType>`、本番と同じモデル）に読ませ、期待するstatus判定になるかを回帰テストする仕組みを用意した。

--- a/scripts/log-subagent-hook-skeleton.sh
+++ b/scripts/log-subagent-hook-skeleton.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SubagentStart/SubagentStop hook（settings.jsonに登録）から標準入力でJSONペイロードを受け取り、
+# logs/subagent-skeleton.jsonlへ「骨格」記録（agent_id・agent_type・開始/終了・timestamp）を
+# 機械的に追記する(issue #423)。
+#
+# 背景: log-agent-progress.sh / log-loop-observability.sh はエージェントへの自然言語指示に
+# 依存しており、呼び忘れると記録が丸ごと欠落する（実際に2026-07-07以降5日分欠落した実績あり）。
+# hookはLLMが実行を選ぶことに頼らず決定論的に実行されるため、呼び忘れという故障モード自体が
+# 構造的に発生しなくなる。issue #423のステップ1実験で、通常のAgent tool経由・Workflowの
+# agent()呼び出し経由の両方でSubagentStart/SubagentStopが発火することを確認済み。
+#
+# 注意（スコープ）: ここで記録するのは「骨格」のみ（agent_id・agent_type・開始/終了時刻・
+# 完了時の最終アシスタントメッセージ）。feature/intent/scenario等の意味情報は引き続き
+# log-agent-progress.sh / log-loop-observability.sh の自己申告に委ねる（保証レベル3層の
+# うち①のみを機械強制する。詳細はdocs/agents/common.md参照）。
+#
+# ペイロードにstatus（pass/fail/blocked）フィールドは含まれないため、pass/fail/blockedの
+# 意味判定はここでは行わない。「SubagentStopが発火した」という事実のみが「エージェントが
+# 完了処理まで到達した」ことの機械的な証拠になる。
+
+LOG_FILE="${SUBAGENT_HOOK_SKELETON_LOG_FILE:-logs/subagent-skeleton.jsonl}"
+
+PAYLOAD="$(cat)"
+
+HOOK_EVENT="$(echo "$PAYLOAD" | jq -r '.hook_event_name // empty')"
+SESSION_ID="$(echo "$PAYLOAD" | jq -r '.session_id // empty')"
+AGENT_ID="$(echo "$PAYLOAD" | jq -r '.agent_id // empty')"
+AGENT_TYPE="$(echo "$PAYLOAD" | jq -r '.agent_type // empty')"
+AGENT_TRANSCRIPT_PATH="$(echo "$PAYLOAD" | jq -r '.agent_transcript_path // empty')"
+LAST_ASSISTANT_MESSAGE="$(echo "$PAYLOAD" | jq -r '.last_assistant_message // empty')"
+
+if [[ -z "$HOOK_EVENT" || -z "$AGENT_ID" ]]; then
+  # ペイロード形状が想定と異なる場合はサイレントに何もしない(hookの失敗でセッション全体を
+  # 止めないため。exit非0にするとhook自体がエラー扱いになりうる)。
+  exit 0
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+jq -nc \
+  --arg timestamp "$TIMESTAMP" \
+  --arg hookEvent "$HOOK_EVENT" \
+  --arg sessionId "$SESSION_ID" \
+  --arg agentId "$AGENT_ID" \
+  --arg agentType "$AGENT_TYPE" \
+  --arg agentTranscriptPath "$AGENT_TRANSCRIPT_PATH" \
+  --arg lastAssistantMessage "$LAST_ASSISTANT_MESSAGE" \
+  '{
+    timestamp: $timestamp,
+    hookEvent: $hookEvent,
+    sessionId: $sessionId,
+    agentId: $agentId,
+    agentType: $agentType
+  }
+  + (if $agentTranscriptPath != "" then {agentTranscriptPath: $agentTranscriptPath} else {} end)
+  + (if $lastAssistantMessage != "" then {lastAssistantMessage: $lastAssistantMessage} else {} end)' \
+  >> "$LOG_FILE"
+
+exit 0

--- a/scripts/log-subagent-hook-skeleton.test.sh
+++ b/scripts/log-subagent-hook-skeleton.test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# WHY: issue #423向けのSubagentStart/SubagentStop hook(scripts/log-subagent-hook-skeleton.sh)の回帰テスト。
+# 実際のhookペイロード(issue #423ステップ1の実験で観測した実物の形状)を標準入力で渡し、
+# logs/subagent-skeleton.jsonl相当の一時ファイルに骨格記録が正しく追記されることを確認する。
+#
+# 実行: bash scripts/log-subagent-hook-skeleton.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/log-subagent-hook-skeleton.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+TMP_LOG="$(mktemp)"
+rm -f "$TMP_LOG"
+
+run_hook() {
+  local input="$1"
+  set +e
+  OUT="$(printf '%s' "$input" | SUBAGENT_HOOK_SKELETON_LOG_FILE="$TMP_LOG" bash "$SCRIPT")"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: SubagentStart ==="
+input='{"session_id":"sess-1","transcript_path":"/tmp/t.jsonl","cwd":"/repo","prompt_id":"p1","agent_id":"agent-abc","agent_type":"sweep-ui","hook_event_name":"SubagentStart"}'
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+LAST_LINE="$(tail -n 1 "$TMP_LOG")"
+assert_contains "$LAST_LINE" '"hookEvent":"SubagentStart"' "hookEventが記録される"
+assert_contains "$LAST_LINE" '"agentId":"agent-abc"' "agentIdが記録される"
+assert_contains "$LAST_LINE" '"agentType":"sweep-ui"' "agentTypeが記録される"
+
+echo "=== scenario 2: SubagentStop（通常のAgent tool経由、実観測ペイロード） ==="
+input='{"session_id":"sess-1","transcript_path":"/tmp/t.jsonl","cwd":"/repo","prompt_id":"p1","permission_mode":"acceptEdits","agent_id":"agent-abc","agent_type":"sweep-ui","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_transcript_path":"/tmp/subagents/agent-abc.jsonl","last_assistant_message":"実験OK","background_tasks":[],"session_crons":[]}'
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+LAST_LINE="$(tail -n 1 "$TMP_LOG")"
+assert_contains "$LAST_LINE" '"hookEvent":"SubagentStop"' "hookEventが記録される"
+assert_contains "$LAST_LINE" '"agentTranscriptPath":"/tmp/subagents/agent-abc.jsonl"' "agentTranscriptPathが記録される"
+assert_contains "$LAST_LINE" '"lastAssistantMessage":"実験OK"' "lastAssistantMessageが記録される"
+
+echo "=== scenario 3: agent_idが欠落したペイロードは何も書き込まずexit 0 ==="
+BEFORE_LINES="$(wc -l < "$TMP_LOG" | tr -d ' ')"
+input='{"session_id":"sess-1","hook_event_name":"SubagentStart"}'
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0（サイレント無視）"
+AFTER_LINES="$(wc -l < "$TMP_LOG" | tr -d ' ')"
+assert_eq "$AFTER_LINES" "$BEFORE_LINES" "行数が増えない（不正ペイロードは書き込まない）"
+
+rm -f "$TMP_LOG"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL"
+  exit 1
+fi
+echo "PASS"


### PR DESCRIPTION
## Summary
- issue #423ステップ1の実験（コメント済み）: 通常のAgent tool経由・Workflowの`agent()`呼び出し経由の両方で`SubagentStart`/`SubagentStop` hookが発火することを確認 → 分岐A（hookで骨格記録を自動書き込み）を採用
- `scripts/log-subagent-hook-skeleton.sh`を追加し、`SubagentStart`/`SubagentStop` hookのペイロードから`agent_id`/`agent_type`/`agent_transcript_path`/`last_assistant_message`を抽出して`logs/subagent-skeleton.jsonl`へ機械的に追記する（`.claude/settings.json`に登録）
- `docs/agents/common.md`に保証レベル3層（①骨格=hook機械強制 ②feature/attempt=label規約・未着手 ③自由記述intent=ベストエフォート）を明記

## Not in scope（意図的に対象外、issueのステップ3）
- feature/attemptのlabel規約化（例: `implementer:${feature}:attempt${n}`）は本PRのスコープ外
- 既存の`log-agent-progress.sh` / `log-loop-observability.sh` / gap check群の削除・変更は行わない（新方式と併存させる）

## Test plan
- [x] `bash scripts/log-subagent-hook-skeleton.test.sh`（3シナリオ pass: Start記録・Stop記録・不正ペイロードのサイレント無視）
- [x] `npx vitest run .claude/workflows/lib/__tests__/`（17ファイル・101件 pass、既存テストの回帰なし）
- [x] 実際に`aidd-phase1`ワークフローを1回実行し、5エージェント（sweep-ui/data/db/types + capture-base-commit）全てのStart/Stopが`logs/subagent-skeleton.jsonl`に記録されることを確認（完了条件）

## 既知の限界（PR本文・common.mdに明記済み）
- ペイロードに`status`（pass/fail/blocked）フィールドは無い。意味判定は引き続き自己申告・transcript突合に委ねる
- このログはセッション全体で共通で、1つのフロー実行にスコープされない（並行して他の作業が走っていると混在する）

Ref #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)