### PR TITLE
feat: aidd-phase2.jsにINTENT規約を埋め込みfeature/attemptを機械復元(issue #423 step3)

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -28,6 +28,20 @@ export const meta = {
 // ────────────────────────────────────────────────────────────────────
 
 const specPath = args?.specPath ?? 'SPEC.md'
+// feature名が呼び出し元から与えられていない場合は'unknown'を使う（write_aidd_stats.sh等の
+// 既存の自己申告系と同じフォールバック規約。docs/agents/common.md「サブエージェント進捗の
+// 可視化」参照）。
+const feature = args?.feature ?? 'unknown'
+
+// issue #423ステップ3: feature/attemptを「モデルの自己申告」ではなく「コードが決定的に
+// 埋め込む構造化データ」に変える。agent()のopts.labelはSubagentStop hookのペイロードに
+// 含まれない（issue #423ステップ1の実験で確認済み）ため、プロンプト本文の先頭に規約行を
+// 埋め込み、hookがagent_transcript_path経由でtranscriptを読んだ際に正規表現で復元できる
+// ようにする。既存のprompt文字列（db-implプロンプトのsync test対象を含む）の中身は一切
+// 変更せず、外側から文字列連結するだけなので workflow-prompt-sync.test.js には影響しない。
+function withIntent(label, prompt) {
+  return `INTENT: ${label} feature=${feature}\n\n${prompt}`
+}
 
 // docs/agents/agent-result-schema.md 参照。実装/統合/レビュー系はpass/fail/blockedの3値。
 // findingsはfail時の重大度分類（severity.js参照）。Sweep/Draft/Adversarial Verify
@@ -132,11 +146,11 @@ const SPEC_CHECK_SCHEMA = {
 }
 
 const specCheck = await agent(
-  `Readツールで ${specPath} が存在し読み込めるか確認してください。指定されたパス以外のファイル（例: リポジトリルート直下の別のSPEC.md）が見つかっても、それは無視して絶対に読まないでください。それ以外は何もしないでください。\n\n完了報告のactualPathフィールドに、実際にReadツールへ渡した絶対パスを（今回指定された ${specPath} をそのまま解決したもので）必ず記載してください。${guide(
+  withIntent('spec-check', `Readツールで ${specPath} が存在し読み込めるか確認してください。指定されたパス以外のファイル（例: リポジトリルート直下の別のSPEC.md）が見つかっても、それは無視して絶対に読まないでください。それ以外は何もしないでください。\n\n完了報告のactualPathフィールドに、実際にReadツールへ渡した絶対パスを（今回指定された ${specPath} をそのまま解決したもので）必ず記載してください。${guide(
     `${specPath}が存在し読み込めた`,
     '（未使用: このエージェントはpass/blockedの2値のみ返す）',
     `${specPath}が存在しない、または読み込めない`
-  )}`,
+  )}`),
   { label: 'spec-check', phase: 'Spec Check', agentType: 'reviewer', schema: SPEC_CHECK_SCHEMA }
 )
 
@@ -200,11 +214,11 @@ const MANIFEST_CHECK_SCHEMA = {
 }
 
 const manifestCheck = await agent(
-  `.aidd/run-manifest.json を Read ツールで読んでください（docs/agents/run-manifest.md にスキーマの説明があります）。\n\n以下を順に確認してください。\n1. .aidd/run-manifest.json が存在しない → blocked。detailに「Run Manifestが存在しません」と書く。\n2. manifest.approval（approvedBy/approvedAt）が無い → blocked。detailに「停止①の承認が記録されていません」と書く。\n3. manifest.specHash が無い → blocked。detailに「specHashが記録されていません」と書く。\n4. 上記が揃っていれば、${specPath} の現在の内容からsha256ハッシュを計算し（Bashツールで shasum -a 256 ${specPath} 等を使ってよい）、manifest.specHash と比較する。\n   - 一致すれば pass。detailに「specHash一致（承認後にSPEC.mdの変更なし）」と書く。\n   - 不一致であれば blocked。detailに「specHash不一致: レビュー承認後にSPEC.mdが変更された可能性があります（manifestの値と実際の値の両方を明記）」と書く。${guide(
+  withIntent('manifest-check', `.aidd/run-manifest.json を Read ツールで読んでください（docs/agents/run-manifest.md にスキーマの説明があります）。\n\n以下を順に確認してください。\n1. .aidd/run-manifest.json が存在しない → blocked。detailに「Run Manifestが存在しません」と書く。\n2. manifest.approval（approvedBy/approvedAt）が無い → blocked。detailに「停止①の承認が記録されていません」と書く。\n3. manifest.specHash が無い → blocked。detailに「specHashが記録されていません」と書く。\n4. 上記が揃っていれば、${specPath} の現在の内容からsha256ハッシュを計算し（Bashツールで shasum -a 256 ${specPath} 等を使ってよい）、manifest.specHash と比較する。\n   - 一致すれば pass。detailに「specHash一致（承認後にSPEC.mdの変更なし）」と書く。\n   - 不一致であれば blocked。detailに「specHash不一致: レビュー承認後にSPEC.mdが変更された可能性があります（manifestの値と実際の値の両方を明記）」と書く。${guide(
     'specHashが一致し、承認記録も揃っている',
     '（未使用: このエージェントはpass/blockedの2値のみ返す）',
     'manifestが存在しない、承認記録が無い、またはspecHashが不一致'
-  )}`,
+  )}`),
   { label: 'manifest-check', phase: 'Manifest Check', agentType: 'reviewer', schema: MANIFEST_CHECK_SCHEMA }
 )
 
@@ -231,11 +245,11 @@ phase('Contract + DB')
 
 const [contractResult, dbResult] = await parallel([
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに src/types/ の型定義・APIインターフェース型を確定させてください。${guide(
+    withIntent('contract-writer', `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに src/types/ の型定義・APIインターフェース型を確定させてください。${guide(
       '型定義・APIインターフェース型を確定できた',
       '型定義を試みたが不完全・矛盾がある',
       'SPEC.mdが存在しない/読めない'
-    )}`,
+    )}`),
     { label: 'contract-writer', phase: 'Contract + DB', agentType: 'contract-writer', schema: AGENT_RESULT_SCHEMA }
   ),
   // db-implプロンプトの正本は .claude/workflows/lib/prompts/db-impl.js（buildDbImplPrompt）。
@@ -243,11 +257,11 @@ const [contractResult, dbResult] = await parallel([
   // 一字一句の同期は .claude/workflows/lib/__tests__/workflow-prompt-sync.test.js が検証する
   // （npm testに含まれる。乖離時は即座にテスト失敗する。issue #391）。
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。\nPart 2にDBスキーマ変更が不要と明記されている場合（例:「該当なし」「DB変更なし」）は、何も実装せずstatus: passでdetailにその旨（不要と判断した根拠）を書いて報告すること。これはblocked（着手不能）ではない。\nDBスキーマ変更が必要そうだが、対象テーブル名・カラム設計・facilityスコープ（RLS）等をPart2や既存の型契約（src/types/）から安全に確定できない場合も、推測でマイグレーションを実装しようとせずstatus: blockedで不足している情報を具体的に書いて報告すること。これはfail（実装エラー・矛盾）ではなくblocked（着手に必要な情報が足りない）として扱う。${guide(
+    withIntent('db-impl', `まず ${specPath} を Read ツールで読んでください。\nPart 2（実装計画）をもとに supabase/migrations/ のマイグレーションファイルを実装してください。src/types/ / src/lib/ / src/app/ は触らないこと。\nPart 2にDBスキーマ変更が不要と明記されている場合（例:「該当なし」「DB変更なし」）は、何も実装せずstatus: passでdetailにその旨（不要と判断した根拠）を書いて報告すること。これはblocked（着手不能）ではない。\nDBスキーマ変更が必要そうだが、対象テーブル名・カラム設計・facilityスコープ（RLS）等をPart2や既存の型契約（src/types/）から安全に確定できない場合も、推測でマイグレーションを実装しようとせずstatus: blockedで不足している情報を具体的に書いて報告すること。これはfail（実装エラー・矛盾）ではなくblocked（着手に必要な情報が足りない）として扱う。${guide(
       'マイグレーション実装が完了した、またはPart2にDBスキーマ変更が不要と明記されており対応不要と判断した',
       'マイグレーションの実装を試みたがSQLの構文誤り・既存スキーマとの矛盾等の実装エラーが生じた',
       'SPEC.mdが存在しない、Part2にDB変更の要否自体を判断できる記載が無い、またはDB変更は必要そうだが対象テーブル・カラム設計・facilityスコープを安全に確定できるだけの情報が無い'
-    )}`,
+    )}`),
     { label: 'db-impl', phase: 'Contract + DB', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
 ])
@@ -289,15 +303,15 @@ const implGuide = guide(
 
 const [dataResult, apiResult, uiResult] = await parallel([
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/lib/supabase/ のデータアクセス関数を実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/lib/supabase/ と src/lib/*/repository.ts。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`,
+    withIntent('data-impl', `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/lib/supabase/ のデータアクセス関数を実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/lib/supabase/ と src/lib/*/repository.ts。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`),
     { label: 'data-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/**/route.ts（/api配下に限らない）を実装してください。\n型定義（src/types/）は確定済みです。\nPart 2 に記載の関数シグネチャに従って src/lib/ の関数を呼ぶこと（実装がまだでも名前・型が確定していれば前進可）。\n触ってよいファイル: src/app/**/route.ts のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`,
+    withIntent('api-impl', `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/**/route.ts（/api配下に限らない）を実装してください。\n型定義（src/types/）は確定済みです。\nPart 2 に記載の関数シグネチャに従って src/lib/ の関数を呼ぶこと（実装がまだでも名前・型が確定していれば前進可）。\n触ってよいファイル: src/app/**/route.ts のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}\n\n## db-impl完了報告\n${dbResult?.detail}${implGuide}`),
     { label: 'api-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
   () => agent(
-    `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/(pages)/ と src/components/ のUIを実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/app/(pages)/ と src/components/ のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}${implGuide}`,
+    withIntent('ui-impl', `まず ${specPath} を Read ツールで読んでください。\nPart 2をもとに src/app/(pages)/ と src/components/ のUIを実装してください。\n型定義（src/types/）は確定済みです。\n触ってよいファイル: src/app/(pages)/ と src/components/ のみ。\n\n## contract-writer完了報告\n${contractResult?.detail}${implGuide}`),
     { label: 'ui-impl', phase: 'Implement', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   ),
 ])
@@ -334,11 +348,11 @@ logMinorOnlyPassThrough('Implement', [dataResult, apiResult, uiResult])
 phase('Integrate')
 
 const integrationResult = await agent(
-  `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. npx tsc --noEmit を実行 → 型エラーがあれば修正（3回まで。issue #46のDONE基準に型検査を含める）\n6. 全テスト・lint・tsc緑を確認して報告\n7. .aidd/run-manifest.json をReadツールで読み、manifest.baseCommitを取得する（無ければこのステップはスキップしてよい）。取得できた場合、Bashツールで \`git diff --name-only \${baseCommit}\`（baseCommitはmanifestの値に置き換える）を実行し、変更されたファイル一覧を取得する。取得できたら .aidd/run-manifest.json の changedFiles フィールドをその一覧で上書きし、Writeツールで保存する（docs/agents/run-manifest.md 参照。他フィールドは変更しないこと）。\n\n## 各完了報告\n### contract-writer\n${contractResult?.detail}\n### db-impl\n${dbResult?.detail}\n### data-impl\n${dataResult?.detail}\n### api-impl\n${apiResult?.detail}\n### ui-impl\n${uiResult?.detail}${guide(
+  withIntent('integrator', `並列実装が完了しました。以下の順で作業してください。\n0. まずReadツールで ${specPath} が存在するか確認する。存在しない場合、または下記の完了報告のいずれかに「仕様書が見つからない」「作業を開始できない」等の記述がある場合は、それを最優先の異常事態として報告の先頭に明記すること（該当implエージェントは未着手として扱い、テスト・lintが緑でも全体を正常完了と報告しないこと）。\n1. マイグレーションが適用済みか確認する（未適用ならSupabase CLIで適用する）\n2. 各implementerの成果を結線し、共有ファイルを編集する\n3. npm test を実行 → 失敗があれば修正（3回まで）\n4. npm run lint を実行 → 失敗があれば修正\n5. npx tsc --noEmit を実行 → 型エラーがあれば修正（3回まで。issue #46のDONE基準に型検査を含める）\n6. 全テスト・lint・tsc緑を確認して報告\n7. .aidd/run-manifest.json をReadツールで読み、manifest.baseCommitを取得する（無ければこのステップはスキップしてよい）。取得できた場合、Bashツールで \`git diff --name-only \${baseCommit}\`（baseCommitはmanifestの値に置き換える）を実行し、変更されたファイル一覧を取得する。取得できたら .aidd/run-manifest.json の changedFiles フィールドをその一覧で上書きし、Writeツールで保存する（docs/agents/run-manifest.md 参照。他フィールドは変更しないこと）。\n\n## 各完了報告\n### contract-writer\n${contractResult?.detail}\n### db-impl\n${dbResult?.detail}\n### data-impl\n${dataResult?.detail}\n### api-impl\n${apiResult?.detail}\n### ui-impl\n${uiResult?.detail}${guide(
     'npm test・npm run lint・npx tsc --noEmitが最終的に全て緑で統合完了',
     '3回の修正試行後もtest/lint/tscのいずれかが赤のまま',
     'SPEC.mdが見つからない、またはいずれかのimplエージェントの完了報告に「仕様書が見つからない」「作業を開始できない」旨の記述がある'
-  )}`,
+  )}`),
   { label: 'integrator', phase: 'Integrate', agentType: 'integrator', schema: AGENT_RESULT_SCHEMA }
 )
 
@@ -416,7 +430,7 @@ while (true) {
 
   reviewResults = await parallel(
     REVIEW_DIMENSIONS.map(dim => () => agent(
-      `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。${reviewGuide}`,
+      withIntent(`review:${dim.key}:R${reviewAttempt}`, `まず ${specPath} を Read ツールで読んでください。\n観点「${dim.label}」の視点のみでレビューしてください。\n指摘のみを箇条書きで返す。修正はしない。問題なければ「指摘なし」と返す。${reviewGuide}`),
       { label: `review:${dim.key}:R${reviewAttempt}`, agentType: 'reviewer', phase: 'Review', schema: AGENT_RESULT_SCHEMA }
     ))
   )
@@ -471,11 +485,11 @@ while (true) {
     .join('\n\n')
 
   await agent(
-    `まず ${specPath} を Read ツールで読んでください。\n以下はコードレビューで検出された指摘です。該当箇所を修正してください（修正のみ、レビューはしない）。\n\n${retryFindings}${guide(
+    withIntent(`implementer-retry:R${reviewAttempt}`, `まず ${specPath} を Read ツールで読んでください。\n以下はコードレビューで検出された指摘です。該当箇所を修正してください（修正のみ、レビューはしない）。\n\n${retryFindings}${guide(
       '指摘箇所をすべて修正できた',
       '修正を試みたが解決できない指摘が残る',
       '指摘内容から修正対象・該当ファイルが特定できない'
-    )}`,
+    )}`),
     { label: `implementer-retry:R${reviewAttempt}`, phase: 'Review', agentType: 'implementer', schema: AGENT_RESULT_SCHEMA }
   )
   countLoggable('implementer')

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -150,8 +150,8 @@ any code. Heed deprecation notices.
 | 層 | 内容 | 記録手段 | 保証レベル |
 |---|---|---|---|
 | ① 骨格 | agent_id・agent_type・開始/終了・timestamp | `scripts/log-subagent-hook-skeleton.sh`（`SubagentStart`/`SubagentStop` hook） | 機械強制（呼び忘れ得ない） |
-| ② feature/attempt | どの機能・何回目の試行か | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`（自然言語指示） | ベストエフォート（label規約化は未着手、issue #423ステップ3） |
-| ③ 自由記述intent/scenario | 何をしようとしていたかの説明 | 同上 | ベストエフォート（欠落許容） |
+| ② feature/attempt | どの機能・何回目の試行か | `aidd-phase2.js`の`withIntent()`がプロンプト先頭に`INTENT: <label> feature=<feature>`規約行を埋め込み、`scripts/log-subagent-hook-skeleton.sh`が`agent_transcript_path`をgrepして`intent`フィールドに復元（issue #423ステップ3実装済み） / 従来の`log-agent-progress.sh` / `log-loop-observability.sh`（自然言語指示）も併存 | コード埋め込み＋hook抽出（labelはコードが決定的に付与するため`agent()`呼び出し自体が漏れなければ欠落しない。ただしtranscriptのテキスト抽出はベストエフォート） |
+| ③ 自由記述intent/scenario | 何をしようとしていたかの説明 | `log-agent-progress.sh` / `log-loop-observability.sh`の自己申告 | ベストエフォート（欠落許容） |
 
 `logs/subagent-skeleton.jsonl`に、通常のAgent tool経由・Workflowの`agent()`呼び出し経由の
 両方のサブエージェント起動が、`{timestamp, hookEvent, sessionId, agentId, agentType,
@@ -168,9 +168,17 @@ agentTranscriptPath?, lastAssistantMessage?}`形式で自動記録される。�
   他の作業（別のAgent tool呼び出し等）が走っていると、そのイベントも同じファイルに混在する。
   特定のフロー実行に絞り込みたい場合は、`agentTranscriptPath`が
   `subagents/workflows/wf_<runId>/`配下かどうかで判別する
-- ②feature/attemptを「モデルの善意の報告」から「コードが決定的に埋め込む構造化データ」に
-  変えるlabel規約化（issue #423ステップ3、例: `agent()`呼び出しの`label`に
-  `implementer:${feature}:attempt${n}`規約を導入する）は未着手のまま残っている
+- ②feature/attemptのlabel規約化（issue #423ステップ3）は`.claude/workflows/aidd-phase2.js`
+  のみ実装済み。`agent()`の`opts.label`自体はhookペイロードに含まれないため、`withIntent()`
+  ヘルパーがプロンプト本文の先頭に`INTENT: <label> feature=<feature>`規約行を文字列連結で
+  埋め込み（既存プロンプト本文の中身は変更しないため`workflow-prompt-sync.test.js`には
+  影響しない）、`scripts/log-subagent-hook-skeleton.sh`が`SubagentStop`ペイロードの
+  `agent_transcript_path`が指すtranscriptファイルをテキストとしてgrepし、規約行を
+  `intent`フィールドとしてベストエフォートで復元する（transcriptの正確なJSONスキーマは
+  未確認のため、厳密なパースはせずテキスト一致のみに依存する割り切った実装）。
+  `feature`は呼び出し元が`args.feature`を渡さない限り`unknown`になる（`write_aidd_stats.sh`
+  と同じフォールバック規約）。`aidd-phase1.js` / `aidd-1-1-deep-task.js`等の他ワークフローは
+  未対応のまま残っている
 - 既存の`log-agent-progress.sh` / `log-loop-observability.sh` / gap check群は削除しておらず、
   新方式と併存させている（新方式が安定稼働することを確認してから、廃止を別issueで検討する）
 

--- a/scripts/log-subagent-hook-skeleton.sh
+++ b/scripts/log-subagent-hook-skeleton.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 # ペイロードにstatus（pass/fail/blocked）フィールドは含まれないため、pass/fail/blockedの
 # 意味判定はここでは行わない。「SubagentStopが発火した」という事実のみが「エージェントが
 # 完了処理まで到達した」ことの機械的な証拠になる。
+#
+# issue #423ステップ3: agent()のopts.labelはペイロードに含まれないため、呼び出し側
+# （aidd-phase2.js）はプロンプト本文の先頭に「INTENT: <label> feature=<feature>」という
+# 規約行を埋め込む。ここではagent_transcript_pathが指すtranscriptファイルをテキストとして
+# grepし、規約行を抽出できた場合のみベストエフォートでintentLineフィールドに追記する
+# （②feature/attempt層。抽出できなくてもhook自体は失敗させない＝欠落は許容する）。
 
 LOG_FILE="${SUBAGENT_HOOK_SKELETON_LOG_FILE:-logs/subagent-skeleton.jsonl}"
 
@@ -41,6 +47,16 @@ mkdir -p "$(dirname "$LOG_FILE")"
 
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
+# INTENT規約行の抽出（ベストエフォート）。transcriptはJSONL（1行1エントリ）だが、規約行
+# `INTENT: <label> feature=<feature>` は通常のASCII文字のみで構成されるためJSON文字列内でも
+# エスケープされずそのまま現れる。厳密なJSON構造のパースは行わず、テキストとして最初の
+# 一致だけを取り出す（transcriptの正確なスキーマに依存しないための割り切り）。
+INTENT_LINE=""
+if [[ -n "$AGENT_TRANSCRIPT_PATH" && -f "$AGENT_TRANSCRIPT_PATH" ]]; then
+  INTENT_LINE="$(grep -m 1 -oE 'INTENT: [^"\\]+' "$AGENT_TRANSCRIPT_PATH" 2>/dev/null || true)"
+fi
+INTENT_VALUE="${INTENT_LINE#INTENT: }"
+
 jq -nc \
   --arg timestamp "$TIMESTAMP" \
   --arg hookEvent "$HOOK_EVENT" \
@@ -49,6 +65,7 @@ jq -nc \
   --arg agentType "$AGENT_TYPE" \
   --arg agentTranscriptPath "$AGENT_TRANSCRIPT_PATH" \
   --arg lastAssistantMessage "$LAST_ASSISTANT_MESSAGE" \
+  --arg intentValue "$INTENT_VALUE" \
   '{
     timestamp: $timestamp,
     hookEvent: $hookEvent,
@@ -57,7 +74,8 @@ jq -nc \
     agentType: $agentType
   }
   + (if $agentTranscriptPath != "" then {agentTranscriptPath: $agentTranscriptPath} else {} end)
-  + (if $lastAssistantMessage != "" then {lastAssistantMessage: $lastAssistantMessage} else {} end)' \
+  + (if $lastAssistantMessage != "" then {lastAssistantMessage: $lastAssistantMessage} else {} end)
+  + (if $intentValue != "" then {intent: $intentValue} else {} end)' \
   >> "$LOG_FILE"
 
 exit 0

--- a/scripts/log-subagent-hook-skeleton.test.sh
+++ b/scripts/log-subagent-hook-skeleton.test.sh
@@ -68,6 +68,31 @@ assert_eq "$EXIT_CODE" "0" "exit 0（サイレント無視）"
 AFTER_LINES="$(wc -l < "$TMP_LOG" | tr -d ' ')"
 assert_eq "$AFTER_LINES" "$BEFORE_LINES" "行数が増えない（不正ペイロードは書き込まない）"
 
+echo "=== scenario 4: agent_transcript_pathにINTENT規約行があればintentフィールドを抽出する（issue #423ステップ3） ==="
+TMP_TRANSCRIPT="$(mktemp)"
+printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"INTENT: db-impl feature=order-history\\n\\nまずSPEC.mdを読んでください..."}]}}' > "$TMP_TRANSCRIPT"
+input="{\"session_id\":\"sess-1\",\"transcript_path\":\"/tmp/t.jsonl\",\"cwd\":\"/repo\",\"prompt_id\":\"p1\",\"permission_mode\":\"acceptEdits\",\"agent_id\":\"agent-abc\",\"agent_type\":\"implementer\",\"hook_event_name\":\"SubagentStop\",\"stop_hook_active\":false,\"agent_transcript_path\":\"$TMP_TRANSCRIPT\",\"last_assistant_message\":\"実験OK\"}"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+LAST_LINE="$(tail -n 1 "$TMP_LOG")"
+assert_contains "$LAST_LINE" '"intent":"db-impl feature=order-history"' "intentフィールドが抽出される"
+rm -f "$TMP_TRANSCRIPT"
+
+echo "=== scenario 5: INTENT規約行が無いtranscriptではintentフィールドを付けない ==="
+TMP_TRANSCRIPT="$(mktemp)"
+printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"レビューしてください"}]}}' > "$TMP_TRANSCRIPT"
+input="{\"session_id\":\"sess-1\",\"transcript_path\":\"/tmp/t.jsonl\",\"cwd\":\"/repo\",\"prompt_id\":\"p1\",\"permission_mode\":\"acceptEdits\",\"agent_id\":\"agent-abc\",\"agent_type\":\"reviewer\",\"hook_event_name\":\"SubagentStop\",\"stop_hook_active\":false,\"agent_transcript_path\":\"$TMP_TRANSCRIPT\",\"last_assistant_message\":\"指摘なし\"}"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+LAST_LINE="$(tail -n 1 "$TMP_LOG")"
+if printf '%s' "$LAST_LINE" | grep -qF '"intent"'; then
+  echo "  NG: intentフィールドが付与されないこと（実際: $LAST_LINE）"
+  fail=1
+else
+  echo "  OK: intentフィールドが付与されない"
+fi
+rm -f "$TMP_TRANSCRIPT"
+
 rm -f "$TMP_LOG"
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- issue #423のステップ3（feature/attemptのlabel規約化）を実装
- `aidd-phase2.js`の`withIntent()`が全10箇所の`agent()`呼び出しプロンプト先頭に`INTENT: <label> feature=<feature>`規約行を埋め込む（既存プロンプト本文は変更せず外側から連結するため`workflow-prompt-sync.test.js`には影響なし）
- `scripts/log-subagent-hook-skeleton.sh`が`SubagentStop`ペイロードの`agent_transcript_path`をテキストとしてgrepし、規約行を`intent`フィールドとしてベストエフォートで復元

## 触っていない範囲
- `aidd-phase1.js` / `aidd-1-1-deep-task.js`等、他のワークフローは未対応
- transcriptの正確なJSONスキーマは未検証。テキスト一致のみに依存する割り切った実装

## Test plan
- [x] `npm test`（1068 tests）全て緑
- [x] `npm run lint` エラー0（既存の無関係な警告1件のみ）
- [x] `bash scripts/log-subagent-hook-skeleton.test.sh` 全シナリオ緑（INTENT抽出あり/なし含む）
- [x] `workflow-prompt-sync.test.js`（db-implプロンプト同期）が引き続きパス

Closes #423 のステップ3部分（issue自体は既にPR #425でクローズ済みのため、こちらは追加issueとしての着地は不要。issue本文/common.mdの記述を更新済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)