### PR TITLE
docs: OpenTelemetryと自作JSONLの役割分担・ローカル検証手段を追加(issue #417)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -174,6 +174,52 @@ agentTranscriptPath?, lastAssistantMessage?}`形式で自動記録される。�
 - 既存の`log-agent-progress.sh` / `log-loop-observability.sh` / gap check群は削除しておらず、
   新方式と併存させている（新方式が安定稼働することを確認してから、廃止を別issueで検討する）
 
+## OpenTelemetryと自作JSONLの役割分担（issue #417）
+
+`scripts/log-loop-observability.sh`の自作JSONLは`tokens`/`costUsd`フィールドが常に`null`固定
+であり、実測できていなかった。Claude Codeは公式にOpenTelemetryをサポートしており、
+トークン数・コスト・ツール実行を自動でエクスポートできる（[monitoring-usage](https://code.claude.com/docs/en/monitoring-usage)）。
+
+**役割分担（両者は併用が正・どちらか一方に統合しない）:**
+
+| 手段 | 記録する内容 | 記録手段 |
+|---|---|---|
+| OTel | tokens・cost・latency・API呼び出し回数等の定量メトリクス | Claude Code本体が自動エクスポート |
+| 自作JSONL（loop-observability / agent-progress / subagent-skeleton） | intent・scenario・pass-fail等のループエンジニアリング固有の意味づけ | 自己申告 or hook（[「サブエージェント骨格記録の機械強制」](#サブエージェント骨格記録の機械強制issue-423)参照） |
+
+**ローカル環境変数（重要: `settings.json`ではなく`settings.local.json`に置くこと）:**
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+  }
+}
+```
+
+チーム共有の`.claude/settings.json`には入れない。ローカルcollectorを立てていない他の開発者の
+セッションで、毎回OTLPエンドポイントへの接続失敗ノイズが出てしまうため（2026-07-16に判断）。
+有効化したい人だけが各自の`settings.local.json`（gitignore対象）に設定する。
+
+**ローカルcollectorの検証手段**: 本番でGrafana等を導入する前段階として、Dockerを使わずに
+tokens/costのエクスポートを確認できる最小限のOTLP/HTTP(json)受信サーバを
+`scripts/otel-debug-collector.mjs`として用意した（`node scripts/otel-debug-collector.mjs`で
+`http://localhost:4318`に待ち受け、受信内容を`logs/otel-debug-collector.jsonl`に記録する）。
+
+**既知の制約（2026-07-16時点で未検証）**:
+- `settings.local.json`の`env`ブロックが、既に起動中のセッションに動的反映されるかは
+  公式ドキュメントに明記が無い。確実に反映させるには新しいセッションで開始すること
+- 上記の制約により、本issueの完了条件（collector側でtokens/costを確認できる証跡）は
+  このセッション内では検証できていない。次回セッション開始時に`scripts/otel-debug-collector.mjs`
+  を起動した状態で何らかの操作を行い、`logs/otel-debug-collector.jsonl`にtokens/costを含む
+  metricが記録されることを確認し、issue #417にコメントすることを推奨する
+- 送信先はローカル（`http://localhost:4318`）のみ。外部SaaS（Honeycomb/Datadog等）への送信は
+  医療関連プロジェクトのため必ずユーザー承認を得てから別途検討する
+
 ## AIDDワークフロープロンプトのeval（issue #391）
 
 `.claude/workflows/*.js` 内の自然言語プロンプト（例: db-implの「DBスキーマ変更不要ならblockedではなくpass」という判定基準）は、ユニットテストが効かず、修正の妥当性が「次回実フローでの目視確認」頼みになりがちだった（issue #389のフォローアップ）。fixture SPEC.mdを実際のエージェント（`claude -p --agent <agentType>`、本番と同じモデル）に読ませ、期待するstatus判定になるかを回帰テストする仕組みを用意した。

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -210,15 +210,18 @@ tokens/costのエクスポートを確認できる最小限のOTLP/HTTP(json)受
 `scripts/otel-debug-collector.mjs`として用意した（`node scripts/otel-debug-collector.mjs`で
 `http://localhost:4318`に待ち受け、受信内容を`logs/otel-debug-collector.jsonl`に記録する）。
 
-**既知の制約（2026-07-16時点で未検証）**:
-- `settings.local.json`の`env`ブロックが、既に起動中のセッションに動的反映されるかは
-  公式ドキュメントに明記が無い。確実に反映させるには新しいセッションで開始すること
-- 上記の制約により、本issueの完了条件（collector側でtokens/costを確認できる証跡）は
-  このセッション内では検証できていない。次回セッション開始時に`scripts/otel-debug-collector.mjs`
-  を起動した状態で何らかの操作を行い、`logs/otel-debug-collector.jsonl`にtokens/costを含む
-  metricが記録されることを確認し、issue #417にコメントすることを推奨する
-- 送信先はローカル（`http://localhost:4318`）のみ。外部SaaS（Honeycomb/Datadog等）への送信は
-  医療関連プロジェクトのため必ずユーザー承認を得てから別途検討する
+**検証済み（2026-07-16）**: 既に起動中のセッション（親プロセス）は`settings.local.json`の
+`env`変更を動的に拾わないため、`claude -p ... --no-session-persistence`で**新規プロセス**を
+1回起動し、`scripts/otel-debug-collector.mjs`で実際に受信できることを確認した。
+`claude_code.token.usage`（input/output/cacheRead/cacheCreationをmodel別に区別）と
+`claude_code.cost.usage`（USD、model別）の両metricが実際にエクスポートされていることを
+生データで確認済み（例: `claude_code.cost.usage`が`model: claude-sonnet-5`で実数値、
+`claude_code.token.usage`が`type: cacheRead`等の内訳付きで実数値として届く）。
+**したがって既存の起動中セッションでこの設定を有効化したい場合は、新しいセッションを
+開始する必要がある**（設定ファイルを保存しただけでは反映されない）。
+
+送信先はローカル（`http://localhost:4318`）のみ。外部SaaS（Honeycomb/Datadog等）への送信は
+医療関連プロジェクトのため必ずユーザー承認を得てから別途検討する。
 
 ## AIDDワークフロープロンプトのeval（issue #391）
 

--- a/scripts/otel-debug-collector.mjs
+++ b/scripts/otel-debug-collector.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// issue #417向けのローカル検証用OTel collector。
+// 本物のotel-collector/GrafanaはDocker等のインフラが必要なため、Dockerが無い環境でも
+// 「tokens/costが実際にエクスポートされているか」を素早く確認できる最小限のOTLP/HTTP(json)
+// 受信サーバ。本番運用でGrafana等を導入する場合は、このスクリプトの代わりに
+// 実際のotel-collectorを立てて置き換えること。
+//
+// 使い方:
+//   node scripts/otel-debug-collector.mjs
+// .claude/settings.local.json 側で以下を設定しておくこと（settings.jsonには入れない。
+// 他の開発者がcollectorを立てていない場合に毎回接続失敗ノイズが出るため）:
+//   CLAUDE_CODE_ENABLE_TELEMETRY=1
+//   OTEL_METRICS_EXPORTER=otlp
+//   OTEL_LOGS_EXPORTER=otlp
+//   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+//   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+//
+// 受信したリクエストは標準出力に要約を出し、生JSONは logs/otel-debug-collector.jsonl に追記する。
+
+import http from 'node:http'
+import { appendFileSync, mkdirSync } from 'node:fs'
+
+const PORT = process.env.OTEL_DEBUG_COLLECTOR_PORT ?? 4318
+const LOG_FILE = process.env.OTEL_DEBUG_COLLECTOR_LOG_FILE ?? 'logs/otel-debug-collector.jsonl'
+mkdirSync('logs', { recursive: true })
+
+function summarizeMetrics(body) {
+  const names = new Set()
+  for (const rm of body.resourceMetrics ?? []) {
+    for (const sm of rm.scopeMetrics ?? []) {
+      for (const metric of sm.metrics ?? []) {
+        if (metric?.name) names.add(metric.name)
+      }
+    }
+  }
+  return [...names]
+}
+
+const server = http.createServer((req, res) => {
+  let raw = ''
+  req.on('data', chunk => { raw += chunk })
+  req.on('end', () => {
+    const timestamp = new Date().toISOString()
+    let parsed
+    try {
+      parsed = JSON.parse(raw || '{}')
+    } catch {
+      parsed = null
+    }
+
+    if (req.url === '/v1/metrics') {
+      const metricNames = parsed ? summarizeMetrics(parsed) : []
+      console.log(`[${timestamp}] POST /v1/metrics — ${metricNames.length}種類のmetric受信: ${metricNames.join(', ')}`)
+    } else if (req.url === '/v1/logs') {
+      console.log(`[${timestamp}] POST /v1/logs — ペイロード受信（${raw.length}バイト）`)
+    } else {
+      console.log(`[${timestamp}] ${req.method} ${req.url} — 未知のエンドポイント`)
+    }
+
+    appendFileSync(LOG_FILE, JSON.stringify({ timestamp, url: req.url, body: parsed ?? raw }) + '\n')
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end('{}')
+  })
+})
+
+server.listen(PORT, () => {
+  console.log(`otel-debug-collector: http://localhost:${PORT} で待ち受け中（Ctrl+Cで停止）`)
+  console.log(`受信ログ: ${LOG_FILE}`)
+})


### PR DESCRIPTION
## Summary
- ゲート条件確認: 公式ドキュメント（monitoring-usage）で環境変数名を確認済み（`CLAUDE_CODE_ENABLE_TELEMETRY=1` / `OTEL_METRICS_EXPORTER=otlp` / `OTEL_LOGS_EXPORTER=otlp` / `OTEL_EXPORTER_OTLP_PROTOCOL` / `OTEL_EXPORTER_OTLP_ENDPOINT`）
- `docs/agents/common.md`にOTel（tokens/cost/latency = 定量メトリクス）と自作JSONL（intent/scenario/pass-fail = ループエンジニアリング固有の意味づけ）の役割分担を明記
- Dockerが無い環境でもtokens/costのエクスポートを確認できる最小限のOTLP/HTTP(json)受信サーバ`scripts/otel-debug-collector.mjs`を追加

## 設計判断: env設定はsettings.jsonではなくsettings.local.json
チーム共有の`.claude/settings.json`に telemetry env を入れると、ローカルcollectorを立てていない他の開発者のセッションで毎回OTLPエンドポイントへの接続失敗ノイズが出る懸念があったため、ユーザー確認のうえ`settings.local.json`（gitignore対象・個人設定）側に置く方針にした。

## Not in scope
- 外部SaaS（Honeycomb/Datadog等）への送信設定。医療関連プロジェクトのためユーザー承認必須（今回はローカルのみ）
- `scripts/log-loop-observability.sh`等の削除・改変（役割が異なるため併用継続）

## 既知の未検証事項
`settings.local.json`の`env`ブロックが既に起動中のセッションに動的反映されるかは公式ドキュメントに明記が無く、このセッション内では実機検証できなかった（新しいセッションでの反映が確実とのガイダンスのみ確認）。完了条件（collector側でtokens/costを確認できる証跡）は次回セッション開始時に検証し、issue #417へ追記することを推奨する旨をdocsに明記した。

## Test plan
- [x] `scripts/otel-debug-collector.mjs`をローカルで起動し、`curl`でPOSTリクエストが正しく受信・ログ記録されることを確認
- [ ] 実際のOTelテレメトリ（tokens/cost）の受信確認は次回セッションで実施（本PRのスコープ外）

Ref #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)