### PR TITLE
OTelローカルcollectorの日付ローテーション・起動忘れ検知(issue #430)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -140,6 +140,11 @@
             "type": "command",
             "command": "scripts/check-branch-pr-status.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-otel-collector-status.sh",
+            "timeout": 5
           }
         ]
       }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -223,6 +223,27 @@ tokens/costのエクスポートを確認できる最小限のOTLP/HTTP(json)受
 送信先はローカル（`http://localhost:4318`）のみ。外部SaaS（Honeycomb/Datadog等）への送信は
 医療関連プロジェクトのため必ずユーザー承認を得てから別途検討する。
 
+**常時記録化と起動忘れ検知（issue #430）**: `otel-debug-collector.mjs`はデバッグ用の手動起動
+collectorであり、常時稼働ではない。issue #419（effortフィールド追加の効果測定）でbefore/after
+比較ができなかった真因は「変更前に計測を忘れた」という運用ミスではなく、「tokens/costが
+どこにも常時記録されていない」という構造の問題だった。これに対応するため以下を実装した:
+
+- `otel-debug-collector.mjs`は`logs/otel/YYYY-MM-DD.jsonl`に日付ローテーションして記録する
+  （既定30日で古いログを自動削除。`OTEL_DEBUG_COLLECTOR_RETENTION_DAYS`で変更可）。単一ファイル
+  への無限追記による肥大化を避け、日付単位で過去のbaselineを事後クエリできるようにした
+- SessionStart hook（`scripts/check-otel-collector-status.sh`）が、`CLAUDE_CODE_ENABLE_TELEMETRY=1`
+  が設定されているにもかかわらずcollectorに接続できない場合に警告する。issue #411原則
+  （「起動トリガーは機械か人か」）に照らし、常時起動そのもの（launchd常駐化等）までは行わず、
+  「起動し忘れても気づける」という最小限のバーに留めた。OTelを有効化していない（既定）環境では
+  何もしない
+- **実測（2026-07-16）**: OTelの各metric（`claude_code.session.count`/`cost.usage`/
+  `token.usage`/`active_time.total`）のdata point属性に`session.id`（Claude Codeのhook入力
+  JSONと同じUUID形式）が含まれることを実際のheadlessセッションで確認した。これにより、
+  自作JSONL（loop-observability.jsonl等、hook入力の`session_id`を記録している）とOTel側の
+  データを`session.id`で突合できる。ただし`agentType`（reviewer/implementer等の粒度）に
+  相当する属性は無く、`query_source`（例: `"main"`）等の粗い区別に留まる。サブエージェント
+  単位での突合には、タイムスタンプの近接性等の追加のヒューリスティックが必要（未実装）。
+
 ## AIDDワークフロープロンプトのeval（issue #391）
 
 `.claude/workflows/*.js` 内の自然言語プロンプト（例: db-implの「DBスキーマ変更不要ならblockedではなくpass」という判定基準）は、ユニットテストが効かず、修正の妥当性が「次回実フローでの目視確認」頼みになりがちだった（issue #389のフォローアップ）。fixture SPEC.mdを実際のエージェント（`claude -p --agent <agentType>`、本番と同じモデル）に読ませ、期待するstatus判定になるかを回帰テストする仕組みを用意した。

--- a/scripts/check-otel-collector-status.sh
+++ b/scripts/check-otel-collector-status.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart hookから呼ばれる。issue #430: settings.local.jsonでOTel送出を有効化した
+# （CLAUDE_CODE_ENABLE_TELEMETRY=1）にもかかわらず、ローカルcollector
+# （scripts/otel-debug-collector.mjs等）を起動し忘れている状態を機械的に検知して警告する。
+# block（session開始そのものの停止）はできない前提のためwarningのみ。
+#
+# 「起動し忘れても気づける」形にする、という issue #430・issue #411原則への対応。
+# OTelを有効化していない（デフォルト）環境では何もしない。
+
+cd "$(dirname "$0")/.."
+
+if [ "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" != "1" ]; then
+  exit 0
+fi
+
+ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  exit 0
+fi
+
+# collectorはPOST以外のメソッドやルート("/")には応答を用意していないことがあるため、
+# 「接続自体ができるか」だけを短いタイムアウトで確認する（内容の正しさまでは見ない）
+if curl -s -o /dev/null --max-time 2 "${ENDPOINT}/v1/metrics" 2>/dev/null; then
+  exit 0
+fi
+
+MSG="OTelテレメトリが有効（CLAUDE_CODE_ENABLE_TELEMETRY=1）ですが、送信先 ${ENDPOINT} に接続できませんでした。ローカルcollectorを起動し忘れている可能性があります（\`node scripts/otel-debug-collector.mjs\` 等）。起動しない場合、tokens/costのメトリクスは記録されずに失われます（docs/agents/common.md「OpenTelemetryと自作JSONLの役割分担」参照）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-otel-collector-status.test.sh
+++ b/scripts/check-otel-collector-status.test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# WHY: scripts/check-otel-collector-status.sh(SessionStart hook)の回帰テスト。
+# scenario 3は実物のscripts/otel-debug-collector.mjsをテスト用ポートで起動して使う
+# （生TCP接続のみ返す代用サーバ(nc等)はHTTPレスポンスを返さずcurlが空応答エラーに
+# なるため、「未起動」と誤判定される。実物同様にHTTPレスポンスを返すサーバでないと
+# 正しく検証できない。issue #430）。
+#
+# 実行: bash scripts/check-otel-collector-status.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-otel-collector-status.sh"
+
+fail=0
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+echo "=== scenario 1: CLAUDE_CODE_ENABLE_TELEMETRYが未設定 → 何も出力しない ==="
+OUT="$(env -u CLAUDE_CODE_ENABLE_TELEMETRY bash "$SCRIPT" < /dev/null)"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: テレメトリ有効だが誰も listen していないポート → 警告する ==="
+OUT="$(CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:19191" bash "$SCRIPT" < /dev/null)"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "起動し忘れている可能性" "起動忘れの警告文言が含まれる"
+
+echo "=== scenario 3: テレメトリ有効かつ実物のcollectorが応答する → 何も出力しない ==="
+COLLECTOR_LOG_DIR="$(mktemp -d)"
+OTEL_DEBUG_COLLECTOR_PORT=19192 OTEL_DEBUG_COLLECTOR_LOG_DIR="$COLLECTOR_LOG_DIR" \
+  node "$SCRIPT_DIR/otel-debug-collector.mjs" > /dev/null 2>&1 &
+COLLECTOR_PID=$!
+trap 'kill "$COLLECTOR_PID" 2>/dev/null || true; rm -rf "$COLLECTOR_LOG_DIR"' EXIT
+sleep 0.5
+OUT="$(CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:19192" bash "$SCRIPT" < /dev/null)"
+assert_empty "$OUT" "出力が空である"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/otel-debug-collector.mjs
+++ b/scripts/otel-debug-collector.mjs
@@ -15,14 +15,44 @@
 //   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
 //   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 //
-// 受信したリクエストは標準出力に要約を出し、生JSONは logs/otel-debug-collector.jsonl に追記する。
+// 受信したリクエストは標準出力に要約を出し、生JSONは logs/otel/YYYY-MM-DD.jsonl に日付ローテーション
+// して追記する（issue #430）。起動時に保持期間（既定30日、OTEL_DEBUG_COLLECTOR_RETENTION_DAYS
+// で変更可）より古いログファイルを削除する。単一ファイルへの無限追記だと肥大化するのと、
+// 「設定変更前のbaseline取得」を事後クエリにする（issue #419の教訓）には日付単位で参照できる
+// 形が必要なため。
 
 import http from 'node:http'
-import { appendFileSync, mkdirSync } from 'node:fs'
+import { appendFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
 
 const PORT = process.env.OTEL_DEBUG_COLLECTOR_PORT ?? 4318
-const LOG_FILE = process.env.OTEL_DEBUG_COLLECTOR_LOG_FILE ?? 'logs/otel-debug-collector.jsonl'
-mkdirSync('logs', { recursive: true })
+const LOG_DIR = process.env.OTEL_DEBUG_COLLECTOR_LOG_DIR ?? 'logs/otel'
+const RETENTION_DAYS = Number(process.env.OTEL_DEBUG_COLLECTOR_RETENTION_DAYS ?? 30)
+mkdirSync(LOG_DIR, { recursive: true })
+
+function currentLogFile() {
+  const date = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+  return join(LOG_DIR, `${date}.jsonl`)
+}
+
+function pruneOldLogs() {
+  if (!(RETENTION_DAYS > 0)) return // 0以下は無効化（保持期間の管理をしない）
+  const cutoffMs = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000
+  let removed = 0
+  for (const name of readdirSync(LOG_DIR)) {
+    if (!/^\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)) continue
+    const path = join(LOG_DIR, name)
+    if (statSync(path).mtimeMs < cutoffMs) {
+      unlinkSync(path)
+      removed++
+    }
+  }
+  if (removed > 0) {
+    console.log(`otel-debug-collector: 保持期間（${RETENTION_DAYS}日）を過ぎたログファイルを${removed}件削除しました`)
+  }
+}
+
+pruneOldLogs()
 
 function summarizeMetrics(body) {
   const names = new Set()
@@ -57,7 +87,7 @@ const server = http.createServer((req, res) => {
       console.log(`[${timestamp}] ${req.method} ${req.url} — 未知のエンドポイント`)
     }
 
-    appendFileSync(LOG_FILE, JSON.stringify({ timestamp, url: req.url, body: parsed ?? raw }) + '\n')
+    appendFileSync(currentLogFile(), JSON.stringify({ timestamp, url: req.url, body: parsed ?? raw }) + '\n')
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end('{}')
@@ -66,5 +96,5 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, () => {
   console.log(`otel-debug-collector: http://localhost:${PORT} で待ち受け中（Ctrl+Cで停止）`)
-  console.log(`受信ログ: ${LOG_FILE}`)
+  console.log(`受信ログ: ${LOG_DIR}/YYYY-MM-DD.jsonl（日付ローテーション、保持期間${RETENTION_DAYS}日）`)
 })

--- a/src/__tests__/otel-debug-collector.test.ts
+++ b/src/__tests__/otel-debug-collector.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, utimesSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const SCRIPT = join(process.cwd(), 'scripts', 'otel-debug-collector.mjs')
+
+describe('otel-debug-collector.mjs', () => {
+  let proc: ChildProcess | null = null
+  let dir: string
+
+  afterEach(() => {
+    proc?.kill()
+    proc = null
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  function waitForListening(child: ChildProcess): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timed out waiting for collector to start')), 5000)
+      child.stdout?.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('で待ち受け中')) {
+          clearTimeout(timeout)
+          resolve()
+        }
+      })
+      child.on('error', reject)
+    })
+  }
+
+  it('writes received metrics to a date-rotated file under the log dir', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'otel-collector-'))
+    const port = 14318 + Math.floor(Math.random() * 1000)
+    const logDir = join(dir, 'otel')
+
+    proc = spawn('node', [SCRIPT], {
+      env: {
+        ...process.env,
+        OTEL_DEBUG_COLLECTOR_PORT: String(port),
+        OTEL_DEBUG_COLLECTOR_LOG_DIR: logDir,
+      },
+    })
+    await waitForListening(proc)
+
+    const res = await fetch(`http://localhost:${port}/v1/metrics`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resourceMetrics: [{ scopeMetrics: [{ metrics: [{ name: 'claude_code.cost.usage' }] }] }] }),
+    })
+    expect(res.status).toBe(200)
+
+    // サーバがファイルへの書き込みを終えるまで少し待つ
+    await new Promise(r => setTimeout(r, 200))
+
+    const files = readdirSync(logDir)
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.jsonl$/)
+
+    const content = readFileSync(join(logDir, files[0]), 'utf-8')
+    expect(content).toContain('claude_code.cost.usage')
+    expect(content).toContain('/v1/metrics')
+  })
+
+  it('prunes log files older than the retention period on startup', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'otel-collector-retention-'))
+    const port = 15318 + Math.floor(Math.random() * 1000)
+    const logDir = join(dir, 'otel')
+
+    // 事前に古いログファイルと新しいログファイルを用意する
+    const fs = await import('node:fs')
+    fs.mkdirSync(logDir, { recursive: true })
+    const oldFile = join(logDir, '2000-01-01.jsonl')
+    const recentFile = join(logDir, '2099-01-01.jsonl')
+    writeFileSync(oldFile, '{}\n')
+    writeFileSync(recentFile, '{}\n')
+    const veryOld = new Date('2000-01-01').getTime() / 1000
+    utimesSync(oldFile, veryOld, veryOld)
+
+    proc = spawn('node', [SCRIPT], {
+      env: {
+        ...process.env,
+        OTEL_DEBUG_COLLECTOR_PORT: String(port),
+        OTEL_DEBUG_COLLECTOR_LOG_DIR: logDir,
+        OTEL_DEBUG_COLLECTOR_RETENTION_DAYS: '30',
+      },
+    })
+    await waitForListening(proc)
+
+    const files = readdirSync(logDir)
+    expect(files).not.toContain('2000-01-01.jsonl')
+    expect(files).toContain('2099-01-01.jsonl')
+  })
+})


### PR DESCRIPTION
## Summary
issue #430「OTelローカルcollectorの常時記録化（日付ローテーション・起動忘れ検知）でbaseline取得を事後クエリにする」に対応。issue本文の3項目（`やること`）のうち2つを実装し、3つ目は実測のみ行った。

1. **`otel-debug-collector.mjs`に日付ローテーション + 保持期間管理を追加**（実装済み）
   - `logs/otel/YYYY-MM-DD.jsonl`へ日付ローテーション（既定30日で自動削除、`OTEL_DEBUG_COLLECTOR_RETENTION_DAYS`で変更可）
2. **常時起動の方式決定と起動忘れ検知**（issue本文の候補(a)(b)(c)のうち(b)/(c)寄りの最小構成で実装）
   - `scripts/check-otel-collector-status.sh`（SessionStart hook）が、`CLAUDE_CODE_ENABLE_TELEMETRY=1`なのにcollectorへ接続できない場合のみ警告する
   - issue #411原則（「起動トリガーは機械か人か」）に照らし、launchd常駐化（候補a）は今回見送った。「起動し忘れても気づける」という最小限のバーで対応
3. **agentType/セッション単位での自作JSONLとの突合方法の検討**（実測のみ、実装は未着手）
   - 実際にテレメトリを有効化したheadlessセッションを1回実行し、collectorで受信した生データを解析した
   - 全metricのdata point属性に`session.id`（Claude Codeのhook入力JSONと同一UUID形式）が含まれることを確認。自作JSONL（loop-observability.jsonl等）との突合が`session.id`で可能
   - ただし`agentType`（reviewer/implementer等）に相当する属性は無い。粗い区別として`query_source`（例: `"main"`）はあるが、サブエージェント単位の突合にはタイムスタンプ近接性等の追加ヒューリスティックが必要（未実装、将来issue化を検討）

詳細は[docs/agents/common.md](../blob/main/docs/agents/common.md)「常時記録化と起動忘れ検知（issue #430）」に記録。

## Test plan
- [x] `npx vitest run src/__tests__/otel-debug-collector.test.ts`（日付ローテーション・保持期間削除の2ケース、実際にHTTPサーバを起動してpass）
- [x] `bash scripts/check-otel-collector-status.test.sh`（3シナリオ: テレメトリ無効/collector未起動/collector稼働中、実物のcollectorを使ってpass）
- [x] `npm run typecheck` / `npm run lint`（既存の無関係な警告1件のみ、エラー0）
- [x] `npm test`（146ファイル・1071テスト全pass）
- [x] 実機検証: テレメトリ有効なheadlessセッションを実行し、collectorが`session.id`付きの`claude_code.token.usage`/`cost.usage`等を実際に受信することを確認

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
