### PR TITLE
Find→Adversarial Verify precision集計を追加(issue #432、前提訂正あり)

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -230,7 +230,11 @@ const findResults = await parallel(
   ))
 )
 
-const allFindResults = findResults.filter(Boolean).flatMap(r => r.findings)
+// issue #432: findingsに発見元のlensをタグ付けする（precision集計をlens別に出すため）。
+// findResultsはFINDERSと同じ順序で並列実行されているため、インデックスで対応付けられる。
+const allFindResults = findResults
+  .map((r, i) => (r?.findings ?? []).map(f => ({ ...f, lens: FINDERS[i].lens })))
+  .flat()
 const seen = new Set()
 const dedupedFindings = allFindResults.filter(f => {
   const key = f.title.slice(0, 30)
@@ -268,6 +272,32 @@ const verdicts = await parallel(
 const survivedFromVerify = toVerify.filter((_, i) => !verdicts[i]?.refuted)
 const survived = [...survivedFromVerify, ...autoSurvivedMinor]
 log(`Adversarial Verify完了: critical/important ${toVerify.length}件検証 → ${survivedFromVerify.length}件生存（+minor自動生存${autoSurvivedMinor.length}件、計${survived.length}件）`)
+
+// issue #432: Find指摘のAV生存率（Sweep指摘のprecisionではない。理由は
+// .claude/workflows/lib/find-av-precision.js のコメント参照）。正本・単体テストは
+// .claude/workflows/lib/find-av-precision.js の computeFindAvPrecision。
+// Workflow DSLはrequire不可のためインライン複製している（プロンプト文言ではなく
+// 集計ロジックのみのため、変更時はfind-av-precision.js側も手動で追従させること）。
+function computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvivedMinor) {
+  const survivedFromVerify = toVerify.filter((_, i) => !verdicts[i]?.refuted)
+  const survived = [...survivedFromVerify, ...autoSurvivedMinor]
+  const byLens = {}
+  toVerify.forEach((f, i) => {
+    const lens = f?.lens ?? 'unknown'
+    byLens[lens] ??= { verified: 0, survived: 0 }
+    byLens[lens].verified++
+    if (!verdicts[i]?.refuted) byLens[lens].survived++
+  })
+  return {
+    findCount: dedupedFindings.length,
+    verifiedCount: toVerify.length,
+    survivedCount: survived.length,
+    autoSurvivedMinorCount: autoSurvivedMinor.length,
+    survivalRate: toVerify.length > 0 ? survivedFromVerify.length / toVerify.length : null,
+    byLens,
+  }
+}
+const findAvPrecision = computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvivedMinor)
 
 // ─── Phase 6: Completeness Critic ────────────────────────────────────
 phase('Completeness Critic')
@@ -424,4 +454,5 @@ return {
   winner:      winner?.proposal,
   winnerScore: winner?.avgScore,
   synthesis,
+  findAvPrecision,
 }

--- a/.claude/workflows/lib/__tests__/find-av-precision.test.js
+++ b/.claude/workflows/lib/__tests__/find-av-precision.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { computeFindAvPrecision } from '../find-av-precision.js'
+
+describe('computeFindAvPrecision', () => {
+  it('全件生存した場合、survivalRateは1', () => {
+    const dedupedFindings = [
+      { title: 'a', lens: 'logic', severity: 'important' },
+      { title: 'b', lens: 'security', severity: 'critical' },
+    ]
+    const toVerify = dedupedFindings
+    const verdicts = [{ refuted: false }, { refuted: false }]
+    const result = computeFindAvPrecision(dedupedFindings, toVerify, verdicts, [])
+
+    expect(result.findCount).toBe(2)
+    expect(result.verifiedCount).toBe(2)
+    expect(result.survivedCount).toBe(2)
+    expect(result.survivalRate).toBe(1)
+  })
+
+  it('全件棄却された場合、survivalRateは0', () => {
+    const dedupedFindings = [{ title: 'a', lens: 'logic', severity: 'important' }]
+    const verdicts = [{ refuted: true }]
+    const result = computeFindAvPrecision(dedupedFindings, dedupedFindings, verdicts, [])
+
+    expect(result.survivedCount).toBe(0)
+    expect(result.survivalRate).toBe(0)
+  })
+
+  it('minor指摘はverifiedCountに含めず、autoSurvivedMinorCountとしてsurvivedCountには加算する', () => {
+    const dedupedFindings = [
+      { title: 'a', lens: 'logic', severity: 'important' },
+      { title: 'b', lens: 'ux', severity: 'minor' },
+    ]
+    const toVerify = [dedupedFindings[0]]
+    const autoSurvivedMinor = [dedupedFindings[1]]
+    const verdicts = [{ refuted: false }]
+    const result = computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvivedMinor)
+
+    expect(result.findCount).toBe(2)
+    expect(result.verifiedCount).toBe(1)
+    expect(result.autoSurvivedMinorCount).toBe(1)
+    expect(result.survivedCount).toBe(2) // 生存1件 + minor自動生存1件
+    expect(result.survivalRate).toBe(1) // minorはverifiedCount側の分母に含めない
+  })
+
+  it('lens別の内訳(byLens)を正しく集計する', () => {
+    const dedupedFindings = [
+      { title: 'a', lens: 'logic', severity: 'important' },
+      { title: 'b', lens: 'logic', severity: 'important' },
+      { title: 'c', lens: 'security', severity: 'critical' },
+    ]
+    const verdicts = [{ refuted: false }, { refuted: true }, { refuted: false }]
+    const result = computeFindAvPrecision(dedupedFindings, dedupedFindings, verdicts, [])
+
+    expect(result.byLens.logic).toEqual({ verified: 2, survived: 1 })
+    expect(result.byLens.security).toEqual({ verified: 1, survived: 1 })
+  })
+
+  it('lensが無い指摘はunknownとして集計する', () => {
+    const dedupedFindings = [{ title: 'a', severity: 'important' }]
+    const verdicts = [{ refuted: false }]
+    const result = computeFindAvPrecision(dedupedFindings, dedupedFindings, verdicts, [])
+
+    expect(result.byLens.unknown).toEqual({ verified: 1, survived: 1 })
+  })
+
+  it('検証対象が0件ならsurvivalRateはnull（0除算を避ける）', () => {
+    const result = computeFindAvPrecision([], [], [], [])
+
+    expect(result.verifiedCount).toBe(0)
+    expect(result.survivalRate).toBeNull()
+  })
+
+  it('verdictがnull/undefinedの指摘は生存扱い（元のaidd-1-1-deep-task.jsのsurvivedFromVerify算出と同一挙動）', () => {
+    const dedupedFindings = [{ title: 'a', lens: 'logic', severity: 'important' }]
+    const result = computeFindAvPrecision(dedupedFindings, dedupedFindings, [null], [])
+
+    expect(result.survivedCount).toBe(1)
+  })
+})

--- a/.claude/workflows/lib/find-av-precision.js
+++ b/.claude/workflows/lib/find-av-precision.js
@@ -1,0 +1,32 @@
+// Find→Adversarial Verify裁定結果からprecision（偽陽性率の裏返し＝生存率）を集計する
+// 純粋関数（issue #432）。
+//
+// 注意（重要な訂正）: issue #432起票時点の想定は「Sweep指摘のprecisionをAV裁定結果から
+// 集計する」だったが、実際にAdversarial Verifyが裁定するのはFindフェーズ（仕様書ドラフトへの
+// logic/data/security/ux/performance5軸の再発見）の指摘であり、Sweepフェーズ（ui/data/db/types
+// 軸のコードベース調査）の指摘ではない（両者は別の生成プロセスで、構造的に1:1対応しない）。
+// このためここでは「Find指摘のAV生存率」として実装している。
+//
+// Workflow DSL（aidd-1-1-deep-task.js）自体はrequire不可のため、この関数の判定ロジックは
+// aidd-1-1-deep-task.js内にインライン複製されている（severity.js等と同じパターン）。
+export function computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvivedMinor) {
+  const survivedFromVerify = toVerify.filter((_, i) => !verdicts[i]?.refuted)
+  const survived = [...survivedFromVerify, ...autoSurvivedMinor]
+
+  const byLens = {}
+  toVerify.forEach((f, i) => {
+    const lens = f?.lens ?? 'unknown'
+    byLens[lens] ??= { verified: 0, survived: 0 }
+    byLens[lens].verified++
+    if (!verdicts[i]?.refuted) byLens[lens].survived++
+  })
+
+  return {
+    findCount: dedupedFindings.length,
+    verifiedCount: toVerify.length,
+    survivedCount: survived.length,
+    autoSurvivedMinorCount: autoSurvivedMinor.length,
+    survivalRate: toVerify.length > 0 ? survivedFromVerify.length / toVerify.length : null,
+    byLens,
+  }
+}

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -250,6 +250,34 @@ beforeデータの取得手段が存在せず（`logs/`はgitignore対象で、`
 - 本仕組みは最初から機械検知（CI）のため、実装後に「検知手段のないルールの棚卸し」表への
   行追加は不要（issue #411の原則どおり）
 
+## Find→Adversarial Verify precision記録（issue #432）
+
+**起票時の前提の訂正:** issue #432は当初「Sweep指摘のprecisionをAdversarial Verify裁定結果
+から集計する（追加のLLM呼び出しゼロ）」という想定だったが、`aidd-1-1-deep-task.js`の実装を
+確認したところ、Adversarial Verifyが裁定するのはFindフェーズ（仕様書ドラフトへのlogic/data/
+security/ux/performance5軸の再発見）の指摘であり、Sweepフェーズ（ui/data/db/types軸の
+コードベース調査）の指摘ではないことが判明した（両者は別の生成プロセスで、構造的に1:1対応
+しない）。このため実装は「Find指摘のAV生存率」として行った（詳細な理由は
+`.claude/workflows/lib/find-av-precision.js`のコメント参照）。
+
+- `aidd-1-1-deep-task.js`の戻り値`stats`に`findAvPrecision`（findCount/verifiedCount/
+  survivedCount/autoSurvivedMinorCount/survivalRate/lens別内訳`byLens`）を追加した。
+  純粋な集計ロジックの正本は`.claude/workflows/lib/find-av-precision.js`の
+  `computeFindAvPrecision`（Workflow DSLはrequire不可のためaidd-1-1-deep-task.js内に
+  インライン複製。severity.js等と同じパターン）
+- 上記#429の`snapshot-agent-baseline.sh`の「既知の限界」（`rounds`/`findingCount`が戻り値
+  にのみ存在しどのJSONLにも永続化されない）と同型の構造的限界を持つ。Workflow DSL自体が
+  filesystem API不可のため、フロー完了後にオーケストレーター（Claude Code）が
+  `scripts/log-find-av-precision.sh --feature "<feature名>" '<findAvPrecisionのJSON>'`を
+  呼んで`logs/find-av-precision.jsonl`へ永続化する必要がある。これは人/エージェント起動の
+  第3層ルールであり、呼び忘れを機械的に検知する手段は無い（issue #411原則に照らし、
+  今回は機械検知までは実装していない）
+- `npm run find-av-precision-summary`（実体は`scripts/summarize-find-av-precision.sh`）で
+  feature別・lens別の生存率を集計できる
+- **限界**: AV自体もLLM判定でありground truthではない（AVが正しい指摘を誤って棄却する
+  ケースはこの指標では測れない）。Sweepの見落とし率（recall）を測る別issue（#431）との
+  二本立ての片翼として扱うこと
+
 ## AIDDワークフロープロンプトのeval（issue #391）
 
 `.claude/workflows/*.js` 内の自然言語プロンプト（例: db-implの「DBスキーマ変更不要ならblockedではなくpass」という判定基準）は、ユニットテストが効かず、修正の妥当性が「次回実フローでの目視確認」頼みになりがちだった（issue #389のフォローアップ）。fixture SPEC.mdを実際のエージェント（`claude -p --agent <agentType>`、本番と同じモデル）に読ませ、期待するstatus判定になるかを回帰テストする仕組みを用意した。

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "playwright test",
     "e2e:auth": "npx -y tsx e2e/generate-auth-state.ts",
     "loop-summary": "bash scripts/summarize-loop-observability.sh",
+    "find-av-precision-summary": "bash scripts/summarize-find-av-precision.sh",
     "eval:workflows": "bash scripts/eval-workflow-prompts.sh",
     "ai:check": "npm run typecheck && npm run lint && npm run test && npm run test:e2e"
   },

--- a/scripts/log-find-av-precision.sh
+++ b/scripts/log-find-av-precision.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# issue #432: aidd-1-1-deep-task.jsの戻り値.findAvPrecision（Find指摘のAdversarial Verify
+# 生存率。Sweep指摘のprecisionではない。理由は.claude/workflows/lib/find-av-precision.jsの
+# コメント参照）を永続化する。
+#
+# Workflow DSL自体はfilesystem API不可のため、フローの戻り値をこのスクリプトへ渡すのは
+# 呼び出し元（Claude Code）の責務。ai_check_suggest.sh等と同じ「機械強制ではなく人/エージェント
+# 起動の第3層ルール」である点に注意（common.md「検知手段のないルールの棚卸し」参照）。
+#
+# 使い方（fourth-argument経由でJSONを渡す。パイプ・stdinは使わない）:
+#   scripts/log-find-av-precision.sh --feature "<feature名>" '<findAvPrecisionのJSON>'
+
+LOG_FILE="logs/find-av-precision.jsonl"
+FEATURE=""
+
+usage() {
+  echo "Usage: $0 --feature NAME '<findAvPrecision JSON>' [--log-file PATH]" >&2
+  exit 1
+}
+
+STATS_JSON=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --feature) FEATURE="$2"; shift 2 ;;
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    *) STATS_JSON="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$FEATURE" || -z "$STATS_JSON" ]]; then
+  usage
+fi
+
+if ! printf '%s' "$STATS_JSON" | jq empty 2>/dev/null; then
+  echo "Invalid JSON: $STATS_JSON" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+jq -nc \
+  --arg timestamp "$TIMESTAMP" \
+  --arg feature "$FEATURE" \
+  --argjson stats "$STATS_JSON" \
+  '{timestamp: $timestamp, feature: $feature} + $stats' \
+  >> "$LOG_FILE"

--- a/scripts/log-find-av-precision.test.sh
+++ b/scripts/log-find-av-precision.test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# WHY: scripts/log-find-av-precision.sh の回帰テスト（issue #432）。
+#
+# 実行: bash scripts/log-find-av-precision.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/log-find-av-precision.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+LOG_FILE="$TMPDIR_TEST/find-av-precision.jsonl"
+
+echo "=== scenario 1: 正常なJSONを渡すと1行追記される ==="
+bash "$SCRIPT" --feature admin-role --log-file "$LOG_FILE" '{"findCount":3,"verifiedCount":2,"survivedCount":1,"autoSurvivedMinorCount":1,"survivalRate":0.5,"byLens":{"logic":{"verified":2,"survived":1}}}'
+LINE_COUNT="$(wc -l < "$LOG_FILE" | tr -d ' ')"
+assert_eq "$LINE_COUNT" "1" "1行追記される"
+CONTENT="$(cat "$LOG_FILE")"
+assert_contains "$CONTENT" '"feature":"admin-role"' "featureが記録される"
+assert_contains "$CONTENT" '"verifiedCount":2' "統計フィールドがそのまま展開される"
+assert_contains "$CONTENT" '"timestamp"' "timestampが付与される"
+
+echo "=== scenario 2: 不正なJSONはエラーで拒否する ==="
+set +e
+OUT="$(bash "$SCRIPT" --feature admin-role --log-file "$LOG_FILE" 'not-json' 2>&1)"
+EXIT_CODE=$?
+set -e
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "  OK: 不正なJSONで非0終了する"
+else
+  echo "  NG: 不正なJSONでも0終了してしまった"
+  fail=1
+fi
+
+echo "=== scenario 3: --featureが無いとusageで終了する ==="
+set +e
+bash "$SCRIPT" --log-file "$LOG_FILE" '{"findCount":1}' > /dev/null 2>&1
+EXIT_CODE=$?
+set -e
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "  OK: --feature省略時に非0終了する"
+else
+  echo "  NG: --feature省略時も0終了してしまった"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/summarize-find-av-precision.sh
+++ b/scripts/summarize-find-av-precision.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# issue #432: logs/find-av-precision.jsonl（scripts/log-find-av-precision.shが書き出す）を
+# lens別・feature別に集計する。Find指摘のAdversarial Verify生存率であり、Sweep指摘の
+# precisionではない点に注意（.claude/workflows/lib/find-av-precision.jsのコメント参照）。
+
+LOG_FILE="logs/find-av-precision.jsonl"
+OUT=""
+
+usage() {
+  echo "Usage: $0 [--log-file PATH] [--out PATH]" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "Log file not found: $LOG_FILE" >&2
+  exit 1
+fi
+
+SUMMARY="$(jq -s -r '
+  . as $all
+  | ($all | length) as $runs
+  | ($all | map(.verifiedCount // 0) | add) as $totalVerified
+  | ($all | map(.survivedCount // 0) | add) as $totalSurvived
+  | "# Find→Adversarial Verify Precision Summary",
+    "",
+    "（Find指摘のAV生存率。Sweep指摘のprecisionではない）",
+    "",
+    "## 全体",
+    "- 記録された実行回数: \($runs)",
+    "- 検証件数合計: \($totalVerified)",
+    "- 生存件数合計（minor自動生存含む）: \($totalSurvived)",
+    "",
+    "## Feature別",
+    (
+      if $runs == 0 then empty
+      else
+        ($all | group_by(.feature)[] |
+          . as $g |
+          ($g[0].feature) as $feature |
+          ($g | length) as $runCount |
+          ($g | map(.verifiedCount // 0) | add) as $verified |
+          ($g | map(.survivedCount // 0) | add) as $survived |
+          "### \($feature)",
+          "- 実行回数: \($runCount)",
+          "- 検証件数: \($verified)",
+          "- 生存件数: \($survived)",
+          ""
+        )
+      end
+    ),
+    "## lens別（全実行を通した累計）",
+    (
+      if $runs == 0 then empty
+      else
+        ($all | map(.byLens // {}) | reduce .[] as $bl (
+            {};
+            reduce ($bl | keys[]) as $lens (
+              .;
+              .[$lens].verified = ((.[$lens].verified // 0) + ($bl[$lens].verified // 0))
+              | .[$lens].survived = ((.[$lens].survived // 0) + ($bl[$lens].survived // 0))
+            )
+          )
+        ) as $lensTotals
+        | ($lensTotals | keys[] | . as $lens |
+            "- \($lens): 検証\($lensTotals[$lens].verified)件 / 生存\($lensTotals[$lens].survived)件"
+          )
+      end
+    )
+' "$LOG_FILE")"
+
+if [[ -n "$OUT" ]]; then
+  mkdir -p "$(dirname "$OUT")"
+  printf '%s\n' "$SUMMARY" > "$OUT"
+else
+  printf '%s\n' "$SUMMARY"
+fi

--- a/src/__tests__/summarize-find-av-precision.test.ts
+++ b/src/__tests__/summarize-find-av-precision.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const SCRIPT = join(process.cwd(), 'scripts', 'summarize-find-av-precision.sh')
+
+describe('summarize-find-av-precision.sh', () => {
+  let dir: string
+  let logFile: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'find-av-precision-summary-'))
+    logFile = join(dir, 'find-av-precision.jsonl')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function run(args: string[]) {
+    return execFileSync(SCRIPT, args, { encoding: 'utf-8' })
+  }
+
+  function writeRecords(records: Record<string, unknown>[]) {
+    writeFileSync(logFile, records.map((r) => JSON.stringify(r)).join('\n') + '\n')
+  }
+
+  it('summarizes total counts, per-feature breakdown, and per-lens breakdown', () => {
+    writeRecords([
+      {
+        timestamp: '2026-07-16T00:00:00Z', feature: 'admin-role',
+        findCount: 5, verifiedCount: 4, survivedCount: 3, autoSurvivedMinorCount: 1,
+        survivalRate: 0.5, byLens: { logic: { verified: 2, survived: 1 } },
+      },
+      {
+        timestamp: '2026-07-16T01:00:00Z', feature: 'admin-role',
+        findCount: 2, verifiedCount: 2, survivedCount: 1, autoSurvivedMinorCount: 0,
+        survivalRate: 0.5, byLens: { logic: { verified: 1, survived: 0 }, security: { verified: 1, survived: 1 } },
+      },
+    ])
+
+    const output = run(['--log-file', logFile])
+
+    expect(output).toContain('- 記録された実行回数: 2')
+    expect(output).toContain('- 検証件数合計: 6')
+    expect(output).toContain('- 生存件数合計（minor自動生存含む）: 4')
+    expect(output).toContain('### admin-role')
+    expect(output).toContain('- 実行回数: 2')
+    expect(output).toContain('- 検証件数: 6')
+    expect(output).toContain('- logic: 検証3件 / 生存1件')
+    expect(output).toContain('- security: 検証1件 / 生存1件')
+  })
+
+  it('does not crash on an empty log file', () => {
+    writeFileSync(logFile, '')
+
+    const output = run(['--log-file', logFile])
+
+    expect(output).toContain('- 記録された実行回数: 0')
+  })
+
+  it('rejects a missing log file', () => {
+    expect(() => run(['--log-file', join(dir, 'missing.jsonl')])).toThrow()
+  })
+
+  it('writes the summary to --out instead of stdout when given', () => {
+    writeRecords([
+      {
+        timestamp: '2026-07-16T00:00:00Z', feature: 'admin-role',
+        findCount: 1, verifiedCount: 1, survivedCount: 1, autoSurvivedMinorCount: 0,
+        survivalRate: 1, byLens: { logic: { verified: 1, survived: 1 } },
+      },
+    ])
+    const outFile = join(dir, 'nested', 'summary.md')
+
+    const stdout = run(['--log-file', logFile, '--out', outFile])
+
+    expect(stdout.trim()).toBe('')
+    const written = execFileSync('cat', [outFile], { encoding: 'utf-8' })
+    expect(written).toContain('- 記録された実行回数: 1')
+  })
+})


### PR DESCRIPTION
## Summary
issue #432に対応。ただし実装前に**issue起票時の前提が実装と食い違っていることを発見**し、ユーザーに確認の上スコープを訂正して実装した。

## 実装前に判明した前提の誤り
issue本文は「aidd-1-1-deep-taskフローではSweep/Completeness Criticの指摘をAdversarial Verifyが裁定しており...追加のLLM呼び出しゼロで取れる」という想定だったが、`aidd-1-1-deep-task.js`を確認したところ:
- Adversarial Verifyが裁定するのは**Findフェーズ**（仕様書ドラフトへのlogic/data/security/ux/performance5軸の再発見）の指摘
- **Sweepフェーズ**（ui/data/db/types軸のコードベース調査）の指摘は、Draft Spec生成の入力にはなるが、Find/Adversarial Verifyの経路には直接乗らない

両者は別の生成プロセスであり構造的に1:1対応しないため、「Sweep指摘のprecision」は成立しない。ユーザーに確認し、「Find指摘のAV生存率」として実装する方針で合意した。

## データ源の確認（issue本文の項目1）
`journal.jsonl`は`label`（`find:logic`等）もプロンプト本文も保持しておらず、ハッシュキーと最終結果のみ。個別findingとAV裁定の対応は既存ログから復元不能なことを確認した。`.claude/agents/adversarial-verify.md`もloop-observabilityへの自己ログ記録を持たない（そもそも`aidd-1-1-deep-task.js`のAV呼び出しはこのagent定義を経由していない）。よって新規の永続化の仕組みが必要と判断した。

## やったこと
1. `aidd-1-1-deep-task.js`: Findフェーズのfindingsに発見元lens（logic/data/security/ux/performance）をタグ付けし、Adversarial Verify完了後に`findAvPrecision`（findCount/verifiedCount/survivedCount/autoSurvivedMinorCount/survivalRate/lens別内訳）を戻り値`stats`に追加。純粋な集計ロジックの正本は[`.claude/workflows/lib/find-av-precision.js`](../blob/main/.claude/workflows/lib/find-av-precision.js)（`severity.js`等と同じインライン複製パターン、Workflow DSLはrequire不可のため）
2. `scripts/log-find-av-precision.sh`: 戻り値をワークフロー完了後に`logs/find-av-precision.jsonl`へ永続化するスクリプト。Workflow DSL自体はfilesystem API不可のため呼び出し元（Claude Code）起動が前提（issue #429の`snapshot-agent-baseline.sh`と同型の構造的限界。この呼び出し忘れの機械検知は今回は未実装）
3. `scripts/summarize-find-av-precision.sh`（`npm run find-av-precision-summary`）: feature別・lens別の生存率集計

詳細な判断根拠は[docs/agents/common.md](../blob/main/docs/agents/common.md)「Find→Adversarial Verify precision記録（issue #432）」に記録した。

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/find-av-precision.test.js`（7ケース全pass、lens別集計・0件時のnull処理・fail-open挙動の一致を含む）
- [x] `npx vitest run src/__tests__/summarize-find-av-precision.test.ts`（4ケース全pass）
- [x] `bash scripts/log-find-av-precision.test.sh`（3シナリオ全pass）
- [x] `node --check .claude/workflows/aidd-1-1-deep-task.js`（構文検証）
- [x] `npm run typecheck` / `npm run lint`（既存の無関係な警告1件のみ、エラー0）
- [x] `npm test`（147ファイル・1080テスト全pass）

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
