### PR TITLE
feat: sweep recallベンチマークのeval基盤を構築(issue #431)

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -48,6 +48,8 @@ const AGENT_RESULT_SCHEMA_PFB = {
   required: ['status', 'detail'],
 }
 
+// 正本: .claude/workflows/lib/prompts/sweep.js。Workflow DSLはrequire不可のため
+// インライン複製している。同期は sweep-prompt-sync.test.js が検証する（issue #431）。
 const SWEEP_GUIDE = `
 
 ## 出力形式

--- a/.claude/workflows/aidd-phase1.js
+++ b/.claude/workflows/aidd-phase1.js
@@ -43,6 +43,8 @@ const AGENT_RESULT_SCHEMA = {
   required: ['status', 'detail'],
 }
 
+// 正本: .claude/workflows/lib/prompts/sweep.js。Workflow DSLはrequire不可のため
+// インライン複製している。同期は sweep-prompt-sync.test.js が検証する（issue #431）。
 const STATUS_GUIDE = `
 
 ## 出力形式

--- a/.claude/workflows/lib/__tests__/sweep-prompt-sync.test.js
+++ b/.claude/workflows/lib/__tests__/sweep-prompt-sync.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractTemplateLiteralContaining } from '../prompts/extract-template-literal.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PHASE1_FILE = path.resolve(__dirname, '../../aidd-phase1.js')
+const DEEP_TASK_FILE = path.resolve(__dirname, '../../aidd-1-1-deep-task.js')
+const LIB_FILE = path.resolve(__dirname, '../prompts/sweep.js')
+// STATUS_GUIDE/SWEEP_GUIDEにのみ登場する文字列。
+const CONTENT_MARKER = '調査を最後まで実行できた'
+
+describe('sweepプロンプトの出力形式ガイドの同期(issue #431)', () => {
+  it('aidd-phase1.js内のSTATUS_GUIDEがlib/prompts/sweep.jsの正本と一字一句一致する', () => {
+    const workflowSource = readFileSync(PHASE1_FILE, 'utf-8')
+    const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+    const workflowGuide = extractTemplateLiteralContaining(workflowSource, CONTENT_MARKER)
+    const libGuide = extractTemplateLiteralContaining(libSource, CONTENT_MARKER)
+
+    expect(workflowGuide).toBe(libGuide)
+  })
+
+  it('aidd-1-1-deep-task.js内のSWEEP_GUIDEがlib/prompts/sweep.jsの正本と一字一句一致する', () => {
+    const workflowSource = readFileSync(DEEP_TASK_FILE, 'utf-8')
+    const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+    const workflowGuide = extractTemplateLiteralContaining(workflowSource, CONTENT_MARKER)
+    const libGuide = extractTemplateLiteralContaining(libSource, CONTENT_MARKER)
+
+    expect(workflowGuide).toBe(libGuide)
+  })
+})

--- a/.claude/workflows/lib/prompts/sweep.js
+++ b/.claude/workflows/lib/prompts/sweep.js
@@ -1,0 +1,19 @@
+// aidd-phase1.js（`.claude/workflows/aidd-phase1.js`）のSweepフェーズが各sweep-*エージェントに
+// 送るプロンプトの正本。Workflow DSLはrequire不可のためaidd-phase1.js側にインライン複製している。
+// aidd-1-1-deep-task.jsのSweepフェーズも同一のSTATUS_GUIDE本文を使う（additionalContext分岐が
+// 追加される点のみ異なる）。
+// 両者の同期は .claude/workflows/lib/__tests__/sweep-prompt-sync.test.js が検証する（issue #431:
+// sweep recallのeval基盤で、実際のsweep-*プロンプトと同じ文言をfixture実行に使うため）。
+//
+// **重要**: このファイルのテンプレートリテラル本文を変更したら、aidd-phase1.js /
+// aidd-1-1-deep-task.js内の対応するインライン複製も一字一句同じ内容に更新すること。
+const STATUS_GUIDE = `
+
+## 出力形式
+status と detail を返すこと。
+- status: "pass"=調査を最後まで実行できた(指摘の有無は問わない) / "blocked"=権限不足・対象コード不在等で調査自体が実行できなかった
+- detail: 調査結果の本文(指摘が無ければ「指摘なし」と書く)`
+
+export function buildSweepPrompt(taskDescription) {
+  return `タスク: ${taskDescription}${STATUS_GUIDE}`
+}

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -278,6 +278,46 @@ security/ux/performance5軸の再発見）の指摘であり、Sweepフェーズ
   ケースはこの指標では測れない）。Sweepの見落とし率（recall）を測る別issue（#431）との
   二本立ての片翼として扱うこと
 
+## Sweep recallベンチマーク（issue #431）
+
+issue #419のような設定変更（effort/model）に対して「精度が落ちていないか」を検証する手段が
+無かった。同一タスクのeffort有り/無しA/B比較はground truthが無く「差分」しか測れないため、
+既知欠陥を埋め込んだfixtureで見落とし率（recall）を測る仕組みを、issue #391のeval基盤
+（`scripts/eval-workflow-prompts.sh`）と同じload-bearing workaroundを再利用して構築した。
+[「Find→Adversarial Verify precision記録」](#findadversarial-verify-precision記録issue-432)
+（指摘の生存率＝偽陽性側）と対になる、見落とし側の指標。
+
+- `npm run` 経由ではなく `scripts/eval-sweep-recall.sh <layer>`（例: `sweep-ui`）で直接実行する
+  （db-implのeval同様、実エージェント呼び出しの課金コストのためCI化は見送り、手動実行）
+- fixtureは `scripts/eval-fixtures/sweep-<layer>/case-*/files/` に、既知の失敗パターン
+  （[`known-failure-patterns.md`](./known-failure-patterns.md)）を埋め込んだファイルツリーを置く
+  形式。db-implのSPEC.md単体コピー方式とは異なり、fixtureごとに任意のファイルツリーをclone先へ
+  上書き配置する（sweepは特定のSPEC.mdではなくリポジトリ全体を調査するため）。現在4層それぞれ
+  1ケースずつ用意済み: sweep-ui（Suspenseフォールバック未設定）・sweep-data（issue #24型の
+  requireAuth欠落）・sweep-db（SECURITY DEFINER + GRANT EXECUTEの認可バイパス）・sweep-types
+  （型定義とmapperの層間フィールド不一致）
+- 判定は決定的（`expectedFilePathContains`の部分文字列 かつ `expectedKeywords`のいずれか1つが
+  sweep出力detailに含まれていればヒット）。LLM judgeは使わない（判定器自体が非決定になると
+  回帰テストの意味が薄れるため。issue本文の設計判断）
+- プロンプト本文のドリフト対策として、sweepプロンプトの正本を
+  `.claude/workflows/lib/prompts/sweep.js` に切り出し、`aidd-phase1.js` /
+  `aidd-1-1-deep-task.js` 側のインライン複製との一致を
+  `.claude/workflows/lib/__tests__/sweep-prompt-sync.test.js` が検証する（`npm test`に含まれる）
+- eval-workflow-prompts.shのload-bearing workaround（`--setting-sources ""` + `--agents`注入、
+  `--permission-mode bypassPermissions`、git clone隔離、`--no-session-persistence`、同時実行数
+  上限のサーキットブレーカー）をそのまま再利用している
+- **実機検証済み（2026-07-17）**: sweep-uiは実エージェントでrecall 1/1を確認。sweep-dataは
+  harness経由の自動実行では後述のタイムアウト・レート制限に阻まれたが、同一fixtureに対する
+  手動実行で実際に欠陥（`requireAuth`欠落）を検出できることを確認済み。sweep-db/sweep-typesは
+  モックでのharness配線検証のみで、実機での最終確認はセッション利用上限に達したため次回に
+  持ち越し
+- **既知の制約**:
+  - sweep-dataは全APIルート・data層を実走査するため、実測で数分〜30分近くかかることがある
+    （デフォルトタイムアウトを300→900秒に変更したが、それでも足りない可能性がある）
+  - 実エージェント呼び出しのため、Claude Codeのセッション利用上限に達すると実行できなくなる
+    （issue #407と同様、このリポジトリ側では制御できない外部制約）
+- 将来layer・caseを追加する場合は `scripts/eval-fixtures/sweep-<layer>/case-*/` を増やすだけでよい
+
 ## AIDDワークフロープロンプトのeval（issue #391）
 
 `.claude/workflows/*.js` 内の自然言語プロンプト（例: db-implの「DBスキーマ変更不要ならblockedではなくpass」という判定基準）は、ユニットテストが効かず、修正の妥当性が「次回実フローでの目視確認」頼みになりがちだった（issue #389のフォローアップ）。fixture SPEC.mdを実際のエージェント（`claude -p --agent <agentType>`、本番と同じモデル）に読ませ、期待するstatus判定になるかを回帰テストする仕組みを用意した。
@@ -375,7 +415,7 @@ security/ux/performance5軸の再発見）の指摘であり、Sweepフェーズ
 |---|---|---|---|---|
 | args `typeof === 'string'` → `JSON.parse`防御 | `.claude/workflows/aidd-phase1-router.js`（正本: `.claude/workflows/lib/resolve-workflow-args.js`） | Workflowツールがargsをobjectで渡してもstringで届く不具合（[`decisions.md`](./decisions.md#なぜaidd-phase1-routerjsでargsをjsonparseする防御コードを入れたか)） | **解除**: ツール側がargsを常にobjectで渡すよう修正されれば、この分岐に到達しなくなるだけで副作用なし（前方互換設計のため削除は任意）。**破損**: このガード自体が壊れることは想定しにくい（`typeof`判定のみのため） | `resolve-workflow-args.test.js`（npm test内） |
 | `--setting-sources ""` + `--agents`フラグでのagent定義注入 | `scripts/lib/build-eval-agent-json.mjs` | `--setting-sources ""`が`.claude/agents/*.md`探索も無効化する挙動 | **解除**: `--setting-sources`が`.claude/agents/`探索のみを無効化しないよう修正されれば不要。**破損**: `--agents`フラグのJSON構造・優先順位が変更されると`--agent implementer`解決自体が失敗し、evalの実エージェント呼び出しが全滅する（common.md「AIDDワークフロープロンプトのeval」に既述のload-bearing箇所） | JSON出力形式は`build-eval-agent-json.test.mjs`（npm test内）で検証済み。**ただし実際に`claude -p --agents ... --agent <type>`でagent解決できるかどうかの専用smoke testは無い**（`claude -p`の実呼び出しが必要でCI化見送り済みのため、issue #391と同じ判断。`npm run eval:workflows db-impl`を手動実行した際に暗黙的に再検証されるのみ） |
-| プロンプト正本の切り出し＋インライン複製＋sync test | `.claude/workflows/lib/prompts/db-impl.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/spec-check.js` / `manifest-check.js` ⇔ `aidd-phase2.js` | Workflow DSLがfilesystem API不可でローカルモジュールをrequire/importできない制約 | **解除**: Workflow DSLがローカルモジュールをimportできるようになれば、インライン複製自体が不要になり正本を直接importする形に変えられる。**破損**: プロンプト文言変更時にインライン複製側を追従させ忘れると乖離する（これを検知するのがsync testの目的そのもの） | `workflow-prompt-sync.test.js`（npm test内） |
+| プロンプト正本の切り出し＋インライン複製＋sync test | `.claude/workflows/lib/prompts/db-impl.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/spec-check.js` / `manifest-check.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/prompts/sweep.js` ⇔ `aidd-phase1.js` / `aidd-1-1-deep-task.js` | Workflow DSLがfilesystem API不可でローカルモジュールをrequire/importできない制約 | **解除**: Workflow DSLがローカルモジュールをimportできるようになれば、インライン複製自体が不要になり正本を直接importする形に変えられる。**破損**: プロンプト文言変更時にインライン複製側を追従させ忘れると乖離する（これを検知するのがsync testの目的そのもの） | `workflow-prompt-sync.test.js` / `sweep-prompt-sync.test.js`（npm test内） |
 | eval fixture manifestとaidd-phase2.js内スキーマ定義の同期 | `scripts/eval-fixtures/db-impl/manifest.json` ⇔ `aidd-phase2.js`内のスキーマ定義 | 同上（Workflow DSL importの制約） | **解除**: 同上。**破損**: スキーマ定義がドリフトすると、evalが実際のプロンプトと異なるスキーマでテストしてしまい気づかれない | `eval-fixture-manifest-schema-sync.test.js`（npm test内） |
 | 進捗・観測ログの自然言語指示依存 | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`呼び出し | Workflow DSLがfilesystem API不可で、ワークフロー本体から機械的にログを書き込めない制約 | **解除**: 同上（importまたは直接fs書き込みが可能になれば、本体側から機械的に記録できる設計に変更可能）。**破損**: 元々「壊れる」ものではなく「そもそも書かれない」リスクが常態（自然言語指示依存のため） | 記録漏れの事後検知（`check-loop-observability-gap.sh` / `check-agent-progress-gap.sh`）はあるが、その実行自体が人起動であり第3層ルールとして上表に残っている（issue #411） |
 

--- a/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/expected.json
+++ b/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/expected.json
@@ -1,0 +1,4 @@
+{
+  "expectedFilePathContains": "eval-fixture-recall/[id]/route.ts",
+  "expectedKeywords": ["requireAuth", "認証", "認可"]
+}

--- a/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/files/src/app/api/eval-fixture-recall/[id]/route.ts
+++ b/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/files/src/app/api/eval-fixture-recall/[id]/route.ts
@@ -1,0 +1,15 @@
+// issue #431のrecallベンチマーク用fixture。既知の失敗パターン
+// （docs/agents/known-failure-patterns.md「動いたからOKでfacility_idフィルタ漏れ・
+// RLS未設定を見逃す」issue #24再発防止）を意図的に再現している:
+// requireAuth/requireFacilityAccessによる認可チェックが一切無いまま、
+// パスパラメータのidをそのままDBクエリに渡している。
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const db = await createServerSupabase()
+  const { data, error } = await db.from('eval_fixture_recall_items').select('*').eq('id', id).single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ item: data })
+}

--- a/scripts/eval-fixtures/sweep-data/manifest.json
+++ b/scripts/eval-fixtures/sweep-data/manifest.json
@@ -1,0 +1,4 @@
+{
+  "agentType": "sweep-data",
+  "model": "haiku"
+}

--- a/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/expected.json
+++ b/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/expected.json
@@ -1,0 +1,4 @@
+{
+  "expectedFilePathContains": "eval_fixture_recall.sql",
+  "expectedKeywords": ["SECURITY DEFINER", "認可", "is_facility_member"]
+}

--- a/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/files/supabase/migrations/29990101000000_eval_fixture_recall.sql
+++ b/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/files/supabase/migrations/29990101000000_eval_fixture_recall.sql
@@ -1,0 +1,13 @@
+-- issue #431のrecallベンチマーク用fixture。既知の失敗パターン
+-- （docs/agents/known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」）を
+-- 意図的に再現している: SECURITY DEFINER関数がis_facility_member/is_adminによる
+-- 明示的な認可チェックを一切行わないまま、施設に紐づく機微データを返し、
+-- GRANT EXECUTEでanonにも実行権限を与えている。
+
+CREATE OR REPLACE FUNCTION get_eval_fixture_recall_items(p_facility_id UUID)
+RETURNS TABLE (id UUID, internal_note TEXT)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT id, internal_note FROM eval_fixture_recall_items WHERE facility_id = p_facility_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_eval_fixture_recall_items TO anon, authenticated;

--- a/scripts/eval-fixtures/sweep-db/manifest.json
+++ b/scripts/eval-fixtures/sweep-db/manifest.json
@@ -1,0 +1,4 @@
+{
+  "agentType": "sweep-db",
+  "model": "haiku"
+}

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/expected.json
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/expected.json
@@ -1,0 +1,4 @@
+{
+  "expectedFilePathContains": "eval-fixture-recall/repository.ts",
+  "expectedKeywords": ["internalNote", "internal_note", "EvalFixtureRecallItem"]
+}

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/lib/eval-fixture-recall/repository.ts
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/lib/eval-fixture-recall/repository.ts
@@ -1,0 +1,18 @@
+// issue #431のrecallベンチマーク用fixture。src/types/eval-fixture-recall.tsの
+// EvalFixtureRecallItem型は`internalNote`を宣言していないが、このmapRow()は
+// DB列`internal_note`を含めてマッピングしている（型定義とmapperの層間不一致）。
+import type { EvalFixtureRecallItem } from '@/types/eval-fixture-recall'
+
+type EvalFixtureRecallRow = {
+  id: string
+  name: string
+  internal_note: string | null
+}
+
+export function mapRow(row: EvalFixtureRecallRow): EvalFixtureRecallItem & { internalNote: string | null } {
+  return {
+    id: row.id,
+    name: row.name,
+    internalNote: row.internal_note,
+  }
+}

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/types/eval-fixture-recall.ts
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/types/eval-fixture-recall.ts
@@ -1,0 +1,7 @@
+// issue #431のrecallベンチマーク用fixture。層をまたぐ型不一致を意図的に再現している。
+// このEvalFixtureRecallItem型は、対応するrepository.tsのmapRow()が実際に返す
+// internalNoteフィールドを宣言していない（DB列は存在するが型定義に欠落）。
+export type EvalFixtureRecallItem = {
+  id: string
+  name: string
+}

--- a/scripts/eval-fixtures/sweep-types/manifest.json
+++ b/scripts/eval-fixtures/sweep-types/manifest.json
@@ -1,0 +1,4 @@
+{
+  "agentType": "sweep-types",
+  "model": "haiku"
+}

--- a/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/expected.json
+++ b/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/expected.json
@@ -1,0 +1,4 @@
+{
+  "expectedFilePathContains": "eval-fixture-recall/page.tsx",
+  "expectedKeywords": ["Suspense", "useSearchParams"]
+}

--- a/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/files/src/app/(pages)/eval-fixture-recall/page.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/files/src/app/(pages)/eval-fixture-recall/page.tsx
@@ -1,0 +1,18 @@
+// issue #431のrecallベンチマーク用fixture。既知の失敗パターン
+// （docs/agents/known-failure-patterns.md「Suspenseフォールバック未設定」）を意図的に
+// 再現している: useSearchParams()を使うクライアントコンポーネントが、
+// Suspenseでラップされずにexportされている。
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export default function EvalFixtureRecallPage() {
+  const searchParams = useSearchParams()
+  const filter = searchParams.get('filter') ?? 'all'
+
+  return (
+    <div>
+      <p>filter: {filter}</p>
+    </div>
+  )
+}

--- a/scripts/eval-fixtures/sweep-ui/manifest.json
+++ b/scripts/eval-fixtures/sweep-ui/manifest.json
@@ -1,0 +1,4 @@
+{
+  "agentType": "sweep-ui",
+  "model": "haiku"
+}

--- a/scripts/eval-sweep-recall.sh
+++ b/scripts/eval-sweep-recall.sh
@@ -20,15 +20,17 @@ set -euo pipefail
 #   EVAL_SWEEP_RECALL_FIXTURES_DIR  - fixtureセットの置き場所（省略時は $REPO_DIR/scripts/eval-fixtures）
 #   EVAL_SWEEP_RECALL_LOCK_DIR      - サーキットブレーカー用ロック置き場
 #   EVAL_SWEEP_RECALL_MAX_CONCURRENT - 同時実行を許すeval呼び出し数の上限（省略時は2）
-#   EVAL_SWEEP_RECALL_TIMEOUT_SECONDS - 1caseあたりのタイムアウト秒数（省略時は300）
+#   EVAL_SWEEP_RECALL_TIMEOUT_SECONDS - 1caseあたりのタイムアウト秒数（省略時は900。sweep-dataは
+#     全リポジトリのAPIルート・data層を走査するため実測で数分〜30分近くかかることがある）
 #   EVAL_SWEEP_RECALL_AGENT_CMD     - 実際の`claude -p`呼び出しの代わりに使うコマンド
+#   EVAL_SWEEP_RECALL_DEBUG_DIR     - 指定すると各caseの生出力(JSON)を<case名>.jsonとして保存する
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="${EVAL_SWEEP_RECALL_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FIXTURES_ROOT="${EVAL_SWEEP_RECALL_FIXTURES_DIR:-$REPO_DIR/scripts/eval-fixtures}"
 LOCK_DIR="${EVAL_SWEEP_RECALL_LOCK_DIR:-$REPO_DIR/.claude/.eval-sweep-recall-lock}"
 MAX_CONCURRENT="${EVAL_SWEEP_RECALL_MAX_CONCURRENT:-2}"
-TIMEOUT_SECONDS="${EVAL_SWEEP_RECALL_TIMEOUT_SECONDS:-300}"
+TIMEOUT_SECONDS="${EVAL_SWEEP_RECALL_TIMEOUT_SECONDS:-900}"
 
 LAYER="${1:-}"
 if [ -z "$LAYER" ]; then
@@ -76,6 +78,8 @@ run_agent() {
   fi
   # scripts/eval-workflow-prompts.shと同じ理由でこの組み合わせが必要
   # (docs/agents/common.md「ツール制約回避のload-bearing workaround棚卸し」参照)。
+  # --permission-mode bypassPermissions: issue #401で実機確認された対策。呼び出し先は
+  # 必ず使い捨てのgit clone上であり実リポジトリは汚さないため全権限自動承認を許容する。
   local agent_md="$PWD/.claude/agents/${AGENT_TYPE}.md"
   local agents_json
   agents_json="$(node "$SCRIPT_DIR/lib/build-eval-agent-json.mjs" "$agent_md" "$AGENT_TYPE")"
@@ -83,6 +87,7 @@ run_agent() {
     --json-schema "$JSON_SCHEMA" \
     --agents "$agents_json" \
     --setting-sources "" \
+    --permission-mode bypassPermissions \
     --no-session-persistence
 }
 
@@ -152,6 +157,11 @@ for case_dir in "$FIXTURE_SET_DIR"/case-*/; do
   AGENT_EXIT=0
   AGENT_OUTPUT="$(cd "$CLONE_DIR/repo" && run_agent_with_timeout "$PROMPT")" || AGENT_EXIT=$?
   rm -rf "$CLONE_DIR"
+
+  if [ -n "${EVAL_SWEEP_RECALL_DEBUG_DIR:-}" ]; then
+    mkdir -p "$EVAL_SWEEP_RECALL_DEBUG_DIR"
+    printf '%s' "$AGENT_OUTPUT" > "$EVAL_SWEEP_RECALL_DEBUG_DIR/${case_name}.json"
+  fi
 
   if [ "$AGENT_EXIT" -ne 0 ]; then
     MISS_LINES="$MISS_LINES

--- a/scripts/eval-sweep-recall.sh
+++ b/scripts/eval-sweep-recall.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# issue #431: sweep-*エージェントの見落とし率(recall)を測る、既知欠陥埋め込みfixtureの
+# 回帰テストharness。issue #391のeval基盤(scripts/eval-workflow-prompts.sh)と同じ
+# load-bearing workaround（--setting-sources "" + --agents注入、git clone隔離、
+# --no-session-persistence、同時実行数の上限によるサーキットブレーカー）をそのまま
+# 再利用する。ただしdb-implのように単一のSPEC.mdをコピーするだけでは足りず、
+# fixtureごとに任意のファイルツリー(files/)をclone先へ上書き配置する点が異なるため、
+# eval-workflow-prompts.shを直接改修せず、並立するスクリプトとして新設した。
+#
+# 判定方法: sweep出力(detail)に対し、期待ファイルパスの部分文字列と期待キーワードの
+# いずれか1つが両方含まれていればヒット(見落としなし)とする決定的判定。LLM judgeは
+# 使わない(判定器自体が非決定になると回帰テストの意味が薄れるため。issue本文の設計判断)。
+#
+# 使い方: scripts/eval-sweep-recall.sh <layer>（例: sweep-ui）
+#
+# 環境変数（テスト容易性のため上書き可能。scripts/eval-workflow-prompts.shと同じパターン）:
+#   EVAL_SWEEP_RECALL_REPO_DIR      - cloneの複製元リポジトリ（省略時はこのスクリプトの親）
+#   EVAL_SWEEP_RECALL_FIXTURES_DIR  - fixtureセットの置き場所（省略時は $REPO_DIR/scripts/eval-fixtures）
+#   EVAL_SWEEP_RECALL_LOCK_DIR      - サーキットブレーカー用ロック置き場
+#   EVAL_SWEEP_RECALL_MAX_CONCURRENT - 同時実行を許すeval呼び出し数の上限（省略時は2）
+#   EVAL_SWEEP_RECALL_TIMEOUT_SECONDS - 1caseあたりのタイムアウト秒数（省略時は300）
+#   EVAL_SWEEP_RECALL_AGENT_CMD     - 実際の`claude -p`呼び出しの代わりに使うコマンド
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${EVAL_SWEEP_RECALL_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FIXTURES_ROOT="${EVAL_SWEEP_RECALL_FIXTURES_DIR:-$REPO_DIR/scripts/eval-fixtures}"
+LOCK_DIR="${EVAL_SWEEP_RECALL_LOCK_DIR:-$REPO_DIR/.claude/.eval-sweep-recall-lock}"
+MAX_CONCURRENT="${EVAL_SWEEP_RECALL_MAX_CONCURRENT:-2}"
+TIMEOUT_SECONDS="${EVAL_SWEEP_RECALL_TIMEOUT_SECONDS:-300}"
+
+LAYER="${1:-}"
+if [ -z "$LAYER" ]; then
+  echo "usage: $0 <layer>（例: sweep-ui）" >&2
+  exit 1
+fi
+
+FIXTURE_SET_DIR="$FIXTURES_ROOT/$LAYER"
+MANIFEST_FILE="$FIXTURE_SET_DIR/manifest.json"
+if [ ! -f "$MANIFEST_FILE" ]; then
+  echo "eval-sweep-recall: manifest not found: $MANIFEST_FILE" >&2
+  exit 1
+fi
+
+AGENT_TYPE="$(jq -r '.agentType' "$MANIFEST_FILE")"
+MODEL="$(jq -r '.model' "$MANIFEST_FILE")"
+
+# docs/agents/agent-result-schema.md参照。aidd-phase1.jsのAGENT_RESULT_SCHEMAと同一。
+JSON_SCHEMA='{"type":"object","properties":{"status":{"type":"string","enum":["pass","blocked"]},"detail":{"type":"string"}},"required":["status","detail"]}'
+
+mkdir -p "$LOCK_DIR"
+
+# --- サーキットブレーカー: eval-workflow-prompts.shと同じパターン ---
+for entry in "$LOCK_DIR"/*; do
+  [ -e "$entry" ] || continue
+  entry_pid="$(basename "$entry")"
+  if ! kill -0 "$entry_pid" 2>/dev/null; then
+    rmdir "$entry" 2>/dev/null || true
+  fi
+done
+CURRENT_CONCURRENT="$(find "$LOCK_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$CURRENT_CONCURRENT" -ge "$MAX_CONCURRENT" ]; then
+  echo "eval-sweep-recall: 同時実行数が上限(${MAX_CONCURRENT})に達しているため中断しました（サーキットブレーカー）。しばらく待って再実行してください。" >&2
+  exit 1
+fi
+LOCK_ENTRY="$LOCK_DIR/$$"
+mkdir "$LOCK_ENTRY" 2>/dev/null || true
+trap 'rmdir "$LOCK_ENTRY" 2>/dev/null || true' EXIT
+
+run_agent() {
+  local prompt="$1"
+  if [ -n "${EVAL_SWEEP_RECALL_AGENT_CMD:-}" ]; then
+    printf '%s' "$prompt" | eval "$EVAL_SWEEP_RECALL_AGENT_CMD"
+    return $?
+  fi
+  # scripts/eval-workflow-prompts.shと同じ理由でこの組み合わせが必要
+  # (docs/agents/common.md「ツール制約回避のload-bearing workaround棚卸し」参照)。
+  local agent_md="$PWD/.claude/agents/${AGENT_TYPE}.md"
+  local agents_json
+  agents_json="$(node "$SCRIPT_DIR/lib/build-eval-agent-json.mjs" "$agent_md" "$AGENT_TYPE")"
+  printf '%s' "$prompt" | claude -p --agent "$AGENT_TYPE" --model "$MODEL" \
+    --json-schema "$JSON_SCHEMA" \
+    --agents "$agents_json" \
+    --setting-sources "" \
+    --no-session-persistence
+}
+
+run_agent_with_timeout() {
+  local out_file
+  out_file="$(mktemp)"
+  set -m
+  ( run_agent "$1" > "$out_file" 2>/dev/null; echo $? > "${out_file}.exit" ) &
+  local pid=$!
+  set +m
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$TIMEOUT_SECONDS" ]; then
+      kill -- "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      cat "$out_file" 2>/dev/null || true
+      rm -f "$out_file" "${out_file}.exit"
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null || true
+  local status
+  status="$(cat "${out_file}.exit" 2>/dev/null || echo 1)"
+  cat "$out_file"
+  rm -f "$out_file" "${out_file}.exit"
+  return "$status"
+}
+
+TOTAL=0
+HIT_COUNT=0
+MISS_LINES=""
+
+for case_dir in "$FIXTURE_SET_DIR"/case-*/; do
+  [ -d "$case_dir" ] || continue
+  case_name="$(basename "$case_dir")"
+  files_dir="${case_dir}files"
+  expected_file="${case_dir}expected.json"
+  if [ ! -d "$files_dir" ] || [ ! -f "$expected_file" ]; then
+    echo "eval-sweep-recall: $case_name はfiles/またはexpected.jsonが無いためスキップします" >&2
+    continue
+  fi
+  TOTAL=$((TOTAL + 1))
+  EXPECTED_PATH="$(jq -r '.expectedFilePathContains' "$expected_file")"
+
+  CLONE_DIR="$(mktemp -d)"
+  CLONE_EXIT=0
+  git clone --quiet --depth 1 "file://$REPO_DIR" "$CLONE_DIR/repo" || CLONE_EXIT=$?
+  if [ "$CLONE_EXIT" -ne 0 ]; then
+    rm -rf "$CLONE_DIR"
+    MISS_LINES="$MISS_LINES
+- [$case_name] NG: リポジトリのcloneに失敗しました(exit=$CLONE_EXIT)"
+    continue
+  fi
+  cp -r "$files_dir"/. "$CLONE_DIR/repo/"
+
+  BUILD_EXIT=0
+  PROMPT="$(node "$SCRIPT_DIR/lib/build-eval-prompt.mjs" "$CLONE_DIR/repo/.claude/workflows/lib/prompts/sweep.js" buildSweepPrompt "現在のコードベース全体の調査")" || BUILD_EXIT=$?
+  if [ "$BUILD_EXIT" -ne 0 ]; then
+    rm -rf "$CLONE_DIR"
+    MISS_LINES="$MISS_LINES
+- [$case_name] NG: プロンプトの構築に失敗しました(exit=$BUILD_EXIT)"
+    continue
+  fi
+
+  AGENT_EXIT=0
+  AGENT_OUTPUT="$(cd "$CLONE_DIR/repo" && run_agent_with_timeout "$PROMPT")" || AGENT_EXIT=$?
+  rm -rf "$CLONE_DIR"
+
+  if [ "$AGENT_EXIT" -ne 0 ]; then
+    MISS_LINES="$MISS_LINES
+- [$case_name] NG: エージェント実行が失敗しました(exit=$AGENT_EXIT)"
+    continue
+  fi
+
+  DETAIL_FILE="$(mktemp)"
+  printf '%s' "$AGENT_OUTPUT" | jq -r '.detail // ""' > "$DETAIL_FILE" 2>/dev/null || echo -n "" > "$DETAIL_FILE"
+  IS_HIT="$(EXPECTED_FILE="$expected_file" DETAIL_FILE="$DETAIL_FILE" python3 "$SCRIPT_DIR/lib/judge-sweep-recall.py")"
+  rm -f "$DETAIL_FILE"
+
+  if [ "$IS_HIT" = "true" ]; then
+    HIT_COUNT=$((HIT_COUNT + 1))
+    echo "[$case_name] HIT: 期待ファイル($EXPECTED_PATH)とキーワードの両方を検出"
+  else
+    MISS_LINES="$MISS_LINES
+- [$case_name] MISS: 期待ファイル($EXPECTED_PATH)またはキーワードを検出できず"
+  fi
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "eval-sweep-recall: $FIXTURE_SET_DIR に case-*/ ディレクトリが1件も見つかりませんでした" >&2
+  exit 1
+fi
+
+echo ""
+echo "=== eval-sweep-recall: $LAYER ==="
+echo "recall: $HIT_COUNT / $TOTAL"
+if [ -n "$MISS_LINES" ]; then
+  echo "$MISS_LINES"
+  exit 1
+fi
+exit 0

--- a/scripts/lib/judge-sweep-recall.py
+++ b/scripts/lib/judge-sweep-recall.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# scripts/eval-sweep-recall.shから呼ばれる決定的判定ロジック(issue #431)。
+# 環境変数EXPECTED_FILE(expected.jsonのパス)・DETAIL_FILE(sweep出力detailを書き出したファイル)
+# を読み、期待ファイルパスの部分文字列と期待キーワードのいずれか1つが両方detail内に
+# 含まれていれば"true"を出力する。ファイル経由にしているのは、detail文字列がシェル引用符・
+# バッククォート等を含んでも安全に受け渡すため。
+import json
+import os
+
+expected_path = os.environ["EXPECTED_FILE"]
+detail_path = os.environ["DETAIL_FILE"]
+
+with open(expected_path) as f:
+    expected = json.load(f)
+with open(detail_path) as f:
+    detail = f.read().lower()
+
+path_hit = expected["expectedFilePathContains"].lower() in detail
+keyword_hit = any(k.lower() in detail for k in expected["expectedKeywords"])
+
+print("true" if (path_hit and keyword_hit) else "false")


### PR DESCRIPTION
## Summary
issue #419のような設定変更（effort/model）の精度検証手段が無かった問題への対応。issue #391のeval基盤（`scripts/eval-workflow-prompts.sh`）と同じload-bearing workaroundを再利用し、既知欠陥を埋め込んだfixtureでsweep-*エージェントの見落とし率（recall）を測るharnessを新設した。

- `.claude/workflows/lib/prompts/sweep.js`: sweepプロンプトの正本を切り出し、`aidd-phase1.js`/`aidd-1-1-deep-task.js`との同期を`sweep-prompt-sync.test.js`で検証
- `scripts/eval-fixtures/sweep-{ui,data,db,types}/`: 既知の失敗パターン（`known-failure-patterns.md`）を埋め込んだfixture各1ケース（Suspenseフォールバック未設定・issue #24型のrequireAuth欠落・SECURITY DEFINER認可バイパス・型定義とmapperの層間不一致）
- `scripts/eval-sweep-recall.sh <layer>`: fixtureごとに任意のファイルツリーをclone先へ上書き配置し、決定的判定（期待ファイルパス＋キーワードのマッチ）でrecallを計測するharness
- `scripts/lib/judge-sweep-recall.py`: 判定ロジック（ファイル経由でdetail文字列を安全に受け渡し）

## 実機検証結果
- **sweep-ui**: recall 1/1 を実エージェントで確認済み
- **sweep-data**: harness経由の自動実行はタイムアウト・セッション利用上限に阻まれたが、同一fixtureへの手動実行で実際に`requireAuth`欠落を検出できることを確認済み（harnessに`--permission-mode bypassPermissions`が抜けていたバグを発見・修正、`--permission-mode bypassPermissions`はissue #401で確立済みの必須パターン）
- **sweep-db / sweep-types**: モックでのharness配線検証は完了。実機での最終確認はClaude Codeのセッション利用上限に達したため次回に持ち越し（docsに明記）

## Not in scope
- CI化（実エージェント呼び出しの課金コストのため、issue #391と同じ判断で手動実行のみ）
- precision（偽陽性率）側の計測は別issue #432で対応済み（マージ済み）

## Test plan
- [x] `npx vitest run .claude/workflows/lib/__tests__/`（19ファイル・110件 pass、既存テストの回帰なし）
- [x] `EVAL_SWEEP_RECALL_AGENT_CMD`によるモックで4層すべてのharness配線（HIT/MISS判定含む）を確認
- [x] sweep-uiを実エージェントで実行しrecall 1/1を確認
- [ ] sweep-db/sweep-typesの実機での最終確認（セッション利用上限のため次回セッションで実施推奨、docsに手順記載済み）

Ref #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)