### PR TITLE
docs: Bashサンドボックス機能(issue #438)の実機検証結果を記録し保留に

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -244,6 +244,13 @@ collectorであり、常時稼働ではない。issue #419（effortフィール�
   相当する属性は無く、`query_source`（例: `"main"`）等の粗い区別に留まる。サブエージェント
   単位での突合には、タイムスタンプの近接性等の追加のヒューリスティックが必要（未実装）。
 
+## Bashサンドボックス機能は現行toolchainと非互換のため保留（issue #438）
+
+実機検証の結果、`sandbox.enabled: true`はgh/supabase CLI（Go製）のHTTPS通信をTLS証明書検証
+エラーで壊すことが確認された。本プロジェクトの開発フローはgh・supabase CLIの両方に強く依存して
+おり導入できない。検証結果・原因の切り分け・再開条件は
+[`decisions.md`の該当項目](./decisions.md#なぜbashサンドボックス機能issue-438を導入せず保留にしたか)を参照。
+
 ## agents設定変更時のbaselineスナップショット機械強制（issue #429）
 
 issue #419の完了条件「loop-observabilityでbefore/afterのコスト・精度を比較」は、着手時点で

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -350,3 +350,52 @@ Spec CheckとManifest Checkで挙動が違う」「再検証結果が再現し�
 一部説明している可能性がある（過去の調査がどちらの呼び出し方を使ったかは記録が無く確認
 できないため、断定はできない）。今後ワークフロースクリプトの挙動を調査・検証する際は、
 `name`ではなく`scriptPath`で実ファイルを指定することを推奨する。
+
+## なぜBashサンドボックス機能（issue #438）を導入せず保留にしたか
+
+issue #438は、公式docs調査で見つかったBashサンドボックス機能（OSレベル分離、macOSはSeatbelt
+実装）を導入し、無人自律実行の安全基盤（データ流出経路の構造的な遮断）を強化する提案だった。
+実装前のゲート条件確認（公式ドキュメントでの仕様実機確認）の過程で、下書き前提との相違が
+複数見つかり、最終的に実機検証で「現行toolchainとは非互換」という結論に至った。
+
+**背景の経緯（下書き前提との相違、判明順）:**
+1. `sandbox.credentials`（deny/mask）は、セキュリティ設計上プロジェクト側設定
+   （`.claude/settings.local.json`含む）では無視され、ユーザー個人の`~/.claude/settings.json`
+   でしか効かない。リポジトリにコミット/共有できるのは`filesystem`/`network`設定のみ
+2. 下書きが想定していた「まずfallback許容モードで観測開始」という専用モードは公式には
+   存在しない。代わりに`allowUnsandboxedCommands`（既定true）がある
+
+**`filesystem.allowWrite`のスコープ設計（実装時点の判断）:** サンドボックスの目的が書き込み
+制限である以上、`$HOME/**`のような広い許可は制約を骨抜きにする。本プロジェクトのCLAUDE.md
+運用が実際にcwd外（`$HOME`配下）への書き込みを要求する箇所を`write_aidd_stats.sh`/
+`aidd_session_report.sh`の実装を読んで洗い出し、`~/.claude/aidd-session-stats/`（書き込み
+先ディレクトリ）と`~/.claude/pending_issues.jsonl`（issue自動作成用の単一ファイル）の2パスに
+個別列挙で絞った。この設計自体は妥当だったが、後述の通りそもそもsandbox自体が導入不能と
+判明したため未使用のまま終わっている。
+
+**実機検証で確定した非互換性:** 隔離ディレクトリ（本体リポジトリとは別）でheadlessセッション
+（`claude -p`）を用い、`sandbox.enabled: true`の複数パターンでgh/supabase CLIの動作を検証した。
+
+| 設定パターン | 認証方式 | 結果 |
+|---|---|---|
+| network.allowedDomains設定あり | keychain(通常) | `gh`がTLS証明書検証エラーで失敗（`x509: OSStatus -26276`） |
+| filesystem.allowWriteのみ（network設定なし） | keychain(通常) | `gh auth status`がkeychainアクセスエラーで失敗（2回再現） |
+| filesystem.allowWriteのみ（network設定なし、確認済み） | GH_TOKEN環境変数（keychain回避） | `gh issue list`がTLS証明書検証エラーで失敗（`x509: OSStatus -26276`） |
+| 同上 | SUPABASE_ACCESS_TOKEN環境変数（keychain回避） | `supabase projects list`が同一のTLS証明書検証エラーで失敗（`x509: OSStatus -26276`） |
+| サンドボックス無効（対照実験） | 通常 | `gh issue list`成功（終了コード0） |
+
+**結論:** `network.allowedDomains`の設定有無に関わらず、`sandbox.enabled: true`にした時点で
+Bashの通信がTLS中継の対象になる。keychain認証を環境変数トークンで迂回してもTLS層で同じ
+エラーが再発することから、keychainアクセスの問題とTLS中継の問題は別々に存在し、片方を回避
+してももう片方で壊れる、という二重の壁だった。gh・supabase CLIの両方で同一エラーが再現して
+おり、Go製CLI全般に共通する非互換性である可能性が高い（curlは同様の状況で成功しており、
+影響を受けるのはGoの`crypto/tls`がサンドボックスのTLS中継プロキシ証明書を信頼しないケースに
+限られると考えられる）。
+
+このリポジトリの開発フローはgh（issue/PR管理）・supabase CLI（migration/DB操作）の両方に
+強く依存しており、`sandbox.enabled: true`を有効化すると開発が成立しない。upstream側でTLS
+中継プロキシの証明書をGoバイナリが信頼できるようにする対応（またはサンドボックス側に除外
+設定）が提供されるまで、issue #438は保留とする。
+
+**再開条件:** Claude Code側のリリースノートでsandbox×Go製CLIの既知問題に対応が入った場合、
+またはTLS中継を回避しつつ書き込み制限のみ有効化する設定が新たに追加された場合。


### PR DESCRIPTION
## Summary
- issue #438（Bashサンドボックス機能によるOSレベル分離の導入）を実装しようとしたが、隔離ディレクトリでの実機検証により`sandbox.enabled: true`がgh/supabase CLI(Go製)のHTTPS通信をTLS証明書検証エラーで壊すことを確認した
- `network.allowedDomains`未設定でも発生し、keychain認証を環境変数トークンで迂回しても再発するため、根本的にGo製CLI全般との非互換性と判断
- 本プロジェクトの開発フローはgh(issue/PR管理)・supabase CLI(migration/DB操作)に強く依存しているため、issue #438は保留(`blocked`ラベル付与)とし、検証結果・原因の切り分け・再開条件を`docs/agents/decisions.md`に記録した

## 変更内容
- `docs/agents/common.md`: サンドボックス機能を保留にした旨と`decisions.md`への参照を追記
- `docs/agents/decisions.md`: 実機検証結果の表・下書き前提との相違・再開条件を記録

## Test plan
- [x] `.claude/settings.local.json`は個人設定でgitignore対象のため、今回の変更に含まれていない(サンドボックス設定は試行→ロールバック済みで最終的に無変更)
- [x] issue #438に検証結果をコメント投稿済み、`blocked`ラベル付与済み
- [x] ドキュメントのみの変更のためnpm test/lint影響なし

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #438実装着手 → 実機検証で導入不能と判明 → 保留理由を記録する方針に転換
- 変更した範囲: `docs/agents/common.md`・`docs/agents/decisions.md`（ドキュメントのみ）、issue #438へのコメント投稿・`blocked`ラベル新規作成/付与
- 触っていない範囲: プロダクトコード（`src/`・`supabase/migrations/`等）は無変更

### 検証済み
- 実行したコマンド: `npm test`/`npm run lint`は未実行（ドキュメントのみの変更のため対象外と判断。テスト忘れではなく意図的な省略）
- 確認した画面: なし（UI変更なし）
- 確認したDB/RLS: 対象外（facility/tenant/RLS/policyに触れる変更なし。Stop hookの機械判定でも確認済み）
- 他テナントIDでのアクセス確認: 対象外（RLS/facility境界に触れていないため不要）

### 既知の未対応
- 今回あえて対応しなかったこと: issue #438自体の実装（sandbox機能の有効化）
- 理由: `sandbox.enabled: true`がgh/supabase CLI(Go製)のHTTPS通信をTLS証明書検証エラーで無条件に壊すことを実機確認したため
- 次に触るなら見る場所: `docs/agents/decisions.md`「なぜBashサンドボックス機能（issue #438）を導入せず保留にしたか」の再開条件

### 後任AIへの注意
- **今回`.claude/settings.local.json`への`sandbox`ブロック追加は試行→ロールバック済みで、最終的には無変更（実施していない）。** もし将来sandbox設定に再挑戦する場合は、事前に隔離ディレクトリ（本体リポジトリ外、`env -C <dir> claude -p ... --permission-mode bypassPermissions --no-session-persistence`のパターン）でgh/supabase CLIの動作確認をしてから本体の`.claude/settings.local.json`に反映すること。本体リポジトリで直接試すと開発フローが止まる
- 似ているが別物の用語: `sandbox.credentials`（deny/mask、ユーザー個人の`~/.claude/settings.json`でしか有効にならない）と`filesystem`/`network`設定（プロジェクト側の`.claude/settings.local.json`でも有効）は有効スコープが異なる。同一視しないこと
- 勝手にリファクタしない場所: なし（今回はドキュメント追記のみ）

### 今後の運用課題（未対応・要検討）
`blocked`ラベルの再開条件（`decisions.md`記載）を誰がいつ見直すかの仕組みが未確立。Claude Codeのリリースノートを定期チェックする仕組みを作るか、「気づいたら見る」運用に留めるかは別途判断が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
