### PR TITLE
feat: PreToolUse hookでrouter迂回警告・直接DDL実行denyを機械強制(issue #444)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,6 +82,10 @@
       "Bash(bash scripts/verify-claims.test.sh*)",
       "Bash(scripts/check-skip-marker-write.sh *)",
       "Bash(bash scripts/check-skip-marker-write.test.sh*)",
+      "Bash(scripts/check-run-manifest-presence.sh *)",
+      "Bash(bash scripts/check-run-manifest-presence.test.sh*)",
+      "Bash(scripts/check-direct-ddl-execution.sh *)",
+      "Bash(bash scripts/check-direct-ddl-execution.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -154,6 +158,18 @@
         "matcher": "Bash|Write|Edit|MultiEdit",
         "hooks": [
           { "type": "command", "command": "scripts/check-skip-marker-write.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "scripts/check-run-manifest-presence.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Bash|mcp__.*execute_sql",
+        "hooks": [
+          { "type": "command", "command": "scripts/check-direct-ddl-execution.sh", "timeout": 5 }
         ]
       }
     ],

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -29,6 +29,12 @@ any code. Heed deprecation notices.
 この判定は人間の裁量で緩めない（機械判定）。迷ったら高リスク側に倒す。
 理由は [`decisions.md`](./decisions.md#なぜtririsk判定を機械判定にし人の裁量で緩めないことにしたか) を参照。
 
+`aidd-phase1-router`を経由せず直接実装に入った場合の検知（issue #444）: 上記の高リスクパスへの
+Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、PreToolUse hook
+（`scripts/check-run-manifest-presence.sh`）がブロックせず警告のみ注入する。ブロックしない
+理由・鮮度判定を見送った理由は同スクリプトのコメント、経緯は
+[`decisions.md`](./decisions.md#なぜissue-444のpretooluse-hookを警告のみdenyの二段構えにしたか)を参照。
+
 ## テスト環境・データ衛生ルール
 
 - **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。
@@ -42,7 +48,10 @@ any code. Heed deprecation notices.
 ## DBスキーマ変更ルール
 
 - **DBスキーマ変更は必ず `supabase/migrations/` 配下のマイグレーションファイル経由で行う。**
-  `execute_sql` 等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）
+  `execute_sql` 等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）。
+  `supabase db execute`・`psql`直接実行、およびMCP経由のexecute_sql系ツール呼び出しは
+  PreToolUse hook（`scripts/check-direct-ddl-execution.sh`、issue #444）で機械的にdenyされる
+  （`db push`/`db reset`等の正規のmigration適用手段は対象外）
 - マイグレーション外で本番/リモートDBに存在するスキーマ変更（トリガー・関数等）を発見した場合は、
   差分をキャッチアップ用マイグレーションとして必ず記録してから作業を進める
 - 理由（過去のスキーマドリフト事例）は [`decisions.md`](./decisions.md#なぜdbスキーマ変更をmigrationファイル経由に限定し直接ddl実行を禁止したか) を参照
@@ -418,13 +427,11 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 
 | ルール | 所在 | 備考 |
 |---|---|---|
-| `aidd-phase1-router`を入口に使うこと自体（TRI/RISK判定の実施） | 本ファイル「TRI/RISK 機械判定基準」 | 判定ロジック自体は機械的だが、routerを経由せず直接実装に入れば判定がまるごとスキップされる（優先度2候補） |
 | 引き継ぎフォーマットの実施 | 本ファイル「引き継ぎフォーマット」 | 既存Stop hook（`ai-check-suggest.sh`等）の拡張候補（優先度3候補） |
 | ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースのみ`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。「別issueの未マージPRが乗っている」ケースと`origin/main`起点確認自体は未検知のまま |
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
 | AIDD stats書き出し（各フェーズでの`write_aidd_stats.sh`呼び出し） | ルートの`CLAUDE.md` | 呼び忘れても気づく手段がない |
-| 直接DDL実行禁止（migration経由限定） | 本ファイル「DBスキーマ変更ルール」 | 事後のスキーマドリフト検知（issue #305）はあるが、実行しようとした瞬間に止める事前ブロックはない |
 | seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
 | `.claude/workflows/*.js` 変更時の`npm run eval:workflows`手動実行 | 本ファイル「AIDDワークフロープロンプトのeval」 | CI化は実エージェント呼び出しの課金コストで見送り。実行し忘れに気づく手段は無い（issue #391） |

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -399,3 +399,63 @@ Bashの通信がTLS中継の対象になる。keychain認証を環境変数ト�
 
 **再開条件:** Claude Code側のリリースノートでsandbox×Go製CLIの既知問題に対応が入った場合、
 またはTLS中継を回避しつつ書き込み制限のみ有効化する設定が新たに追加された場合。
+
+## なぜissue #444のPreToolUse hookを警告のみ/denyの二段構えにしたか
+
+issue #444（issue #339の優先度2候補2件の機械化）で、2本のPreToolUse hookを実装した。
+
+**① `scripts/check-run-manifest-presence.sh`（Write/Edit/MultiEdit、警告のみ）:**
+TRI/RISK基準に該当する高リスクパスへの書き込み時に`.aidd/run-manifest.json`が無ければ、
+`aidd-phase1-router`を経由せず直接実装に入った可能性を警告する。**ブロックしない**理由は、
+Phase 1調査の初期段階（run-manifest.jsonがまだ書き出されていない正当なタイミング）や、
+AIDDフローを使わない軽微な修正でも高リスクパスに触れることが普通にあり、これらを毎回denyや
+askで止めると開発体験を大きく損なうため。まずは`additionalContext`でモデルに気づかせる
+observeファーストの設計とした（issue #438の教訓とは別に、[OTel](#opentelemetryと自作jsonlの役割分担issue-417)・
+[baseline snapshot](#agents設定変更時のbaselineスナップショット機械強制issue-429)等と同じ
+「まず観測から」という一貫した方針）。
+
+v1スコープは**存在チェックのみ**とし、issue原案にあった「鮮度」（baseCommitと現在のHEADの
+乖離検知等）は見送った。長時間の実装セッションでは正当な理由でHEADが進むことが多く、
+鮮度判定を入れると誤検知率が上がるリスクの方が高いと判断した。
+
+**② `scripts/check-direct-ddl-execution.sh`（Bash + MCP、deny）:**
+`supabase db execute`・`psql`直接実行によるmigrationファイルを経由しないDDL適用を無条件で
+denyする。①と異なりwarningではなくdenyにした理由は、common.mdの既存ルール
+「execute_sql等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）」が既に
+例外なき禁止として明文化されており、「まず観測」の余地がない（正当なユースケースが
+存在しない）ため。`supabase db push`/`db reset`等はmigration適用の正規手段そのものであり
+対象外とした（denyすると正しいワークフローを壊す）。SQL内容の解析（DDL文かどうかの判定）は
+せず、コマンド/ツール自体を丸ごとdenyする設計とした（内容ベースの判定は誤検知・すり抜け
+双方のリスクが高く、`scripts/check-skip-marker-write.sh`と同じ設計方針）。
+
+**実装レビュー時に見つかったスコープの穴（MCPツール経由の抜け道）:** 当初の設計は
+`matcher: "Bash"`のみで、`supabase db execute`/`psql`のBash実行だけを対象にしていた。
+レビューで「Supabase MCPサーバーの`execute_sql`ツールを直接呼び出せば、このガードレールを
+素通りする」という指摘を受けた。確認したところ、このリポジトリの`.mcp.json`には現時点で
+Supabase MCPサーバーは定義されておらず、今すぐ悪用可能な状態ではなかったが、個人設定や
+将来の追加でMCPサーバーが有効化された場合に備え、matcherを`"Bash|mcp__.*execute_sql"`
+（サーバー名を固定しない正規表現）に拡張し、スクリプト側もcase文で両方を扱うようにした。
+common.mdの既存文言「execute_sql等」という書き方自体が、この種のMCPツールを念頭に置いた
+表現だったと考えられる。
+
+**実装中に実機で発見した2件のバグ（テスト作成時に自己適用して判明）:**
+1. `check-run-manifest-presence.sh`の初期実装は、`tool_input.file_path`が絶対パスの場合に
+   そのままドメインキーワード（`inventory`等）と正規表現照合していた。このリポジトリ自身が
+   「medical-inventory-vkumai」という名前のため、**リポジトリ内外を問わずあらゆる書き込みで
+   常に誤検知する**バグだった。実際にこのhookを自分自身で動かした際、スクラッチディレクトリ
+   （リポジトリ外）への無関係なファイル書き込みで発火し、その場で発覚した。修正として、
+   `tool_input.file_path`を必ずリポジトリルートからの相対パスに正規化してから照合するように
+   変更した。単純な文字列prefix比較では不十分で、macOSの`/var` → `/private/var`シンボリック
+   リンクにより`git rev-parse --show-toplevel`（正規化済みパスを返す）と`tool_input.file_path`
+   （非正規化パスのことがある）が文字列として一致しないケースがテスト作成時に発覚したため、
+   `python3`の`os.path.realpath`で両者を同じ基準に正規化してから`os.path.relpath`で相対パスを
+   求める方式にした。
+2. `check-direct-ddl-execution.sh`の初期実装は、コマンド境界の表現に`\b`（単語境界）を
+   使っていたが、bashの`[[ =~ ]]`（POSIX ERE相当）は`\b`を単語境界として解釈せず、
+   パターンごと静かにマッチしなくなっていた（`supabase db execute`が検知されないという
+   形でテスト失敗として顕在化）。`[[:space:]]|$`を使った明示的な境界表現に置き換えて修正した。
+
+いずれも「テストを書いて実際に動かす」ことで発見できたバグであり、レビューコメントの指摘
+（MCPツールの抜け道）とは独立に、実装者自身のセルフテストで見つかった。issue #438の
+「実装前に実機確認する」という教訓の延長で、「実装後もテストで実機確認する」ことの価値を
+改めて示す事例になった。

--- a/scripts/check-direct-ddl-execution.sh
+++ b/scripts/check-direct-ddl-execution.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse hook。issue #444（issue #339「直接DDL実行禁止は事後のドリフト検知(issue #305)
+# のみで、実行しようとした瞬間に止める事前ブロックはない」の機械化・優先度2候補）。
+#
+# docs/agents/common.md「DBスキーマ変更ルール」の
+# 「execute_sql等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）」を、
+# ブロックせず警告するだけのPreToolUse hookとは異なり、実行そのものをdenyする形で機械強制する。
+#
+# 対象は「migrationファイルを経由しないアドホックなSQL実行」に絞る:
+# - Bash経由の `supabase db execute` / `psql` 直接呼び出し
+# - MCPツール経由の execute_sql系ツール（例: mcp__supabase__execute_sql）。このリポジトリの
+#   .mcp.jsonには現時点でSupabase MCPサーバーは定義されていないが、個人設定や将来の追加で
+#   有効化された場合にBash側のガードを素通りする抜け道になるため、matcherレベルで先回りして
+#   塞ぐ（issue #444レビュー時の指摘）。サーバー名を固定しない正規表現で、将来サーバー名が
+#   変わっても拾えるようにしている。
+#
+# `supabase db push` / `db reset` / `functions deploy` 等は対象外（migrationファイルを適用する
+# 正規の手段そのもの、またはDB操作でも「直接DDL適用」に該当しないため）。既にsettings.jsonで
+# askとして人間の確認を要求している。
+#
+# SQL内容の解析（DDL文かどうかの判定）はしない。コマンド/ツール自体を丸ごとdenyする
+# （内容ベースの判定は誤検知・すり抜け双方のリスクが高いため。scripts/check-skip-marker-write.sh
+# と同じ設計方針）。
+#
+# 対象ツール: Bash / mcp__*execute_sql*（case文のパターン）。.claude/settings.jsonのmatcher
+# （"Bash|mcp__.*execute_sql"）と本スクリプトのcase文の両方を揃える必要がある。
+
+# WHY: bashの[[ =~ ]]（ERE）は\bを単語境界として解釈しない(実機確認済み: パターンごと
+# 静かにマッチしなくなる)。[[:space:]]|$ で明示的に境界を表現する。
+DIRECT_EXEC_PATTERN='(^|[;&[:space:]])(npx[[:space:]]+)?supabase[[:space:]]+db[[:space:]]+execute([[:space:]]|$)|(^|[;&[:space:]])psql([[:space:]]|$)'
+
+INPUT="$(cat)"
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')"
+
+DENY=0
+REASON=""
+
+case "$TOOL_NAME" in
+  Bash)
+    COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+    if [[ "$COMMAND" =~ $DIRECT_EXEC_PATTERN ]]; then
+      DENY=1
+      REASON="supabase db execute・psqlの直接実行はDBスキーマ変更ルール（migration経由）で禁止されています。supabase/migrations/配下にマイグレーションファイルを作成し、supabase db pushで適用してください。"
+    fi
+    ;;
+  mcp__*execute_sql*)
+    DENY=1
+    REASON="MCPツール経由のSQL直接実行はDBスキーマ変更ルール（migration経由）で禁止されています。supabase/migrations/配下にマイグレーションファイルを作成してください。"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [[ "$DENY" -eq 1 ]]; then
+  jq -n --arg reason "$REASON" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+fi
+
+exit 0

--- a/scripts/check-direct-ddl-execution.test.sh
+++ b/scripts/check-direct-ddl-execution.test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# WHY: issue #444向けのPreToolUse hook(scripts/check-direct-ddl-execution.sh)の回帰テスト。
+# supabase db execute/psqlの直接実行、およびMCP経由のexecute_sql系ツール呼び出しを
+# permissionDecision: "deny"で拒否すること・db push等の正規手段は対象外であることを確認する。
+#
+# 実行: bash scripts/check-direct-ddl-execution.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-direct-ddl-execution.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+run_hook() {
+  local input="$1"
+  set +e
+  OUT="$(printf '%s' "$input" | bash "$SCRIPT")"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: supabase db execute → deny ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "supabase db execute --sql \"select 1\""}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "deny"' "permissionDecision: denyが出力される"
+
+echo "=== scenario 2: npx supabase db execute → deny ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "npx supabase db execute --sql \"alter table x add column y int\""}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "deny"' "permissionDecision: denyが出力される"
+
+echo "=== scenario 3: psql直接実行 → deny ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "psql postgres://localhost/db -c \"drop table x\""}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "deny"' "permissionDecision: denyが出力される"
+
+echo "=== scenario 4: supabase db push → 対象外(正規のmigration適用手段) ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "supabase db push"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(db pushはdeny対象外)"
+
+echo "=== scenario 5: supabase db reset → 対象外 ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "supabase db reset"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(db resetはdeny対象外)"
+
+echo "=== scenario 6: 無関係な通常コマンド(npm test) → 何も出力しない ==="
+input="$(jq -n '{tool_name: "Bash", tool_input: {command: "npm test"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 7: MCP経由のexecute_sqlツール(mcp__supabase__execute_sql) → deny ==="
+input="$(jq -n '{tool_name: "mcp__supabase__execute_sql", tool_input: {sql: "drop table x"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "deny"' "permissionDecision: denyが出力される(MCPツール経由でも素通りしない)"
+
+echo "=== scenario 8: MCPでもexecute_sql以外のツール(mcp__supabase__apply_migration)は対象外 ==="
+input="$(jq -n '{tool_name: "mcp__supabase__apply_migration", tool_input: {name: "x", query: "create table x()"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(apply_migrationは正規のmigration適用手段)"
+
+echo "=== scenario 9: サーバー名が異なるMCPツール(mcp__postgres__execute_sql)でも検知する(サーバー名非依存の設計確認) ==="
+input="$(jq -n '{tool_name: "mcp__postgres__execute_sql", tool_input: {sql: "drop table x"}}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "deny"' "permissionDecision: denyが出力される"
+
+echo "=== scenario 10: .claude/settings.jsonのmatcherが両パターンをカバーしている(Bash・mcp__.*execute_sql) ==="
+SETTINGS_FILE="$SCRIPT_DIR/../.claude/settings.json"
+MATCHER="$(jq -r '.hooks.PreToolUse[] | select(.hooks[].command | endswith("check-direct-ddl-execution.sh")) | .matcher' "$SETTINGS_FILE")"
+assert_contains "$MATCHER" "Bash" "matcherにBashが含まれる"
+assert_contains "$MATCHER" "execute_sql" "matcherにexecute_sqlパターンが含まれる"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/check-run-manifest-presence.sh
+++ b/scripts/check-run-manifest-presence.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse hook。issue #444（issue #339「aidd-phase1-routerを経由せず直接実装に入れば
+# 判定がまるごとスキップされる」の機械化・優先度2候補）。
+#
+# TRI/RISK基準（docs/agents/common.md「TRI/RISK 機械判定基準」）に該当する高リスクパスへの
+# 書き込み(Write/Edit/MultiEdit)時に、.aidd/run-manifest.json（docs/agents/run-manifest.md）が
+# 存在しなければ、ブロックせず警告のみをモデルに注入する（permissionDecision: "allow" +
+# additionalContext）。人間の確認を要求する"ask"や実行そのものを止める"deny"ではない。
+#
+# v1スコープの明示（ファイル名を "presence" とした理由）:
+# 本スクリプトはrun-manifest.jsonの**存在**のみを見る。issue #444の設計案が挙げていた
+# 「鮮度」（baseCommitが現在のHEADと大きくズレていないか等）は、実装セッションが長時間に
+# 及ぶ場合の誤検知リスクが高く、このプロジェクトの「まず観測から始める」方針
+# （decisions.md「なぜ新しい運用ルールに『検知手段を先に決める』原則を導入したか」等）に
+# 合わせて今回は見送った。鮮度判定を追加する場合は本ファイルを拡張するか、ファイル名ごと
+# 見直すこと。
+#
+# 対象ツール: Write / Edit / MultiEdit（tool_input.file_pathに書き込み先が現れる）。
+# .claude/settings.jsonのmatcherと本スクリプトのcase文の両方を揃える必要がある。
+
+HIGH_RISK_PATTERN='(^|/)supabase/migrations/|(^|/)src/lib/supabase/|(^|/)middleware\.ts$|[Aa]uth|[Ff]acility|[Tt]enant|[Oo]rganization|[Ii]nventory|[Rr][Ll][Ss]|[Pp]olicy'
+
+INPUT="$(cat)"
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')"
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // ""')"
+
+TARGET=""
+case "$TOOL_NAME" in
+  Write|Edit|MultiEdit)
+    TARGET="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [[ -z "$TARGET" ]]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git -C "${CWD:-.}" rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# WHY: tool_input.file_pathは絶対パスで渡ってくることがある。絶対パスのまま
+# HIGH_RISK_PATTERNと照合すると、リポジトリの置き場所（worktreeパス等）自体に
+# "inventory"のようなドメイン語が含まれているだけで常に誤検知する
+# （実機で発見: /private/tmp/.../medical-inventory-vkumai/... への無関係な書き込みで発火した）。
+# 必ずリポジトリルートからの相対パスに正規化してから照合する。
+#
+# 単純な文字列prefix比較(${TARGET#"$REPO_ROOT"/})はmacOSで実際に破綻することを実機確認済み:
+# `git rev-parse --show-toplevel`はシンボリックリンクを解決した正規パス(/private/var/...)を
+# 返すが、tool_input.file_path/cwdは非正規パス(/var/...、/varは/private/varへのシンボリック
+# リンク)のまま渡ってくることがあり、文字列としては一致しない。python3のos.path.realpathで
+# 両者を同じ基準に正規化してから比較する（このリポジトリの他スクリプトと同様、pathlib的な
+# 処理はpython3に委ねる方針）。
+RELATIVE_TARGET="$TARGET"
+if [[ "$TARGET" = /* ]]; then
+  if [[ -z "$REPO_ROOT" ]]; then
+    exit 0
+  fi
+  RELATIVE_TARGET="$(python3 -c '
+import os, sys
+target, repo_root = sys.argv[1], sys.argv[2]
+real_target = os.path.realpath(target)
+real_root = os.path.realpath(repo_root)
+rel = os.path.relpath(real_target, real_root)
+if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+    sys.exit(1)
+print(rel)
+' "$TARGET" "$REPO_ROOT")" || exit 0
+fi
+
+if ! [[ "$RELATIVE_TARGET" =~ $HIGH_RISK_PATTERN ]]; then
+  exit 0
+fi
+
+MANIFEST_PATH="${REPO_ROOT:-${CWD:-.}}/.aidd/run-manifest.json"
+
+if [[ -f "$MANIFEST_PATH" ]]; then
+  exit 0
+fi
+
+jq -n --arg ctx "高リスクパス($TARGET)への変更ですが、.aidd/run-manifest.jsonが見当たりません。aidd-phase1-routerを経由せず直接実装に入っていないか確認してください（意図した変更であればこのまま進めて構いません）。" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", additionalContext: $ctx}}'
+
+exit 0

--- a/scripts/check-run-manifest-presence.test.sh
+++ b/scripts/check-run-manifest-presence.test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# WHY: issue #444向けのPreToolUse hook(scripts/check-run-manifest-presence.sh)の回帰テスト。
+# 合成したtool_name/tool_inputのhook入力JSONを標準入力で渡し、高リスクパスへの書き込み時に
+# .aidd/run-manifest.jsonが無ければpermissionDecision: "allow" + additionalContextを
+# 返すこと・それ以外は何も出力しないことを確認する。
+#
+# 実行: bash scripts/check-run-manifest-presence.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-run-manifest-presence.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+run_hook() {
+  local input="$1"
+  set +e
+  OUT="$(printf '%s' "$input" | bash "$SCRIPT")"
+  EXIT_CODE=$?
+  set -e
+}
+
+# manifest無しの隔離リポジトリを用意
+NO_MANIFEST_REPO="$(mktemp -d)"
+git -C "$NO_MANIFEST_REPO" init -q
+mkdir -p "$NO_MANIFEST_REPO/src/lib/supabase"
+
+# manifest有りの隔離リポジトリを用意
+WITH_MANIFEST_REPO="$(mktemp -d)"
+git -C "$WITH_MANIFEST_REPO" init -q
+mkdir -p "$WITH_MANIFEST_REPO/src/lib/supabase" "$WITH_MANIFEST_REPO/.aidd"
+echo '{}' > "$WITH_MANIFEST_REPO/.aidd/run-manifest.json"
+
+# issue #444レビュー中に実機で発見した誤検知の回帰テスト用: リポジトリの置き場所自体に
+# ドメイン語("inventory")が含まれるケース(このリポジトリ自身が"medical-inventory-vkumai"
+# という名前であることに由来する)
+INVENTORY_NAMED_PARENT="$(mktemp -d)/medical-inventory-fixture"
+mkdir -p "$INVENTORY_NAMED_PARENT"
+git -C "$INVENTORY_NAMED_PARENT" init -q
+
+cleanup() { rm -rf "$NO_MANIFEST_REPO" "$WITH_MANIFEST_REPO" "$(dirname "$INVENTORY_NAMED_PARENT")"; }
+trap cleanup EXIT
+
+echo "=== scenario 1: 高リスクパス(src/lib/supabase配下) + manifest無し → allow+additionalContext ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Edit", tool_input: {file_path: "src/lib/supabase/client.ts", old_string: "x", new_string: "y"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される"
+assert_contains "$OUT" "additionalContext" "additionalContextフィールドが出力される"
+
+echo "=== scenario 2: 高リスクパス + manifest有り → 何も出力しない ==="
+input="$(jq -n --arg cwd "$WITH_MANIFEST_REPO" '{tool_name: "Edit", tool_input: {file_path: "src/lib/supabase/client.ts", old_string: "x", new_string: "y"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(manifestが存在するため警告不要)"
+
+echo "=== scenario 3: 低リスクパス(README.md) + manifest無し → 何も出力しない ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Edit", tool_input: {file_path: "README.md", old_string: "x", new_string: "y"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(低リスクパスのため対象外)"
+
+echo "=== scenario 4: supabase/migrations/配下 + manifest無し → allow+additionalContext ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Write", tool_input: {file_path: "supabase/migrations/20260101000000_add_x.sql", content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される"
+
+echo "=== scenario 5: middleware.ts + manifest無し → allow+additionalContext ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Write", tool_input: {file_path: "middleware.ts", content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される"
+
+echo "=== scenario 6: facility関連ファイル名 + manifest無し → allow+additionalContext ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Write", tool_input: {file_path: "src/components/FacilitySelector.tsx", content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される"
+
+echo "=== scenario 7: MultiEditツールでも同様に検知する(matcher抜け漏れ防止) ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "MultiEdit", tool_input: {file_path: "src/lib/supabase/queries.ts", edits: [{old_string: "x", new_string: "y"}]}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される"
+
+echo "=== scenario 7b: 絶対パスかつリポジトリ名自体にドメイン語('inventory')を含む + 低リスクな相対パス → 何も出力しない(実機で発見した誤検知の回帰テスト) ==="
+input="$(jq -n --arg cwd "$INVENTORY_NAMED_PARENT" --arg fp "$INVENTORY_NAMED_PARENT/README.md" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(リポジトリ名の'inventory'ではなく相対パスで判定する)"
+
+echo "=== scenario 7c: 絶対パスかつリポジトリ名自体にドメイン語を含む + 高リスクな相対パス → allow+additionalContext(相対パス側は正しく検知する) ==="
+input="$(jq -n --arg cwd "$INVENTORY_NAMED_PARENT" --arg fp "$INVENTORY_NAMED_PARENT/src/lib/supabase/client.ts" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" '"permissionDecision": "allow"' "permissionDecision: allowが出力される(相対パス側のsupabaseで正しく検知)"
+
+echo "=== scenario 7d: 絶対パスがリポジトリの外(REPO_ROOT配下ではない) → 何も出力しない ==="
+OUTSIDE_FILE="$(mktemp -d)/inventory-unrelated-scratch-file.ts"
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" --arg fp "$OUTSIDE_FILE" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(リポジトリ外への書き込みは対象外)"
+rm -rf "$(dirname "$OUTSIDE_FILE")"
+
+echo "=== scenario 8: Bashツールは対象外(matcherに含まれない) → 何も出力しない ==="
+input="$(jq -n --arg cwd "$NO_MANIFEST_REPO" '{tool_name: "Bash", tool_input: {command: "cat src/lib/supabase/client.ts"}, cwd: $cwd}')"
+run_hook "$input"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である(Bashは対象ツール外)"
+
+echo "=== scenario 9: .claude/settings.jsonのmatcherと本スクリプトのcase文のツール一覧が一致する ==="
+SETTINGS_FILE="$SCRIPT_DIR/../.claude/settings.json"
+MATCHER_TOOLS="$(jq -r '.hooks.PreToolUse[] | select(.hooks[].command | endswith("check-run-manifest-presence.sh")) | .matcher' "$SETTINGS_FILE" | tr '|' '\n' | sort)"
+CASE_TOOLS="$(grep -oE '^  [A-Za-z]+(\|[A-Za-z]+)*\)' "$SCRIPT" | grep -v '^  \*)' | tr -d ' )' | tr '|' '\n' | sort -u)"
+assert_eq "$CASE_TOOLS" "$MATCHER_TOOLS" "settings.jsonのmatcherとcase文のツール一覧(Write/Edit/MultiEdit)が一致する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- issue #444の1・2（PreToolUseベースの部分）を実装した。issue #339の優先度2候補2件の機械化にあたる
  - `aidd-phase1-router`を経由せず直接実装に入れば判定がまるごとスキップされる → 高リスクパスへの書き込み時、`.aidd/run-manifest.json`不在ならブロックせず警告のみ注入（`scripts/check-run-manifest-presence.sh`）
  - 直接DDL実行禁止は事後のドリフト検知のみで事前ブロックがない → `supabase db execute`/`psql`直接実行、およびMCP経由の`execute_sql`系ツールを無条件deny（`scripts/check-direct-ddl-execution.sh`）。`db push`/`db reset`等の正規のmigration適用手段は対象外
- 3番目（ConfigChange系イベントによる設定変更監査）は別途ゲート条件（イベント実在確認）が必要なため、今回のスコープ外

## レビューで見つかった設計の穴
当初`check-direct-ddl-execution.sh`のmatcherは`Bash`のみだったが、レビューで「Supabase MCPサーバーの`execute_sql`ツールを直接呼び出せばBashのガードを素通りする」という指摘を受けた。このリポジトリの`.mcp.json`には現時点でSupabase MCPサーバーは定義されていないが、将来の追加に備えmatcherを`Bash|mcp__.*execute_sql`（サーバー名非依存の正規表現）に拡張した。

## 実装中に発見・修正した2件の実バグ
テスト作成中に自己適用して発覚したもの（レビュー指摘とは独立）:
1. `check-run-manifest-presence.sh`の初期実装は絶対パスのままドメインキーワードと照合しており、このリポジトリ自身の名前「medical-inventory-vkumai」の"inventory"に常に誤ヒットしていた。リポジトリルートからの相対パスに正規化して修正（macOSの`/var`→`/private/var`シンボリックリンクでの文字列prefix比較の破綻もあわせて発見し、`python3`の`os.path.realpath`ベースの比較に変更）
2. `check-direct-ddl-execution.sh`の初期実装は`\b`（単語境界）を使っていたが、bashの`[[ =~ ]]`はこれを解釈せず`supabase db execute`が検知されなかった。`[[:space:]]|$`による明示的な境界表現に置き換えて修正

詳細な経緯は`docs/agents/decisions.md`「なぜissue #444のPreToolUse hookを警告のみ/denyの二段構えにしたか」を参照。

## 変更内容
- `scripts/check-run-manifest-presence.sh` / `.test.sh`（新規）
- `scripts/check-direct-ddl-execution.sh` / `.test.sh`（新規）
- `.claude/settings.json`: PreToolUse hooksに2エントリ追加
- `docs/agents/common.md`: 該当ルールから新hookへのリンクを追加、「検知手段のないルールの棚卸し」表から該当2行を削除
- `docs/agents/decisions.md`: 設計判断・実装中に見つかったバグの記録を追加

## Test plan
- [x] `bash scripts/check-run-manifest-presence.test.sh` 全12シナリオ通過
- [x] `bash scripts/check-direct-ddl-execution.test.sh` 全10シナリオ通過
- [x] `bash scripts/check-skip-marker-write.test.sh`（既存hook）で回帰なしを確認
- [x] `bash -n` で両スクリプトの構文チェック、`jq empty .claude/settings.json` でJSON構文チェック
- [x] TypeScript/JSファイルへの変更なし（`npm test`/`lint`/`typecheck`は対象外と判断）

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #444の1・2（PreToolUseベースの部分）実装
- 変更した範囲: `.claude/settings.json`のPreToolUse hooks・`scripts/check-run-manifest-presence*`・`scripts/check-direct-ddl-execution*`・`docs/agents/common.md`・`docs/agents/decisions.md`
- 触っていない範囲: issue #444の3番目（ConfigChange監査）は未実装。プロダクトコード（`src/`・`supabase/migrations/`実体）は無変更

### 検証済み
- 実行したコマンド: 上記Test plan参照。`npm test`/`npm run lint`は対象ファイルがTS/JSでないため未実行（意図的な省略）
- 確認した画面: なし（UI変更なし）
- 確認したDB/RLS: 対象外（hookはRLSポリシー自体を変更しない。ただし高リスクパス判定にRLS/facility等のドメインキーワードを使っているため、判定ロジック自体はfacilityドメインに間接的に関連する）
- 他テナントIDでのアクセス確認: 対象外

### 既知の未対応
- 今回あえて対応しなかったこと: issue #444の3番目（設定変更監査、ConfigChange系イベント）
- 理由: ConfigChange系イベントの実在・正確なイベント名・ペイロード仕様の確認（ゲート条件）が必要で、今回はPreToolUseの2件（実在確認済み・実機検証済み）のみに絞った
- 次に触るなら見る場所: issue #444本文の3番目の設計案

### 後任AIへの注意
- `check-run-manifest-presence.sh`のv1スコープは**存在チェックのみ**。「鮮度」（baseCommitと現在HEADの乖離検知）は意図的に見送った設計判断であり、実装漏れではない
- `check-direct-ddl-execution.sh`のmatcherを変更する場合、`.claude/settings.json`側とスクリプトのcase文の両方を揃えること（`check-skip-marker-write.test.sh`と同様の一致テストが両新規スクリプトにもある）
- PreToolUse hookで絶対パスをファイルパスパターンと照合する場合、文字列prefix比較ではなくrealpathベースの正規化を使うこと（今回のバグそのもの。このリポジトリ名に"inventory"を含むため特に踏みやすい罠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
