### PR TITLE
docs: autoMode(hard_deny)を個人設定オプトイン化し設定し忘れをSessionStart hookで検知(issue #439)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,6 +86,8 @@
       "Bash(bash scripts/check-run-manifest-presence.test.sh*)",
       "Bash(scripts/check-direct-ddl-execution.sh *)",
       "Bash(bash scripts/check-direct-ddl-execution.test.sh*)",
+      "Bash(scripts/check-automode-config.sh *)",
+      "Bash(bash scripts/check-automode-config.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -148,6 +150,11 @@
           {
             "type": "command",
             "command": "scripts/check-otel-collector-status.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-automode-config.sh",
             "timeout": 5
           }
         ]

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -260,6 +260,36 @@ collectorであり、常時稼働ではない。issue #419（effortフィール�
 おり導入できない。検証結果・原因の切り分け・再開条件は
 [`decisions.md`の該当項目](./decisions.md#なぜbashサンドボックス機能issue-438を導入せず保留にしたか)を参照。
 
+## autoMode(hard_deny)は個人設定のみ有効・設定し忘れ検知はSessionStart hookで（issue #439）
+
+`autoMode.hard_deny`（ユーザー意図でも上書き不可の無条件ブロック）は、公式仕様上
+**ユーザー個人の`~/.claude/settings.json`でしか読まれない**（プロジェクト側の
+`.claude/settings.json`・`.claude/settings.local.json`はリポジトリが自身に許可ルールを
+注入するのを防ぐため対象外。出典・理由は
+[`decisions.md`の該当項目](./decisions.md#なぜautomodehard_denyを個人設定のみにしsessionstart-hookで設定し忘れを検知することにしたかissue-439)を参照）。
+このためリポジトリにコミットして全員へ強制することはできない。
+
+**有効化したい場合、各自の`~/.claude/settings.json`に以下を追加する（推奨設定・任意）:**
+
+```json
+{
+  "autoMode": {
+    "environment": "Supabase(prod)には患者・施設の実データが保存されている。supabase/migrations/配下がRLSポリシーの正本。",
+    "hard_deny": [
+      "患者・施設の実データをSupabase以外のドメイン（外部API・PR本文・issue本文等）へ送信しない",
+      "RLS policyの無効化・変更をブロックする",
+      "本番Supabaseへの直接DDL実行をブロックする"
+    ]
+  }
+}
+```
+
+**設定し忘れ検知**: `scripts/check-automode-config.sh`（SessionStart hook）が、個人設定に
+`autoMode.hard_deny`が無ければセッション開始時に警告する（block不可・warningのみ）。
+「ドキュメントに書いただけでは気づかれない」という同型の問題（issue #423の発端になった
+loop-observability記録漏れ等）を繰り返さないための対応。ただし内容の妥当性までは検証せず、
+`hard_deny`に1件以上のルールがあるかという存在チェックに留まる。
+
 ## agents設定変更時のbaselineスナップショット機械強制（issue #429）
 
 issue #419の完了条件「loop-observabilityでbefore/afterのコスト・精度を比較」は、着手時点で

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -459,3 +459,51 @@ common.mdの既存文言「execute_sql等」という書き方自体が、この
 （MCPツールの抜け道）とは独立に、実装者自身のセルフテストで見つかった。issue #438の
 「実装前に実機確認する」という教訓の延長で、「実装後もテストで実機確認する」ことの価値を
 改めて示す事例になった。
+
+## なぜautoMode(hard_deny)を個人設定のみにし、SessionStart hookで設定し忘れを検知することにしたか（issue #439）
+
+issue #439は当初「autoMode設定(hard_deny)で医療データ外部送信・RLS無効化を無条件ブロックする」
+という機能導入提案だったが、ゲート条件確認（公式ドキュメント実機確認）の結果、issue #438の
+`sandbox.credentials`と同型の制約が判明し、方針を変更した。
+
+**確認した事実（推測ではなく公式ドキュメントの原文で確認済み）:** `autoMode`のclassifierは
+`.claude/settings.json`・`.claude/settings.local.json`（どちらもリポジトリのディレクトリ内に
+存在するファイル）から`autoMode`設定を読まない。
+出典: https://code.claude.com/docs/en/auto-mode-config.md 「Where the classifier reads
+configuration」セクション。理由も明記されている: "a checked-in repo or a build step could
+otherwise inject its own allow rules"（コミットされたリポジトリやビルドステップが、独自の
+許可ルールを勝手に注入できてしまうため）。`.claude/settings.local.json`を対象外にしている
+理由も同様（"Excluding .claude/settings.local.json also closes the case where a repository
+commits the file or a local tool or build step writes it."）。
+
+この事実確認自体、当初は調査エージェントの要約を鵜呑みにしそうになったが、「その理由は
+本当にドキュメントに書かれているのか、それとも推測か」という指摘を受けて出典URLと原文引用を
+再確認する一手間を挟んだ。issue #438の「実装前に実機確認する」を、「実機確認の結果自体も
+一次情報で裏取りする」までもう一段踏み込んだ形。
+
+**判明した仕様（下書き想定と一致した部分）:** キー名（`environment`/`hard_deny`/`soft_deny`/
+`allow`）・評価順序（`hard_deny → soft_deny → allow → 明示的なユーザー意図`、`permissions.deny`
+より後に評価される追加の層）は下書きどおりだった。
+
+**判明した既知の限界（下書きに無かった情報）:** 各classifier呼び出しはトークンコストが
+増加する。また3回連続/20回総ブロックで自動fallbackする仕様があり、「ユーザー意図でも
+上書き不可の無条件ブロック」という説明どおりには機能しきらない可能性がある（一定数
+ブロックが続くと効かなくなる）。
+
+**結論・設計判断:** `autoMode`はプロジェクト側にコミットして全員へ強制する形では実装
+できない。issue #438のcredentials設定と同じ構造的制約であり、[「Bashサンドボックス機能は
+現行toolchainと非互換のため保留」](#なぜbashサンドボックス機能issue-438を導入せず保留にしたか)
+と同種の判断が必要になった。ただし#438（toolchain非互換で使用そのものが不可能）とは異なり、
+#439は「使うこと自体は個人設定で可能・プロジェクト側からは強制できないだけ」という違いが
+あるため、保留にはせず「推奨設定をdocs/agents/common.mdに文書化し、各自の
+`~/.claude/settings.json`への追加を促す」個人オプトイン方式で実装した。
+
+**「書いただけでは気づかれない」への追加対応:** ドキュメント化のみで終えると、issue #423
+（loop-observability記録漏れ、自然言語指示への依存が実際に5日分の記録欠落を招いた事例）と
+同型の弱さが残るという指摘を受け、`scripts/check-automode-config.sh`（SessionStart hook）を
+追加した。個人設定に`autoMode.hard_deny`が存在しなければセッション開始時に警告する
+（block不可・warningのみ、`check-otel-collector-status.sh`と同じパターン）。ただし
+`hard_deny`の**内容**（実際に医療データ外部送信・RLS無効化を正しくカバーしているか）までは
+検証しない。存在チェックに留めた理由は、`environment`/`hard_deny`が自然言語記述であり、
+内容の妥当性を機械的に判定する信頼できる方法が無いため（issue #438のcredentials同様、
+platform側の内部メカニズムが完全には文書化されていない）。

--- a/scripts/check-automode-config.sh
+++ b/scripts/check-automode-config.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart hookから呼ばれる。issue #439: autoMode(hard_deny)による医療データ外部送信・
+# RLS無効化の無条件ブロックは、公式仕様上ユーザー個人の~/.claude/settings.jsonでしか
+# 有効にならず（.claude/settings.json・settings.local.jsonからは読まれない設計。
+# 出典: https://code.claude.com/docs/en/auto-mode-config.md
+# 「Where the classifier reads configuration」）、このリポジトリにコミットして全員へ
+# 強制することができない。docs/agents/common.mdへの文書化だけでは「書いたのに
+# 気づかれない」という同型の問題（issue #423の発端になったloop-observability記録漏れ等）を
+# 繰り返すリスクがあるため、check-otel-collector-status.shと同じパターンで
+# 「設定し忘れても気づける」形の検知を追加する。
+#
+# block（session開始そのものの停止）はできない前提のためwarningのみ。autoModeを
+# 個人設定として導入するかどうかの判断自体は人間に委ねる（強制はしない）。
+#
+# テスト容易性のため、ユーザー設定ファイルのパスは環境変数で上書き可能にしている
+# （デフォルトは $HOME/.claude/settings.json）。
+
+SETTINGS_PATH="${CLAUDE_USER_SETTINGS_PATH:-$HOME/.claude/settings.json}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+if [ ! -f "$SETTINGS_PATH" ]; then
+  HAS_HARD_DENY="false"
+else
+  HAS_HARD_DENY="$(jq -r '(.autoMode.hard_deny // []) | length > 0' "$SETTINGS_PATH" 2>/dev/null || echo "false")"
+fi
+
+if [ "$HAS_HARD_DENY" = "true" ]; then
+  exit 0
+fi
+
+MSG="autoMode(hard_deny)による医療データ外部送信・RLS無効化の無条件ブロックが、個人設定(${SETTINGS_PATH})に見当たりません。プロジェクト側の設定ファイルでは強制できない仕様のため、有効化したい場合は docs/agents/common.md の推奨autoMode設定を各自の ~/.claude/settings.json に追加してください（任意、issue #439）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-automode-config.test.sh
+++ b/scripts/check-automode-config.test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# WHY: scripts/check-automode-config.sh(SessionStart hook)の回帰テスト。
+# 個人設定(~/.claude/settings.json相当)にautoMode.hard_denyが無ければ警告し、
+# 有れば何も出力しないことを確認する。CLAUDE_USER_SETTINGS_PATHでテスト用パスに
+# 差し替える（本物の$HOME/.claude/settings.jsonを書き換えないため）。
+#
+# 実行: bash scripts/check-automode-config.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-automode-config.sh"
+
+fail=0
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+echo "=== scenario 1: 設定ファイルが存在しない → 警告する ==="
+OUT="$(CLAUDE_USER_SETTINGS_PATH="$TMPDIR_TEST/no-such-file.json" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "autoMode" "autoMode未設定の警告文言が含まれる"
+
+echo "=== scenario 2: 設定ファイルは存在するがautoModeキー自体が無い → 警告する ==="
+echo '{"permissions": {"allow": []}}' > "$TMPDIR_TEST/settings-no-automode.json"
+OUT="$(CLAUDE_USER_SETTINGS_PATH="$TMPDIR_TEST/settings-no-automode.json" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+
+echo "=== scenario 3: autoModeはあるがhard_denyが空配列 → 警告する ==="
+echo '{"autoMode": {"environment": "x", "hard_deny": []}}' > "$TMPDIR_TEST/settings-empty-hard-deny.json"
+OUT="$(CLAUDE_USER_SETTINGS_PATH="$TMPDIR_TEST/settings-empty-hard-deny.json" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+
+echo "=== scenario 4: autoMode.hard_denyに1件以上ルールがある → 何も出力しない ==="
+echo '{"autoMode": {"environment": "x", "hard_deny": ["do not send patient data externally"]}}' > "$TMPDIR_TEST/settings-with-hard-deny.json"
+OUT="$(CLAUDE_USER_SETTINGS_PATH="$TMPDIR_TEST/settings-with-hard-deny.json" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空である(既に設定済みのため警告不要)"
+
+echo "=== scenario 5: 設定ファイルが壊れたJSON → エラーにせず警告する(fail-safe) ==="
+echo '{invalid json' > "$TMPDIR_TEST/settings-broken.json"
+OUT="$(CLAUDE_USER_SETTINGS_PATH="$TMPDIR_TEST/settings-broken.json" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "壊れたJSONでもクラッシュせず警告する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- issue #439（autoMode(hard_deny)で医療データ外部送信・RLS無効化を無条件ブロックする）に着手したが、ゲート条件確認（公式ドキュメント実機確認）の結果、issue #438の`sandbox.credentials`と同型の制約が判明した
- `autoMode`のclassifierはユーザー個人の`~/.claude/settings.json`でしか設定を読まない（プロジェクト側の`.claude/settings.json`/`.claude/settings.local.json`はリポジトリが自身に許可ルールを注入するのを防ぐため対象外。出典・原文引用は`docs/agents/decisions.md`に記録）
- プロジェクト側にコミットして全員へ強制する実装はできないため、**推奨設定のドキュメント化＋個人オプトイン**の形にした
- ドキュメント化だけで終えると「書いたのに気づかれない」という同型の問題（issue #423の発端になったloop-observability記録漏れ等）を繰り返すため、**SessionStart hookで設定し忘れを検知する仕組み**を追加した（レビューで提案を受けて実装）

## 変更内容
- `scripts/check-automode-config.sh` / `.test.sh`（新規）: 個人設定に`autoMode.hard_deny`が無ければセッション開始時に警告（block不可・warningのみ、`check-otel-collector-status.sh`と同じパターン）
- `.claude/settings.json`: SessionStart hooksに登録、permissions.allowにテストスクリプトのエントリ追加
- `docs/agents/common.md`: 推奨`autoMode`設定（`environment`/`hard_deny`の具体例）を追記
- `docs/agents/decisions.md`: 設計判断の記録（出典URL・原文引用付き。ゲート条件確認の過程で「調査エージェントの要約の理由部分が本当にドキュメントに書かれているか」を追加で裏取りした経緯も含む）

## Test plan
- [x] `bash scripts/check-automode-config.test.sh` 全5シナリオ通過（存在しない/hard_deny空配列/壊れたJSONのfail-safe含む）
- [x] 既存hookテスト3本（`check-skip-marker-write`/`check-run-manifest-presence`/`check-direct-ddl-execution`、計32シナリオ）で回帰なし確認
- [x] `jq empty .claude/settings.json` でJSON構文チェック
- [x] 実機の`~/.claude/settings.json`に対して読み取り専用で動作確認（未設定環境で正しく警告文言が出ることを確認、ファイルは変更していない）
- [x] TypeScript/JSファイルへの変更なし（`npm test`/`lint`/`typecheck`は対象外と判断）

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #439着手 → プロジェクト側で強制不能と判明 → 個人オプトイン+設定し忘れ検知の方針に転換
- 変更した範囲: `scripts/check-automode-config.sh`・`.claude/settings.json`のSessionStart hooks・`docs/agents/common.md`・`docs/agents/decisions.md`
- 触っていない範囲: プロダクトコード（`src/`・`supabase/migrations/`実体）は無変更。ユーザー個人の`~/.claude/settings.json`自体への書き込みは行っていない（個人の判断に委ねる）

### 検証済み
- 実行したコマンド: 上記Test plan参照
- 確認した画面: なし
- 確認したDB/RLS: 対象外（hookはRLSポリシー自体を変更しない）
- 他テナントIDでのアクセス確認: 対象外

### 既知の未対応
- 今回あえて対応しなかったこと: `autoMode.hard_deny`の**内容**の妥当性検証（存在チェックのみ）
- 理由: `environment`/`hard_deny`は自然言語記述であり、内容の妥当性を機械的に判定する信頼できる方法が無い
- 次に触るなら見る場所: `docs/agents/decisions.md`の該当項目

### 後任AIへの注意
- `autoMode`設定を**プロジェクト側の`.claude/settings.json`や`.claude/settings.local.json`に書いても一切効かない**（公式仕様で意図的に無視される）。個人の`~/.claude/settings.json`にしか書けないことを忘れないこと
- `check-automode-config.sh`は`CLAUDE_USER_SETTINGS_PATH`環境変数でテスト用パスに差し替え可能（本物の`$HOME/.claude/settings.json`を書き換えずにテストするため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
