### PR TITLE
fix: get_distributor_product_price_history RPCにOR is_admin()を追加(issue #458)

### DIFF
--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -46,6 +46,26 @@ Next.js API Route（`requireFacilityAccess`等）を経由せず直接呼び出�
 
 詳細: [`decisions.md`](./decisions.md#なぜ施設分離をrls--is_facility_member関数で実現したか)
 
+### 新しい認可プリミティブ導入時、既存のSECURITY DEFINER関数が取り残される（issue #458）
+
+**チェック内容:** `is_admin()`のような新しい認可プリミティブを導入し、既存のRLSポリシーを
+一斉更新する変更（`CREATE POLICY`の書き換え等）を行う場合、**同じタイミングで既存の
+SECURITY DEFINER関数（手書きWHERE句で認可を実装しているもの）も棚卸しの対象に含める**。
+
+**なぜ再発したか:** `get_distributor_product_price_history` RPCは`is_admin()`導入前に
+書かれており、`is_facility_member(...)`のみで認可していた。翌日`is_admin()`が導入され、
+全RLSポリシーに`OR is_admin()`が一斉追加されたが、このRPCは**RLSポリシーではなく
+SECURITY DEFINER関数内の手書きWHERE句**だったため、その一斉更新の対象から漏れた。
+RLSポリシーの棚卸し（`pg_policies`を見る、または`CREATE POLICY`をgrepする）では
+この種の関数は見つからない。「RLSポリシー」と「SECURITY DEFINER関数内の認可ロジック」は
+別物であり、片方だけを更新して安心してはいけない。
+
+**推奨:** 新しい認可プリミティブを追加する変更では、RLSポリシーの一斉更新と合わせて
+`grep -rl "SECURITY DEFINER" supabase/migrations/*.sql`で全SECURITY DEFINER関数を洗い出し、
+その認可プリミティブ導入前に書かれたものが同様の認可チェックを持っているか確認する。
+
+詳細: [`docs/specs/issue-458-459-price-history-admin-and-unit-price.md`](../specs/issue-458-459-price-history-admin-and-unit-price.md)（横断確認の実施結果を含む）
+
 ### クエリパラメータのバリデーション漏れ（NaN・負数・上限）
 
 **チェック内容:** APIルートで `Number(request.nextUrl.searchParams.get(...))` のように

--- a/docs/specs/issue-458-459-price-history-admin-and-unit-price.md
+++ b/docs/specs/issue-458-459-price-history-admin-and-unit-price.md
@@ -1,0 +1,112 @@
+# 機能仕様書 — issue #458 / #459: admin価格履歴閲覧漏れ・unit_price未配線バグの修正
+
+> ステータス: **レビュー待ち（停止①）**
+> 作成日: 2026-07-18
+> 由来: プロダクトコード実バグ調査（Explore agentによる横断調査、原因調査は完了済み）。
+> TRI/RISK機械判定によりM/Lレーン対象（supabase/migrations・facility/inventory領域に該当）。
+> 原因調査（Phase 1 Sweep相当）は既に完了しているため省略するが、レビューゲート（停止①・②）
+> とRLS/facility境界の攻撃者視点テストは省略しない方針で進める（`docs/agents/decisions.md`
+> 「なぜTRI/RISK判定を機械判定にし人の裁量で緩めないことにしたか」を踏まえた判断）。
+
+---
+
+## Part 1 — 仕様（★人間がレビューする部分）
+
+### 対象issue
+
+- [#458](https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/issues/458) get_distributor_product_price_history RPCがadminの全施設閲覧権限を無視している
+- [#459](https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/issues/459) unit_priceカラムがcase/consumable/loan-ordersのアプリ層(型・リポジトリ)で無視されている
+
+無関係な2つのバグだが、同じ調査セッションで見つかったためSPECはまとめて作成する。**実装・PRは別ブランチに分ける**（1つのPRに無関係なissueのコミットが混ざらないようにする、`docs/agents/common.md`「ブランチ運用ルール」）。
+
+---
+
+### issue #458: admin価格履歴閲覧漏れ
+
+#### 背景・課題
+
+`get_distributor_product_price_history` RPC（`supabase/migrations/20260627010000_add_multitenant.sql:155-191`）は `SECURITY DEFINER` でRLSをバイパスするため、施設アクセス制御を関数内のWHERE句で自前実装している。hospital_price側のブランチ（179-190行目）は `AND is_facility_member(hp.facility_id)` のみでフィルタしており、`OR is_admin()` が無い。
+
+`is_admin()` 関数自体は翌日の `20260628010000_add_role_to_user_facilities.sql` で新設され、`20260628010001_update_rls_admin.sql` で `hospital_prices` 本体を含む全RLSポリシーに `OR is_admin()` が追加された。しかしこのRPCはRLSポリシーではなくSECURITY DEFINER関数内の手書きWHERE句のため、その一斉更新の対象から漏れた（コードを確認し原因を特定済み）。
+
+#### 何が変わるか
+
+admin権限を持つユーザーが、自分が`user_facilities`に所属していない施設の病院別価格変更履歴も閲覧できるようになる（他の画面・RPCと同じadmin権限の扱いに揃える）。
+
+#### 今回やらないこと
+
+- `is_admin()`より前の設計だった他の関数・ポリシーへの遡及的な監査（横断確認はやることに含めるが、見つかった場合は別issueとして切り出す。今回のスコープは本RPCの修正のみ）
+- UI側の変更（既存のadmin向け全施設アクセスUIをそのまま利用できる想定。もし専用のUI導線が無ければ別途確認）
+
+#### 受け入れ条件（チェックリスト）
+
+- [ ] `is_admin()` が真のユーザーが、`user_facilities`に自分の割当が無い施設の`distributor_product`の価格履歴を取得すると、その施設のhospital_price変更履歴が結果に含まれる
+- [ ] `is_admin()` が偽（一般ユーザー）で、かつ対象施設の`user_facilities`に割当が無いユーザーが同じRPCを呼ぶと、**その施設のhospital_price変更履歴は結果に含まれない**（他テナントIDでアクセスし、正しく弾かれることを確認する。issue #24再発防止チェック）
+- [ ] 一般ユーザーが自分の所属施設のhospital_price変更履歴を取得すると、従来どおり結果に含まれる（既存の正常系が壊れていないことの回帰確認）
+- [ ] `distributor_product`側のブランチ（施設に依存しない全体価格履歴、174-176行目）は今回変更しない（挙動が変わらないことを確認）
+
+---
+
+### issue #459: unit_priceカラムのアプリ層未配線
+
+#### 背景・課題
+
+`supabase/migrations/20260715000001_add_unit_price_to_order_items.sql` で `case_order_items`/`consumable_order_items`/`loan_order_items` に `unit_price NUMERIC(12,2)`（発注時点の単価スナップショット、既存行はNULL）が追加され、発注作成時のRPC（`20260715000002_add_unit_price_snapshot_to_order_rpcs.sql`）で算出・INSERTされている。
+
+しかし `src/lib/case-orders/repository.ts`・`src/lib/consumable-orders/repository.ts`・`src/lib/loan-orders/repository.ts` の `*ItemRow` インターフェースと `mapItem()`、および `src/types/order.ts` の `CaseOrderItem`/`ConsumableOrderItem`/`LoanOrderItem` のいずれにも `unit_price`/`unitPrice` が無く、DBから取得しても静かに破棄されている（コードを確認し原因を特定済み）。
+
+#### 何が変わるか
+
+`listCaseOrders`/`listConsumableOrders`/`listLoanOrders` 等が返す各注文明細の型に `unitPrice: number | null` が追加され、実際にDBの値がマッピングされるようになる。既存データはNULLのままなので `null` を許容する。
+
+#### 今回やらないこと
+
+- UI側で単価を実際に表示する機能の追加（今回は「型・データ層に正しく配線する」までがスコープ。表示するかどうかは別issue・別画面の話）
+- `unit_price` を使った金額再計算ロジックの変更（既存の `get_order_amount_report` RPC経由の集計は今回変更しない）
+
+#### 受け入れ条件（チェックリスト）
+
+- [ ] `CaseOrderItem`/`ConsumableOrderItem`/`LoanOrderItem`（`src/types/order.ts`）に `unitPrice: number | null` が追加される
+- [ ] 3つの `repository.ts` の `*ItemRow` インターフェースに `unit_price?: unknown` が追加され、`mapItem()` が `unitPrice: asNullableNumber(row.unit_price)` を返す
+- [ ] `unit_price` がNULLの行（既存データ）でも `mapItem()` がエラーにならず `unitPrice: null` を返す
+- [ ] `unit_price` に数値が入っている行で、`mapItem()` が正しい数値型（文字列のままではなく`number`）で返す（PostgreSQLのNUMERIC型はJSでは文字列として返ってくることがあるため、`asNullableNumber`による変換が効いていることを確認）
+- [ ] 既存の `npm test` が全てパスし続ける（既存のテストで`unitPrice`未定義を前提にしていた箇所があれば型エラーで検出される）
+
+---
+
+### 判断が必要な点（レビュー時に確認・レビュー済み）
+
+1. **#458の修正はマイグレーション（`CREATE OR REPLACE FUNCTION`）で行うが、これは新しいテーブル追加・削除ではないため `refresh_schema_baseline_snapshot` は不要という理解でよいか**（`20260715000001`のWHYコメントと同じ判断）→ **承認**。CREATE OR REPLACE FUNCTIONはテーブルに一切触れないため対象外。
+2. **#459で追加するのは型とマッピングのみで、UIには一切手を入れない**という今回のスコープでよいか → **承認**。`src/app`/`src/components`配下でCaseOrderItem等の型を直接importしている箇所は無く、UI層は構造的に依存していないため安全な追加的変更。
+3. **#458の横断確認（他にも`is_admin()`導入前の同種の漏れが無いか）を今回のPRに含めるか、見つかった場合のみ別issueにするか** → **調査のみ実施、実装はこのPRに含めない**方針で承認。
+
+#### 横断確認の結果（2026-07-18実施）
+
+`is_admin()`導入（`20260628010000_add_role_to_user_facilities.sql`）より前に定義されたSECURITY DEFINER関数を全て洗い出した。
+
+- `get_distributor_product_price_history`（本issue #458で修正対象）以外に、**read-access（閲覧系）のSECURITY DEFINER関数で同種の漏れは見つからなかった**（トリガー関数`trg_distributor_products_price_history`/`trg_hospital_prices_price_history`は施設チェック自体を持たないため対象外）
+- `create_case_order_atomic`/`create_loan_order_atomic`/`create_consumable_order_atomic`（発注作成RPC）は`is_facility_member`のみで`is_admin()`が無いが、最新版（`20260715000002_add_unit_price_snapshot_to_order_rpcs.sql`）まで一貫してこの形であり、「更新漏れ」ではなく「adminでも所属施設以外への発注作成は意図的に不可」という設計の可能性が高い（write-pathの権限設計は#458のread-pathの話とは別カテゴリ）。**#458と同じバグパターンではないため今回のPRには含めない**。admin全施設モードの要否自体は別途の設計判断が必要であれば改めてissue化する。
+
+---
+
+## Part 2 — 実装計画（AI用・技術詳細・レビュー不要）
+
+### issue #458
+
+- 新規マイグレーション（例: `supabase/migrations/20260718000001_fix_price_history_admin_access.sql`）を作成
+- `CREATE OR REPLACE FUNCTION get_distributor_product_price_history(...)` で関数全体を再定義し、hospital_price側ブランチのWHERE句を `AND (is_facility_member(hp.facility_id) OR is_admin())` に変更する（`SECURITY DEFINER SET search_path = public` 等の既存属性は維持）
+- ローカルSupabase（`supabase db reset`後）で以下を実測確認する:
+  - admin・非member施設のRPC呼び出しで履歴が見えること
+  - 非admin・非member施設のRPC呼び出しで履歴が見えないこと（弾かれることの確認）
+  - 既存member施設のRPC呼び出しが従来通り動作すること
+- `docs/agents/known-failure-patterns.md`に該当する再発防止パターンがあれば追記を検討する
+
+### issue #459
+
+- `src/types/order.ts`: `CaseOrderItem`/`ConsumableOrderItem`/`LoanOrderItem` それぞれに `unitPrice: number | null` を追加
+- `src/lib/case-orders/repository.ts`: `CaseOrderItemRow` に `unit_price?: unknown` 追加、`mapItem()` に `unitPrice: asNullableNumber(row.unit_price)` 追加
+- `src/lib/consumable-orders/repository.ts`: 同様に `ConsumableOrderItemRow`/`mapItem()` を修正
+- `src/lib/loan-orders/repository.ts`: 同様に `LoanOrderItemRow`/`mapItem()` を修正
+- `asNullableNumber` は既に `src/lib/mapping.ts` に実装済み（追加実装不要）
+- 既存の `*.test.ts`（vitest）に `unitPrice` のnull/数値ケースのアサーションを追加
+- `npm run typecheck`・`npm test`・`npm run lint` を実行し全て通ることを確認

--- a/supabase/migrations/20260718000001_fix_price_history_admin_access.sql
+++ b/supabase/migrations/20260718000001_fix_price_history_admin_access.sql
@@ -1,0 +1,51 @@
+-- supabase/migrations/20260718000001_fix_price_history_admin_access.sql
+-- issue #458: get_distributor_product_price_history RPC(SECURITY DEFINER)が
+-- adminの全施設閲覧権限を無視している。
+--
+-- WHY: 20260627010000_add_multitenant.sqlでこのRPCが定義された時点ではis_admin()が
+-- まだ存在せず(is_admin()は翌日の20260628010000_add_role_to_user_facilities.sqlで新設)、
+-- 翌日の20260628010001_update_rls_admin.sqlで全RLSポリシーにOR is_admin()が追加された際、
+-- このRPCはRLSポリシーではなくSECURITY DEFINER関数内の手書きWHERE句のため、その一斉更新の
+-- 対象から漏れていた。hospital_prices本体のRLS(is_facility_member(facility_id) OR is_admin())
+-- と挙動を揃える。
+
+CREATE OR REPLACE FUNCTION get_distributor_product_price_history(
+  p_distributor_product_id UUID
+)
+RETURNS TABLE (
+  id                     UUID,
+  entity_type            TEXT,
+  entity_id              UUID,
+  dist_product_id        UUID,
+  field_name             TEXT,
+  old_value              NUMERIC,
+  new_value              NUMERIC,
+  changed_at             TIMESTAMPTZ,
+  facility_name          TEXT
+) LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
+  SELECT
+    ph.id, ph.entity_type, ph.entity_id, ph.distributor_product_id AS dist_product_id,
+    ph.field_name, ph.old_value, ph.new_value, ph.changed_at,
+    NULL::TEXT AS facility_name
+  FROM price_histories ph
+  WHERE ph.entity_type = 'distributor_product'
+    AND ph.distributor_product_id = p_distributor_product_id
+
+  UNION ALL
+
+  SELECT
+    ph.id, ph.entity_type, ph.entity_id, ph.distributor_product_id AS dist_product_id,
+    ph.field_name, ph.old_value, ph.new_value, ph.changed_at,
+    f.name AS facility_name
+  FROM price_histories ph
+  LEFT JOIN hospital_prices hp ON hp.id = ph.entity_id
+  LEFT JOIN facilities f ON f.id = hp.facility_id
+  WHERE ph.entity_type = 'hospital_price'
+    AND ph.distributor_product_id = p_distributor_product_id
+    AND (is_facility_member(hp.facility_id) OR is_admin())
+
+  ORDER BY changed_at DESC;
+$$;
+
+-- カラム追加・テーブル新設/削除ではないため refresh_schema_baseline_snapshot は不要
+-- (issue #305要件の対象外。20260715000001_add_unit_price_to_order_items.sqlと同じ判断)

--- a/supabase/migrations/__tests__/price_history_admin_access.test.ts
+++ b/supabase/migrations/__tests__/price_history_admin_access.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: issue #458の回帰テスト。get_distributor_product_price_history RPC(SECURITY DEFINER)が
+// hospital_price側のWHERE句にOR is_admin()を持つことを静的に固定する。
+// ローカルSupabaseでの実機検証(admin/非member/施設memberの3パターンでRLS境界を確認、PASS済み)は
+// 別途手動で実施済みだが、CI環境では実DB接続が無いため、admin_rls.test.tsと同じパターンで
+// マイグレーションファイルの内容を静的に検証する。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+const FIX_FILE = path.join(MIGRATIONS_DIR, '20260718000001_fix_price_history_admin_access.sql')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+describe('20260718000001_fix_price_history_admin_access.sql', () => {
+  it('ファイルが存在する', () => {
+    expect(existsSync(FIX_FILE)).toBe(true)
+  })
+
+  const sql = existsSync(FIX_FILE) ? readFileSync(FIX_FILE, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('get_distributor_product_price_history をCREATE OR REPLACEで再定義する', () => {
+    expect(n).toContain('create or replace function get_distributor_product_price_history(')
+    expect(n).toContain('security definer')
+    expect(n).toContain('set search_path = public')
+  })
+
+  it('hospital_price側のブランチでOR is_admin()を含む施設チェックになっている', () => {
+    // WHY: is_facility_member単独ではなく、OR is_admin()と組み合わせた条件になっていることを
+    // 確認する(単にis_admin()という文字列が別の場所にあるだけでは合格させない)
+    expect(n).toMatch(/\(is_facility_member\(hp\.facility_id\)\s+or\s+is_admin\(\)\)/)
+  })
+
+  it('distributor_product側のブランチ(施設非依存)は変更しない', () => {
+    expect(n).toContain("where ph.entity_type = 'distributor_product'")
+    expect(n).toContain("and ph.distributor_product_id = p_distributor_product_id")
+  })
+})


### PR DESCRIPTION
## Summary
- issue #458: `get_distributor_product_price_history` RPC（SECURITY DEFINER）のhospital_price側ブランチが`is_facility_member`のみでフィルタしており、`is_admin()`導入前（`20260627010000`）に書かれたため、翌日の一斉RLS更新（`20260628010001`）の対象から漏れていた
- adminが自分の所属していない施設の病院別価格変更履歴を見られない、という閲覧漏れ（機能バグ。セキュリティ的に危険な方向ではない）を修正した
- TRI/RISK基準（`supabase/migrations/`・facility/RLSドメイン該当）に沿い、SPEC.md作成→停止①レビュー→横断確認→実装→実機検証、という手順を踏んだ（Phase 1のマルチエージェントSweepは原因調査が既に完了していたため省略。詳細は`docs/agents/decisions.md`参照ではなく本SPEC.md冒頭に経緯を明記）

## 実機検証（ローカルSupabase、RLS境界テスト）
3種のユーザーで`get_distributor_product_price_history`を実際に呼び出して確認した（anon keyでのユーザー別クライアント使用、service roleではRLSがバイパスされるため区別）。

| ユーザー | 所属・権限 | 施設Bのhospital_price履歴 |
|---|---|---|
| admin | 施設Aのadmin、施設B未所属 | 2件見える（修正が効いている） |
| memberA | 施設Aのstaff、施設B未所属 | **0件（他テナントへのアクセスが正しく弾かれることを確認）** |
| memberB | 施設Bのstaff | 2件見える（自施設は従来通り） |

## 横断確認
`is_admin()`導入前に定義されたSECURITY DEFINER関数を全て洗い出し、同種の漏れが他に無いか確認した。read-access系では本RPC以外に該当なし。`create_case_order_atomic`等の発注作成RPCも`is_admin()`が無いが、これは「adminでも所属外施設への発注作成は意図的に不可」という別カテゴリの設計判断の可能性が高く、#458と同じバグパターンではないため今回のPRには含めない（詳細はSPEC.md参照）。

## 変更内容
- `supabase/migrations/20260718000001_fix_price_history_admin_access.sql`（新規）: RPCを`CREATE OR REPLACE`で再定義し、hospital_price側のWHERE句を`(is_facility_member(hp.facility_id) OR is_admin())`に変更
- `supabase/migrations/__tests__/price_history_admin_access.test.ts`（新規）: マイグレーション内容の静的回帰テスト
- `docs/specs/issue-458-459-price-history-admin-and-unit-price.md`（新規）: SPEC.md（issue #459分も含む。実装は別PRに分離）

## Test plan
- [x] ローカルSupabase実機検証（上記表、PASS）
- [x] `npx vitest run supabase/migrations/__tests__/price_history_admin_access.test.ts` 4件通過
- [x] `npm test` 全150ファイル1088テスト通過
- [x] `npm run lint` 私の変更に起因するエラーなし（既存の無関係な警告1件のみ、`.claude/workflows/lib/__tests__/`配下）
- [x] `npm run typecheck` 私の変更に起因するエラーなし（既存の無関係なエラー、`scripts/eval-fixtures/sweep-types/`配下の意図的に壊れたevalフィクスチャ、今回のブランチ作成前から存在）
- [ ] **停止②（構造化レビュー）は`/structured-review`でユーザーが起動するまで実施しない**（RLS/facility境界に関わる変更のため、マージ前に必須）

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #458（admin価格履歴閲覧漏れ）の修正
- 変更した範囲: `get_distributor_product_price_history` RPCの1関数のみ。distributor_product側ブランチ（施設非依存）は変更していない
- 触っていない範囲: issue #459（unit_price未配線）は別PRで対応。`create_*_atomic`系RPCの`is_admin()`欠如は今回のスコープ外（横断確認の結果、別カテゴリと判断）

### 検証済み
- 実行したコマンド: 上記Test plan参照（`npm run ai:check`は個別に`typecheck`/`lint`/`test`を実行、`test:e2e`は今回未実行）
- 確認した画面: なし（RPCの直接検証のみ、UI経由の確認は未実施）
- 確認したDB/RLS: 実施済み（上記表）
- 他テナントIDでのアクセス確認: **実施済み**（memberAが施設Bのデータにアクセスできないことを確認。issue #24再発防止チェック）

### 既知の未対応
- 今回あえて対応しなかったこと: `create_*_atomic`系RPCの`is_admin()`欠如の是非
- 理由: 「adminによる横断監視」（今回のRPC）と「他施設への発注作成という書き込み操作」は権限の性質が異なり、同じバグパターンと決めつけられない
- 次に触るなら見る場所: 過去メモリーに記録されている「Admin all-facilities mode」の既知の仕様ギャップ。必要なら別issueとして起票する

### 後任AIへの注意
- この実装で壊してはいけない前提: distributor_product側ブランチ（174-176行目相当）は施設非依存の設計であり、今回の修正で触っていない。触る場合は別の検討が必要
- 似ているが別物の用語: 「RLSポリシー」と「SECURITY DEFINER関数内のWHERE句」は別物。前者はDB側で自動適用されるが、後者は関数の実装者が手動でis_admin()等を書かないと反映されない（今回のバグの根本原因）
- 勝手にリファクタしない場所: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
