### PR TITLE
journal.jsonlのresultをloop-observability再構築で優先取得する

### DIFF
--- a/scripts/lib/reconstruct-loop-observability.test.ts
+++ b/scripts/lib/reconstruct-loop-observability.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   assignAttempts,
   buildLoopObservabilityEntry,
@@ -6,6 +9,8 @@ import {
   mapAgentTypeToLoop,
   pairAgentFiles,
   parseAgentTranscriptLines,
+  parseJournalResults,
+  reconstructWorkflowDir,
 } from './reconstruct-loop-observability'
 
 function line(obj: unknown): string {
@@ -172,6 +177,160 @@ describe('pairAgentFiles', () => {
   it('meta.jsonが無いjsonlは無視する（journal.jsonl等）', () => {
     const pairs = pairAgentFiles(['journal.jsonl', 'agent-a1.jsonl'])
     expect(pairs).toHaveLength(0)
+  })
+})
+
+describe('parseJournalResults', () => {
+  it('type:"result"かつstatusが既知の値の行をagentIdごとにMap化する', () => {
+    const lines = [
+      line({ type: 'started', key: 'v2:aaa', agentId: 'a1' }),
+      line({ type: 'result', key: 'v2:aaa', agentId: 'a1', result: { status: 'pass', detail: '指摘なし' } }),
+      line({
+        type: 'result',
+        key: 'v2:bbb',
+        agentId: 'a2',
+        result: { status: 'fail', detail: '実装漏れ', findings: [{ severity: 'critical', description: 'x' }] },
+      }),
+    ]
+    const results = parseJournalResults(lines)
+    expect(results.size).toBe(2)
+    expect(results.get('a1')).toEqual({ status: 'pass', detail: '指摘なし', findings: null })
+    expect(results.get('a2')).toEqual({
+      status: 'fail',
+      detail: '実装漏れ',
+      findings: [{ severity: 'critical', description: 'x' }],
+    })
+  })
+
+  it('resultがプレーンな文字列（statusを持たない）の行は無視する（実データで観測されたケース）', () => {
+    const lines = [
+      line({ type: 'result', key: 'v2:ccc', agentId: 'a3', result: 'af57a6077ca388dede819b409c55a1216b5eb329' }),
+    ]
+    expect(parseJournalResults(lines).size).toBe(0)
+  })
+
+  it('statusが既知の値（pass/fail/blocked）以外の行は無視する', () => {
+    const lines = [line({ type: 'result', key: 'v2:ddd', agentId: 'a4', result: { status: 'unknown-status' } })]
+    expect(parseJournalResults(lines).size).toBe(0)
+  })
+
+  it('type:"started"の行は無視する', () => {
+    const lines = [line({ type: 'started', key: 'v2:eee', agentId: 'a5' })]
+    expect(parseJournalResults(lines).size).toBe(0)
+  })
+
+  it('JSONとしてパースできない行は無視する', () => {
+    expect(() => parseJournalResults(['not json'])).not.toThrow()
+    expect(parseJournalResults(['not json']).size).toBe(0)
+  })
+
+  it('同じagentIdの行が複数ある場合は最後の行を採用する', () => {
+    const lines = [
+      line({ type: 'result', key: 'v2:fff', agentId: 'a6', result: { status: 'fail', detail: '1回目' } }),
+      line({ type: 'result', key: 'v2:ggg', agentId: 'a6', result: { status: 'pass', detail: '2回目' } }),
+    ]
+    expect(parseJournalResults(lines).get('a6')).toEqual({ status: 'pass', detail: '2回目', findings: null })
+  })
+})
+
+describe('reconstructWorkflowDir', () => {
+  function agentTranscriptLines(status: string, detail: string, timestamp: string): string {
+    return [
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
+      line({
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status, detail } }],
+          usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+        timestamp,
+      }),
+    ].join('\n')
+  }
+
+  it('journal.jsonlが存在し該当agentIdの構造化resultがある場合、そのstatus/detail/findingsを優先する（transcript側と異なる値で検証）', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reconstruct-journal-test-'))
+    // transcript側はfailを記録しているが、journal.jsonl側はpassを記録している状況を作り、
+    // journal.jsonl優先で復元されることを確認する
+    writeFileSync(
+      join(dir, 'agent-a1.jsonl'),
+      agentTranscriptLines('fail', 'transcript側のdetail(古い/不整合を想定)', '2026-07-11T03:00:01.000Z'),
+      'utf-8',
+    )
+    writeFileSync(join(dir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    writeFileSync(
+      join(dir, 'journal.jsonl'),
+      [
+        line({ type: 'started', key: 'v2:xxx', agentId: 'a1' }),
+        line({ type: 'result', key: 'v2:xxx', agentId: 'a1', result: { status: 'pass', detail: 'journal側のdetail' } }),
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const entries = reconstructWorkflowDir(dir, 'feature-x')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].result).toBe('pass')
+    expect(entries[0].reason).toBe('journal側のdetail')
+    // model/tokensはjournal.jsonlに存在しないためtranscript側の値のまま復元されることを確認
+    expect(entries[0].model).toBe('claude-sonnet-5')
+    expect(entries[0].tokens).toBe(15)
+  })
+
+  it('journal.jsonlが存在しない場合、既存のtranscriptパース方式にフォールバックする（回帰確認）', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reconstruct-no-journal-test-'))
+    writeFileSync(
+      join(dir, 'agent-a2.jsonl'),
+      agentTranscriptLines('blocked', 'transcriptのみのdetail', '2026-07-11T03:00:01.000Z'),
+      'utf-8',
+    )
+    writeFileSync(join(dir, 'agent-a2.meta.json'), JSON.stringify({ agentType: 'reviewer' }), 'utf-8')
+
+    const entries = reconstructWorkflowDir(dir, 'feature-y')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].result).toBe('blocked')
+    expect(entries[0].reason).toBe('transcriptのみのdetail')
+  })
+
+  it('journal.jsonlは存在するが該当agentIdの行が無い場合、そのagentはtranscriptパース方式にフォールバックする', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reconstruct-journal-no-match-test-'))
+    writeFileSync(
+      join(dir, 'agent-a3.jsonl'),
+      agentTranscriptLines('pass', 'transcript側フォールバックのdetail', '2026-07-11T03:00:01.000Z'),
+      'utf-8',
+    )
+    writeFileSync(join(dir, 'agent-a3.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    // journal.jsonlはあるが、別のagentId(a-other)の行しか無い
+    writeFileSync(
+      join(dir, 'journal.jsonl'),
+      line({ type: 'result', key: 'v2:yyy', agentId: 'a-other', result: { status: 'fail', detail: '別agent' } }),
+      'utf-8',
+    )
+
+    const entries = reconstructWorkflowDir(dir, 'feature-z')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].result).toBe('pass')
+    expect(entries[0].reason).toBe('transcript側フォールバックのdetail')
+  })
+
+  it('journal.jsonlのresultがプレーンな文字列（statusを持たない）の場合、transcriptパース方式にフォールバックする', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'reconstruct-journal-plain-string-test-'))
+    writeFileSync(
+      join(dir, 'agent-a4.jsonl'),
+      agentTranscriptLines('pass', 'transcript側フォールバック(文字列result)', '2026-07-11T03:00:01.000Z'),
+      'utf-8',
+    )
+    writeFileSync(join(dir, 'agent-a4.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    writeFileSync(
+      join(dir, 'journal.jsonl'),
+      line({ type: 'result', key: 'v2:zzz', agentId: 'a4', result: 'af57a6077ca388dede819b409c55a1216b5eb329' }),
+      'utf-8',
+    )
+
+    const entries = reconstructWorkflowDir(dir, 'feature-w')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].result).toBe('pass')
+    expect(entries[0].reason).toBe('transcript側フォールバック(文字列result)')
   })
 })
 

--- a/scripts/lib/reconstruct-loop-observability.ts
+++ b/scripts/lib/reconstruct-loop-observability.ts
@@ -160,6 +160,68 @@ export function deriveIntent(promptText: string | null): string {
 const SCENARIO_UNKNOWN = '(transcriptから復元: scenario情報は失われている)'
 const MAX_REASON_LENGTH = 300
 
+// issue #462: Workflowツールが`agent()`呼び出しごとに書き出す`journal.jsonl`は、各行が
+// `{"type":"started"|"result","key":"v2:<promptとoptsのハッシュ>","agentId":"...","result"?:...}`
+// という形式で、`agentId`が同じディレクトリの`agent-<agentId>.jsonl`/`.meta.json`と一致する
+// ことを実機観測済み（docs/agents/common.md「サブエージェント骨格記録の機械強制」参照）。
+// `result`フィールドの形は必ずしも{status,detail,findings?}のStructuredOutput互換オブジェクトとは
+// 限らず、実データではagent()がプレーンな文字列（例: コミットハッシュ文字列）を返すケースも
+// 観測されている。そのためstatusが既知の値である場合のみ「構造化されたresult」とみなし、
+// それ以外（文字列・statusを持たないobject等）は従来のtranscriptパース結果へフォールバックする。
+const KNOWN_STATUSES = new Set(['pass', 'fail', 'blocked'])
+
+interface JournalLine {
+  type?: string
+  agentId?: string
+  result?: unknown
+}
+
+interface JournalResultPayload {
+  status?: unknown
+  detail?: unknown
+  findings?: unknown
+}
+
+export interface JournalStructuredResult {
+  status: AgentTranscriptSummary['status']
+  detail: string | null
+  findings: Finding[] | null
+}
+
+function parseJournalLine(line: string): JournalLine | null {
+  try {
+    return JSON.parse(line) as JournalLine
+  } catch {
+    return null
+  }
+}
+
+function extractStructuredJournalResult(result: unknown): JournalStructuredResult | null {
+  if (typeof result !== 'object' || result === null) return null
+  const payload = result as JournalResultPayload
+  if (typeof payload.status !== 'string' || !KNOWN_STATUSES.has(payload.status)) return null
+
+  return {
+    status: payload.status as AgentTranscriptSummary['status'],
+    detail: typeof payload.detail === 'string' ? payload.detail : null,
+    findings: Array.isArray(payload.findings) ? (payload.findings as Finding[]) : null,
+  }
+}
+
+// journal.jsonlの`type:"result"`行をagentIdごとにMap化する。同じagentIdの行が複数あった場合は
+// 最後に出現したものを採用する（journal.jsonlは追記専用ログのため、後勝ちが最新の実行結果）。
+export function parseJournalResults(lines: string[]): Map<string, JournalStructuredResult> {
+  const results = new Map<string, JournalStructuredResult>()
+  for (const raw of lines) {
+    const parsed = parseJournalLine(raw)
+    if (!parsed || parsed.type !== 'result' || typeof parsed.agentId !== 'string') continue
+
+    const structured = extractStructuredJournalResult(parsed.result)
+    if (structured) results.set(parsed.agentId, structured)
+  }
+  return results
+}
+
 export function pairAgentFiles(filenames: string[]): { agentId: string; jsonlFile: string; metaFile: string }[] {
   const jsonlFiles = new Set(filenames.filter((f) => /^agent-.+\.jsonl$/.test(f)))
   const metaFiles = new Set(filenames.filter((f) => /^agent-.+\.meta\.json$/.test(f)))
@@ -226,14 +288,40 @@ interface WorkflowAgentMeta {
   agentType?: string
 }
 
+const JOURNAL_FILENAME = 'journal.jsonl'
+
+// journal.jsonlはWorkflowツール経由の`agent()`呼び出しでのみ生成される（通常のAgent tool
+// 直接起動には存在しない）。存在しない場合は空のMapを返し、呼び出し側は自動的に
+// transcriptパース方式（従来どおりの`parseAgentTranscriptLines`の結果）にフォールバックする。
+function loadJournalResults(wfDirPath: string, filenames: string[]): Map<string, JournalStructuredResult> {
+  if (!filenames.includes(JOURNAL_FILENAME)) return new Map()
+  const lines = readFileSync(join(wfDirPath, JOURNAL_FILENAME), 'utf-8').split('\n').filter(Boolean)
+  return parseJournalResults(lines)
+}
+
 export function reconstructWorkflowDir(wfDirPath: string, feature: string): LoopObservabilityEntry[] {
   const filenames = readdirSync(wfDirPath)
   const pairs = pairAgentFiles(filenames)
+  const journalResults = loadJournalResults(wfDirPath, filenames)
 
   const parsed = pairs.map(({ agentId, jsonlFile, metaFile }) => {
     const meta = JSON.parse(readFileSync(join(wfDirPath, metaFile), 'utf-8')) as WorkflowAgentMeta
     const lines = readFileSync(join(wfDirPath, jsonlFile), 'utf-8').split('\n').filter(Boolean)
-    const summary = parseAgentTranscriptLines(lines)
+    const transcriptSummary = parseAgentTranscriptLines(lines)
+
+    // journal.jsonlに該当agentIdの構造化resultがあればstatus/detail/findingsをそちらで上書きする
+    // （journal.jsonlにはmodel/tokens/timestamp/promptTextが含まれないため、それらは引き続き
+    // transcriptパース結果を使う）。無ければtranscriptパース結果のままフォールバックする。
+    const journalResult = journalResults.get(agentId)
+    const summary: AgentTranscriptSummary = journalResult
+      ? {
+          ...transcriptSummary,
+          status: journalResult.status,
+          detail: journalResult.detail,
+          findings: journalResult.findings,
+        }
+      : transcriptSummary
+
     return { agentId, agentType: meta.agentType ?? 'unknown', startTimestamp: summary.startTimestamp, summary }
   })
 


### PR DESCRIPTION
## Summary
- `scripts/lib/reconstruct-loop-observability.ts`の`result`（status/detail/findings）復元を、Workflowツールが自動生成する`journal.jsonl`の`type:"result"`行から直接取得する経路を追加した
- journal.jsonlが存在しない・該当agentIdの行が無い・resultが構造化データ（statusフィールドを持つオブジェクト）でない場合は、従来のtranscript最終メッセージパース方式にフォールバックする

## 変更内容
- `parseJournalResults(lines)`: journal.jsonlの各行を解析し、`type:"result"`かつ`result.status`が既知の値（pass/fail/blocked）の行のみをagentIdごとにMap化する新規エクスポート関数を追加
  - 実データ調査で`result`が構造化オブジェクトではなくプレーンな文字列（コミットハッシュ等）になっているケースを実際に観測したため、statusを検証できないものは意図的に対象外とし、フォールバックに委ねる設計にした
- `reconstructWorkflowDir`: ディレクトリ内に`journal.jsonl`があれば`parseJournalResults`でMap化し、各agentIdごとにtranscriptパース結果の`status`/`detail`/`findings`をjournal側の値で上書きする。`model`/`tokens`/`costUsd`/`timestamp`/`promptText`はjournal.jsonlに含まれないため、引き続きtranscriptパース結果を使う
- 既存のテスト（`scripts/lib/reconstruct-loop-observability.test.ts`）に以下を追加
  - `parseJournalResults`の単体テスト6件（正常系、プレーンな文字列resultの無視、未知statusの無視、started行の無視、パース不能行の無視、同一agentId複数行時の後勝ち）
  - `reconstructWorkflowDir`の統合テスト4件（一時ディレクトリに`agent-*.jsonl`/`.meta.json`/`journal.jsonl`を実際に書き出し検証）
    - journal.jsonl優先ルート（transcript側と異なる値を用意し、journal側が優先されることを確認）
    - journal.jsonlが存在しない場合のフォールバック（回帰確認）
    - journal.jsonlはあるが該当agentIdの行が無い場合のフォールバック
    - journal.jsonlのresultがプレーンな文字列の場合のフォールバック

## 回帰確認（issue #462の要求事項）
実際にローカルに存在する2件のWorkflow実行ディレクトリ（`wf_c8423571-4ac`, `wf_d1078b0d-976`。いずれも`journal.jsonl`と複数の`agent-*.jsonl`/`.meta.json`を含む）に対し、変更前（`git stash`で旧実装へ一時的に戻した状態）と変更後の`reconstructWorkflowDir`出力を`tsx`で実行し`diff`で突き合わせた。差分はゼロで、既存の正しいケースに対する回帰がないことを確認した。

## Test plan
- [x] `npx vitest run scripts/lib/reconstruct-loop-observability.test.ts` — 新規10件 + 既存15件 = 25件すべてpass
- [x] `npm test` — 151ファイル / 1118件すべてpass
- [x] `npm run lint` — 0 errors（既存の無関係なwarning1件のみ、本PRの変更対象外ファイル）
- [x] `npm run typecheck` — 本PRの変更ファイルには起因しないエラー（`scripts/eval-fixtures/sweep-types/`の意図的に壊されたfixtureファイル由来、main上でも同じエラーが再現することを確認済み）のみで、本変更による新規エラーはなし
- [x] 実データ2件でreconstructWorkflowDirの変更前後diffがゼロであることを確認（回帰なし）

refs #462