### PR TITLE
feat: メタ改修検知でAIDD Sweepをスキップ(issue #457)

### DIFF
--- a/.claude/workflows/aidd-phase1-router.js
+++ b/.claude/workflows/aidd-phase1-router.js
@@ -1,9 +1,9 @@
 export const meta = {
   name: 'aidd-phase1-router',
-  description: 'taskDescriptionとchangedFiles(変更ファイル一覧)をTRI/RISK基準に照合し、aidd-phase1（軽量Sweep）とaidd-1-1-deep-task（深掘り）のどちらを起動するか自動判定する。',
-  whenToUse: 'Phase 1調査の入り口として使う。DBスキーマ変更・auth/facility/tenant/organization/inventory/RLS/policy等の高リスク判定を機械的に行い、手動判断を不要にする。呼び出し側は事前に `git diff --name-only` 等で変更（予定）ファイル一覧を取得し、changedFilesとして渡すこと。',
+  description: 'taskDescriptionとchangedFiles(変更ファイル一覧)をTRI/RISK基準に照合し、aidd-phase1（軽量Sweep）・aidd-1-1-deep-task（深掘り）・メタ改修(Sweepスキップ)のいずれを起動するか自動判定する。',
+  whenToUse: 'Phase 1調査の入り口として使う。DBスキーマ変更・auth/facility/tenant/organization/inventory/RLS/policy等の高リスク判定に加え、.claude/workflows/・.claude/agents/・docs/agents/のみの変更（AIDDパイプライン自体のメタ改修、issue #457）を検知してSweepスキップに振り分ける。呼び出し側は事前に `git diff --name-only` 等で変更（予定）ファイル一覧を取得し、changedFilesとして渡すこと。',
   phases: [
-    { title: 'Route', detail: 'ファイルパス（優先）とtaskDescriptionキーワード（補助）でTRI/RISK判定' },
+    { title: 'Route', detail: 'ファイルパス（優先）とtaskDescriptionキーワード（補助）でTRI/RISK判定、メタ改修は最優先で分岐' },
   ],
 }
 
@@ -11,10 +11,13 @@ export const meta = {
 // changedFiles: 変更対象ファイルパスの配列。Workflowスクリプト自体はgit diffを実行できない
 //   （filesystem/Node.js APIアクセス無し）ため、呼び出し側（Claude Code）が
 //   `git diff --name-only` や変更予定ファイルリストから取得して渡すこと。
-// 判定優先順位: changedFilesが1件以上ある場合はパス一致（matchedPaths）のみで判定する。
-//   taskDescriptionのキーワード一致は「〜には触れない」等の否定文脈でも単純一致してしまうため
-//   （issue #456）、変更対象ファイルが分かっている場合はそちらを信頼する。changedFilesが
-//   空（未指定含む）の場合のみ、後方互換としてキーワード一致で判定する（issue #286時点の挙動）。
+// 判定優先順位:
+//   1. changedFilesが1件以上あり、全てMETA_PATH_PREFIXES配下 → メタ改修（Sweepスキップ、issue #457）
+//   2. changedFilesが1件以上ある場合はパス一致（matchedPaths）のみで判定する。
+//      taskDescriptionのキーワード一致は「〜には触れない」等の否定文脈でも単純一致してしまうため
+//      （issue #456）、変更対象ファイルが分かっている場合はそちらを信頼する。
+//   3. changedFilesが空（未指定含む）の場合のみ、後方互換としてキーワード一致で判定する
+//      （issue #286時点の挙動）。
 //   正本・単体テストは .claude/workflows/lib/router-risk.js を参照。
 
 // common.md記載のパスベース基準: supabase/migrations/ 配下、src/lib/supabase/ 配下
@@ -22,6 +25,12 @@ const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
 
 // common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
 const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
+
+// AIDDパイプライン自体（ツール層）のパス（issue #457）。プロダクトコード向けの4軸Sweepは
+// これらの変更に対して無意味（対象コードがそもそも存在しないため3軸が「指摘なし」を返すだけ）
+// なので、変更ファイルが全てこれらの配下ならSweep自体をスキップし、直接Read/Grep調査へ回す
+// （issue #442・#456で実績のあるパターン）。
+const META_PATH_PREFIXES = ['.claude/workflows/', '.claude/agents/', 'docs/agents/']
 
 const RISK_KEYWORDS = [
   // パス由来
@@ -48,6 +57,11 @@ function isHighRiskPath(filePath) {
   return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
 }
 
+function isMetaPath(filePath) {
+  const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
+  return META_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))
+}
+
 // Workflowツール実行系のargsがverbatimでなく文字列化されて渡ってくる既知の不具合への回避策。
 // argsが文字列で届いた場合はJSONとしてパースしてから使う。
 // 正本・単体テストは .claude/workflows/lib/resolve-workflow-args.js を参照（issue #413）。
@@ -64,7 +78,40 @@ const lowerTask = taskDescription.toLowerCase()
 const matchedKeywords = RISK_KEYWORDS.filter(kw => lowerTask.includes(kw.toLowerCase()))
 const matchedPaths = changedFiles.filter(isHighRiskPath)
 const hasChangedFiles = changedFiles.length > 0
-const isHighRisk = hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
+const isMetaModification = hasChangedFiles && changedFiles.every(isMetaPath)
+const isHighRisk = isMetaModification ? false : hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
+
+// メタ改修（issue #457）: .claude/workflows/・.claude/agents/・docs/agents/のみの変更は
+// プロダクトコード向け4軸Sweepが無意味（3軸が「指摘なし」を返すだけ）なため、Sweep自体を
+// 呼ばず直接Read/Grep調査へ回す（issue #442・#456の実績パターン）。isHighRiskの判定より
+// 優先する分岐なので、ログ・return共にaidd-1-1-deep-task/aidd-phase1より先に処理する。
+if (isMetaModification) {
+  log(`メタ改修検知（変更ファイル: ${changedFiles.join(', ')}）→ Sweepをスキップし直接調査へ`)
+  return {
+    route: 'meta-modification',
+    matchedKeywords,
+    matchedPaths,
+    result: {
+      findings: {
+        meta: 'AIDDパイプライン自体の変更（.claude/workflows/・.claude/agents/・docs/agents/のみ）のため4軸Sweepをスキップしました。対象ファイルをRead/Grepで直接調査した上でSPEC.mdを作成してください（issue #442・#456と同じ直接調査パターン）。',
+      },
+      stats: {
+        phase: 'phase1',
+        agents: 0,
+        rounds: 0,
+        findingCount: 0,
+        blockedCount: 0,
+        expectedAgentProgressRecords: 0,
+        skipped: true,
+        skippedReason: 'meta-modification',
+      },
+      runManifestSeed: {
+        baseCommit: null,
+        changedFiles,
+      },
+    },
+  }
+}
 
 log(
   isHighRisk

--- a/.claude/workflows/lib/__tests__/router-risk-sync.test.js
+++ b/.claude/workflows/lib/__tests__/router-risk-sync.test.js
@@ -41,4 +41,25 @@ describe('router-risk.jsとaidd-phase1-router.jsの判定ロジック同期(issu
 
     expect(extractArray(routerSource, 'RISK_PATH_PREFIXES')).toBe(extractArray(libSource, 'RISK_PATH_PREFIXES'))
   })
+
+  it('META_PATH_PREFIXESが両ファイルで同じ内容（issue #457）', () => {
+    const routerSource = readFileSync(ROUTER_FILE, 'utf-8')
+    const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+    expect(extractArray(routerSource, 'META_PATH_PREFIXES')).toBe(extractArray(libSource, 'META_PATH_PREFIXES'))
+  })
+
+  it('isMetaModification判定式（isHighRiskより優先する式）が両ファイルに同じ形で存在する（issue #457）', () => {
+    const routerSource = readFileSync(ROUTER_FILE, 'utf-8')
+    const libSource = readFileSync(LIB_FILE, 'utf-8')
+    const META_LOGIC = 'hasChangedFiles && changedFiles.every(isMetaPath)'
+    const RISK_WITH_META_LOGIC = 'isMetaModification ? false : hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0'
+
+    // lib側はローカル変数名がchangedFilesではなく引数(changedFiles ?? [])のため、
+    // メタ判定式のみ表記が異なる。式の意味的な同一性は router-risk.test.js のテストケース
+    // （router-risk.jsの単体テスト）とaidd-phase1-router.jsの手動レビューで担保する。
+    expect(routerSource).toContain(META_LOGIC)
+    expect(routerSource).toContain(RISK_WITH_META_LOGIC)
+    expect(libSource).toContain(RISK_WITH_META_LOGIC)
+  })
 })

--- a/.claude/workflows/lib/__tests__/router-risk.test.js
+++ b/.claude/workflows/lib/__tests__/router-risk.test.js
@@ -69,4 +69,37 @@ describe('classifyRisk', () => {
     expect(result.isHighRisk).toBe(true)
     expect(result.matchedPaths).toEqual(['src/lib/supabase/orders.ts'])
   })
+
+  it('changedFilesが全て.claude/workflows/配下ならメタ改修と判定する（issue #457）', () => {
+    const result = classifyRisk('Workflow DSL未使用機能の採用', ['.claude/workflows/aidd-phase2.js', '.claude/workflows/aidd-1-1-deep-task.js'])
+    expect(result.isMetaModification).toBe(true)
+  })
+
+  it('changedFilesが全て.claude/agents/配下ならメタ改修と判定する（issue #457）', () => {
+    const result = classifyRisk('reviewerエージェントの指示文を調整', ['.claude/agents/reviewer.md'])
+    expect(result.isMetaModification).toBe(true)
+  })
+
+  it('changedFilesが全てdocs/agents/配下ならメタ改修と判定する（issue #457）', () => {
+    const result = classifyRisk('common.mdにルールを追記', ['docs/agents/common.md'])
+    expect(result.isMetaModification).toBe(true)
+  })
+
+  it('changedFilesがメタ改修パスとプロダクトコードの混在なら、メタ改修とは判定しない', () => {
+    const result = classifyRisk('ルーターとUIを両方直す', ['.claude/workflows/aidd-phase1-router.js', 'src/app/page.tsx'])
+    expect(result.isMetaModification).toBe(false)
+  })
+
+  it('changedFilesが空ならメタ改修と判定しない', () => {
+    const result = classifyRisk('現在のコードベース全体の調査', [])
+    expect(result.isMetaModification).toBe(false)
+  })
+
+  it('メタ改修パスがドメインキーワードを含んでいても、メタ改修判定がisHighRiskより優先される（issue #457症状2の再現ケース）', () => {
+    // docs/agents/配下だが「policy」という語をファイル名に含むため、素朴なキーワード一致だと
+    // 誤ってRISK_DOMAIN_KEYWORDSにヒットしうる。メタ改修判定が優先されるべきケース。
+    const result = classifyRisk('AIDDのpolicyドキュメントを更新', ['docs/agents/policy-notes.md'])
+    expect(result.isMetaModification).toBe(true)
+    expect(result.isHighRisk).toBe(false)
+  })
 })

--- a/.claude/workflows/lib/router-risk.js
+++ b/.claude/workflows/lib/router-risk.js
@@ -30,12 +30,23 @@ const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
 // common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
 const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
 
+// AIDDパイプライン自体（ツール層）のパス（issue #457）。プロダクトコード向けの4軸Sweepは
+// これらの変更に対して無意味（対象コードがそもそも存在しないため3軸が「指摘なし」を返すだけ）
+// なので、変更ファイルが全てこれらの配下ならSweep自体をスキップし、直接Read/Grep調査へ回す
+// （issue #442・#456で実績のあるパターン）。
+const META_PATH_PREFIXES = ['.claude/workflows/', '.claude/agents/', 'docs/agents/']
+
 function isHighRiskPath(filePath) {
   const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
   if (RISK_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))) return true
   // middleware.ts はプロジェクト内のすべてのmiddlewareが対象（common.md）
   if (normalized === 'middleware.ts' || normalized.endsWith('/middleware.ts')) return true
   return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
+}
+
+function isMetaPath(filePath) {
+  const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
+  return META_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))
 }
 
 function matchTaskKeywords(taskDescription) {
@@ -58,10 +69,17 @@ function matchTaskKeywords(taskDescription) {
 // changedFilesが空（未指定含む）の場合は、パスベース判定ができないため、後方互換として
 // キーワード一致のみで判定する（issue #286時点の挙動を維持）。
 // matchedKeywordsはisHighRiskの判定に使われない場合でも、補助情報としてそのまま返す。
+//
+// isMetaModification: changedFilesが1件以上あり、かつ全てMETA_PATH_PREFIXES配下の場合にtrue
+// （issue #457）。プロダクトコードとの混在（例: ルーターとUIを同時に直す）はメタ改修と
+// 扱わない（プロダクトコード側の調査は依然として必要なため）。isMetaModificationがtrueの
+// 場合はisHighRiskの判定より優先する（メタ改修パスがdocs/agents/policy-notes.mdのように
+// 偶然RISK_DOMAIN_KEYWORDSの語を含んでいても、高リスク扱いにしない）。
 export function classifyRisk(taskDescription, changedFiles = []) {
   const matchedKeywords = matchTaskKeywords(taskDescription)
   const matchedPaths = (changedFiles ?? []).filter(isHighRiskPath)
   const hasChangedFiles = (changedFiles ?? []).length > 0
-  const isHighRisk = hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
-  return { isHighRisk, matchedKeywords, matchedPaths }
+  const isMetaModification = hasChangedFiles && (changedFiles ?? []).every(isMetaPath)
+  const isHighRisk = isMetaModification ? false : hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
+  return { isHighRisk, matchedKeywords, matchedPaths, isMetaModification }
 }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -35,6 +35,23 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
 理由・鮮度判定を見送った理由は同スクリプトのコメント、経緯は
 [`decisions.md`](./decisions.md#なぜissue-444のpretooluse-hookを警告のみdenyの二段構えにしたか)を参照。
 
+**AIDDパイプライン自体のメタ改修時はSweepをスキップする（issue #457）**: issue #442の実施中に、
+`.claude/workflows/`・`.claude/agents/`・`docs/agents/`のみを変更するタスク（＝AIDDパイプライン
+自体の改修）に対して4軸並列Sweep（aidd-phase1）を実行すると、UI/データ/型の3軸は「指摘なし」
+（対象コードがそもそも存在しないので当然）、DB軸のみが「タスク指示と実際のタスクが矛盾している」
+と報告する構造的な無駄が判明した（ルーターの否定文脈誤判定バグ症状1はissue #456で別途解消済み）。
+これに対し`aidd-phase1-router.js`（正本の判定ロジックは`.claude/workflows/lib/router-risk.js`）に
+`isMetaModification`判定を追加した:
+- changedFilesが1件以上あり、**全て**`.claude/workflows/`・`.claude/agents/`・`docs/agents/`配下
+  の場合にtrueとなり、`isHighRisk`判定より優先する（メタ改修パスがドメインキーワード
+  （例: `docs/agents/policy-notes.md`の"policy"）を偶然含んでいても高リスク扱いにしない）
+- trueの場合、`aidd-phase1`・`aidd-1-1-deep-task`のどちらも呼ばずroute: `meta-modification`で
+  即座に返す（agents: 0）。issue #442・#456で実績のある「サブエージェントを使わず直接Read/Grepで
+  調査する」パターンを、ルーターが機械的に指示する形にした
+- プロダクトコードとの混在（例: ルーターとUIコンポーネントを同時に直すタスク）は
+  メタ改修と扱わない（プロダクトコード側の調査は引き続き必要なため）
+- 同期は`.claude/workflows/lib/__tests__/router-risk-sync.test.js`が検証する（`npm test`に含まれる）
+
 ## テスト環境・データ衛生ルール
 
 - **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。


### PR DESCRIPTION
## Summary
- issue #442・#456で判明した「AIDDパイプライン自体（.claude/workflows/・.claude/agents/・docs/agents/）の改修に対して4軸並列Sweepを実行すると、UI/データ/型の3軸が対象コード不在のため無意味な『指摘なし』を返すだけ」という構造的無駄（issue #457症状2）を解消する
- `aidd-phase1-router.js`（正本ロジックは`.claude/workflows/lib/router-risk.js`）に`isMetaModification`判定を追加：changedFilesが1件以上あり、全て`.claude/workflows/`・`.claude/agents/`・`docs/agents/`配下の場合、`aidd-phase1`（軽量Sweep）・`aidd-1-1-deep-task`（深掘り）のどちらも呼ばず、route: `meta-modification`で即座に返す（agents: 0）
- メタ改修判定は`isHighRisk`判定より優先する（例: `docs/agents/policy-notes.md`のように偶然ドメインキーワード"policy"を含んでいても高リスク扱いにしない）
- プロダクトコードとの混在（例: ルーターとUIコンポーネントを同時に変更）はメタ改修と扱わない（プロダクトコード側の調査は引き続き必要なため）
- 症状1（ルーター否定文脈誤判定）は既にissue #456（PR #466）で解消済み。本PRは症状2のみ対応

## 作業サマリ（common.md引き継ぎフォーマット）
- 変更した目的: AIDDパイプライン自体のメタ改修時にSweepエージェントを無駄に起動しないようにする
- 変更した範囲: `.claude/workflows/aidd-phase1-router.js`・`.claude/workflows/lib/router-risk.js`・両ファイルの単体テスト・sync test・`docs/agents/common.md`
- 触っていない範囲: `aidd-phase1.js`（4軸Sweep自体の構造）・`aidd-1-1-deep-task.js`・auth/facility/tenant等のドメインロジック

## 検証済み
- 実行したコマンド: `npm test`（152 test files / 1131 tests 全パス）、`npm run lint`（既存の無関係な警告1件のみ、エラー0）
- 確認した画面: なし（Workflow DSLのロジック変更のみ、UI変更なし）
- 確認したDB/RLS: 該当なし（DB/RLSに触れる変更ではない）
- 他テナントIDアクセス確認: 該当なし（auth/facility/tenant等のドメインには触れていない）

## 既知の未対応
- issue #457の「4軸Sweepにツール層向けの軸を追加する」案は採用せず、「Sweep自体をスキップする」設計を採用した（issue本文の検討事項のうち後者を選択）
- メタ改修時のRun Manifest用baseCommitはagent呼び出しをせず`null`のまま返す設計にした（オーケストレーター側が必要な場合は直接`git rev-parse HEAD`で取得する想定）

## 後任AIへの注意
- この実装で壊してはいけない前提: `isMetaModification`は`isHighRisk`より必ず優先されること（判定順序を入れ替えない）
- 似ているが別物の用語: `RISK_PATH_PREFIXES`（プロダクトコードの高リスクパス）と`META_PATH_PREFIXES`（AIDDパイプライン自体のツール層パス）は別の配列で、混同しない
- 勝手にリファクタしない場所: `router-risk.js`と`aidd-phase1-router.js`のロジックはWorkflow DSLがrequire不可という制約によるインライン複製（issue #413のload-bearing workaround）。片方だけ変更すると`router-risk-sync.test.js`が落ちる

## Test plan
- [x] `npm test` 全件パス
- [x] `npm run lint` エラー0
- [ ] CI（GitHub Actions）でも同様に緑になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)