### PR TITLE
fix: product_compatibilitiesテーブルのanon向け権限をREVOKE(issue #461)

### DIFF
--- a/supabase/migrations/20260718000002_revoke_product_compatibilities_anon.sql
+++ b/supabase/migrations/20260718000002_revoke_product_compatibilities_anon.sql
@@ -1,0 +1,22 @@
+-- supabase/migrations/20260718000002_revoke_product_compatibilities_anon.sql
+-- issue #461: product_compatibilitiesテーブルへのanon向けGRANT ALLが、
+-- 他マスタテーブル（products/categories等、20260626001000_enable_rls.sqlでREVOKE済み）
+-- との一貫性を欠いていた。
+--
+-- WHY: 20260714224053_create_product_compatibilities.sqlは
+-- `GRANT ALL ON TABLE public.product_compatibilities TO postgres, anon, authenticated, service_role;`
+-- でanonにも書き込み権限まで含む広い権限を付与していたが、RLSポリシー（同ファイル54-56行目）は
+-- authenticatedのみを対象にしているため、現状anonは実質アクセス不能（RLSのdeny-by-defaultで
+-- 防御済み・実害なし）。ただし将来ポリシーの書き方を誤ると（例えばUSING句をtrueに緩める等）
+-- 即座に匿名アクセスを許してしまうリスクがあるため、防御を多層化する。
+--
+-- 横断確認（issue #461対応時に実施）: product_compatibilities以降に作成された他のテーブル
+-- （schema_drift_log・schema_baseline_snapshots・news関連・user_facilities）は、いずれも
+-- anonへテーブルレベルのGRANT ALLを付与しておらず（user_facilitiesは一切anon grantなし、
+-- schema_drift関連はdrift_alert_viewへのGRANT SELECTのみに限定）、product_compatibilities
+-- が唯一の例外だった。他に同種の是正が必要なテーブルは無い。
+
+REVOKE ALL ON product_compatibilities FROM anon;
+
+-- テーブル権限のREVOKEのみでテーブル新設/削除ではないため、
+-- refresh_schema_baseline_snapshot は不要（issue #305要件の対象外）。

--- a/supabase/migrations/__tests__/product_compatibilities_anon_revoke.test.ts
+++ b/supabase/migrations/__tests__/product_compatibilities_anon_revoke.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: issue #461の回帰テスト。product_compatibilitiesテーブルへのanon向けGRANT ALLが
+// 他マスタテーブル（REVOKE ALL FROM anon済み）との一貫性を欠いていた問題を修正した
+// マイグレーションの内容を静的に固定する。ローカルSupabaseでの実機検証
+// （anon keyでSELECT/INSERTを試み、GRANTレベルでpermission denied(42501)になることを確認、
+// PASS済み）は別途手動で実施済みだが、CI環境では実DB接続が無いため、admin_rls.test.ts等と
+// 同じパターンでマイグレーションファイルの内容を静的に検証する。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+const REVOKE_FILE = path.join(MIGRATIONS_DIR, '20260718000002_revoke_product_compatibilities_anon.sql')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+describe('20260718000002_revoke_product_compatibilities_anon.sql', () => {
+  it('ファイルが存在する', () => {
+    expect(existsSync(REVOKE_FILE)).toBe(true)
+  })
+
+  const sql = existsSync(REVOKE_FILE) ? readFileSync(REVOKE_FILE, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('product_compatibilitiesからanonの権限をREVOKEする', () => {
+    expect(n).toContain('revoke all on product_compatibilities from anon')
+  })
+})


### PR DESCRIPTION
## Summary
- issue #461: `product_compatibilities`テーブル（`20260714224053_create_product_compatibilities.sql`）が`GRANT ALL ... TO ..., anon, ...`でanonにも広い権限を付与していたが、RLSポリシー（同ファイル）は`authenticated`のみが対象で、他マスタテーブル（`products`/`categories`等、`20260626001000_enable_rls.sql`で`REVOKE ALL FROM anon`済み）との一貫性を欠いていた
- RLSのdeny-by-defaultで実害は無かった（`anon`は実質アクセス不能）が、将来ポリシーの書き方を誤った場合の多層防御として是正した

## 横断確認
`product_compatibilities`作成以降に新設された他テーブル（`schema_drift_log`・`schema_baseline_snapshots`・news feed関連・`user_facilities`）を全て確認したところ、いずれも`anon`へのテーブルレベル広範GRANTを持たない（`user_facilities`は`anon`への付与自体が無い、`schema_drift`関連は特定viewへの`GRANT SELECT`のみに限定）。この不整合は`product_compatibilities`のみの例外だった。

## 実機検証（ローカルSupabase）
修正後、anon keyで`product_compatibilities`への`SELECT`/`INSERT`を試みた。

```
SELECT: permission denied for table product_compatibilities (42501)
INSERT: permission denied for table product_compatibilities (42501)
```

GRANTレベルで明確に`permission denied`となることを確認した（修正前はRLSによる空配列フィルタのみで、GRANT自体は素通りしていた）。

## 変更内容
- `supabase/migrations/20260718000002_revoke_product_compatibilities_anon.sql`（新規）: `REVOKE ALL ON product_compatibilities FROM anon;`
- `supabase/migrations/__tests__/product_compatibilities_anon_revoke.test.ts`（新規）: マイグレーション内容の静的回帰テスト

## Test plan
- [x] ローカルSupabase実機検証（上記、PASS）
- [x] `npx vitest run supabase/migrations/__tests__/product_compatibilities_anon_revoke.test.ts` 2件通過
- [x] `npm test` 全154ファイル1148テスト通過
- [x] `npm run lint`/`typecheck` 私の変更に起因するエラーなし（既存の無関係なエラー・警告のみ）

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #461（`product_compatibilities`のanon向けGRANT不整合）の是正
- 変更した範囲: `product_compatibilities`テーブルの権限のみ。RLSポリシー自体・テーブル構造は無変更
- 触っていない範囲: 他テーブルの権限（横断確認の結果、是正が必要な箇所は無かった）

### 検証済み
- 実行したコマンド: 上記Test plan参照
- 確認した画面: なし
- 確認したDB/RLS: 実施済み（anon keyでのSELECT/INSERTがGRANTレベルでpermission deniedになることを確認）
- 他テナントIDでのアクセス確認: 対象外（`product_compatibilities`はテナント非分離の単一共有マスタ。今回の変更もanon対象のみでauthenticated/facility境界には影響しない）

### 既知の未対応
- 今回あえて対応しなかったこと: なし（横断確認の結果、他に是正対象は見つからなかった）

### 後任AIへの注意
- `product_compatibilities`は意図的にテナント非分離（施設スコープなし）の設計。RLSが`authenticated`全員にSELECTを許可しているのは正しい仕様であり、今回の変更は`anon`のみを対象にしている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
