### PR TITLE
docs: dashboard route.tsの多層防御コメントを実態に合わせて修正(issue #460)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -19,8 +19,15 @@ export async function GET() {
       return apiError('認証が必要です', 401)
     }
 
-    // WHY: 自分が所属する施設のみを対象にすることで施設間データ隔離を担保する
-    // （RLSに加えてアプリ側でも facilityId を絞り込む多層防御）
+    // WHY: 自分が所属する施設のみを対象にすることで施設間データ隔離を担保する（issue #460）。
+    // ここでのfacilityIdはクライアント入力を一切経由せず、listUserFacilities(db, user.id)
+    // （user.idはrequireAuth経由のセッション由来）からのみ得ている。user_facilitiesへの読み取りは
+    // クエリ絞り込み(.eq('user_id', userId))とRLS(self_read: user_id = auth.uid())の二重で保護され、
+    // 下流のcase_orders等も is_facility_member RLS で独立に保護される。
+    // news/route.ts・hospital-prices/[id]/route.tsのrequireFacilityAccessは「クライアントが指定した
+    // facilityId（またはクライアント指定IDで引いたレコードのfacilityId）」を検証するためのものであり、
+    // ここでは検証対象となるクライアント入力自体が存在しないため使用しない（同じ関数を混ぜて使うと
+    // 「なぜここだけ違うパターンか」の判断がその都度必要になり、かえって見落としの元になる）。
     const memberships = await listUserFacilities(db, user.id)
 
     const facilitySummaries: DashboardFacilitySummary[] = await Promise.all(


### PR DESCRIPTION
## Summary
- `src/app/api/dashboard/route.ts:22-24`の「RLSに加えてアプリ側でも facilityId を絞り込む多層防御」というコメントが実装の実態と食い違っていた問題（issue #460）を調査し、**コメントのみ修正**した（機能変更なし）
- 結論: `requireFacilityAccess`の追加は不要。理由は下記「作業サマリ」参照

## 作業サマリ（common.md引き継ぎフォーマット）
- 変更した目的: dashboard route.tsのfacilityId取り扱いに関する誤解を招くコメントを、実態（クライアント入力を経由しない設計）に即して修正する
- 変更した範囲: `src/app/api/dashboard/route.ts`のコメントのみ（1ファイル、機能変更なし）
- 触っていない範囲: `listUserFacilities`・`getFacilityOrderSummary`・`getLoanOutstandingCount`・`requireFacilityAccess`の実装本体、RLSポリシー定義

## 調査結果（AIDD Phase1 軽量Sweep 4軸で実施）
- `facilityId`はクライアント入力を一切経由せず、`listUserFacilities(db, user.id)`（`user.id`は`requireAuth`経由のセッション由来、`db.auth.getUser()`）からのみ取得している
- `user_facilities`への読み取りはクエリ絞り込み(`.eq('user_id', userId)`)とRLS(`self_read: user_id = auth.uid()`)の二重で保護され、下流の`case_orders`/`consumable_orders`/`loan_orders`/`loan_returns`も`is_facility_member`（`facility_member_or_admin`ポリシー、RLS有効化済みを migration で確認）で独立に保護されている
- `requireFacilityAccess`は「クライアントが指定したfacilityId」（`news/route.ts`のURLクエリパラメータ、`hospital-prices/[id]/route.ts`のクライアント指定IDで引いたレコードのfacilityId）を検証するためのものであり、dashboard/route.tsには検証対象となるクライアント入力自体が存在しないため、追加しても意味的に重複するだけで新たな防御にならない
- 既存の`listRecentPriceHistories`（同route内、price_histories向け）は「DBクエリでは facility_id で絞り込めない（ポリモーフィックFK）ためアプリ層で後段フィルタする」という別種の多層防御であり、`getFacilityOrderSummary`/`getLoanOutstandingCount`（DBクエリ自体が`.eq('facility_id', ...)`で絞り込み可能）とは構造が異なる。旧コメントはこの違いを踏まえていなかった

## 検証済み
- 実行したコマンド: `npm test`（153 test files / 1146 tests 全パス）、`npm run lint`（既存の無関係な警告1件のみ、エラー0）
- 確認した画面: なし（コメントのみの変更）
- 確認したDB/RLS: `supabase/migrations/20260626001000_enable_rls.sql`・`20260627010000_add_multitenant.sql`・`20260628010001_update_rls_admin.sql`を読み、`case_orders`/`consumable_orders`/`loan_orders`/`loan_returns`全てにRLS有効化＋`facility_member_or_admin`ポリシーが存在することを確認した
- 他テナントIDでアクセスし、弾かれることを確認したか: 今回は機能変更を行っていないため新規のIDOR確認は実施していない。既存の`supabase/__tests__/integration/{case,consumable,loan}-orders-rls-idor.integration.test.ts`が該当テーブルのRLSを既にカバーしている。`loan_returns`単体の専用IDOR統合テストは無い（`loan_orders`と同じ`facility_member_or_admin`パターンだが個別テストが未整備）ことに気づいたが、issue #460のスコープ外のため本PRでは対応せず、別issueとして切り出すことを推奨する

## 既知の未対応
- 今回あえて対応しなかったこと: `requireFacilityAccess`の追加（上記理由により不要と判断）、`loan_returns`専用のRLS/IDOR統合テスト追加
- 理由: いずれもissue #460の「コメントと実装の不一致を解消する」というスコープを超えるため
- 次に触るなら見る場所: `loan_returns`のRLS/IDOR統合テスト追加は`supabase/__tests__/integration/loan-orders-rls-idor.integration.test.ts`を参考に新規issueとして起票するのが良い

## 後任AIへの注意
- この実装で壊してはいけない前提: dashboard route.tsの`facilityId`は今後も「クライアント入力を経由しない」設計を維持すること。もしdashboard route.tsに新しいクエリパラメータ等からfacilityIdを受け取る変更を加える場合は、その時点で`requireFacilityAccess`の追加が必須になる
- 似ているが別物の用語: 「RLSのみに依存する多層防御」（本PRのcase_orders等）と「アプリ層フィルタによる多層防御」（`listRecentPriceHistories`のケース）は同じ「多層防御」という言葉を使うが構造が異なる。混同して同じコメントを使い回さないこと

## Test plan
- [x] `npm test` 全件パス
- [x] `npm run lint` エラー0
- [ ] CI（GitHub Actions）でも同様に緑になることを確認

refs #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)