### PR TITLE
feat: statuslineでcontext・コスト・レート制限を可視化(issue #446)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -294,6 +294,48 @@ collectorであり、常時稼働ではない。issue #419（effortフィール�
   相当する属性は無く、`query_source`（例: `"main"`）等の粗い区別に留まる。サブエージェント
   単位での突合には、タイムスタンプの近接性等の追加のヒューリスティックが必要（未実装）。
 
+## statuslineでcontext・コスト・レート制限を可視化（issue #446）
+
+サーキットブレーカー運用（ルートの`CLAUDE.md`参照）は`/goal`のターン/時間上限設定に依存するが、
+context使用率・セッションコスト・5h/7dレート制限の消費状況を気づく手段が手動確認
+（`/context`等の実行）のみで、常時可視化する仕組みが無かった。公式のstatusline機能
+（stdin JSONをシェルスクリプトに渡し、出力をターミナル下部に表示する仕組み。
+[公式ドキュメント](https://code.claude.com/docs/en/statusline)でスキーマを確認済み）を使い、
+`scripts/statusline.sh`として実装した。
+
+- 表示内容: モデル名・現在のgitブランチ・context使用率（`context_window.used_percentage`）・
+  セッションコスト（`cost.total_cost_usd`）・5時間/週次レート制限使用率
+  （`rate_limits.five_hour/seven_day.used_percentage`）
+- `rate_limits`はClaude.ai Pro/Max契約かつセッション最初のAPI応答後にのみ存在し、
+  `context_window.used_percentage`もセッション序盤は`null`になりうる（公式ドキュメント記載の
+  既知の欠落パターン）ため、いずれも`jq`の`// empty`で欠落・nullを許容し、値が無い項目は
+  行から消える設計にした
+- **個人opt-in方式**: [OpenTelemetryの節](#opentelemetryと自作jsonlの役割分担issue-417)と同じ
+  理由（表示スタイルの好み・ターミナルのUnicode/絵文字対応状況は開発者ごとに異なるため）で、
+  チーム共有の`.claude/settings.json`には登録しない。有効化したい人だけ各自の
+  `settings.local.json`（gitignore対象）に以下を追加する:
+  ```json
+  {
+    "statusLine": {
+      "type": "command",
+      "command": "<リポジトリ絶対パス>/scripts/statusline.sh"
+    }
+  }
+  ```
+- テストは`scripts/statusline.test.sh`（`bash scripts/statusline.test.sh`で実行、`npm test`には
+  含まれない。statusline.shはClaude Code本体からstdin経由で呼ばれる性質上vitest対象外という、
+  `show-agent-status.sh`等と同じ理由）。公式ドキュメント掲載のサンプルJSON・欠落パターンを
+  fixtureとして固定した
+- **未実装（issue #446の設計案2）**: `subagentStatusLine`（AIDD並列実行中のサブエージェント行を
+  カスタマイズする設定）は今回見送った。公式ドキュメントに`tasks`配列の各フィールド名
+  （`id`/`name`/`type`/`status`/`description`/`label`/`startTime`/`model`/`contextWindowSize`/
+  `tokenCount`/`tokenSamples`/`cwd`）は記載があるものの、メインのstatusLineと異なりフィールド値の
+  完全なJSONサンプルが提供されておらず（特に`startTime`の型・フォーマットが未確認）、実機観測も
+  現行の実行環境（Claude Agent SDK経由）ではstatusLine自体が呼び出されず不可能だった。
+  誤った型の想定で実装すると気づかれないまま壊れるため、確度の低いフィールド仮定のまま実装するのは
+  見送り、`show-agent-status.sh`（履歴側）で当面代替する。実機（通常のターミナルCLI）で
+  `tasks`配列の実際のJSONを観測できる環境がある場合は、別issueとして着手すること
+
 ## Bashサンドボックス機能は現行toolchainと非互換のため保留（issue #438）
 
 実機検証の結果、`sandbox.enabled: true`はgh/supabase CLI（Go製）のHTTPS通信をTLS証明書検証

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# issue #446: statuslineでcontext使用率・セッションコスト・レート制限使用率・現在ブランチを
+# 常時可視化する。サーキットブレーカー運用（財布を守る）の可視化面が手動確認のみだった問題への対応。
+#
+# stdinで渡されるJSONフィールドはcode.claude.com/docs/en/statuslineで実在確認済み。
+# rate_limitsはClaude.ai Pro/Max契約かつセッション最初のAPI応答後にのみ存在するため、
+# `// empty`で欠落・null双方を許容する（公式ドキュメント推奨パターン）。
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model.display_name // "?"')
+CTX_PCT=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+FIVE_H=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+SEVEN_D=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+
+BRANCH=""
+git rev-parse --git-dir > /dev/null 2>&1 && BRANCH=$(git branch --show-current 2>/dev/null)
+
+LINE="[$MODEL]"
+[ -n "$BRANCH" ] && LINE="$LINE branch:$BRANCH"
+[ -n "$CTX_PCT" ] && LINE="$LINE ctx:$(printf '%.0f' "$CTX_PCT")%"
+LINE="$LINE cost:$(printf '$%.2f' "$COST")"
+[ -n "$FIVE_H" ] && LINE="$LINE 5h:$(printf '%.0f' "$FIVE_H")%"
+[ -n "$SEVEN_D" ] && LINE="$LINE 7d:$(printf '%.0f' "$SEVEN_D")%"
+
+echo "$LINE"

--- a/scripts/statusline.test.sh
+++ b/scripts/statusline.test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# WHY: statusline.shはClaude Code本体からstdin経由で呼ばれるためvitestの対象外。issue #446の
+# ゲート条件（公式ドキュメントで確認したstdin JSONスキーマに沿って動くこと）を、公式ドキュメント
+# 掲載のサンプルJSON・欠落パターンをそのままfixtureとして固定し回帰テストする。
+#
+# 実行: bash scripts/statusline.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUSLINE="$SCRIPT_DIR/statusline.sh"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+git init -q
+git checkout -q -b test-branch
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual output: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  NG: $label (should NOT contain: $needle)"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+
+echo "=== test: 公式ドキュメント掲載のフルサンプルJSON（rate_limits・context_window等すべて存在） ==="
+FULL_JSON='{"model":{"id":"claude-opus-4-8","display_name":"Opus"},"cost":{"total_cost_usd":0.01234,"total_duration_ms":45000},"context_window":{"used_percentage":8,"remaining_percentage":92},"rate_limits":{"five_hour":{"used_percentage":23.5},"seven_day":{"used_percentage":41.2}},"session_id":"abc123"}'
+OUTPUT="$(echo "$FULL_JSON" | bash "$STATUSLINE")"
+assert_contains "$OUTPUT" "[Opus]" "モデル表示名が表示される"
+assert_contains "$OUTPUT" "branch:test-branch" "現在のgitブランチが表示される"
+assert_contains "$OUTPUT" "ctx:8%" "context使用率が整数で表示される"
+assert_contains "$OUTPUT" "cost:\$0.01" "セッションコストがUSDで表示される"
+assert_contains "$OUTPUT" "5h:24%" "5時間レート制限使用率が四捨五入して表示される"
+assert_contains "$OUTPUT" "7d:41%" "週次レート制限使用率が表示される"
+
+echo "=== test: rate_limits不在（Claude.ai Pro/Max未契約、公式ドキュメント記載の欠落パターン） ==="
+NO_RL_JSON='{"model":{"display_name":"Sonnet"},"cost":{"total_cost_usd":0},"context_window":{"used_percentage":null},"session_id":"def456"}'
+OUTPUT="$(echo "$NO_RL_JSON" | bash "$STATUSLINE")"
+assert_contains "$OUTPUT" "[Sonnet]" "モデル表示名が表示される"
+assert_contains "$OUTPUT" "cost:\$0.00" "コスト0円も表示される"
+assert_not_contains "$OUTPUT" "5h:" "rate_limits不在時は5h表示が出ない"
+assert_not_contains "$OUTPUT" "7d:" "rate_limits不在時は7d表示が出ない"
+assert_not_contains "$OUTPUT" "ctx:" "context_window.used_percentageがnullの場合ctx表示が出ない"
+
+echo "=== test: five_hourのみ存在しseven_dayが不在（rate_limitsの各windowが独立して不在になりうる公式仕様） ==="
+PARTIAL_RL_JSON='{"model":{"display_name":"Opus"},"cost":{"total_cost_usd":1.5},"rate_limits":{"five_hour":{"used_percentage":10}}}'
+OUTPUT="$(echo "$PARTIAL_RL_JSON" | bash "$STATUSLINE")"
+assert_contains "$OUTPUT" "5h:10%" "five_hourのみ表示される"
+assert_not_contains "$OUTPUT" "7d:" "seven_day不在時は7d表示が出ない"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- サーキットブレーカー運用（ルートのCLAUDE.md参照）の可視化面が手動確認のみだった問題に対応するため、公式statusline機能で`scripts/statusline.sh`を実装した
- 表示内容: モデル名・現在のgitブランチ・context使用率・セッションコスト(USD)・5h/7dレート制限使用率
- 個人opt-in方式（OpenTelemetryの節と同じ理由）。チーム共有の`.claude/settings.json`には登録せず、各自の`settings.local.json`に追加する

## 作業サマリ（common.md引き継ぎフォーマット）
- 変更した目的: issue #446（サーキットブレーカーの可視化面がゼロ）への対応
- 変更した範囲: `scripts/statusline.sh`（新規）・`scripts/statusline.test.sh`（新規）・`docs/agents/common.md`（新セクション追加）
- 触っていない範囲: `.claude/settings.json`（意図的にopt-in、共有設定へは追加していない）、`subagentStatusLine`（設計案2、今回は見送り）

## ゲート条件（issue #446記載）への対応
> stdin JSONの現行スキーマ（context_window/cost/rate_limitsフィールドの実在）を公式docで確認し、実機で1回観測してから実装。

- 公式ドキュメント（code.claude.com/docs/en/statusline）をWebFetchで直接取得し、全フィールドの完全なJSONスキーマ・サンプルを確認済み（`context_window.used_percentage`等・`cost.total_cost_usd`等・`rate_limits.five_hour/seven_day.used_percentage`等、いずれも実在確認済み）
- **実機観測は不可**: このセッションが動作している実行環境（Claude Agent SDK経由）では、statusLineコマンド自体が呼び出されないことを確認した（デバッグ用の一時statusLine設定をworktree限定の個人設定に追加し、captureを試みたが一切呼ばれなかった）。statusLineは通常のターミナルCLI UIの機能のため、この実行環境固有の制約と判断した
- 公式ドキュメントが推奨する代替検証方法（モックJSON入力を標準入力に渡すテスト実行）で全パターン（フルサンプル・rate_limits不在・context_window.used_percentageがnull・five_hourのみ存在等）を検証した

## 検証済み
- 実行したコマンド: `npm test`（154 test files / 1148 tests 全パス）、`npm run lint`（既存の無関係な警告1件のみ、エラー0）、`bash scripts/statusline.test.sh`（新規、全件パス）
- 確認した画面: なし（実機のstatusLine表示は上記の理由により確認不可。ユーザー自身の通常ターミナルCLIセッションでの実機確認を推奨）
- 確認したDB/RLS: 該当なし
- 他テナントIDでのアクセス確認: 該当なし（facility/tenant/auth等のドメインに触れていない）

## 既知の未対応
- 今回あえて対応しなかったこと: issue #446の設計案2（`subagentStatusLine`によるAIDD並列実行の進捗可視化）
- 理由: 公式ドキュメントに`tasks`配列のフィールド名（`id`/`name`/`type`/`status`/`startTime`等）は記載があるが、メインのstatusLineと異なり完全なJSONサンプルが提供されておらず、`startTime`等の型・フォーマットが未確認。この実行環境では実機観測も不可能だったため、確度の低い実装で「気づかれないまま壊れる」リスクを避けて見送った
- 次に触るなら見る場所: 通常のターミナルCLIで`tasks`配列の実際のJSONを観測できる環境がある場合、別issueとして着手すること（`docs/agents/common.md`「statuslineでcontext・コスト・レート制限を可視化」参照）

## 後任AIへの注意
- この実装で壊してはいけない前提: `.claude/settings.json`（チーム共有）には`statusLine`を追加しないこと。個人opt-inの設計判断であり、勝手に共有設定へ昇格させない
- 似ているが別物の用語: `statusLine`（メインのステータスバー、本PRで実装）と`subagentStatusLine`（サブエージェント行のカスタマイズ、未実装）は別の設定項目

## Test plan
- [x] `npm test` 全件パス
- [x] `npm run lint` エラー0
- [x] `bash scripts/statusline.test.sh` 全件パス（モックJSON、公式ドキュメント記載の欠落パターン含む）
- [ ] CI（GitHub Actions）でも同様に緑になることを確認
- [ ] ユーザー自身の通常ターミナルCLIセッションでの実機表示確認（推奨、必須ではない）

refs #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)