### PR TITLE
feat: subagentStatusLineでサブエージェントのcontext使用率を表示(issue #446)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -326,15 +326,40 @@ context使用率・セッションコスト・5h/7dレート制限の消費状�
   含まれない。statusline.shはClaude Code本体からstdin経由で呼ばれる性質上vitest対象外という、
   `show-agent-status.sh`等と同じ理由）。公式ドキュメント掲載のサンプルJSON・欠落パターンを
   fixtureとして固定した
-- **未実装（issue #446の設計案2）**: `subagentStatusLine`（AIDD並列実行中のサブエージェント行を
-  カスタマイズする設定）は今回見送った。公式ドキュメントに`tasks`配列の各フィールド名
-  （`id`/`name`/`type`/`status`/`description`/`label`/`startTime`/`model`/`contextWindowSize`/
-  `tokenCount`/`tokenSamples`/`cwd`）は記載があるものの、メインのstatusLineと異なりフィールド値の
-  完全なJSONサンプルが提供されておらず（特に`startTime`の型・フォーマットが未確認）、実機観測も
-  現行の実行環境（Claude Agent SDK経由）ではstatusLine自体が呼び出されず不可能だった。
-  誤った型の想定で実装すると気づかれないまま壊れるため、確度の低いフィールド仮定のまま実装するのは
-  見送り、`show-agent-status.sh`（履歴側）で当面代替する。実機（通常のターミナルCLI）で
-  `tasks`配列の実際のJSONを観測できる環境がある場合は、別issueとして着手すること
+- **`subagentStatusLine`実装（issue #446の設計案2、2026-07-18実機観測により着手）**: 見送りの
+  理由だった「フィールド値の完全なJSONサンプルが無い・`startTime`の型が未確認」を、実際の
+  ターミナルCLI（通常のインタラクティブ`claude`セッション、Claude Agent SDK経由のセッションでは
+  `subagentStatusLine`自体が発火しないため不可）で解消してから実装した。
+  - **実機観測の手順**: `scripts/subagent-statusline-debug-collector.sh`を一時的に
+    `subagentStatusLine`として`settings.local.json`に配線し、受け取った生JSONを
+    `logs/subagent-statusline-debug.jsonl`（gitignore対象）にそのまま追記するだけの捕捉専用
+    スクリプトを用意した。人間が実際のターミナルでExploreエージェントを複数並列実行する
+    タスクを依頼し、パネル表示中に捕捉した
+  - **実機観測で確定した事実**:
+    - `startTime`はUnix epochミリ秒（13桁、実測値`1784374971089`は2026-07-18と整合）
+    - `tasks[]`の各要素に`name`が無いケースがある（Task tool経由の`local_agent`型は
+      `label`/`description`のみで`name`は付与されない）
+    - タスク完了時は`status`が`"done"`等に変わるのではなく、**`tasks`配列から丸ごと消える**
+      （実測ではrunning以外のstatus値は一度も観測できなかった）
+    - `contextWindowSize`はモデル未解決時は省略される（公式ドキュメント記載どおり実測でも確認）
+  - 上記を踏まえ`scripts/subagent-statusline.sh`を実装した。表示内容は
+    `<状態アイコン> <label優先のフォールバック名> <tokenCountをk単位に整形> <context使用率%>`を
+    `columns`幅に切り詰めて`{"id":..., "content":...}`形式で1行ずつ出力する
+  - **既知の未確認事項**: `status`が`"running"`以外の値を取るケース（`waiting`/`failed`等）は
+    実機で一度も観測できておらず、アイコン分岐は公式ドキュメントの一般的な語彙からの類推に
+    とどまる。`startTime`から経過時間を表示する機能は型が確定した後でも今回は実装していない
+    （tokenベースの表示のみで着手条件を満たしたため。追加する場合は別issueで検討すること）
+  - 個人opt-in方式・テスト方針は上記statusline.shと同じ。設定は
+    ```json
+    {
+      "subagentStatusLine": {
+        "type": "command",
+        "command": "<リポジトリ絶対パス>/scripts/subagent-statusline.sh"
+      }
+    }
+    ```
+    テストは`scripts/subagent-statusline.test.sh`（`bash scripts/subagent-statusline.test.sh`で
+    実行、`npm test`には含まれない。fixtureは実機捕捉した実際のJSON構造を元にしている）
 
 ## Bashサンドボックス機能は現行toolchainと非互換のため保留（issue #438）
 

--- a/scripts/subagent-statusline-debug-collector.sh
+++ b/scripts/subagent-statusline-debug-collector.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# issue #446フォローアップ: subagentStatusLineのtasks配列（id/name/type/status/description/
+# label/startTime/model/contextWindowSize/tokenCount/tokenSamples/cwd）は公式ドキュメントに
+# フィールド名の記載はあるが完全なJSONサンプルが無く、特にstartTimeの型・フォーマットが未確認。
+# このスクリプトは実装のための一時的な実測専用ツールで、subagentStatusLineとして設定し、
+# 受け取った生JSONをそのままlogs/subagent-statusline-debug.jsonlに追記する。
+# 行のoverrideは一切出力しない（=デフォルト表示のまま）。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_FILE="$REPO_ROOT/logs/subagent-statusline-debug.jsonl"
+
+mkdir -p "$REPO_ROOT/logs"
+
+input=$(cat)
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "$input" | jq -c --arg capturedAt "$ts" '. + {_capturedAt: $capturedAt}' >> "$LOG_FILE" 2>/dev/null || true
+
+exit 0

--- a/scripts/subagent-statusline.sh
+++ b/scripts/subagent-statusline.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# issue #446フォローアップ: subagentStatusLineでサブエージェント行にcontext使用率・
+# token数を表示する。show-agent-status.sh（履歴側）を補完するリアルタイム表示。
+#
+# フィールドの型・挙動は2026-07-18に実機（通常のターミナルCLIでのインタラクティブ
+# セッション、scripts/subagent-statusline-debug-collector.shで捕捉）で確認済み:
+# - startTimeはUnix epochミリ秒（13桁）。本スクリプトでは未使用（elapsed計算はしない。
+#   捕捉できたのはtoken推移のみで、経過時間表示の要否・単位は別途検討）
+# - tasks[]の各要素にnameが無いケースがある（Task tool経由のlocal_agent型はlabel/
+#   descriptionのみ）。フォールバックはlabel→name→description→type→"agent"の順
+# - タスク完了時はstatusが"done"等に変わるのではなく、tasks配列から丸ごと消える。
+#   そのため本スクリプトが完了状態のアイコンを描画する機会は実測では確認できていない
+#   （running以外のstatus値は公式ドキュメントの一般的な語彙から類推してフォールバック
+#   分岐のみ用意し、実機未確認のまま残す）
+# - contextWindowSizeはモデル未解決時は省略される（公式ドキュメント記載どおり実測でも
+#   確認、その場合は%表示を省く）
+input=$(cat)
+
+echo "$input" | jq -c '
+  (.columns // 80) as $cols
+  | (.tasks // [])[]
+  | (.label // .name // .description // .type // "agent") as $label
+  | (.status // "running") as $status
+  | (.tokenCount // 0) as $tokens
+  | (.contextWindowSize // null) as $ctxSize
+  | (
+      if $status == "running" then "▸"
+      elif ($status == "waiting" or $status == "pending" or $status == "queued") then "◦"
+      elif ($status == "failed" or $status == "error") then "✗"
+      elif ($status == "done" or $status == "completed") then "✓"
+      else "•"
+      end
+    ) as $icon
+  | (
+      if $tokens >= 1000 then
+        (( ($tokens / 1000 * 10 | round) / 10 ) | tostring) + "k"
+      else
+        ($tokens | tostring)
+      end
+    ) as $tokensFmt
+  | (
+      if $ctxSize != null and $ctxSize > 0 then
+        " " + (( ($tokens / $ctxSize * 100 * 10 | round) / 10 ) | tostring) + "%"
+      else
+        ""
+      end
+    ) as $pctStr
+  | ($icon + " " + $label + " " + $tokensFmt + "tok" + $pctStr) as $content
+  | {id: .id, content: $content[0:$cols]}
+'

--- a/scripts/subagent-statusline.test.sh
+++ b/scripts/subagent-statusline.test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# WHY: subagent-statusline.shはClaude Code本体からstdin経由で呼ばれるためvitestの対象外
+# （statusline.test.shと同じ理由）。fixtureは2026-07-18に実機（scripts/
+# subagent-statusline-debug-collector.shで捕捉した実際のtasks配列JSON）で確認した構造を
+# 元にしている。公式ドキュメントのみを根拠にした憶測フィールドは含まない。
+#
+# 実行: bash scripts/subagent-statusline.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBAGENT_STATUSLINE="$SCRIPT_DIR/subagent-statusline.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual output: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  NG: $label (should NOT contain: $needle)"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+assert_equal() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected: $expected"
+    echo "      actual:   $actual"
+    fail=1
+  fi
+}
+
+echo "=== test: 実機捕捉した複数taskペイロード（2026-07-18、columns:37の狭い実測値） ==="
+REAL_JSON='{"session_id":"5f156845-402e-4078-9e08-ce7129859f93","cwd":"/repo","prompt_id":"79b6c8d3","columns":37,"tasks":[{"id":"a9b77940bac699b4f","type":"local_agent","status":"running","description":"Grep TODO occurrences","label":"Grep TODO occurrences","startTime":1784374971089,"model":"claude-sonnet-5","contextWindowSize":1000000,"tokenCount":21668,"tokenSamples":[0,0,0,21668],"cwd":"/repo"},{"id":"a6dd56ba2c7ff457b","type":"local_agent","status":"running","description":"Grep FIXME occurrences","label":"Grep FIXME occurrences","startTime":1784374972500,"model":"claude-sonnet-5","contextWindowSize":1000000,"tokenCount":21089,"tokenSamples":[0,0,21089],"cwd":"/repo"}]}'
+OUTPUT="$(echo "$REAL_JSON" | bash "$SUBAGENT_STATUSLINE")"
+LINE_COUNT="$(echo "$OUTPUT" | wc -l | tr -d ' ')"
+assert_equal "$LINE_COUNT" "2" "task数ぶんの行数が出力される"
+assert_contains "$OUTPUT" '"id":"a9b77940bac699b4f"' "1件目のidがそのまま反映される"
+assert_contains "$OUTPUT" "Grep TODO occurrences" "labelが表示される"
+assert_contains "$OUTPUT" "21.7ktok" "tokenCountが1000以上のときk単位で小数第1位まで表示される"
+assert_contains "$OUTPUT" "2.2%" "tokenCount/contextWindowSizeから算出したcontext使用率が表示される"
+TRUNC_OK=1
+echo "$OUTPUT" | while IFS= read -r line; do
+  LEN=$(echo "$line" | jq -r '.content | length')
+  if [ "$LEN" -gt 37 ]; then
+    echo "  NG: content が columns(37) を超えている: ${LEN}コードポイント ($line)"
+    exit 1
+  fi
+done || TRUNC_OK=0
+if [ "$TRUNC_OK" -eq 1 ]; then
+  echo "  OK: 各contentがcolumns(37)以内に切り詰められている"
+else
+  fail=1
+fi
+
+echo "=== test: contextWindowSize不在（モデル未解決、公式ドキュメント記載の欠落パターン） ==="
+NO_CTXSIZE_JSON='{"columns":80,"tasks":[{"id":"t1","label":"Investigating foo","status":"running","tokenCount":500}]}'
+OUTPUT="$(echo "$NO_CTXSIZE_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_contains "$OUTPUT" "Investigating foo" "labelが表示される"
+assert_contains "$OUTPUT" "500tok" "1000未満のtokenCountはk単位に変換されずそのまま表示される"
+assert_not_contains "$OUTPUT" "%" "contextWindowSize不在時は%表示が出ない"
+
+echo "=== test: name/label/descriptionがすべて無い（typeへフォールバック） ==="
+NO_LABEL_JSON='{"columns":80,"tasks":[{"id":"t2","type":"external_agent","status":"running","tokenCount":0}]}'
+OUTPUT="$(echo "$NO_LABEL_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_contains "$OUTPUT" "external_agent" "label/name/description不在時はtypeにフォールバックする"
+
+echo "=== test: nameのみ存在するケース（実機ではlabel優先だがname単独ケースも許容） ==="
+NAME_ONLY_JSON='{"columns":80,"tasks":[{"id":"t3","name":"security-reviewer","status":"running","tokenCount":0}]}'
+OUTPUT="$(echo "$NAME_ONLY_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_contains "$OUTPUT" "security-reviewer" "nameが表示される"
+
+echo "=== test: tasks配列が空 ==="
+EMPTY_TASKS_JSON='{"columns":80,"tasks":[]}'
+OUTPUT="$(echo "$EMPTY_TASKS_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_equal "$OUTPUT" "" "tasksが空配列のときは出力なし"
+
+echo "=== test: tasksフィールド自体が不在 ==="
+NO_TASKS_JSON='{"columns":80}'
+OUTPUT="$(echo "$NO_TASKS_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_equal "$OUTPUT" "" "tasksフィールド不在のときは出力なし"
+
+echo "=== test: columns不在時は既定幅(80)で切り詰められる ==="
+NO_COLUMNS_JSON='{"tasks":[{"id":"t4","label":"short","status":"running","tokenCount":0}]}'
+OUTPUT="$(echo "$NO_COLUMNS_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_contains "$OUTPUT" "short" "columns不在でもエラーにならず出力される"
+
+echo "=== test: status不明値は汎用アイコンにフォールバック ==="
+UNKNOWN_STATUS_JSON='{"columns":80,"tasks":[{"id":"t5","label":"mystery","status":"blocked","tokenCount":0}]}'
+OUTPUT="$(echo "$UNKNOWN_STATUS_JSON" | bash "$SUBAGENT_STATUSLINE")"
+assert_contains "$OUTPUT" "• mystery" "未知のstatus値は汎用アイコン(•)で表示される"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- issue #446のPR #472で「型未確認のまま実装するのは見送り」と判断していたsubagentStatusLineを、実際のターミナルCLI（インタラクティブセッション）でtasks配列の実データを観測してから実装
- `startTime`がUnix epochミリ秒であること、Task tool経由のtaskには`name`が付与されないケースがあること、タスク完了時は`status`が変わるのではなく`tasks`配列から消えることを実測で確認
- `scripts/subagent-statusline.sh`: 状態アイコン・token数(k単位)・context使用率(%)を`columns`幅に切り詰めて表示
- `scripts/subagent-statusline-debug-collector.sh`: 実測に使った捕捉専用スクリプト（今後の追加調査用に残置）
- `docs/agents/common.md`: issue #446セクションを実装済みの記述に更新（実機で確定した事実・未確認事項を明記）

## Test plan
- [x] `bash scripts/subagent-statusline.test.sh` — 9ケース全PASS（実機捕捉データを元にしたfixture含む）
- [x] `bash scripts/statusline.test.sh` — 既存分の回帰なし
- [x] `npm test` — 154ファイル/1148テスト全PASS
- [x] 実機（実際のターミナルでのインタラクティブ`claude`セッション、Explore並列実行）でtasks配列の実ペイロードを観測し、それを元にfixtureを作成

## 既知の未対応
- `status`が`"running"`以外の値（`waiting`/`failed`等）は実機で一度も観測できておらず、アイコン分岐は未確認のまま
- `startTime`からの経過時間表示は未実装（token表示のみで着手条件を満たしたため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)