### PR TITLE
feat: fault injection訓練の期限切れ検知をSessionStart hookで機械トリガー化(issue #443)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,6 +90,8 @@
       "Bash(bash scripts/check-automode-config.test.sh*)",
       "Bash(scripts/check-blocked-issues-staleness.sh *)",
       "Bash(bash scripts/check-blocked-issues-staleness.test.sh*)",
+      "Bash(scripts/check-fault-injection-drill-staleness.sh *)",
+      "Bash(bash scripts/check-fault-injection-drill-staleness.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -163,6 +165,11 @@
             "type": "command",
             "command": "scripts/check-blocked-issues-staleness.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-fault-injection-drill-staleness.sh",
+            "timeout": 5
           }
         ]
       }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -372,6 +372,21 @@ GitHub Actions内でclaude-code-action（@claudeメンションでのissue/PR自
 設計判断の詳細は
 [`decisions.md`の該当項目](./decisions.md#なぜblockedラベルの再開条件見直しをcronではなくsessionstart-hookのポーリングにしたかissue-453)を参照。
 
+## 定期実行の機械トリガー化はSessionStart hookに一本化、OS launchdは見送り（issue #443）
+
+issue #443は当初「OS launchd等による夜間バッチジョブで、複数の人起動チェック（gap check・
+baseline鮮度・fault injection訓練・eval:workflows未実行検知）をまとめて機械トリガー化する」
+という提案だった。調査の結果、対象として挙げられていたチェックの大半（`check-loop-observability-gap.sh`・
+`check-agent-progress-gap.sh`は単発フロー実行の前後差分が前提、`check-agent-baseline-freshness.sh`
+はCI/PR diff前提、eval:workflowsは実行記録の仕組み自体が無い）が夜間バッチに転用できないと
+判明し、実装可能だったのは`scripts/check-fault-injection-drill-staleness.sh`
+（`docs/agents/fault-injection-drill.md`「## 次回実施予定日」の期限切れ検知）1件のみだった。
+
+OS launchd等の常時稼働の仕組みは、無人でGitHub issue作成等の外部作用を持ちうる恒久的な
+バックグラウンドサービスの新設になるため導入を見送り、`#453`と同じSessionStart hook
+パターンに一本化した。設計判断の詳細は
+[`decisions.md`の該当項目](./decisions.md#なぜissue-443の夜間バッチ構想をsessionstart-hookに縮小したか)を参照。
+
 ## autoMode(hard_deny)は個人設定のみ有効・設定し忘れ検知はSessionStart hookで（issue #439）
 
 `autoMode.hard_deny`（ユーザー意図でも上書き不可の無条件ブロック）は、公式仕様上

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -715,3 +715,41 @@ API従量課金という追加コストが重複して発生するだけにな�
 
 **再開条件:** ローカルセッションでは手が回らない規模までissue/PR量が増えた場合、または
 API課金がClaude Pro/Maxサブスクに統合される等、追加コスト構造が変わった場合。
+
+## なぜissue #443の夜間バッチ構想をSessionStart hookに縮小したか
+
+issue #443は「検知手段のないルールの棚卸し」（issue #339）の第3層ルールのうち、検査
+スクリプト自体はあるのに起動が人依存のもの（loop-observability/agent-progress gap check・
+baseline鮮度チェック・fault injection四半期訓練・eval:workflows未実行検知）を、OS launchd等の
+夜間バッチジョブでまとめて機械トリガー化する提案だった。
+
+**実装前に対象スクリプトを実際に読んで判明した制約:**
+- `scripts/check-loop-observability-gap.sh`・`scripts/check-agent-progress-gap.sh`は
+  `--before N --expected M`という、**単発のAIDDフロー実行の直前直後の件数差分**を引数に
+  要求する設計だった。これは「フロー実行直後にオーケストレーターが呼ぶ」ことを前提にした
+  チェックであり、独立した夜間バッチジョブには「直前のフロー」という文脈が無いため、
+  そのままでは呼び出せない
+- `scripts/check-agent-baseline-freshness.sh`（issue #429）も同様に、`<base-ref> <head-ref>`
+  というPR diffを前提にした設計で、CI（PRの差分チェック）用途としては正しく機能している。
+  夜間バッチに無理に転用する動機が薄い
+- eval:workflows（`scripts/eval-workflow-prompts.sh`）は`logs/`に何も書き込んでおらず、
+  「最終実行日時」を記録する仕組み自体がそもそも存在しなかった。未実行検知を作るには、
+  まず実行記録の仕組みを別途追加する必要がある（本issueの前提が成立していなかった）
+
+**唯一そのまま実装可能だったもの:** `docs/agents/fault-injection-drill.md`の
+「## 次回実施予定日」欄は、既に「次回実施予定日」という単一の日付フィールドを持ち、
+「リマインド機構は無い」と明記されていた（issue #443がまさに埋めようとしていたギャップ
+そのもの）。これだけは追加の前提無しに、日付比較だけで機械化できた。
+
+**OS launchdを見送り、SessionStart hookに一本化した判断:** issue原案は「launchdはClaude
+不要で軽い」という利点を挙げていたが、launchdの`.plist`インストール（`~/Library/LaunchAgents/`
+配下への恒久的な登録、`launchctl load`によるOS常駐サービス化）は、リポジトリの外側で
+ユーザーの実行環境そのものに手を入れる操作であり、しかも無人でGitHub issue作成等の外部作用を
+持ちうる。これは今回セッション内で完結する他の変更（フックスクリプト追加等）とは質的に
+異なるリスクを持つと判断した。一方、SessionStart hookは既にこのリポジトリで「機械トリガー」
+として扱われており（issue #411の原則を満たす。`check-blocked-issues-staleness.sh`（issue
+#453）と同型）、恒久的なOS常駐サービスを新設せずとも「セッションが始まった時に気づける」
+という目的は達成できる。この判断により、issue原案の「棚卸し表から最大4行削減」という見込みは
+実質1行（fault injection訓練の放置検知）に縮小したが、残りの3項目（gap check 2件・
+eval:workflows未実行検知）は本issueとは別に、それぞれの前提（実行記録の仕組み等）を
+別途整備してから再検討することとした。

--- a/scripts/check-fault-injection-drill-staleness.sh
+++ b/scripts/check-fault-injection-drill-staleness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart hookから呼ばれる。issue #443: 「検知手段のないルールの棚卸し」（issue #339）の
+# 第3層ルールのうち、fault injection四半期訓練（issue #395）は
+# docs/agents/fault-injection-drill.md「## 次回実施予定日」に「リマインド機構は無い」と
+# 明記されたまま放置されていた。
+#
+# 設計判断（issue #443スコープの絞り込み。詳細はdocs/agents/decisions.md参照）:
+# issue原案は「OS launchd等による夜間バッチジョブ」を想定していたが、対象読者(loop-observability
+# /agent-progress gap check)は単発フロー実行の前後差分が前提の設計で夜間バッチに転用できず、
+# eval:workflowsの実行記録自体も存在しないため、今回実装可能なのは本チェック（fault injection
+# 訓練の期限切れ検知）のみだった。OS launchdのような常時稼働・無人でGitHub issueを作成しうる
+# 仕組みを新設するのではなく、SessionStart hook（既に機械トリガーとして扱われる。issue #411の
+# 原則を満たす）で「次回実施予定日」を過ぎていないか警告する形に留めた
+# （check-blocked-issues-staleness.shと同じ「セッションが始まった時に気づける」最小限のバー）。
+#
+# 日付抽出はmacOS/Linuxのdate非互換を避けるため他のスクリプトと同様にpython3に委ねる。
+
+DRILL_DOC="${FAULT_INJECTION_DRILL_DOC:-docs/agents/fault-injection-drill.md}"
+
+if [ ! -f "$DRILL_DOC" ]; then
+  exit 0
+fi
+
+RESULT="$(python3 -c "
+import re, sys
+from datetime import date
+
+with open('$DRILL_DOC', encoding='utf-8') as f:
+    text = f.read()
+
+m = re.search(r'## 次回実施予定日\s*\n+(\d{4}-\d{2}-\d{2})', text)
+if not m:
+    print('NO_DATE')
+    sys.exit(0)
+
+due = date.fromisoformat(m.group(1))
+today = date.today()
+if today >= due:
+    print(f'DUE {due.isoformat()} {(today - due).days}')
+else:
+    print('OK')
+" 2>/dev/null || echo 'OK')"
+
+if [ "$RESULT" = "OK" ]; then
+  exit 0
+fi
+
+if [ "$RESULT" = "NO_DATE" ]; then
+  MSG="${DRILL_DOC}の「## 次回実施予定日」欄から日付を読み取れませんでした。書式が崩れていないか確認してください（issue #443）。"
+  jq -n --arg msg "$MSG" '{
+    systemMessage: $msg,
+    hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: $msg }
+  }'
+  exit 0
+fi
+
+DUE_DATE="$(printf '%s' "$RESULT" | cut -d' ' -f2)"
+DAYS_OVERDUE="$(printf '%s' "$RESULT" | cut -d' ' -f3)"
+
+MSG="fault injection訓練（${DRILL_DOC}）の次回実施予定日（${DUE_DATE}）を${DAYS_OVERDUE}日過ぎています。4シナリオを実施し、実施記録欄への追記と次回予定日の更新（\`docs/agents/fault-injection-drill.md\`「## 次回実施予定日」）をお願いします（issue #443）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: $msg }
+}'

--- a/scripts/check-fault-injection-drill-staleness.test.sh
+++ b/scripts/check-fault-injection-drill-staleness.test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# WHY: scripts/check-fault-injection-drill-staleness.sh(SessionStart hook)の回帰テスト。
+# 実物のdocs/agents/fault-injection-drill.mdを書き換えず、テスト用の一時ファイルを
+# FAULT_INJECTION_DRILL_DOC環境変数で差し替えて決定的に検証する。
+#
+# 実行: bash scripts/check-fault-injection-drill-staleness.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-fault-injection-drill-staleness.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+future_iso() {
+  python3 -c "
+from datetime import date, timedelta
+print((date.today() + timedelta(days=$1)).isoformat())
+"
+}
+past_iso() {
+  python3 -c "
+from datetime import date, timedelta
+print((date.today() - timedelta(days=$1)).isoformat())
+"
+}
+
+echo "=== scenario 1: 次回実施予定日が未来 → 何も出力しない ==="
+FUTURE="$(future_iso 30)"
+cat > "$TMPDIR_TEST/drill-future.md" <<EOF
+## 次回実施予定日
+
+$FUTURE（四半期後の目安。手動で書き換える。リマインド機構は無い）
+EOF
+OUT="$(FAULT_INJECTION_DRILL_DOC="$TMPDIR_TEST/drill-future.md" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: 次回実施予定日が過去(期限切れ) → 警告する ==="
+PAST="$(past_iso 10)"
+cat > "$TMPDIR_TEST/drill-past.md" <<EOF
+## 次回実施予定日
+
+$PAST（四半期後の目安。手動で書き換える。リマインド機構は無い）
+EOF
+OUT="$(FAULT_INJECTION_DRILL_DOC="$TMPDIR_TEST/drill-past.md" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "$PAST" "期限日が含まれる"
+assert_contains "$OUT" "additionalContext" "additionalContextフィールドがある"
+
+echo "=== scenario 3: 次回実施予定日が今日ちょうど → 警告する(期限当日も対象) ==="
+TODAY="$(past_iso 0)"
+cat > "$TMPDIR_TEST/drill-today.md" <<EOF
+## 次回実施予定日
+
+$TODAY（四半期後の目安。手動で書き換える。リマインド機構は無い）
+EOF
+OUT="$(FAULT_INJECTION_DRILL_DOC="$TMPDIR_TEST/drill-today.md" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "当日も警告対象になる"
+
+echo "=== scenario 4: 見出し自体が無い/日付を抽出できない → 警告する(書式崩れの検知) ==="
+cat > "$TMPDIR_TEST/drill-broken.md" <<EOF
+## 別の見出し
+
+本文のみで日付が無い
+EOF
+OUT="$(FAULT_INJECTION_DRILL_DOC="$TMPDIR_TEST/drill-broken.md" bash "$SCRIPT")"
+assert_contains "$OUT" "読み取れませんでした" "書式崩れの警告が出る"
+
+echo "=== scenario 5: ドキュメント自体が存在しない → 何も出力しない ==="
+OUT="$(FAULT_INJECTION_DRILL_DOC="$TMPDIR_TEST/no-such-file.md" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空である"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- issue #443（人起動の検査スクリプト群を定期実行で機械トリガー化する提案）に着手したが、対象として挙げられていたチェックの大半が夜間バッチに転用できない設計と判明し、スコープを縮小した
- 実装できたのは`docs/agents/fault-injection-drill.md`「## 次回実施予定日」（「リマインド機構は無い」と明記されていた）の期限切れ検知のみ
- OS launchd等の常時稼働の仕組みは導入せず、issue #453と同じSessionStart hookパターンに一本化した

## 調査で判明した制約（実装前にスクリプトを実際に読んで確認）
- `check-loop-observability-gap.sh`・`check-agent-progress-gap.sh`は単発AIDDフロー実行の直前直後の件数差分（`--before N --expected M`）を要求する設計で、夜間バッチには「直前のフロー」という文脈が無いためそのまま呼び出せない
- `check-agent-baseline-freshness.sh`（issue #429）もPR diff（`<base-ref> <head-ref>`）前提で、CI用途としては正しく機能しており夜間バッチへの転用動機が薄い
- eval:workflows（`scripts/eval-workflow-prompts.sh`）は`logs/`に何も書き込んでおらず、「最終実行日時」の記録自体が存在しなかった

## OS launchdを見送った理由
launchdの`.plist`インストールはリポジトリの外側でユーザーの実行環境に手を入れる操作であり、無人でGitHub issue作成等の外部作用を持ちうる恒久的なOS常駐サービスの新設になる。SessionStart hookは既にこのリポジトリで「機械トリガー」として扱われており（issue #411の原則を満たす）、恒久的なサービスを新設せずとも目的を達成できると判断した。

## 変更内容
- `scripts/check-fault-injection-drill-staleness.sh`（新規、SessionStart hook）: 「次回実施予定日」を過ぎていれば警告する。block不可・warningのみ
- `scripts/check-fault-injection-drill-staleness.test.sh`（新規）: `check-blocked-issues-staleness.test.sh`と同型のテスト、5シナリオ
- `.claude/settings.json`: SessionStart hooksに登録
- `docs/agents/common.md`・`docs/agents/decisions.md`: スコープ縮小の経緯・設計判断を記録

## Test plan
- [x] `bash scripts/check-fault-injection-drill-staleness.test.sh` 全5シナリオ通過
- [x] 実際の`docs/agents/fault-injection-drill.md`に対して動作確認（次回実施予定日2026-10-16は未来のため無音を確認）
- [x] `bash scripts/check-blocked-issues-staleness.test.sh`（既存の同型hook）で回帰なし確認
- [x] `npm test` 全154ファイル1148テスト通過
- [x] `npm run lint`/`typecheck` 私の変更に起因するエラーなし（既存の無関係なエラー・警告のみ）
- [x] `jq empty .claude/settings.json` でJSON構文チェック

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #443（人起動検査スクリプトの機械トリガー化）のうち実装可能だった1件
- 変更した範囲: 新規SessionStart hookスクリプト1本とそのテスト、settings.json登録、ドキュメント
- 触っていない範囲: gap check 2件・baseline鮮度チェックの夜間バッチ化（設計上不可能と判明）、eval:workflows未実行検知（実行記録の仕組み自体が無いため別issueが必要）

### 検証済み
- 実行したコマンド: 上記Test plan参照
- 確認した画面: なし
- 確認したDB/RLS: 対象外
- 他テナントIDでのアクセス確認: 対象外

### 既知の未対応
- 今回あえて対応しなかったこと: gap check 2件の夜間バッチ化、eval:workflows未実行検知、OS launchdの導入
- 理由: 前者2つは前提となる設計変更（before/after引数を使わない集計方式への変更、実行記録の仕組みの新設）が別途必要。launchdは恒久的な無人サービス新設のリスクを避けた
- 次に触るなら見る場所: eval:workflows未実行検知をやるなら、まず`scripts/eval-workflow-prompts.sh`に実行記録（`logs/eval-workflow-prompts-last-run.json`等）を書き込む仕組みを別issueとして追加してから

### 後任AIへの注意
- 「棚卸し表から最大4行削減」というissue #443原案の見込みは実質1行に縮小している。棚卸し表（`docs/agents/common.md`「検知手段のないルールの棚卸し」）を見て「#443で全部解決したはず」と誤解しないこと
- `docs/agents/fault-injection-drill.md`「## 次回実施予定日」は今後も**手動で書き換える**運用のまま（訓練実施後に人間が更新する必要がある）。本PRは「更新し忘れに気づく」仕組みを追加しただけで、更新自体は自動化していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
