### PR TITLE
feat: security-guidanceプラグインでknown-failure-patterns.mdを機械検知化(issue #440)

### DIFF
--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -1,0 +1,20 @@
+# Security guidance for this repo
+
+このプロジェクトは医療施設向け在庫管理アプリで、施設（facility）単位のテナント分離が
+セキュリティ上の最重要事項です。詳細は `docs/agents/decisions.md`・
+`docs/agents/known-failure-patterns.md` を参照してください。
+
+- すべてのRLSポリシーは `auth.uid()` または `facility_id`（`is_facility_member(...)`経由）を
+  参照すること。どちらも参照しないポリシーは他施設のデータ漏洩に直結する
+- admin権限は `user_facilities.role = 'admin'` をDB側で判定する（`is_admin()`関数経由）。
+  環境変数（`ADMIN_EMAILS`等）によるフォールバック判定を新設しない
+- `SECURITY DEFINER` 関数はRLSをバイパスする。新規・変更時は関数内で明示的な認可チェック
+  （`is_facility_member(...) OR is_admin()`等）を行っているか必ず確認する。まず
+  `SECURITY DEFINER` を使わずに済ませられないか（`SECURITY INVOKER`でRLSが自動適用される
+  設計にできないか）を先に検討する
+- DBスキーマ変更は必ず `supabase/migrations/` 配下のマイグレーションファイル経由で行う。
+  `execute_sql`・`executeRaw`・生SQL実行による直接DDL適用は禁止（ローカル・リモート問わず）
+- `facility_id`・患者情報等の機微データをINFO以上のログレベルで出力しない
+- seed・E2Eテスト・スクリーンショット・issue添付には実在施設名・実データを一切使わない。
+  施設名・ユーザー名・在庫品目などはすべてダミー（例: `テスト施設A`、
+  `e2e-test-user@example.com`）を使う

--- a/.claude/security-patterns.json
+++ b/.claude/security-patterns.json
@@ -1,0 +1,28 @@
+{
+  "patterns": [
+    {
+      "rule_name": "rls_bypass",
+      "regex": "([Dd][Ii][Ss][Aa][Bb][Ll][Ee]\\s+[Rr][Oo][Ww]\\s+[Ll][Ee][Vv][Ee][Ll]\\s+[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]|[Aa][Ll][Tt][Ee][Rr]\\s+[Pp][Oo][Ll][Ii][Cc][Yy])",
+      "paths": ["**/supabase/migrations/**"],
+      "reminder": "RLSポリシーの無効化・変更の可能性があります。facility/tenantスコープが引き続き正しく機能するか確認してください（docs/agents/known-failure-patterns.md参照）。"
+    },
+    {
+      "rule_name": "bare_sql_in_data_layer",
+      "regex": "(execute_sql|executeRaw|\\.raw\\()",
+      "paths": ["**/src/lib/supabase/**"],
+      "reminder": "生SQL実行の可能性があります。まずSECURITY DEFINERを使わずに済ませられないか検討し、必要な場合はmigrationファイル経由・型付きクエリビルダーの利用を検討してください（docs/agents/known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」参照）。"
+    },
+    {
+      "rule_name": "possible_real_facility_name",
+      "regex": "(病院|クリニック|医院|医科大学)",
+      "paths": ["**/e2e/**", "**/scripts/eval-fixtures/**", "**/*seed*"],
+      "reminder": "実在施設名に見える文字列が含まれている可能性があります。seed・E2E・スクリーンショットには実在施設名を使わないでください（ダミー名を使用。docs/agents/common.md「テスト環境・データ衛生ルール」参照）。"
+    },
+    {
+      "rule_name": "security_definer_grant",
+      "substrings": ["SECURITY DEFINER"],
+      "paths": ["**/supabase/migrations/**"],
+      "reminder": "SECURITY DEFINER関数です。RLSをバイパスするため、関数内で明示的な認可チェック（is_facility_member(...) OR is_admin()等）を行っているか確認してください。まずSECURITY DEFINERを使わずに済ませられないか検討してください（docs/agents/known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」参照）。"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -237,5 +237,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
   }
 }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -389,6 +389,31 @@ GitHub Actions内でclaude-code-action（@claudeメンションでのissue/PR自
 「単純な費用対効果」の判断であることに注意。詳細・再開条件は
 [`decisions.md`の該当項目](./decisions.md#なぜclaude-code-actionissue-447を導入せず見送ったか)を参照。
 
+## security-guidanceプラグインでknown-failure-patterns.mdを機械検知化（issue #440）
+
+公式プラグイン`security-guidance@claude-plugins-official`を導入し、`docs/agents/
+known-failure-patterns.md`のチェックリスト（自然言語のみ、レビュー系エージェントが
+「読むこと」に依存していた）の一部を機械検知化した。`.claude/settings.json`の
+`enabledPlugins`にチーム共有で有効化した（per-edit層は無料でありセキュリティ検知機能を
+チーム全員に一律適用すべきという判断。詳細は`decisions.md`参照）。
+
+- `.claude/security-patterns.json`: `rls_bypass`（RLS無効化・ポリシー変更検知）・
+  `bare_sql_in_data_layer`（`src/lib/supabase/**`での生SQL実行検知）・
+  `possible_real_facility_name`（seed/E2E/eval-fixturesパスへの実在施設名らしき文字列の検知）・
+  `security_definer_grant`（`SECURITY DEFINER`関数の検知）の4パターンを定義
+- `.claude/claude-security-guidance.md`: RLS/facility境界の原則（全ポリシーが`auth.uid()`
+  または`facility_id`参照、admin判定はDB role経由、機微データをINFO以上でログ出力しない等）
+  を自然言語で記述
+- **既知の限界**: プラグインの実際のインストール（`/plugin install
+  security-guidance@claude-plugins-official`）は対話的な操作が必要で、このセッションでは
+  実行できていない。`enabledPlugins`の設定のみ先行してコミットしており、実際に機能するかは
+  次回以降のセッションで人間が`/plugin install`を実行してから確認する必要がある
+- ターン末diffレビュー・commit時レビューはモデル呼び出しを伴いトークンコストが発生する
+  （`ENABLE_STOP_REVIEW=0`・`ENABLE_COMMIT_REVIEW=0`環境変数で個別に無効化可能）。今回は
+  per-edit層と合わせて3層とも有効化する判断をした（人間の確認済み）
+- 詳細・スキーマの出典は
+  [`decisions.md`の該当項目](./decisions.md#なぜsecurity-guidanceプラグインissue-440をチーム共有で全層有効化したか)を参照。
+
 ## blockedラベルの再開条件見直しはSessionStart hookで機械ポーリング（issue #453）
 
 `blocked`ラベルの再開条件（例: issue #438の`decisions.md`記載事項）を誰がいつ見直すかの

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -785,3 +785,49 @@ issue #441は「CLAUDE.mdのサーキットブレーカー運用（`/goal`設定
    別レイヤーの防御であることをCLAUDE.mdに追記した
 3. 検知不能という結論自体を棚卸し表の該当行に追記し、今後の検討で「issue #441は解決済みなのに
    なぜまだ棚卸し表に載っているのか」と誤解されないようにした
+
+## なぜsecurity-guidanceプラグイン（issue #440）をチーム共有で全層有効化したか
+
+issue #440は「公式のsecurity-guidance機能を導入し、`known-failure-patterns.md`の自然言語
+チェックリストを機械検知化する」という提案で、ゲート条件（機能の正確な名称・導入手順・
+`security-patterns.yaml`のスキーマを公式docで実機確認してから着手）に従い実機確認した。
+
+**確認できた事実（下書きとほぼ一致、issue #438・#448とは異なり前提が崩れなかった）:**
+- 正式名称は「Security guidance plugin」（`security-guidance@claude-plugins-official`）。
+  公式プラグインとして実在する
+- 3層構成: ①per-edit正規表現/部分文字列検知（LLM呼び出しなし・無料）②ターン末diffレビュー
+  （モデル呼び出しあり）③commit/push時レビュー（より深いエージェントレビュー、20/時間の上限）
+- 設定ファイルは`.claude/claude-security-guidance.md`（自然言語ガイダンス、特定の見出し構造
+  不要）+ `.claude/security-patterns.yaml`または`.json`（パターン定義）。YAML形式は
+  PyYAMLへの依存が生じるため、外部依存を増やさないよう本プロジェクトでは**JSON形式**を採用した
+- `security-patterns.json`のスキーマ: パターンごとに`rule_name`・`regex`または
+  `substrings`・`paths`（任意、globパターン）・`exclude_paths`（任意）・`reminder`
+  （警告メッセージ、1KB制限）
+- 有効化は`.claude/settings.json`の`enabledPlugins`（オブジェクト形式、
+  `{"security-guidance@claude-plugins-official": true}`）
+- 各層は環境変数で個別に無効化できる（`ENABLE_PATTERN_RULES`・`ENABLE_STOP_REVIEW`・
+  `ENABLE_COMMIT_REVIEW`・`ENABLE_CODE_SECURITY_REVIEW`）
+
+**判断: チーム共有（`.claude/settings.json`）で3層とも有効化。** OTel（issue #417）や
+autoMode（issue #439）は「プラットフォーム側の制約でプロジェクト設定に書いても効かない」
+という技術的制約があったため個人オプトインにしたが、security-guidanceにはそのような制約は
+無い（`enabledPlugins`はプロジェクト側`settings.json`で有効に機能する）。per-edit層が無料で
+価値が明確な一方、ターン末・commit時レビューにはモデル呼び出しに伴うトークンコストが生じる
+ため、「チーム全員に一律適用すべきセキュリティ機能か、個人が選ぶコスト要因か」を人間に確認し、
+医療プロジェクトとしてセキュリティ検知は全員に一律適用すべきという判断で、3層とも共有設定で
+有効化することにした（層ごとの無効化オプションが環境変数として存在することも記録しておき、
+将来コストが問題になった場合に`ENABLE_STOP_REVIEW=0`等で個別に絞れるようにしている）。
+
+**実装したパターン（4件、issue原案どおり）:** `rls_bypass`・`bare_sql_in_data_layer`・
+`possible_real_facility_name`・`security_definer_grant`。正規表現はJS系エンジンでも
+確実に動くよう、インラインフラグ（`(?i)`）に頼らず文字クラス（`[Dd][Ii][Ss]...`）で
+大文字小文字を吸収する書き方に統一した（プラグインの正規表現エンジンの実装言語が
+公式docに明記されておらず、Python固有の`(?i)`構文がサポートされない可能性を考慮した）。
+各パターンはpython3の`re`モジュールでテストケース11件を用いて動作確認済み（実際の
+プラグインの正規表現エンジンでの動作は別途確認が必要、後述の既知の限界参照）。
+
+**既知の限界:** プラグインの実際のインストール（`/plugin install
+security-guidance@claude-plugins-official`）は対話的操作が必要で、このセッションでは
+実行できていない。`enabledPlugins`の設定・パターンファイルの作成までをこのPRで行い、
+実際に機能する状態になっているかの確認は次回以降のセッションで人間が`/plugin install`を
+実行してから行う必要がある。


### PR DESCRIPTION
## Summary
- issue #440（公式security-guidance機能で`known-failure-patterns.md`を機械検知化する提案）のゲート条件（機能の正確な名称・導入手順・スキーマを公式docで確認してから着手）に従い実機確認した
- issue #438・#448とは異なり、下書きの前提はほぼ正確で実装可能と判明した
- `.claude/security-patterns.json`に4パターン、`.claude/claude-security-guidance.md`にRLS/facility境界の原則を実装し、`.claude/settings.json`の`enabledPlugins`でチーム共有有効化した

## 確認できた事実
- 正式名称「Security guidance plugin」（`security-guidance@claude-plugins-official`）、公式プラグインとして実在
- 3層構成: ①per-edit正規表現検知（無料）②ターン末diffレビュー（モデル呼び出しあり）③commit/push時レビュー（モデル呼び出しあり、20/時間上限）
- 設定ファイルは`claude-security-guidance.md`+`security-patterns.yaml`/`.json`。YAML形式はPyYAML依存が生じるため、本PRでは**JSON形式**を採用（外部依存を増やさない判断）
- 各層は環境変数（`ENABLE_PATTERN_RULES`等）で個別に無効化可能

## 有効化範囲の判断（要相談・確認済み）
per-edit層（無料）と、モデル呼び出しを伴う残り2層（コスト発生）のどちらもチーム共有で有効化するか、コストのかかる層だけ個人オプトインにするか、ユーザーに確認した。医療プロジェクトとしてセキュリティ検知は全員に一律適用すべきという判断で、3層ともチーム共有（`.claude/settings.json`）で有効化することにした。

## 実装したパターン（4件、issue原案どおり）
- `rls_bypass`: `supabase/migrations/**`でのRLS無効化・ポリシー変更検知
- `bare_sql_in_data_layer`: `src/lib/supabase/**`での生SQL実行検知
- `possible_real_facility_name`: `e2e/**`・`scripts/eval-fixtures/**`・seed系パスへの実在施設名らしき文字列（病院/クリニック/医院/医科大学）の検知
- `security_definer_grant`: `supabase/migrations/**`での`SECURITY DEFINER`関数の検知

正規表現はプラグインの実装言語（JS系の可能性）を考慮し、Python固有の`(?i)`インラインフラグに頼らず文字クラスで大文字小文字を吸収する書き方に統一した。

## 変更内容
- `.claude/security-patterns.json`（新規）
- `.claude/claude-security-guidance.md`（新規）
- `.claude/settings.json`: `enabledPlugins`に追加
- `docs/agents/common.md`・`docs/agents/decisions.md`: 設計判断・スキーマ出典を記録

## Test plan
- [x] python3の`re`モジュールで4パターン×11テストケースの動作確認（regex/substringsのマッチ・非マッチ）
- [x] `jq empty .claude/settings.json` / `jq empty .claude/security-patterns.json` でJSON構文チェック
- [x] `npm test` 全154ファイル1148テスト通過（TS/JSファイルへの変更は無いため対象外だが念のため実行）
- [ ] **プラグインの実際のインストール・動作確認は未実施**（`/plugin install security-guidance@claude-plugins-official`は対話操作が必要。次回以降のセッションで人間が実行する必要がある）

## 引き継ぎメモ

### 作業サマリ
- 変更した目的: issue #440（known-failure-patterns.mdの機械検知化）
- 変更した範囲: `.claude/security-patterns.json`・`.claude/claude-security-guidance.md`・`.claude/settings.json`のenabledPlugins・ドキュメント
- 触っていない範囲: プラグイン自体のインストール（対話操作が必要なため未実施）

### 検証済み
- 実行したコマンド: 上記Test plan参照
- 確認した画面: なし（プラグイン未インストールのため実際の動作画面は未確認）
- 確認したDB/RLS: 対象外（パターン定義のみ、実際のDB操作なし）
- 他テナントIDでのアクセス確認: 対象外

### 既知の未対応
- 今回あえて対応しなかったこと: プラグインの実際のインストール（`/plugin install`）と、インストール後の実機動作確認
- 理由: 対話的な操作が必要でこのセッションでは実行できなかった
- 次に触るなら見る場所: マージ後、次回セッションで`/plugin install security-guidance@claude-plugins-official`を実行し、実際に4パターンが検知されるか（例: `supabase/migrations/`にSECURITY DEFINER関数を試験的に書いてみて警告が出るか）を確認すること

### 後任AIへの注意
- `security-patterns.json`の正規表現は、プラグインの実際の正規表現エンジンでの動作を実機確認していない（python3の`re`でのテストのみ）。導入後に意図通り動かない場合は、まずここを疑うこと
- プラグインインストール前は、設定ファイルが存在するだけで実際には何も検知しない状態

🤖 Generated with [Claude Code](https://claude.com/claude-code)
