### PR TITLE
docs: 棚卸し表のseed実在施設名行を更新(issue #487)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -641,7 +641,7 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | issue #441で検知手段を調査したが、「`/goal`が設定されているか」を外部から機械的に問い合わせるAPI/hookは公式に存在しないと判明（実機確認済み）。条件テンプレート化・役割分担の明文化（Workflow内部retryとの切り分け）は完了したが、呼び忘れ自体の検知は依然できないままこの表に残る |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
 | AIDD stats書き出し（各フェーズでの`write_aidd_stats.sh`呼び出し） | ルートの`CLAUDE.md` | 呼び忘れても気づく手段がない |
-| seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | |
+| seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | per-edit層で部分検知（`.claude/security-patterns.json`の`possible_real_facility_name`、issue #440）。ただし`/plugin install security-guidance@claude-plugins-official`の実機有効性は未確認、かつスクリーンショット・issue添付・E2E失敗ログは検知対象外 |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
 | `.claude/workflows/*.js` 変更時の`npm run eval:workflows`手動実行 | 本ファイル「AIDDワークフロープロンプトのeval」 | CI化は実エージェント呼び出しの課金コストで見送り。実行し忘れに気づく手段は無い（issue #391） |
 


### PR DESCRIPTION
## Summary
- `.claude/security-patterns.json`の`possible_real_facility_name`(issue #440)によるper-edit層の部分検知が既にあるにもかかわらず、「検知手段のないルールの棚卸し」表が未追従だった
- 行を完全に外さず、部分検知の内容・未確認事項(`/plugin install`の実機有効性)・対象外範囲(スクリーンショット・issue添付・E2E失敗ログ)を注記する形に更新

## Test plan
- [x] 表の記述が実際の検知状況と一致していることを確認
- 軽微なドキュメント変更のためAIDDフロー省略（issue本文に明記）

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)