### PR TITLE
docs: 削除済みscripts/doc-suggest-check.shへの残存参照3箇所を掃除する(issue #492)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,6 @@
       "Bash(scripts/log-agent-progress.sh *)",
       "Bash(scripts/show-agent-status.sh *)",
       "Bash(scripts/verify-agent-progress-transcript.sh *)",
-      "Bash(scripts/doc-suggest-check.sh *)",
       "Bash(scripts/check-branch-pr-status.sh*)",
       "Bash(bash scripts/*.test.sh*)",
       "Bash(bash scripts/check-branch-pr-status.test.sh*)",

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -231,7 +231,7 @@ pass/fail実績（試行回数・fail率のagent別集計）に絞った。ゲ�
 `.gitignore`で除外されておりリポジトリにコミットされない（ローカル専用ログ）。GitHub Actions
 はfresh checkoutで動くためローカルの`logs/loop-observability.jsonl`を参照できず、この方式は
 不採用にした。代わりに、セッション終了ごとに必ず発火する既存のStop hook機構
-（`scripts/doc-suggest-check.sh`等と同じパターン）を使い、`.claude/.gate-effectiveness-state/
+（`scripts/verify-claims.sh`等と同じパターン）を使い、`.claude/.gate-effectiveness-state/
 last-summary-at`のmtimeで前回出力から30日経過したかを判定して間引く方式にした。これにより
 「起動トリガーは機械」という原則（issue #411のレビューで確認した観点）を保ちながら、GitHub
 Secretsやリモートのステータス源を新設せずに済む。

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -48,7 +48,7 @@ INPUT="$(cat)"
 SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
 TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')"
 
-# 7日より古い状態ファイルは掃除する（doc-suggest-check.shと同様のパターン）
+# 7日より古い状態ファイルは掃除する（ai-check-suggest.shと同様のパターン）
 find "$STATE_DIR" -name '*.json' -mtime +7 -delete 2>/dev/null || true
 
 STATE_FILE="$STATE_DIR/${SESSION_ID}.json"


### PR DESCRIPTION
## Summary
issue #418で削除済みの`scripts/doc-suggest-check.sh`が現存を前提にした記述として残っていた3箇所を、現行構成に合わせて更新:
- `decisions.md` L233-234: Stop hook機構の例を`verify-claims.sh`（現存）に差し替え
- `.claude/settings.json` L76: 対象スクリプト専用の許可ルールを削除（他の許可ルールは無変更）
- `scripts/verify-claims.sh` L51: 参照先を`ai-check-suggest.sh`（同じ7日クリーンアップパターンを現在も使用）に差し替え

## 受け入れ条件との差分（意図的）
issueの受け入れ条件は`grep -rn "doc-suggest-check" .`で0件を求めているが、以下2箇所は意図的に残した:
- `decisions.md`のissue #418エントリ（253-255行目）: 「doc-suggest-check.shを置き換えた理由」を説明する歴史的決定記録そのもの
- `docs/superpowers/specs/2026-07-14-verification-subagent-design.md`: 2026-07-14時点（doc-suggest-check.shがまだ存在していた時点）のスペック文書

どちらも「今も存在する」という誤った現在形の主張ではなく、「過去に存在した」という正しい事実の記録のため、書き換えると履歴を破壊してしまうと判断した。

## Test plan
- [x] `.claude/settings.json`がvalid JSONであることを確認
- [x] `git grep doc-suggest-check`で対象3箇所が解消されたことを確認
- 軽微な変更（3ファイル）のためAIDDフロー省略（issue本文に明記）

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)