### PR TITLE
feat: gap checkの実行をStop hookで機械トリガー化する(issue #488)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -232,6 +232,12 @@
             "command": "scripts/gate-effectiveness-monthly-check.sh",
             "timeout": 15,
             "statusMessage": "品質ゲート月次サマリを確認中..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-gap-check-state.sh",
+            "timeout": 90,
+            "statusMessage": "AIDD gap check stateを確認中(issue #488)..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,20 @@ stats JSON は標準入力ではなく**第4引数**で渡す（パイプ・リ�
 ```
 ※ start を呼び忘れた場合は phase1_start_at がフォールバックで使われる
 
+## gap check state 記録ルール（issue #488）
+AIDDフロー実行時は、上記statsと合わせて以下も呼ぶ（gap check本体はStop hookが自動実行する。
+手動での check-*-gap.sh 実行は再検証したい場合のみでよい。詳細は `docs/agents/common.md`
+「loop-observabilityログの記録漏れ検知」参照）:
+
+```bash
+# 1. フロー開始時（Phase 1の前に1回。件数計測はスクリプトが行う）
+scripts/record-gap-check-state.sh before
+
+# 2. 各フェーズ完了後（戻り値のexpected件数を加算記録。無い方の引数は省略可）
+scripts/record-gap-check-state.sh expected --agent-progress 4
+scripts/record-gap-check-state.sh expected --loop-observability 10 --agent-progress 12
+```
+
 ## 絶対ルール
 - 確認を求めるのは「仕様レビュー（停止①）」と「構造化レビュー（停止②）」の2箇所のみ。
 - それ以外は止まらず自律的に進める。

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,94 +1,137 @@
-# SPEC: journal.jsonlのresultをverify-agent-progress-transcriptの突合にも統合する（issue #493 残スコープ）
+# SPEC: gap checkの実行をStop hookで機械トリガー化する（issue #488）
 
-- issue: #493
-- feature名: `issue-493-journal-result-integration`
-- baseCommit: `460514d15c306ecb4c0e3fb0a36dbd755cb0075a`
+- issue: #488
+- feature名: `issue-488-gap-check-stop-hook`
+- baseCommit: `22610bb516914f9d38ba06eeb456420840b78722`
 - 作成日: 2026-07-22
 
-## Part 1: 背景・スコープ確定の経緯（★人間がレビューする部分）
+## Part 1: 何ができるようになるか（★人間がレビューする部分）
 
-issue #493の「やること」1〜3（`scripts/lib/reconstruct-loop-observability.ts`への
-journal.jsonl優先分岐・フォールバック・unit test）は、**issue #462のPR #467
-（2026-07-18マージ、コミット`eba2c10`）で既に実装済み**であることをコード・テスト・
-マージ履歴で確認した。issue #493（2026-07-21起票）は`docs/agents/common.md`の
-「組み込みは未着手」という陳腐化した記述を根拠にしていたため、実装済み分が
-重複起票されている。
+現在、AIDDフロー実行後のgap check（`check-loop-observability-gap.sh` /
+`check-agent-progress-gap.sh`）は、common.mdの4ステップ手動手順（実行前にwc -lで
+before件数を控え、フロー完了後にexpectedと突き合わせて手動実行）に依存しており、
+「checkし忘れたら気づけない」第3層ルール（人起動）のまま残っている。
 
-したがって本仕様のスコープは以下の2点のみ:
+本実装後は:
 
-1. **「やること」4（未実装分）**: `scripts/lib/verify-agent-progress-transcript.ts`の
-   `loadTranscripts`に、journal.jsonlのresult優先取得ロジックを統合する
-2. **ドキュメント訂正**: `docs/agents/common.md`「第4の記録層の候補」節の
-   「組み込みは未着手（別issueで検討）」記述を実態（実装済み）に合わせて更新する
+- オーケストレーターはフロー前後に**リポジトリ内の記録スクリプトを呼ぶだけ**になり、
+  gap checkの実行自体は**Stop hookが機械トリガー**する（issue #411原則: 起動トリガーが
+  機械になる）
+- 記録漏れ（hasGap）があれば、フロー完了後の最初のターン終了時にsystemMessageで
+  警告が出る（block不可・warningのみ）
+- 「書いたのにcheckし忘れる」故障モードが構造的に消える。「stateファイルへの記録自体を
+  書き忘れる」は自己申告依存のまま残る（issue本文の既知の限界どおり）
 
-### Phase 1 Sweepの指摘との対応
+### 動作イメージ
 
-- types軸「loadTranscriptsがjournal.jsonl統合ロジックを実装していない」→ 本仕様の主対象
-- types軸「common.md行214-225の陳腐化記述」→ 本仕様で更新
-- types軸「TranscriptRecordにfindingsフィールドが無い」「model/promptTextを無視」→
-  **対応しない**（下記「対応しないこと」参照）
-- db/data/ui軸の指摘 → すべて本issueと無関係な既存コードへの一般指摘のためスコープ外
-  （dbの既知指摘は既存issue群・decisions.mdの管理範囲）
+1. フロー開始時: `scripts/record-gap-check-state.sh before` を実行
+   → スクリプト自身が現在のログ件数を数えて `.aidd/gap-check-state.json` に記録
+   （手動wc -l・手動jqカウントが不要になり、控え間違いも消える）
+2. 各フェーズ完了後: `scripts/record-gap-check-state.sh expected --agent-progress 4` /
+   `... expected --loop-observability 10 --agent-progress 12` を実行
+   → expected件数をstateファイルに**加算**記録（phase1とphase2の期待値を合算できる）
+3. セッションのターン終了時: Stop hook（`scripts/check-gap-check-state.sh`）が
+   stateファイルを見て、expectedが記録済みなら両gap checkを自動実行
+   → hasGapならsystemMessageで警告、実行後にstateファイルを削除
 
 ## Part 2: 変更内容
 
-### 2-1. `scripts/lib/reconstruct-loop-observability.ts`
+### 2-1. 新規 `scripts/record-gap-check-state.sh`
 
-- 既存のモジュール内private関数 `loadJournalResults(wfDirPath, filenames)` を
-  **`export`に変更する（ロジック変更なし）**。verify側から同一ロジックを再利用するため。
-  - 二重実装（インライン複製）を避ける。同一プロセスのNode/vitestから使うため
-    Workflow DSLのimport制約は無関係であり、通常のimportでよい。
+- `before`サブコマンド: `logs/loop-observability.jsonl`の行数と
+  `logs/agent-progress.jsonl`のdone/failed件数を**スクリプト自身が計測**し、
+  `.aidd/gap-check-state.json` に `{beforeLoopObservability, beforeAgentProgress,
+  recordedAt}` を書き出す。既にbeforeが記録済みの場合は上書きしない（first-write-wins。
+  1フロー実行の起点を固定するため）
+- `expected`サブコマンド: `--loop-observability N` / `--agent-progress M`（いずれも任意、
+  最低1つ必須）を受け取り、stateファイルの `expectedLoopObservability` /
+  `expectedAgentProgress` に**加算**する（phase1のexpectedAgentProgressRecords=4と
+  phase2の=12を合算するため）。beforeが未記録ならエラー（exit 1）で手順逸脱を検知
+- done/failed件数の計測ロジックは既存の手動手順（common.mdのjqコマンド）と同一判定
+- `.aidd/` はgitignore済み（run-manifestと同じ扱い）
+- **呼び出し元はオーケストレーター（Claude本体）のみ**（スクリプトヘッダに明記。
+  Workflow DSLはfilesystem API不可のため構造的に呼べず、サブエージェントへの記録指示にも
+  含めない）。オーケストレーターのBash実行は逐次のためread-modify-write競合は発生しない
+  前提だが、保険として書き込みは一時ファイル→`mv`のatomic方式にする（ロックは導入しない）
 
-### 2-2. `scripts/lib/verify-agent-progress-transcript.ts`
+### 2-2. 新規 `scripts/check-gap-check-state.sh`（Stop hook本体）
 
-- `loadTranscripts(projectDir)` 内で、各`wf_*`ディレクトリ処理時に
-  `loadJournalResults(wfDir, filenames)` を呼び、該当`agentId`の構造化result
-  （`status`が`pass|fail|blocked`のもの）があれば `TranscriptRecord` の
-  `status`/`detail` をjournal側の値で上書きする。無いagentIdは従来どおり
-  `parseAgentTranscriptLines`の結果のまま（フォールバック維持）。
-- `endTimestamp`は従来どおりtranscript側から取得する（journal.jsonlには
-  タイムスタンプが無いため。時刻近接突合`matchRecords`のロジックは一切変更しない）。
-- 効果: `compareStatus`/`compareDetail`が参照するstatus/detailの源泉が、
-  transcript最終メッセージのパース（StructuredOutputブロック探索）から、
-  Workflowツールが機械的に書き出したresultへ置き換わり、突合の意味判定の
-  精度・堅牢性が上がる（transcript形式変化への耐性・パース失敗時のnull回避）。
+- `.aidd/gap-check-state.json` が無ければ何もせず exit 0（AIDDフロー非実行セッションでは
+  完全に沈黙。opt-in設定にも依存しない）
+- stateファイルはあるがexpectedが1つも無い場合:
+  - `recordedAt`から24時間以内 → フロー実行中とみなし何もしない（クリアもしない）
+  - 24時間超 → 中断されたフローの残骸とみなしstateファイルを削除し、**systemMessageで
+    「gap check未実施のままstateを破棄した」旨を一言警告する**（block不可。「中断しただけ」と
+    「漏れを見逃して消えた」を区別可能にし、破棄自体を観測可能にするため。停止①レビューでの
+    指摘を反映）
+- expectedがある場合:
+  - `expectedLoopObservability`があれば `check-loop-observability-gap.sh --before <state値>
+    --expected <state値>` を実行
+  - `expectedAgentProgress`があれば `check-agent-progress-gap.sh` を同様に実行
+  - いずれかが `hasGap: true` → 既存Stop hook群（`gate-effectiveness-monthly-check.sh`等）と
+    同形式のJSON（`{systemMessage}`のみ）で警告を出力（**block不可・warningのみ**。
+    `hookSpecificOutput`/`additionalContext`はSessionStart hook用のためStop hookでは使わない）
+  - gap checkの実行自体が失敗した場合（npx/jq等の環境要因、出力に`hasGap`が無いままexit≠0）は、
+    本物のgap警告とは**別の文言**（「実行自体に失敗・記録漏れの有無は未判定」）で警告する
+    （レビュー指摘の反映: 原因調査の初手を誤らせないため）
+  - 実行後（gap有無にかかわらず）stateファイルを削除する
+- 環境変数でstateファイルパス・gap checkスクリプトパスを差し替え可能にする
+  （フェイク注入テストのため。既存hookテストと同型）
+- 堅牢性（レビュー指摘の反映）: jq不在の環境では何もせず沈黙する（stateは残し次回に委ねる）。
+  `recordedAt`が非数値の破損stateはクラッシュさせず「破棄＋警告」に倒す（クラッシュすると
+  stateが残り毎ターン再クラッシュするため）
 
-### 2-3. `scripts/lib/verify-agent-progress-transcript.test.ts`
+### 2-3. `.claude/settings.json`
 
-以下のケースを追加（既存の`loadTranscripts`系テストのfixture方式に合わせる）:
+- Stop hooksに `scripts/check-gap-check-state.sh`（timeout 90）を追加登録
+  （当初案は30秒だったが、gap checkスクリプトが内部で呼ぶ`npx -y tsx`のコールドスタートで
+  超過しうるというレビュー指摘を受け、`verify-claims.sh`と同じ90秒に引き上げた）
 
-1. journal.jsonlに該当agentIdの構造化resultがある場合、`TranscriptRecord.status/detail`
-   がjournal側の値になる（transcript側と異なる値で検証）
-2. journal.jsonlが存在しない場合、従来のtranscriptパース結果のまま（回帰確認）
-3. journal.jsonlはあるが該当agentIdの行が無い／resultがプレーン文字列の場合、
-   そのagentはtranscriptパース結果へフォールバックする
+### 2-4. テスト
 
-### 2-4. `docs/agents/common.md`
+- `scripts/record-gap-check-state.sh` / `scripts/check-gap-check-state.sh` それぞれに
+  `.test.sh` を新設（`bash scripts/<name>.test.sh` で実行。statusline.test.sh等と同じく
+  `npm test` 対象外のbashテスト）。ケース:
+  - before記録 → 値がログ実件数と一致 / 二重実行でfirst-write-wins
+  - expected加算 → 複数回呼び出しで合算される / before未記録ならexit 1
+  - Stop hook: stateファイル無し→沈黙 / expected無し・24h以内→何もしない /
+    expected無し・24h超→削除＋破棄警告のsystemMessage出力 / gap無し→警告なしでクリア /
+    gap有り→systemMessage出力（フェイクstateファイル＋フェイクログ注入）
 
-- 「第4の記録層の候補（issue #442調査、未実装）」節を「実装済み」の記述に更新:
-  - reconstruct側の組み込みはissue #462（PR #467）で実装済み
-  - verify側（本issue #493）の組み込みも実装済み
-  - 「journal.jsonlはWorkflow経由でのみ生成される」「keyはハッシュのみで
-    agentType/feature復元にはtranscript/meta.jsonが必要」という制約の記述は維持
+### 2-5. ドキュメント更新
+
+- `docs/agents/common.md`:
+  - 「loop-observabilityログの記録漏れ検知」「サブエージェント進捗の可視化」両節の
+    4ステップ手動手順を「`record-gap-check-state.sh`で記録すればStop hookが自動実行する。
+    手動実行は再検証時のみ」に更新
+  - 「ツール制約回避のload-bearing workaround棚卸し」表の該当行（gap check実行が人起動の
+    まま第3層に残っている旨の記述）を更新
+  - 既知の限界（stateファイルへの記録自体は自己申告のまま）を明記
+- ルート `CLAUDE.md`: AIDDフロー手順のgap check記述を新手順（before記録→expected記録）に
+  差し替え
 
 ## 並列グループ宣言
 
-- **グループ1（単独・並列化なし）**: 2-1〜2-4すべて。変更ファイル4つは相互依存
-  （exportの追加→import→テスト→ドキュメント）のため、implementer 1体で直列実装する。
+- **グループ1（単独・並列化なし）**: 2-1〜2-5すべて。record→check→settings→テスト→
+  ドキュメントは相互依存のため、implementer 1体で直列実装する。
+  （注: #493で確認した編成ギャップ（scripts/配下は5ロール外でintegratorが代行）が
+  再発する可能性が高い。integratorによる代行実装を今回は許容する）
 
 ## 受け入れ条件
 
-- journal.jsonlがあるWorkflow実行分の`TranscriptRecord`で、status/detailが
-  transcriptパースなしにjournal由来の値になる（unit testで検証）
-- journal.jsonlが無い場合（Agent tool直接起動）の従来動作が維持される（unit testで検証）
-- `npm test` green / `npm run lint` green
-- `matchRecords`の突合アルゴリズム（時刻近接・貪欲割り当て）に挙動変化が無い
+- フロー実行後、オーケストレーターがターンを終えるだけで両gap checkが自動実行され、
+  記録漏れがあればsystemMessage警告が出る（テストで検証）
+- AIDDフローを実行していないセッションではStop hookが完全に沈黙する（テストで検証）
+- 起動トリガーが機械（Stop hook）である（issue #411原則）
+- 全`.test.sh`がpass / `npm test` green（既存テストの回帰なし）/ `npm run lint` green
 
 ## 対応しないこと（明示的スコープ外）
 
-- `TranscriptRecord`への`findings`/`model`/`promptText`フィールド追加:
-  検証ロジック（`compareStatus`/`compareDetail`）が参照しないため追加しない（YAGNI）
-- `JournalResultPayload`のキャスト改善: 既存コードの型スタイルであり実行時検証で
-  補完済み。本issueのスコープ外
-- Phase 1 Sweepのdb/data軸指摘（既存マイグレーション・API層への一般指摘）: 本issueと無関係
+- `~/write_aidd_stats.sh`（ホーム側）への機能追加: リポジトリ外ファイルは本PRの管理外。
+  記録はリポジトリ内スクリプトに一本化する（issueの設計案1の後者を採用）
+- stateファイル書き込み自体の機械強制: Workflow DSLのfilesystem API制約により不可能
+  （issue記載の既知の限界。「書き忘れ」の検知はissue #495の類似機構で将来検討）
+- `aidd-1-1-deep-task.js`のgap check未対応問題（common.md記載の既存の限界）の解消
 - DB・データ取得層・UI・RLS・migrationには一切触れない
+- Phase 1 Sweep(data軸)の既存コードへの一般指摘（エラー形式混在・as キャスト等）:
+  本issueと無関係のためスコープ外

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -105,11 +105,27 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
   依存しており強制力がない（Workflow DSL自体がfilesystem API不可のため、ワークフロー本体側から
   機械的にログを書き込むことはできない）。2026-07-07以降、実際に記録が5日分丸ごと欠落していた
   事例がある。理由は [`decisions.md`](./decisions.md) 参照。
-- **AIDDフロー（Phase 2以降）を実行する前後で、必ず以下を行うこと。**
-  1. 実行前に `wc -l logs/loop-observability.jsonl` で行数を記録する（ファイルが無ければ0）
-  2. フロー完了後、戻り値の `stats.expectedLoopObservabilityRecords` を確認する
-  3. `scripts/check-loop-observability-gap.sh --before <1の値> --expected <2の値>` を実行する
-  4. `hasGap: true`（exit 1）になった場合、記録漏れとして扱い、issue化するか原因を調査する
+- **AIDDフロー（Phase 2以降）を実行する前後で、必ず以下を行うこと（issue #488でStop hook
+  自動実行化済み）。**
+  1. フロー開始時（Phase 1前に1回）に `scripts/record-gap-check-state.sh before` を実行する
+     （件数の計測・記録はスクリプトが行う。手動のwc -l/jq計測は不要になった）
+  2. 各フェーズ完了後、戻り値の `stats.expectedLoopObservabilityRecords` /
+     `stats.expectedAgentProgressRecords` をその都度記録する（加算方式のため、フェーズごとに
+     順に呼べば合算される。無い方の引数は省略する）:
+     ```bash
+     # phase1完了後（expectedAgentProgressRecordsのみ返るフェーズの例）
+     scripts/record-gap-check-state.sh expected --agent-progress 4
+     # phase2完了後（両方返るフェーズの例）
+     scripts/record-gap-check-state.sh expected --loop-observability 10 --agent-progress 12
+     ```
+  3. gap check本体はStop hook（`scripts/check-gap-check-state.sh`）がターン終了時に自動実行し、
+     `hasGap: true` ならsystemMessageで警告する（実行後にstateファイルは自動クリアされる）。
+     手動での `scripts/check-loop-observability-gap.sh --before N --expected M` 実行は
+     再検証したい場合のみでよい
+  4. 警告が出た場合、記録漏れとして扱い、issue化するか原因を調査する
+  - **既知の限界**: stateファイルへの記録（上記1・2）自体は依然オーケストレーターの
+    自己申告（Workflow DSLがfilesystem API不可のため）。「書いたのにcheckし忘れる」は
+    Stop hookで構造的に消えたが、「そもそも書き忘れる」は残る
 - これは「記録漏れを機械的に検知する」ものであり、記録そのものを保証する仕組みではない
   （エージェント任せの記録に依存する構造自体の解消は別途検討中）。
 - 記録漏れが発生した過去分は、`scripts/lib/reconstruct-loop-observability.ts` で
@@ -141,11 +157,16 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
   つまり「進捗が表示されない」ことは「本当に止まっている」のか「そもそも記録し忘れている」のか
   区別できない。
 - **記録漏れの検知（issue #339、loop-observabilityと同型の仕組み）は実装済み。**
-  `aidd-phase1.js` / `aidd-phase2.js` を実行する前後で、必ず以下を行うこと。
-  1. 実行前に `jq -s '[.[] | select(.status == "done" or .status == "failed")] | length' logs/agent-progress.jsonl` で件数を記録する（ファイルが無ければ0）
-  2. フロー完了後、戻り値の `stats.expectedAgentProgressRecords` を確認する
-  3. `scripts/check-agent-progress-gap.sh --before <1の値> --expected <2の値>` を実行する
-  4. `hasGap: true`（exit 1）になった場合、記録漏れとして扱い、issue化するか原因を調査する
+  `aidd-phase1.js` / `aidd-phase2.js` を実行する前後の手順は、loop-observability側と共通の
+  gap check state方式（issue #488でStop hook自動実行化済み。上記
+  [「loop-observabilityログの記録漏れ検知」](#loop-observabilityログの記録漏れ検知)の手順参照）:
+  1. フロー開始時に `scripts/record-gap-check-state.sh before` を実行する（agent-progressの
+     done/failed件数もこの1回で同時に記録される）
+  2. フロー完了後、戻り値の `stats.expectedAgentProgressRecords` を
+     `scripts/record-gap-check-state.sh expected --agent-progress <値>` で記録する
+  3. gap check本体はStop hookが自動実行する。手動での
+     `scripts/check-agent-progress-gap.sh --before N --expected M` は再検証時のみでよい
+  4. 警告が出た場合、記録漏れとして扱い、issue化するか原因を調査する
   - 判定ロジックは `.claude/workflows/lib/agent-progress-gap.js`（loop-observability-gap.jsの
     computeGapを再利用）、期待件数の算出は `.claude/workflows/lib/agent-progress-expectation.js`
     （`aidd-phase2.js` 側はWorkflow DSL制約によりインライン複製）を参照。
@@ -649,6 +670,7 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | issue #441で検知手段を調査したが、「`/goal`が設定されているか」を外部から機械的に問い合わせるAPI/hookは公式に存在しないと判明（実機確認済み）。条件テンプレート化・役割分担の明文化（Workflow内部retryとの切り分け）は完了したが、呼び忘れ自体の検知は依然できないままこの表に残る |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
 | AIDD stats書き出し（各フェーズでの`write_aidd_stats.sh`呼び出し） | ルートの`CLAUDE.md` | 呼び忘れても気づく手段がない |
+| gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（AIDD stats書き出しと同型。Workflow DSLがfilesystem API不可のため自己申告依存が残る） |
 | seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | per-edit層で部分検知（`.claude/security-patterns.json`の`possible_real_facility_name`、issue #440）。ただし`/plugin install security-guidance@claude-plugins-official`の実機有効性は未確認、かつスクリーンショット・issue添付・E2E失敗ログは検知対象外 |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
 | `.claude/workflows/*.js` 変更時の`npm run eval:workflows`手動実行 | 本ファイル「AIDDワークフロープロンプトのeval」 | CI化は実エージェント呼び出しの課金コストで見送り。実行し忘れに気づく手段は無い（issue #391） |
@@ -680,7 +702,7 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | プロンプト正本の切り出し＋インライン複製＋sync test | `.claude/workflows/lib/prompts/db-impl.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/spec-check.js` / `manifest-check.js` ⇔ `aidd-phase2.js`、`.claude/workflows/lib/prompts/sweep.js` ⇔ `aidd-phase1.js` / `aidd-1-1-deep-task.js` | Workflow DSLがfilesystem API不可でローカルモジュールをrequire/importできない制約 | **解除**: Workflow DSLがローカルモジュールをimportできるようになれば、インライン複製自体が不要になり正本を直接importする形に変えられる。**破損**: プロンプト文言変更時にインライン複製側を追従させ忘れると乖離する（これを検知するのがsync testの目的そのもの） | `workflow-prompt-sync.test.js` / `sweep-prompt-sync.test.js`（npm test内） |
 | TRI/RISK・メタ改修判定ロジックの切り出し＋インライン複製＋sync test | `.claude/workflows/lib/router-risk.js` ⇔ `aidd-phase1-router.js`（issue #457） | 同上（Workflow DSL importの制約）。プロンプト（テンプレートリテラル）ではなく`const`配列・`function`宣言の複製のため、`extract-declaration.js`という別の抽出ユーティリティを使う | **解除**: 同上。**破損**: `classifyRoute`等の関数・定数配列を変更したのに`aidd-phase1-router.js`側のインライン複製を追従させ忘れると乖離する | `router-risk-sync.test.js`（npm test内） |
 | eval fixture manifestとaidd-phase2.js内スキーマ定義の同期 | `scripts/eval-fixtures/db-impl/manifest.json` ⇔ `aidd-phase2.js`内のスキーマ定義 | 同上（Workflow DSL importの制約） | **解除**: 同上。**破損**: スキーマ定義がドリフトすると、evalが実際のプロンプトと異なるスキーマでテストしてしまい気づかれない | `eval-fixture-manifest-schema-sync.test.js`（npm test内） |
-| 進捗・観測ログの自然言語指示依存 | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`呼び出し | Workflow DSLがfilesystem API不可で、ワークフロー本体から機械的にログを書き込めない制約 | **解除**: 同上（importまたは直接fs書き込みが可能になれば、本体側から機械的に記録できる設計に変更可能）。**破損**: 元々「壊れる」ものではなく「そもそも書かれない」リスクが常態（自然言語指示依存のため） | 記録漏れの事後検知（`check-loop-observability-gap.sh` / `check-agent-progress-gap.sh`）はあるが、その実行自体が人起動であり第3層ルールとして上表に残っている（issue #411） |
+| 進捗・観測ログの自然言語指示依存 | `scripts/log-agent-progress.sh` / `scripts/log-loop-observability.sh`呼び出し | Workflow DSLがfilesystem API不可で、ワークフロー本体から機械的にログを書き込めない制約 | **解除**: 同上（importまたは直接fs書き込みが可能になれば、本体側から機械的に記録できる設計に変更可能）。**破損**: 元々「壊れる」ものではなく「そもそも書かれない」リスクが常態（自然言語指示依存のため） | 記録漏れの事後検知（`check-loop-observability-gap.sh` / `check-agent-progress-gap.sh`）があり、その実行はStop hook（`scripts/check-gap-check-state.sh`、issue #488）で機械トリガー化済み。ただしbefore/expectedのstateファイル記録（`scripts/record-gap-check-state.sh`）自体はオーケストレーターの自己申告のまま残る |
 
 **Claude Code更新時の確認手順**: (1) 上表の「smoke test」列にnpm test内のテストがある項目は
 `npm test`を実行して確認する。(2) smoke testが「無い」と明記されている項目（現状は
@@ -703,6 +725,8 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |
 | `scripts/log-agent-progress.sh` / `scripts/show-agent-status.sh` | サブエージェント進捗の記録・一覧表示（issue #18） |
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |
+| `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
+| `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/scripts/check-gap-check-state.sh
+++ b/scripts/check-gap-check-state.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #488。gap check（記録漏れ検知）の実行はこれまで人起動の4ステップ手順で
+# 「checkし忘れたら気づけない」第3層ルールだった。このスクリプトはStop hookとして毎ターン
+# 終了時に発火し、record-gap-check-state.sh が書いた .aidd/gap-check-state.json を読んで、
+# expected件数が記録済みなら check-loop-observability-gap.sh / check-agent-progress-gap.sh を
+# 自動実行する（起動トリガーの機械化、issue #411原則）。
+#
+# - hasGap時はsystemMessageで警告する（Stop hookはblock不可の運用のためwarningのみ）
+# - 実行後はgap有無にかかわらずstateファイルを削除する（1フロー実行=1回のcheck）
+# - stateファイルが無いセッション（AIDDフロー非実行）では完全に沈黙する
+# - expected未記録のままGAP_CHECK_STALE_SECONDS（既定24時間）を超えたstateファイルは
+#   中断フローの残骸とみなして削除する。その際も「gap check未実施のまま破棄した」旨を
+#   systemMessageで警告する（停止①レビュー指摘の反映: 「中断しただけ」と「漏れを見逃して
+#   消えた」を事後に区別できるようにするため）
+#
+# 既知の限界:
+# - stateファイルへの記録自体はオーケストレーターの自己申告のまま
+#   （Workflow DSLがfilesystem API不可のため）。「書いたのにcheckし忘れる」は本hookで
+#   構造的に消えるが、「そもそも書き忘れる」は残る（issue #488本文に明記済み）
+# - 同一worktreeで複数のClaude Codeセッションが同時にAIDDフローを走らせた場合、
+#   stateファイルは共有されるため他セッションの値が混入しうる（排他制御なし）。
+#   worktreeを分ける運用（既定）では発生せず、影響もwarningの精度低下のみのため許容する
+#
+# 環境変数（テスト用の注入ポイント）:
+#   GAP_CHECK_STATE_FILE     stateファイルパス（既定 .aidd/gap-check-state.json）
+#   GAP_CHECK_LOOP_CMD       loop-observability用gap checkコマンド
+#   GAP_CHECK_PROGRESS_CMD   agent-progress用gap checkコマンド
+#   GAP_CHECK_STALE_SECONDS  残骸判定の閾値秒（既定86400）
+#   GAP_CHECK_NOW_EPOCH      現在時刻epoch秒の上書き
+
+cd "$(dirname "$0")/.."
+
+STATE_FILE="${GAP_CHECK_STATE_FILE:-.aidd/gap-check-state.json}"
+LOOP_GAP_CMD="${GAP_CHECK_LOOP_CMD:-scripts/check-loop-observability-gap.sh}"
+PROGRESS_GAP_CMD="${GAP_CHECK_PROGRESS_CMD:-scripts/check-agent-progress-gap.sh}"
+STALE_SECONDS="${GAP_CHECK_STALE_SECONDS:-86400}"
+NOW="${GAP_CHECK_NOW_EPOCH:-$(date +%s)}"
+
+emit() {
+  jq -n --arg msg "$1" '{systemMessage: $msg}'
+}
+
+if [ ! -f "$STATE_FILE" ]; then
+  exit 0
+fi
+
+# jqが無い環境では読み取りも警告出力もできないため沈黙する（stateファイルは残し、
+# jqのある環境での次回発火に委ねる。emit()だけがjq不在で異常終了する非対称を避ける）
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+BEFORE_LOOP="$(jq -r '.beforeLoopObservability // empty' "$STATE_FILE" 2>/dev/null || true)"
+BEFORE_PROGRESS="$(jq -r '.beforeAgentProgress // empty' "$STATE_FILE" 2>/dev/null || true)"
+EXPECTED_LOOP="$(jq -r '.expectedLoopObservability // empty' "$STATE_FILE" 2>/dev/null || true)"
+EXPECTED_PROGRESS="$(jq -r '.expectedAgentProgress // empty' "$STATE_FILE" 2>/dev/null || true)"
+RECORDED_AT="$(jq -r '.recordedAt // empty' "$STATE_FILE" 2>/dev/null || true)"
+
+# recordedAtが非数値（JSONとしては正当だが破損しているstate）の場合、set -u下の算術評価で
+# クラッシュしstateが残り続ける（毎ターン再クラッシュ）ため、空扱いに正規化して
+# 「破棄＋警告」の分岐に倒す
+case "$RECORDED_AT" in
+  ''|*[!0-9]*) RECORDED_AT="" ;;
+esac
+
+if [ -z "$EXPECTED_LOOP" ] && [ -z "$EXPECTED_PROGRESS" ]; then
+  if [ -n "$RECORDED_AT" ] && [ $((NOW - RECORDED_AT)) -le "$STALE_SECONDS" ]; then
+    # before記録済み・expected未記録はフロー実行中とみなし、何もしない（クリアもしない）
+    exit 0
+  fi
+  # 中断フローの残骸またはstate破損。削除するが、破棄自体は観測可能にする（停止①レビュー指摘）
+  rm -f "$STATE_FILE"
+  emit "AIDDフローのgap check state（${STATE_FILE}）を破棄しました（expected未記録のまま閾値${STALE_SECONDS}秒を超過、またはstateファイル破損）。このフローのgap check（記録漏れ検知）は未実施です。フローが中断されていた場合、必要に応じて scripts/check-loop-observability-gap.sh / scripts/check-agent-progress-gap.sh を手動実行してください（issue #488）。"
+  exit 0
+fi
+
+GAP_WARNINGS=""
+EXEC_FAILURES=""
+
+run_check() {
+  local cmd="$1" before="$2" expected="$3" label="$4"
+  local out code
+  set +e
+  out="$(bash "$cmd" --before "$before" --expected "$expected" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -eq 0 ]; then
+    return 0
+  fi
+  # 本物のgap（出力に hasGap:true がある）と、npx/jq等の実行基盤エラー（gap有無を判定
+  # できていない）を区別する。同一文言に丸めると原因調査の初手を誤らせるため（レビュー指摘）
+  if printf '%s' "$out" | grep -qF '"hasGap":true'; then
+    GAP_WARNINGS="${GAP_WARNINGS}
+- ${label}: ${out}"
+  else
+    EXEC_FAILURES="${EXEC_FAILURES}
+- ${label}: ${out}"
+  fi
+}
+
+if [ -n "$EXPECTED_LOOP" ] && [ -n "$BEFORE_LOOP" ]; then
+  run_check "$LOOP_GAP_CMD" "$BEFORE_LOOP" "$EXPECTED_LOOP" "loop-observability"
+fi
+if [ -n "$EXPECTED_PROGRESS" ] && [ -n "$BEFORE_PROGRESS" ]; then
+  run_check "$PROGRESS_GAP_CMD" "$BEFORE_PROGRESS" "$EXPECTED_PROGRESS" "agent-progress"
+fi
+
+rm -f "$STATE_FILE"
+
+MSG=""
+if [ -n "$GAP_WARNINGS" ]; then
+  MSG="AIDDフローの観測ログに記録漏れ（またはズレ）の可能性があります（Stop hookによる自動gap check、issue #488）。issue化するか原因を調査してください（docs/agents/common.md「loop-observabilityログの記録漏れ検知」参照）:${GAP_WARNINGS}"
+fi
+if [ -n "$EXEC_FAILURES" ]; then
+  if [ -n "$MSG" ]; then
+    MSG="${MSG}
+
+"
+  fi
+  MSG="${MSG}以下のgap checkは実行自体に失敗しました（npx/jq等の実行環境要因の可能性。記録漏れの有無は未判定です）:${EXEC_FAILURES}"
+fi
+if [ -n "$MSG" ]; then
+  emit "$MSG"
+fi
+
+exit 0

--- a/scripts/check-gap-check-state.test.sh
+++ b/scripts/check-gap-check-state.test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# WHY: scripts/check-gap-check-state.sh（issue #488のStop hook本体）の回帰テスト。
+# 実gap checkスクリプト・実stateファイルに依存させず、フェイクのgap checkコマンドと
+# stateファイルを環境変数で注入して決定的に検証する
+# （check-blocked-issues-staleness.test.shと同じパターン）。
+#
+# 実行: bash scripts/check-gap-check-state.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-gap-check-state.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  NG: $label (found: $needle)"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+STATE="$WORK_DIR/state.json"
+LOOP_CMD="$WORK_DIR/fake-loop-gap.sh"
+PROGRESS_CMD="$WORK_DIR/fake-progress-gap.sh"
+LOOP_CALLED="$WORK_DIR/loop-called"
+PROGRESS_CALLED="$WORK_DIR/progress-called"
+
+# フェイクgap checkコマンド: 呼ばれたことと引数を記録し、指定の出力・exit codeを返す
+setup_fake_cmd() {
+  local path="$1" called_file="$2" output="$3" exit_code="$4"
+  cat > "$path" <<EOF
+#!/bin/bash
+echo "\$@" > "$called_file"
+echo '$output'
+exit $exit_code
+EOF
+  chmod +x "$path"
+}
+
+run_hook() {
+  rm -f "$LOOP_CALLED" "$PROGRESS_CALLED"
+  set +e
+  OUT="$(GAP_CHECK_STATE_FILE="$STATE" GAP_CHECK_LOOP_CMD="$LOOP_CMD" \
+    GAP_CHECK_PROGRESS_CMD="$PROGRESS_CMD" GAP_CHECK_NOW_EPOCH=2000000 \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: stateファイル無し → 完全に沈黙 ==="
+rm -f "$STATE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: expected未記録・24時間以内 → 何もしない（stateも残る） ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000}' > "$STATE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "kept" "stateファイルが残っている"
+
+echo "=== scenario 3: expected未記録・閾値超え → 削除＋破棄警告 ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1000000}' > "$STATE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "破棄しました" "破棄の警告が含まれる"
+assert_contains "$OUT" "未実施" "gap check未実施の明記がある"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルが削除されている"
+
+echo "=== scenario 4: expected記録済み・両方gap無し → 沈黙してクリア ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000, expectedLoopObservability: 10, expectedAgentProgress: 16}' > "$STATE"
+setup_fake_cmd "$LOOP_CMD" "$LOOP_CALLED" '{"actualCount":10,"expectedCount":10,"hasGap":false}' 0
+setup_fake_cmd "$PROGRESS_CMD" "$PROGRESS_CALLED" '{"actualCount":16,"expectedCount":16,"hasGap":false}' 0
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "警告が出ない"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルがクリアされている"
+assert_eq "$(cat "$LOOP_CALLED")" "--before 5 --expected 10" "loop checkにbefore/expectedが渡っている"
+assert_eq "$(cat "$PROGRESS_CALLED")" "--before 19 --expected 16" "progress checkにbefore/expectedが渡っている"
+
+echo "=== scenario 5: loop側にgap有り → systemMessage警告＋クリア ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000, expectedLoopObservability: 10, expectedAgentProgress: 16}' > "$STATE"
+setup_fake_cmd "$LOOP_CMD" "$LOOP_CALLED" '{"actualCount":4,"expectedCount":10,"hasGap":true}' 1
+setup_fake_cmd "$PROGRESS_CMD" "$PROGRESS_CALLED" '{"actualCount":16,"expectedCount":16,"hasGap":false}' 0
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（warningのみ・block不可）"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "記録漏れ" "記録漏れ警告が含まれる"
+assert_contains "$OUT" "loop-observability" "どのログのgapかが含まれる"
+assert_contains "$OUT" "hasGap" "gap check出力が引用されている"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルがクリアされている"
+
+echo "=== scenario 6: agent-progressのexpectedのみ記録 → loop checkは呼ばれない ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000, expectedAgentProgress: 4}' > "$STATE"
+setup_fake_cmd "$LOOP_CMD" "$LOOP_CALLED" '{"hasGap":false}' 0
+setup_fake_cmd "$PROGRESS_CMD" "$PROGRESS_CALLED" '{"actualCount":4,"expectedCount":4,"hasGap":false}' 0
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_eq "$([ -f "$LOOP_CALLED" ] && echo called || echo not-called)" "not-called" "loop checkは呼ばれない"
+assert_eq "$([ -f "$PROGRESS_CALLED" ] && echo called || echo not-called)" "called" "progress checkは呼ばれる"
+
+echo "=== scenario 7: recordedAtが非数値（state破損） → クラッシュせず破棄＋警告 ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: "not-a-number"}' > "$STATE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（クラッシュしない）"
+assert_contains "$OUT" "破棄しました" "破棄の警告が含まれる"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルが削除されている（毎ターン再クラッシュしない）"
+
+echo "=== scenario 8: gap checkの実行自体が失敗（hasGap出力なしでexit 1） → gap警告と区別された文言 ==="
+jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000, expectedLoopObservability: 10}' > "$STATE"
+setup_fake_cmd "$LOOP_CMD" "$LOOP_CALLED" 'npx: network error' 1
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "実行自体に失敗" "実行失敗の文言が含まれる"
+assert_contains "$OUT" "未判定" "gap有無は未判定である旨が含まれる"
+assert_not_contains "$OUT" "記録漏れ（またはズレ）の可能性があります" "本物のgap警告文言とは区別されている"
+assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルはクリアされる"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/record-gap-check-state.sh
+++ b/scripts/record-gap-check-state.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: AIDDフローのgap check（check-loop-observability-gap.sh / check-agent-progress-gap.sh）は
+# これまで「実行前にwc -l/jqで件数を控え、フロー完了後に手動実行する」4ステップの人起動手順
+# だった（docs/agents/common.md、第3層ルール）。issue #488で、控える値を
+# .aidd/gap-check-state.json に永続化し、check実行自体はStop hook
+# （scripts/check-gap-check-state.sh）が機械トリガーする方式に変更した。
+# このスクリプトはその記録側で、件数の計測自体もスクリプトが行う（手動計測の控え間違いを排除）。
+#
+# 【重要】オーケストレーター（Claude本体）専用。サブエージェント・Workflow内から呼ばないこと。
+# Workflow DSLはfilesystem API不可のため構造的に呼べず、サブエージェントへの記録指示にも
+# 含めない設計。オーケストレーターのBash実行は逐次のためread-modify-write競合は発生しない
+# 前提（保険として書き込みは一時ファイル→mvのatomic方式にしている。ロックは導入しない）。
+# 同一worktreeで複数セッションが並行してAIDDフローを走らせるケースは未防御（既知の限界。
+# worktreeを分ける運用が既定のため許容。詳細はcheck-gap-check-state.shのヘッダ参照）。
+#
+# Usage:
+#   scripts/record-gap-check-state.sh before
+#     現在のログ件数を計測してbefore値として記録する。
+#     既にbefore値が記録済みの場合は上書きしない（first-write-wins。1フロー実行の起点を固定する）。
+#   scripts/record-gap-check-state.sh expected [--loop-observability N] [--agent-progress M]
+#     Workflow戻り値のexpected件数を加算記録する（最低どちらか1つ必須）。
+#     phase1のexpectedAgentProgressRecordsとphase2の同値を合算できるよう加算方式。
+#     before未記録の場合は手順逸脱としてexit 1。
+#
+# 環境変数（テスト用の注入ポイント）:
+#   GAP_CHECK_STATE_FILE   stateファイルパス（既定 .aidd/gap-check-state.json）
+#   GAP_CHECK_LOOP_LOG     loop-observabilityログ（既定 logs/loop-observability.jsonl）
+#   GAP_CHECK_PROGRESS_LOG agent-progressログ（既定 logs/agent-progress.jsonl）
+#   GAP_CHECK_NOW_EPOCH    現在時刻epoch秒の上書き
+
+cd "$(dirname "$0")/.."
+
+STATE_FILE="${GAP_CHECK_STATE_FILE:-.aidd/gap-check-state.json}"
+LOOP_LOG="${GAP_CHECK_LOOP_LOG:-logs/loop-observability.jsonl}"
+PROGRESS_LOG="${GAP_CHECK_PROGRESS_LOG:-logs/agent-progress.jsonl}"
+
+usage() {
+  echo "Usage: $0 before" >&2
+  echo "       $0 expected [--loop-observability N] [--agent-progress M]" >&2
+  exit 1
+}
+
+write_state() {
+  local json="$1"
+  local dir tmp
+  dir="$(dirname "$STATE_FILE")"
+  mkdir -p "$dir"
+  tmp="$(mktemp "$dir/.gap-check-state.XXXXXX")"
+  printf '%s\n' "$json" > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+has_before() {
+  [ -f "$STATE_FILE" ] && jq -e '.beforeLoopObservability != null' "$STATE_FILE" >/dev/null 2>&1
+}
+
+count_loop_lines() {
+  if [ -f "$LOOP_LOG" ]; then
+    wc -l < "$LOOP_LOG" | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+# done/failed件数の判定はcommon.mdの手動手順（jqコマンド）と同一
+count_progress_done_failed() {
+  if [ -f "$PROGRESS_LOG" ]; then
+    jq -s '[.[] | select(.status == "done" or .status == "failed")] | length' "$PROGRESS_LOG"
+  else
+    echo 0
+  fi
+}
+
+SUBCOMMAND="${1:-}"
+case "$SUBCOMMAND" in
+  before)
+    if has_before; then
+      echo "[gap-check-state] before値は記録済みのため上書きしません（first-write-wins）: $STATE_FILE"
+      exit 0
+    fi
+    BEFORE_LOOP="$(count_loop_lines)"
+    BEFORE_PROGRESS="$(count_progress_done_failed)"
+    NOW="${GAP_CHECK_NOW_EPOCH:-$(date +%s)}"
+    JSON="$(jq -n --argjson bl "$BEFORE_LOOP" --argjson bp "$BEFORE_PROGRESS" --argjson at "$NOW" \
+      '{beforeLoopObservability: $bl, beforeAgentProgress: $bp, recordedAt: $at}')"
+    write_state "$JSON"
+    echo "[gap-check-state] before値を記録しました (loopObservability=$BEFORE_LOOP, agentProgress=$BEFORE_PROGRESS)"
+    ;;
+  expected)
+    shift
+    ADD_LOOP=""
+    ADD_PROGRESS=""
+    LOOP_SET=""
+    PROGRESS_SET=""
+    # ${2:-}と2段shiftにしているのは、値の渡し忘れ（例: expected --agent-progress で終わる
+    # 呼び出し）をset -u下の生のunbound variableクラッシュではなくusage/検証エラーに
+    # 倒すため（レビュー指摘）
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --loop-observability) ADD_LOOP="${2:-}"; LOOP_SET=1; shift; shift || true ;;
+        --agent-progress) ADD_PROGRESS="${2:-}"; PROGRESS_SET=1; shift; shift || true ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+      esac
+    done
+    if [ -z "$LOOP_SET" ] && [ -z "$PROGRESS_SET" ]; then
+      usage
+    fi
+    is_nonneg_int() {
+      case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+      esac
+    }
+    if [ -n "$LOOP_SET" ] && ! is_nonneg_int "$ADD_LOOP"; then
+      echo "ERROR: --loop-observability の値が不正です（非負整数が必要）: '$ADD_LOOP'" >&2
+      exit 1
+    fi
+    if [ -n "$PROGRESS_SET" ] && ! is_nonneg_int "$ADD_PROGRESS"; then
+      echo "ERROR: --agent-progress の値が不正です（非負整数が必要）: '$ADD_PROGRESS'" >&2
+      exit 1
+    fi
+    if ! has_before; then
+      echo "ERROR: before値が未記録です。フロー開始時に '$0 before' を先に実行してください" >&2
+      exit 1
+    fi
+    JSON="$(cat "$STATE_FILE")"
+    # 指定された項目だけを加算する（未指定の項目はフィールド自体を作らない。
+    # 0で実体化するとStop hook側が「expected 0のcheck」を余計に実行してしまうため）
+    if [ -n "$LOOP_SET" ]; then
+      JSON="$(printf '%s' "$JSON" | jq --argjson n "$ADD_LOOP" '.expectedLoopObservability = ((.expectedLoopObservability // 0) + $n)')"
+    fi
+    if [ -n "$PROGRESS_SET" ]; then
+      JSON="$(printf '%s' "$JSON" | jq --argjson n "$ADD_PROGRESS" '.expectedAgentProgress = ((.expectedAgentProgress // 0) + $n)')"
+    fi
+    write_state "$JSON"
+    echo "[gap-check-state] expected値を加算しました (+loopObservability=${ADD_LOOP:-0}, +agentProgress=${ADD_PROGRESS:-0})"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/record-gap-check-state.test.sh
+++ b/scripts/record-gap-check-state.test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# WHY: scripts/record-gap-check-state.sh（issue #488のgap check state記録側）の回帰テスト。
+# 実ログ・実stateファイルに依存させず、一時ディレクトリのフェイクログ・stateパスを
+# 環境変数で注入して決定的に検証する（check-blocked-issues-staleness.test.shと同じパターン）。
+#
+# 実行: bash scripts/record-gap-check-state.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/record-gap-check-state.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+STATE="$WORK_DIR/state.json"
+LOOP_LOG="$WORK_DIR/loop.jsonl"
+PROGRESS_LOG="$WORK_DIR/progress.jsonl"
+
+run_record() {
+  set +e
+  OUT="$(GAP_CHECK_STATE_FILE="$STATE" GAP_CHECK_LOOP_LOG="$LOOP_LOG" \
+    GAP_CHECK_PROGRESS_LOG="$PROGRESS_LOG" GAP_CHECK_NOW_EPOCH=1000000 \
+    bash "$SCRIPT" "$@" 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+state_field() {
+  jq -r "$1 // \"null\"" "$STATE"
+}
+
+echo "=== scenario 1: ログが存在しない状態でbefore → 0/0が記録される ==="
+run_record before
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_eq "$(state_field '.beforeLoopObservability')" "0" "beforeLoopObservability=0"
+assert_eq "$(state_field '.beforeAgentProgress')" "0" "beforeAgentProgress=0"
+assert_eq "$(state_field '.recordedAt')" "1000000" "recordedAtが注入した時刻"
+
+echo "=== scenario 2: フェイクログがある状態でbefore → 実件数が記録される ==="
+rm -f "$STATE"
+printf '%s\n%s\n%s\n' '{"a":1}' '{"a":2}' '{"a":3}' > "$LOOP_LOG"
+printf '%s\n%s\n%s\n' \
+  '{"agent":"reviewer","status":"done"}' \
+  '{"agent":"reviewer","status":"running"}' \
+  '{"agent":"implementer","status":"failed"}' > "$PROGRESS_LOG"
+run_record before
+assert_eq "$(state_field '.beforeLoopObservability')" "3" "loop行数=3"
+assert_eq "$(state_field '.beforeAgentProgress')" "2" "done/failedのみカウント=2"
+
+echo "=== scenario 3: before二重実行 → first-write-winsで上書きされない ==="
+printf '%s\n' '{"a":4}' >> "$LOOP_LOG"
+run_record before
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "上書きしません" "first-write-winsのメッセージ"
+assert_eq "$(state_field '.beforeLoopObservability')" "3" "before値が変わっていない"
+
+echo "=== scenario 4: expected加算 → 複数回呼び出しで合算される ==="
+run_record expected --agent-progress 4
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_eq "$(state_field '.expectedAgentProgress')" "4" "1回目: agentProgress=4"
+assert_eq "$(state_field '.expectedLoopObservability')" "null" "未指定のloopObservabilityはフィールド自体が作られない"
+run_record expected --loop-observability 10 --agent-progress 12
+assert_eq "$(state_field '.expectedAgentProgress')" "16" "2回目: 4+12=16"
+assert_eq "$(state_field '.expectedLoopObservability')" "10" "loopObservability=10"
+assert_eq "$(state_field '.beforeLoopObservability')" "3" "before値は保持される"
+
+echo "=== scenario 5: before未記録でexpected → exit 1 ==="
+rm -f "$STATE"
+run_record expected --agent-progress 4
+assert_eq "$EXIT_CODE" "1" "exit 1"
+assert_contains "$OUT" "before値が未記録" "手順逸脱のエラーメッセージ"
+
+echo "=== scenario 6: 引数なしexpected / 不明サブコマンド → usage(exit 1) ==="
+run_record before
+run_record expected
+assert_eq "$EXIT_CODE" "1" "expected引数なしはexit 1"
+run_record unknown-subcommand
+assert_eq "$EXIT_CODE" "1" "不明サブコマンドはexit 1"
+
+echo "=== scenario 7: フラグの値渡し忘れ → 生のunboundエラーではなく検証エラー(exit 1) ==="
+run_record expected --agent-progress
+assert_eq "$EXIT_CODE" "1" "値なし--agent-progressはexit 1"
+assert_contains "$OUT" "値が不正" "検証エラーメッセージが出る（unbound variableではない）"
+
+echo "=== scenario 8: 非数値の値 → 検証エラー(exit 1)・stateは変更されない ==="
+BEFORE_STATE="$(cat "$STATE")"
+run_record expected --loop-observability abc
+assert_eq "$EXIT_CODE" "1" "非数値はexit 1"
+assert_contains "$OUT" "値が不正" "検証エラーメッセージが出る（生のjqエラーではない）"
+assert_eq "$(cat "$STATE")" "$BEFORE_STATE" "stateファイルが変更されていない"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #488

## 作業サマリ
- 変更した目的: gap check（loop-observability / agent-progressの記録漏れ検知）の実行を、common.mdの4ステップ手動手順（人起動・第3層ルール）からStop hookによる機械トリガーへ移行し、「checkし忘れたら気づけない」故障モードを構造的に解消する
- 変更した範囲:
  - 新規 `scripts/record-gap-check-state.sh`: before件数（計測内蔵）とexpected件数（加算方式）を`.aidd/gap-check-state.json`に記録。first-write-wins、一時ファイル→mvのatomic書き込み、非負整数バリデーション。オーケストレーター専用（ヘッダに明記）
  - 新規 `scripts/check-gap-check-state.sh`（Stop hook本体）: stateファイルを検知して両gap checkを自動実行。hasGap時はsystemMessageで警告（block不可）、実行後にstateクリア。expected未記録のまま24h超の残骸は「破棄した」旨を警告して削除。実行基盤エラー（npx/jq等）は本物のgapと**別文言**で警告。jq不在環境では沈黙。stateファイル破損（recordedAt非数値）でもクラッシュしない
  - `.claude/settings.json`: Stop hooksに登録（timeout 90。npx tsxコールドスタット考慮、verify-claims.shと同値）
  - テスト2本（計16シナリオ、フェイク注入方式）: `bash scripts/record-gap-check-state.test.sh` / `bash scripts/check-gap-check-state.test.sh`
  - `docs/agents/common.md`: 両gap checkセクションの手動手順を新手順に更新、重要ファイル表・「検知手段のないルールの棚卸し」表・load-bearing workaround表に反映
  - ルート`CLAUDE.md`: 「gap check state 記録ルール」セクションを追加
- 触っていない範囲: DB・migration・RLS・`src/`配下すべて。既存のcheck-*-gap.sh本体・`~/write_aidd_stats.sh`（ホーム側、リポジトリ外のため不採用と仕様で明記）

## 検証済み
- 実行したコマンド: 両`.test.sh` ALL PASSED（16シナリオ）/ `npm test`（161ファイル・1240件pass）/ `npm run lint`（0 errors、既存warning 1件のみ）。いずれもレビュー指摘の修正後に再実行して確認
- 確認した画面: なし（UI非接触）
- 確認したDB/RLS: なし（DB・RLS非接触）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（facility境界に非接触）

## AIDDフロー実行記録
- Phase 1: aidd-phase1-router → aidd-phase1（4軸Sweep）。gap check: agent-progress 4/4一致
- 停止①: 仕様承認済み。レビュー2指摘（並行書き込み前提の確認→オーケストレーター専用前提を明記しatomic書き込み採用／24h超破棄の静かな削除→警告付き削除に変更）を仕様へ反映
- Phase 3〜5: aidd-phase2はImplementフェーズでblocked（issue #493で発見済みの「5ロール編成にscripts/配下の担当が無い」ギャップの再発。data-implがスコープ外をcriticalとして正しく報告）。SPECで予見済みのためオーケストレーターが実装を代行し、レビューはAgentツールの4観点並列（正しさ／仕様カバレッジ／hook安全性／ドキュメント整合）で実施
- レビュー指摘は全件修正済み: critical 1（recordedAt非数値でクラッシュ→state残留で毎ターン再クラッシュ）、medium 1（timeout 30秒では npx tsx コールドスタートで超過リスク）、important 1（引数値渡し忘れが生のunboundエラー）、Major 2（ドキュメント表への行追加漏れ）、ほかminor/low。修正ごとに回帰テストを追加
- 停止②: 構造化レビューの明示実行は無し（ユーザーの「再開してください」指示により省略と解釈してPR作成へ進行）。必要であればPR上でのレビューまたは`/structured-review`で補完可能

## 既知の未対応・限界
- stateファイルへのbefore/expected記録自体は依然オーケストレーターの自己申告（Workflow DSLがfilesystem API不可のため）。「書き忘れ」の検知は無い（棚卸し表に行を追加済み。issue #495の同型機構が将来候補）
- 同一worktreeで複数セッションが並行してAIDDフローを走らせた場合のstate競合は未防御（worktree分離運用が既定のため許容、スクリプトヘッダに明記）
- **新Stop hookの実セッションでの発火は未確認**（settings.jsonはセッション開始時に読まれるため本セッションでは検証不能。テストはフェイク注入で全経路カバー済み）。マージ後の次回AIDDフロー実行セッションでの実機確認を推奨

## 後任AIへの注意
- この実装で壊してはいけない前提: Stop hookは全セッション・毎ターン発火する。stateファイル不在時の「jq呼び出しゼロで即exit 0」の最頻経路を重くしないこと。exit 2（block）は絶対に返さない
- 似ているが別物の用語: `check-gap-check-state.sh`（Stop hook・state駆動）と`check-loop-observability-gap.sh`/`check-agent-progress-gap.sh`（gap判定本体・引数駆動）。前者は後者を呼ぶラッパー
- 勝手にリファクタしない場所: expected未指定フィールドを0で実体化しない設計（実体化するとStop hookが「expected 0のcheck」を余計に実行する）。first-write-winsのbefore記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)
