### PR TITLE
feat: AIDD stats start呼び忘れの機械検知をStop hookに追加する(issue #495)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -238,6 +238,12 @@
             "command": "scripts/check-gap-check-state.sh",
             "timeout": 90,
             "statusMessage": "AIDD gap check stateを確認中(issue #488)..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-aidd-stats-recorded.sh",
+            "timeout": 15,
+            "statusMessage": "AIDD stats記録の有無を確認中(issue #495)..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,9 @@ stats JSON は標準入力ではなく**第4引数**で渡す（パイプ・リ�
 ~/write_aidd_stats.sh phase2 "" "" '{"implAgents":2,"reviewAgents":4,"totalAgents":7,"implSuccessCount":2}'
 ```
 ※ start を呼び忘れた場合は phase1_start_at がフォールバックで使われる
+※ start の呼び忘れは Stop hook（`scripts/check-aidd-stats-recorded.sh`、issue #495）が
+  Workflow実行の形跡と突き合わせて機械検知し警告する（セッションにつき1回・warningのみ。
+  phase単位の呼び忘れは検知対象外）
 
 ## gap check state 記録ルール（issue #488）
 AIDDフロー実行時は、上記statsと合わせて以下も呼ぶ（gap check本体はStop hookが自動実行する。

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,137 +1,134 @@
-# SPEC: gap checkの実行をStop hookで機械トリガー化する（issue #488）
+# SPEC: AIDD stats書き出し呼び忘れの機械検知をStop hookに追加（issue #495）
 
-- issue: #488
-- feature名: `issue-488-gap-check-stop-hook`
-- baseCommit: `22610bb516914f9d38ba06eeb456420840b78722`
+- issue: #495
+- feature名: `issue-495-aidd-stats-forgotten-detection`
+- baseCommit: `95db91ceb638efe1c92260c28629d6cbbd248b94`（PR #511マージ後のorigin/main HEAD）
 - 作成日: 2026-07-22
 
 ## Part 1: 何ができるようになるか（★人間がレビューする部分）
 
-現在、AIDDフロー実行後のgap check（`check-loop-observability-gap.sh` /
-`check-agent-progress-gap.sh`）は、common.mdの4ステップ手動手順（実行前にwc -lで
-before件数を控え、フロー完了後にexpectedと突き合わせて手動実行）に依存しており、
-「checkし忘れたら気づけない」第3層ルール（人起動）のまま残っている。
+「AIDD stats書き出し（`~/write_aidd_stats.sh`）の呼び忘れ」は棚卸し表の第3層ルール
+（検知手段なし）のまま残っている。issue #495の分析どおり、呼び忘れの主因は指示違反ではなく
+**長時間セッションでのコンテキスト圧縮による指示喪失**であり、モデル世代によらず構造的に
+再発しうる。本実装後は:
 
-本実装後は:
+- Workflow実行を含むセッションで`start`記録が無いままターンを終えると、Stop hookが
+  systemMessageで警告する（block不可・warningのみ）
+- 警告は**同一セッションにつき1回だけ**出す（毎ターン繰り返される警告ノイズを避ける）
+- AIDDフロー非実行セッション・判定材料が得られないセッションでは完全に沈黙する
+  （fail-open。警告機能のエラーでセッションを妨げない）
+- OTel等のopt-in設定には依存しない（既定環境で動く = 受け入れ条件どおり）
 
-- オーケストレーターはフロー前後に**リポジトリ内の記録スクリプトを呼ぶだけ**になり、
-  gap checkの実行自体は**Stop hookが機械トリガー**する（issue #411原則: 起動トリガーが
-  機械になる）
-- 記録漏れ（hasGap）があれば、フロー完了後の最初のターン終了時にsystemMessageで
-  警告が出る（block不可・warningのみ）
-- 「書いたのにcheckし忘れる」故障モードが構造的に消える。「stateファイルへの記録自体を
-  書き忘れる」は自己申告依存のまま残る（issue本文の既知の限界どおり）
+### 検知ロジック（issueの設計案2を具体化）
 
-### 動作イメージ
+1. **Workflow実行の形跡**: `logs/subagent-skeleton.jsonl`（SubagentStart/Stop hookの機械強制
+   記録、issue #423）のうち、`sessionId`が**現在のセッション**（Stop hook stdinの`session_id`）
+   と一致し、かつ`agentTranscriptPath`が`subagents/workflows/wf_`配下のイベントが1件以上
+   あるか。無ければ即沈黙
+2. **start記録の有無**: statsファイル（`~/.claude/aidd-session-stats/<sha256(cwd)先頭16桁>.json`、
+   `write_aidd_stats.sh`と同一のキー生成）に`session_start_at`（フォールバック:
+   `phase1_start_at`）があり、かつその値が**現在セッションの開始時刻以降**であるか。
+   古い値しか無い場合は「前セッションの残骸」であり、今セッションのstartは未実行と判定
+3. **セッション開始時刻の取得**: Stop hook stdinの`transcript_path`の先頭行のtimestampを使う
+   （hook入力に開始時刻そのものは無いため）。取得できない場合は判定不能として沈黙（fail-open）
 
-1. フロー開始時: `scripts/record-gap-check-state.sh before` を実行
-   → スクリプト自身が現在のログ件数を数えて `.aidd/gap-check-state.json` に記録
-   （手動wc -l・手動jqカウントが不要になり、控え間違いも消える）
-2. 各フェーズ完了後: `scripts/record-gap-check-state.sh expected --agent-progress 4` /
-   `... expected --loop-observability 10 --agent-progress 12` を実行
-   → expected件数をstateファイルに**加算**記録（phase1とphase2の期待値を合算できる）
-3. セッションのターン終了時: Stop hook（`scripts/check-gap-check-state.sh`）が
-   stateファイルを見て、expectedが記録済みなら両gap checkを自動実行
-   → hasGapならsystemMessageで警告、実行後にstateファイルを削除
+### 実装先はリポジトリ内の新規Stop hook
+
+issueの設計案1は「既存のaidd statsレポート生成hook」への追加を挙げているが、その実体は
+`~/aidd_session_report.sh`（**ユーザーグローバル設定・リポジトリ外**）と確認した。
+issue #488の`write_aidd_stats.sh`拡張を見送ったのと同じ理由（リポジトリ外ファイルは
+PRで管理・レビューできない）で、**リポジトリ内の新規スクリプト + `.claude/settings.json`
+登録**（#488と同型）とする。
 
 ## Part 2: 変更内容
 
-### 2-1. 新規 `scripts/record-gap-check-state.sh`
+### 2-1. 新規 `scripts/check-aidd-stats-recorded.sh`（Stop hook本体）
 
-- `before`サブコマンド: `logs/loop-observability.jsonl`の行数と
-  `logs/agent-progress.jsonl`のdone/failed件数を**スクリプト自身が計測**し、
-  `.aidd/gap-check-state.json` に `{beforeLoopObservability, beforeAgentProgress,
-  recordedAt}` を書き出す。既にbeforeが記録済みの場合は上書きしない（first-write-wins。
-  1フロー実行の起点を固定するため）
-- `expected`サブコマンド: `--loop-observability N` / `--agent-progress M`（いずれも任意、
-  最低1つ必須）を受け取り、stateファイルの `expectedLoopObservability` /
-  `expectedAgentProgress` に**加算**する（phase1のexpectedAgentProgressRecords=4と
-  phase2の=12を合算するため）。beforeが未記録ならエラー（exit 1）で手順逸脱を検知
-- done/failed件数の計測ロジックは既存の手動手順（common.mdのjqコマンド）と同一判定
-- `.aidd/` はgitignore済み（run-manifestと同じ扱い）
-- **呼び出し元はオーケストレーター（Claude本体）のみ**（スクリプトヘッダに明記。
-  Workflow DSLはfilesystem API不可のため構造的に呼べず、サブエージェントへの記録指示にも
-  含めない）。オーケストレーターのBash実行は逐次のためread-modify-write競合は発生しない
-  前提だが、保険として書き込みは一時ファイル→`mv`のatomic方式にする（ロックは導入しない）
+- stdin（hook入力JSON）から`session_id`・`transcript_path`を読む（`jq`。読めなければ沈黙）
+- 上記検知ロジック1→3→2の順で判定（安い判定から。skeleton形跡なしが最頻経路）
+- 警告済みマーカー: `.aidd/aidd-stats-warning-shown.json`に`{sessionId}`を記録し、
+  同一セッションでは2回目以降沈黙（`.aidd/`はgitignore済み）。書き込みは#488と同じ
+  一時ファイル→`mv`のatomic方式を踏襲する（停止①レビュー指摘の反映。なお最悪ケースでも
+  「警告が2回出る」のみでデータ破損・ブロックには繋がらない）
+- 警告文言には「コンテキスト圧縮で指示が失われた可能性」と「今からでも
+  `~/write_aidd_stats.sh start`を呼べば以降のphaseは記録される」旨を含める
+- 出力形式は既存Stop hook群と同じ`{systemMessage}`のみ。全経路exit 0（block不可）
+- 環境変数注入ポイント（テスト用）: skeletonログパス・statsディレクトリ・マーカーファイル
+  パス・stdin代替（session_id/transcript_pathの直接指定）
+- jq・python3不在時は沈黙（#488レビュー指摘の横展開。python3はepoch変換と
+  `sha256(cwd)`キー計算に使用しており、`write_aidd_stats.sh`自体もpython3依存のため
+  実質的な追加依存ではない）
+- 堅牢性（Phase 5レビュー指摘の反映）:
+  - skeletonログの走査は末尾2000行に限定（追記専用・無ローテーションの肥大化対策。
+    現在セッションのイベントは必ず末尾側にある）
+  - jqは`-R` + `fromjson?`で1行ずつパースし、壊れた行が混在しても後続の正当な
+    イベントを見失わない（共有ファイルへの排他制御なし並行追記が前提のため）
+  - マーカー書き込み失敗（read-only等）でもクラッシュせず警告は出す（全経路exit 0の
+    絶対要件。書けない間の警告重複は許容）
+  - 完全一致キーで見つからない場合、statsディレクトリ全体を走査して今セッションの
+    start記録を探す（cwdドリフト＝既知障害でキーがズレた場合の誤警告防止。
+    他worktreeの並行セッションによる沈黙側の見逃しは意図的なトレードオフ）
+  - transcriptのtimestampは末尾Z（UTC）形式のみ信頼し、それ以外は沈黙
+  - `$HOME`未設定環境では沈黙（set -uクラッシュ防止）
+  - 存在チェック（ビルトイン）をコマンド存在確認より先に置き、AIDD未使用セッションでは
+    サブプロセス起動ゼロで終える
 
-### 2-2. 新規 `scripts/check-gap-check-state.sh`（Stop hook本体）
+### 2-2. `.claude/settings.json`
 
-- `.aidd/gap-check-state.json` が無ければ何もせず exit 0（AIDDフロー非実行セッションでは
-  完全に沈黙。opt-in設定にも依存しない）
-- stateファイルはあるがexpectedが1つも無い場合:
-  - `recordedAt`から24時間以内 → フロー実行中とみなし何もしない（クリアもしない）
-  - 24時間超 → 中断されたフローの残骸とみなしstateファイルを削除し、**systemMessageで
-    「gap check未実施のままstateを破棄した」旨を一言警告する**（block不可。「中断しただけ」と
-    「漏れを見逃して消えた」を区別可能にし、破棄自体を観測可能にするため。停止①レビューでの
-    指摘を反映）
-- expectedがある場合:
-  - `expectedLoopObservability`があれば `check-loop-observability-gap.sh --before <state値>
-    --expected <state値>` を実行
-  - `expectedAgentProgress`があれば `check-agent-progress-gap.sh` を同様に実行
-  - いずれかが `hasGap: true` → 既存Stop hook群（`gate-effectiveness-monthly-check.sh`等）と
-    同形式のJSON（`{systemMessage}`のみ）で警告を出力（**block不可・warningのみ**。
-    `hookSpecificOutput`/`additionalContext`はSessionStart hook用のためStop hookでは使わない）
-  - gap checkの実行自体が失敗した場合（npx/jq等の環境要因、出力に`hasGap`が無いままexit≠0）は、
-    本物のgap警告とは**別の文言**（「実行自体に失敗・記録漏れの有無は未判定」）で警告する
-    （レビュー指摘の反映: 原因調査の初手を誤らせないため）
-  - 実行後（gap有無にかかわらず）stateファイルを削除する
-- 環境変数でstateファイルパス・gap checkスクリプトパスを差し替え可能にする
-  （フェイク注入テストのため。既存hookテストと同型）
-- 堅牢性（レビュー指摘の反映）: jq不在の環境では何もせず沈黙する（stateは残し次回に委ねる）。
-  `recordedAt`が非数値の破損stateはクラッシュさせず「破棄＋警告」に倒す（クラッシュすると
-  stateが残り毎ターン再クラッシュするため）
+- Stop hooksに `scripts/check-aidd-stats-recorded.sh`（timeout 15。純粋なファイル読みのみで
+  npx等の重い依存なし）を追加登録
 
-### 2-3. `.claude/settings.json`
+### 2-3. テスト `scripts/check-aidd-stats-recorded.test.sh`
 
-- Stop hooksに `scripts/check-gap-check-state.sh`（timeout 90）を追加登録
-  （当初案は30秒だったが、gap checkスクリプトが内部で呼ぶ`npx -y tsx`のコールドスタートで
-  超過しうるというレビュー指摘を受け、`verify-claims.sh`と同じ90秒に引き上げた）
+フェイク注入方式（#488のテストと同型）。ケース:
+- skeletonログ無し／このセッションのwf_イベント無し → 沈黙
+- wf_イベントあり・statsファイル無し → 警告
+- wf_イベントあり・statsのstart時刻がセッション開始より古い（前セッション残骸） → 警告
+- wf_イベントあり・statsのstart時刻がセッション開始以降 → 沈黙
+- 警告済みマーカーあり → 2回目は沈黙
+- transcript先頭行が読めない → 沈黙（fail-open）
+- 別セッションのwf_イベントのみ（sessionId不一致） → 沈黙
 
-### 2-4. テスト
-
-- `scripts/record-gap-check-state.sh` / `scripts/check-gap-check-state.sh` それぞれに
-  `.test.sh` を新設（`bash scripts/<name>.test.sh` で実行。statusline.test.sh等と同じく
-  `npm test` 対象外のbashテスト）。ケース:
-  - before記録 → 値がログ実件数と一致 / 二重実行でfirst-write-wins
-  - expected加算 → 複数回呼び出しで合算される / before未記録ならexit 1
-  - Stop hook: stateファイル無し→沈黙 / expected無し・24h以内→何もしない /
-    expected無し・24h超→削除＋破棄警告のsystemMessage出力 / gap無し→警告なしでクリア /
-    gap有り→systemMessage出力（フェイクstateファイル＋フェイクログ注入）
-
-### 2-5. ドキュメント更新
+### 2-4. ドキュメント更新
 
 - `docs/agents/common.md`:
-  - 「loop-observabilityログの記録漏れ検知」「サブエージェント進捗の可視化」両節の
-    4ステップ手動手順を「`record-gap-check-state.sh`で記録すればStop hookが自動実行する。
-    手動実行は再検証時のみ」に更新
-  - 「ツール制約回避のload-bearing workaround棚卸し」表の該当行（gap check実行が人起動の
-    まま第3層に残っている旨の記述）を更新
-  - 既知の限界（stateファイルへの記録自体は自己申告のまま）を明記
-- ルート `CLAUDE.md`: AIDDフロー手順のgap check記述を新手順（before記録→expected記録）に
-  差し替え
+  - 「検知手段のないルールの棚卸し」表の「AIDD stats書き出し」行を更新する。本検知が
+    カバーするのは`start`の呼び忘れのみのため、行を丸ごと外すのではなく、**検知済みのstart
+    部分への言及（検知手段リンク付き）を備考に記載した上で、未検知のまま残るphase単位の
+    呼び出しに行の対象を狭めて残す**（表自身のルール「検知手段を実装したら表から外す」を、
+    検知済みになった範囲にのみ適用する。全体を外すとphase単位の未検知が棚卸しから
+    消えてしまうため）
+  - 重要ファイル表に新スクリプトの行を追加
+- ルート`CLAUDE.md`: 「AIDD stats 書き出しルール」に検知hookの存在を1行追記
 
 ## 並列グループ宣言
 
-- **グループ1（単独・並列化なし）**: 2-1〜2-5すべて。record→check→settings→テスト→
-  ドキュメントは相互依存のため、implementer 1体で直列実装する。
-  （注: #493で確認した編成ギャップ（scripts/配下は5ロール外でintegratorが代行）が
-  再発する可能性が高い。integratorによる代行実装を今回は許容する）
+- **グループ1（単独・並列化なし）**: 2-1〜2-4すべて。implementer 1体相当で直列実装
+  （#488と同様、5ロール編成ギャップ再発時はオーケストレーター実装を許容）
 
 ## 受け入れ条件
 
-- フロー実行後、オーケストレーターがターンを終えるだけで両gap checkが自動実行され、
-  記録漏れがあればsystemMessage警告が出る（テストで検証）
-- AIDDフローを実行していないセッションではStop hookが完全に沈黙する（テストで検証）
-- 起動トリガーが機械（Stop hook）である（issue #411原則）
-- 全`.test.sh`がpass / `npm test` green（既存テストの回帰なし）/ `npm run lint` green
+- Workflow実行を含むセッションでstats start記録が無いままターンを終えると警告が出る
+  （テストで検証）
+- 同一セッションで警告は1回のみ（テストで検証)
+- AIDDフロー非実行セッション・判定不能時は完全沈黙（テストで検証）
+- OTel等のopt-in設定に依存しない
+- 全`.test.sh` pass / `npm test` green / `npm run lint` green
+
+## 既知の限界（issue記載＋設計由来）
+
+- `subagent-skeleton.jsonl`はセッション全体で共通のため、同一セッション内の
+  「AIDDフローではないWorkflow実行」（例: 単発のresearch系Workflow）も形跡として拾い、
+  誤検知しうる（issue記載どおりwarning-onlyのため許容）
+- 検知できるのは「startの呼び忘れ」のみ。phase1/phase2等の途中フェーズの呼び忘れは
+  検知しない（startさえあればレポートは生成されるため、最小バーとして妥当）
+- セッション開始時刻はtranscript先頭行のtimestampに依存する（Claude Codeのtranscript形式
+  変更で判定不能→沈黙に縮退する。fail-open設計のため安全側）
 
 ## 対応しないこと（明示的スコープ外）
 
-- `~/write_aidd_stats.sh`（ホーム側）への機能追加: リポジトリ外ファイルは本PRの管理外。
-  記録はリポジトリ内スクリプトに一本化する（issueの設計案1の後者を採用）
-- stateファイル書き込み自体の機械強制: Workflow DSLのfilesystem API制約により不可能
-  （issue記載の既知の限界。「書き忘れ」の検知はissue #495の類似機構で将来検討）
-- `aidd-1-1-deep-task.js`のgap check未対応問題（common.md記載の既存の限界）の解消
+- `~/aidd_session_report.sh`・`~/write_aidd_stats.sh`（ホーム側）の変更
+- phase単位の呼び忘れ検知・stats内容の妥当性検証
 - DB・データ取得層・UI・RLS・migrationには一切触れない
-- Phase 1 Sweep(data軸)の既存コードへの一般指摘（エラー形式混在・as キャスト等）:
-  本issueと無関係のためスコープ外
+- Phase 1 Sweepの既存コードへの一般指摘（news routeのバリデーション・ItemRow型不一致等）:
+  本issueと無関係のためスコープ外（必要なら別issue）

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -669,8 +669,8 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースのみ`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。「別issueの未マージPRが乗っている」ケースと`origin/main`起点確認自体は未検知のまま |
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | issue #441で検知手段を調査したが、「`/goal`が設定されているか」を外部から機械的に問い合わせるAPI/hookは公式に存在しないと判明（実機確認済み）。条件テンプレート化・役割分担の明文化（Workflow内部retryとの切り分け）は完了したが、呼び忘れ自体の検知は依然できないままこの表に残る |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
-| AIDD stats書き出し（各フェーズでの`write_aidd_stats.sh`呼び出し） | ルートの`CLAUDE.md` | 呼び忘れても気づく手段がない |
-| gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（AIDD stats書き出しと同型。Workflow DSLがfilesystem API不可のため自己申告依存が残る） |
+| AIDD stats書き出しのうち**phase単位**の呼び出し（`write_aidd_stats.sh` phase1/phase2等） | ルートの`CLAUDE.md` | **start呼び忘れはissue #495でStop hook検知済み**（`scripts/check-aidd-stats-recorded.sh`。Workflow実行の形跡があるのにstart記録が無ければ警告）。phase単位の呼び忘れ検知は未実装のままこの表に残る |
+| gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（上記「AIDD stats書き出しのphase単位」行と同型。Workflow DSLがfilesystem API不可のため自己申告依存が残る） |
 | seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | per-edit層で部分検知（`.claude/security-patterns.json`の`possible_real_facility_name`、issue #440）。ただし`/plugin install security-guidance@claude-plugins-official`の実機有効性は未確認、かつスクリーンショット・issue添付・E2E失敗ログは検知対象外 |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
 | `.claude/workflows/*.js` 変更時の`npm run eval:workflows`手動実行 | 本ファイル「AIDDワークフロープロンプトのeval」 | CI化は実エージェント呼び出しの課金コストで見送り。実行し忘れに気づく手段は無い（issue #391） |
@@ -727,6 +727,7 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |
 | `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
 | `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |
+| `scripts/check-aidd-stats-recorded.sh` | Stop hookによるAIDD stats start呼び忘れの機械検知（issue #495） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/scripts/check-aidd-stats-recorded.sh
+++ b/scripts/check-aidd-stats-recorded.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #495。「AIDD stats書き出し（~/write_aidd_stats.sh）の呼び忘れ」は棚卸し表の
+# 第3層ルール（検知手段なし）だった。呼び忘れの主因は指示違反ではなく、長時間セッションでの
+# コンテキスト圧縮による指示喪失であり、モデル世代によらず構造的に再発しうる。
+# このスクリプトはStop hookとして毎ターン終了時に発火し、
+# 「このセッションでWorkflow経由のサブエージェント実行の形跡があるのに、statsファイルに
+# このセッションのstart記録が無い」場合にsystemMessageで警告する（block不可・warningのみ）。
+#
+# 検知ロジック:
+# 1. logs/subagent-skeleton.jsonl（SubagentStart/Stop hookの機械強制記録、issue #423）から、
+#    sessionIdが現在セッションと一致し、agentTranscriptPathが subagents/workflows/wf_ 配下の
+#    イベントを探す。無ければWorkflow未実行セッションとして沈黙
+# 2. セッション開始時刻は hook入力の transcript_path の先頭行timestampから取得する
+#    （hook入力に開始時刻そのものは無いため）
+# 3. statsファイル（~/.claude/aidd-session-stats/<sha256(cwd)先頭16桁>.json、
+#    write_aidd_stats.shと同一のキー生成）の session_start_at（フォールバック:
+#    phase1_start_at）がセッション開始時刻以降なら記録済みとして沈黙。古い値のみ・
+#    ファイル無しなら「今セッションのstart呼び忘れ」として警告
+#
+# 設計方針:
+# - fail-open: 判定材料が取れないケース（jq/python3不在・stdin欠損・transcript読めない等）は
+#   すべて沈黙する。警告機能の故障でセッションを妨げない
+# - 警告は同一セッションにつき1回のみ（.aidd/aidd-stats-warning-shown.json のマーカーで抑止。
+#   書き込みは一時ファイル→mvのatomic方式。最悪ケースでも警告が2回出るだけで実害なし）
+# - 全経路 exit 0（blockしない）
+#
+# 既知の限界（issue #495本文・SPEC参照）:
+# - subagent-skeleton.jsonlはセッション全体で共通のため、AIDDフロー以外のWorkflow実行
+#   （単発のresearch系等）も形跡として拾い、誤検知しうる（warning-onlyのため許容）
+# - 検知できるのは「startの呼び忘れ」のみ（phase単位の呼び忘れは対象外）
+# - 警告済みマーカーはworktree（ディレクトリ）単位の1ファイルのため、同一ディレクトリで
+#   複数セッションが同時に動くと上書きし合い、「セッションにつき1回」の保証が崩れて
+#   警告が余分に出ることがある（worktree分離運用が既定のため許容。実害は警告の重複のみ）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   AIDD_STATS_CHECK_SESSION_ID       hook stdinのsession_idの代替
+#   AIDD_STATS_CHECK_TRANSCRIPT_PATH  hook stdinのtranscript_pathの代替
+#   AIDD_STATS_CHECK_SKELETON_LOG     skeletonログパス（既定 logs/subagent-skeleton.jsonl）
+#   AIDD_STATS_CHECK_STATS_DIR        statsディレクトリ（既定 ~/.claude/aidd-session-stats）
+#   AIDD_STATS_CHECK_MARKER_FILE      警告済みマーカー（既定 .aidd/aidd-stats-warning-shown.json）
+
+cd "$(dirname "$0")/.."
+
+SKELETON_LOG="${AIDD_STATS_CHECK_SKELETON_LOG:-logs/subagent-skeleton.jsonl}"
+MARKER_FILE="${AIDD_STATS_CHECK_MARKER_FILE:-.aidd/aidd-stats-warning-shown.json}"
+
+# skeletonログが無ければWorkflow実行の形跡は取得不能 → 沈黙。
+# ビルトインの存在チェックを最初に置き、AIDD未使用セッション（最頻経路）では
+# サブプロセス起動ゼロで終える（レビュー指摘の反映）
+[ -f "$SKELETON_LOG" ] || exit 0
+
+# jq/python3不在の環境では判定も警告出力もできないため沈黙（fail-open）
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+# statsディレクトリ: HOME未設定環境ではset -uクラッシュさせず沈黙（レビュー指摘の反映）
+if [ -n "${AIDD_STATS_CHECK_STATS_DIR:-}" ]; then
+  STATS_DIR="$AIDD_STATS_CHECK_STATS_DIR"
+elif [ -n "${HOME:-}" ]; then
+  STATS_DIR="$HOME/.claude/aidd-session-stats"
+else
+  exit 0
+fi
+
+# hook入力（stdin JSON）からsession_id / transcript_pathを取得（テスト時は環境変数で代替）
+HOOK_INPUT=""
+if [ -z "${AIDD_STATS_CHECK_SESSION_ID:-}" ] || [ -z "${AIDD_STATS_CHECK_TRANSCRIPT_PATH:-}" ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+fi
+SESSION_ID="${AIDD_STATS_CHECK_SESSION_ID:-$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)}"
+TRANSCRIPT_PATH="${AIDD_STATS_CHECK_TRANSCRIPT_PATH:-$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)}"
+
+[ -n "$SESSION_ID" ] || exit 0
+
+# 警告済みマーカー: 同一セッションでは2回目以降沈黙
+if [ -f "$MARKER_FILE" ]; then
+  WARNED_SESSION="$(jq -r '.sessionId // empty' "$MARKER_FILE" 2>/dev/null || true)"
+  if [ "$WARNED_SESSION" = "$SESSION_ID" ]; then
+    exit 0
+  fi
+fi
+
+# 1. このセッションのWorkflow経由サブエージェント実行の形跡。
+# skeletonログは追記専用・無ローテーションで長期的に肥大化するため、末尾2000行に
+# 走査を限定する（現在セッションのイベントは必ず末尾側に追記されている。1セッションで
+# 2000件超のサブエージェントイベントは非現実的な規模。レビュー指摘の反映）
+# jqは-R + fromjson?で1行ずつパースする: skeletonログは複数セッション・複数hookから
+# 排他制御なしで並行追記される共有ファイルのため、壊れた行が混入しうる。素のjqだと
+# 壊れた行でパースを打ち切り、それ以降の正当なイベントを見失う（レビューcritical指摘の反映）
+set +e
+WF_COUNT="$(tail -n 2000 "$SKELETON_LOG" 2>/dev/null \
+  | jq -R -r --arg sid "$SESSION_ID" \
+      'fromjson? | select(.sessionId == $sid) | .agentTranscriptPath // ""' 2>/dev/null \
+  | grep -c "/subagents/workflows/wf_")"
+set -e
+if [ -z "$WF_COUNT" ] || [ "$WF_COUNT" -eq 0 ] 2>/dev/null; then
+  exit 0
+fi
+
+# 2. セッション開始時刻（transcript先頭行のtimestamp → epoch秒）。
+# 末尾ZのUTC表記のみ信頼する: Z以外（+09:00等のオフセット付き）を先頭19文字だけで
+# UTCとしてパースするとサイレントにズレたepochになるため、想定外形式は沈黙に倒す
+# （レビューminor指摘の反映）
+[ -f "$TRANSCRIPT_PATH" ] || exit 0
+FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+[ -n "$FIRST_TS" ] || exit 0
+case "$FIRST_TS" in
+  *Z) : ;;
+  *) exit 0 ;;
+esac
+SESSION_START_EPOCH="$(python3 -c "
+import sys, datetime
+try:
+    ts = sys.argv[1][:19]
+    dt = datetime.datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=datetime.timezone.utc)
+    print(int(dt.timestamp()))
+except Exception:
+    pass
+" "$FIRST_TS" 2>/dev/null || true)"
+[ -n "$SESSION_START_EPOCH" ] || exit 0
+
+# 3. statsファイルのstart記録（write_aidd_stats.shと同一のcwdハッシュキー）
+STATS_KEY="$(python3 -c 'import hashlib, os; print(hashlib.sha256(os.getcwd().encode()).hexdigest()[:16])' 2>/dev/null || true)"
+[ -n "$STATS_KEY" ] || exit 0
+STATS_FILE="$STATS_DIR/$STATS_KEY.json"
+
+START_AT=""
+if [ -f "$STATS_FILE" ]; then
+  START_AT="$(jq -r '.session_start_at // .phase1_start_at // empty' "$STATS_FILE" 2>/dev/null || true)"
+fi
+case "$START_AT" in
+  *[!0-9]*) START_AT="" ;;
+esac
+
+# start記録がセッション開始以降（時計ズレ許容60秒）なら記録済み → 沈黙
+if [ -n "$START_AT" ] && [ "$START_AT" -ge $((SESSION_START_EPOCH - 60)) ]; then
+  exit 0
+fi
+
+# 警告前の最終ガード: 他キーのstatsファイルに今セッションのstart記録が無いか走査する。
+# write_aidd_stats.shのキーは「呼び出し時点のcwd」から計算されるため、cwdドリフト
+# （既知障害: EnterWorktree後にcwdが静かに戻ることがある、ユーザーMemory記載）で
+# キーがズレると、実際にはstartを呼んだのに本hookの完全一致キーからは見えず
+# 誤警告になる（レビューimportant指摘の反映）。誤警告よりも沈黙側に倒す。
+# トレードオフ: statsディレクトリは全worktree共有（キー=cwdハッシュ）のため、この走査は
+# 「他worktreeの並行セッションが直近にstartを呼んだ」場合にも沈黙し、本worktreeの
+# 呼び忘れを見逃しうる。警告の信頼性（誤警告でオオカミ少年化しない）を優先した意図的な
+# 選択。ディレクトリ内はworktreeごとに1ファイル程度で走査コストは無視できる
+for other_file in "$STATS_DIR"/*.json; do
+  [ -f "$other_file" ] || continue
+  OTHER_AT="$(jq -r '.session_start_at // .phase1_start_at // empty' "$other_file" 2>/dev/null || true)"
+  case "$OTHER_AT" in
+    ''|*[!0-9]*) continue ;;
+  esac
+  if [ "$OTHER_AT" -ge $((SESSION_START_EPOCH - 60)) ]; then
+    exit 0
+  fi
+done
+
+# 呼び忘れと判定 → マーカーをatomicに書いてから1回だけ警告。
+# マーカー書き込みに失敗しても（disk full・read-only等）クラッシュせず警告は出す
+# （Stop hookの「全経路exit 0」が絶対要件のため。書けない間は毎ターン警告が繰り返される
+# 可能性があるが、沈黙やクラッシュより安全側。レビューHigh指摘の反映）
+write_marker() {
+  local dir tmp
+  dir="$(dirname "$MARKER_FILE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(mktemp "$dir/.aidd-stats-warning.XXXXXX" 2>/dev/null)" || return 1
+  jq -n --arg sid "$SESSION_ID" '{sessionId: $sid}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  return 0
+}
+set +e
+write_marker
+set -e
+
+MSG="このセッションではWorkflow経由のサブエージェント実行（AIDDフローの可能性）が記録されていますが、AIDD statsのstart記録（~/write_aidd_stats.sh start）が見当たりません（issue #495）。長時間セッションではコンテキスト圧縮でCLAUDE.mdのstats書き出し指示が失われることがあります。AIDDフローを実行中の場合は、今からでも CLAUDE.md「AIDD stats 書き出しルール」の手順で start を呼べば、以降のphase記録・セッションレポート生成は機能します（この警告はセッションにつき1回のみ表示されます）。"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+
+exit 0

--- a/scripts/check-aidd-stats-recorded.test.sh
+++ b/scripts/check-aidd-stats-recorded.test.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# WHY: scripts/check-aidd-stats-recorded.sh（issue #495のStop hook）の回帰テスト。
+# 実skeletonログ・実statsファイル・実transcriptに依存させず、一時ディレクトリの
+# フェイクファイル群を環境変数で注入して決定的に検証する
+# （check-gap-check-state.test.sh等と同じパターン）。
+#
+# 実行: bash scripts/check-aidd-stats-recorded.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-aidd-stats-recorded.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SKELETON="$WORK_DIR/skeleton.jsonl"
+STATS_DIR="$WORK_DIR/stats"
+MARKER="$WORK_DIR/marker.json"
+TRANSCRIPT="$WORK_DIR/transcript.jsonl"
+mkdir -p "$STATS_DIR"
+
+SESSION="session-aaa"
+OTHER_SESSION="session-bbb"
+
+# セッション開始時刻: 2026-07-22T04:00:00Z = epoch 1784692800
+SESSION_START_ISO="2026-07-22T04:00:00.123Z"
+SESSION_START_EPOCH=1784692800
+
+# statsファイルのキーはスクリプトのcwd（リポジトリルート）から算出されるため、
+# テスト側でも同じ計算で予め求めておく
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATS_KEY="$(cd "$REPO_ROOT" && python3 -c 'import hashlib, os; print(hashlib.sha256(os.getcwd().encode()).hexdigest()[:16])')"
+
+wf_event() {
+  printf '{"timestamp":"%s","hookEvent":"SubagentStop","sessionId":"%s","agentId":"a1","agentTranscriptPath":"/home/u/.claude/projects/p/s/subagents/workflows/wf_abc123/agent-a1.jsonl"}\n' "$1" "$2"
+}
+non_wf_event() {
+  printf '{"timestamp":"%s","hookEvent":"SubagentStop","sessionId":"%s","agentId":"a2","agentTranscriptPath":"/home/u/.claude/projects/p/s/subagents/agent-a2.jsonl"}\n' "$1" "$2"
+}
+
+setup_transcript() {
+  printf '{"type":"user","timestamp":"%s"}\n' "$SESSION_START_ISO" > "$TRANSCRIPT"
+}
+
+run_hook() {
+  set +e
+  OUT="$(AIDD_STATS_CHECK_SESSION_ID="$SESSION" \
+    AIDD_STATS_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+    AIDD_STATS_CHECK_SKELETON_LOG="$SKELETON" \
+    AIDD_STATS_CHECK_STATS_DIR="$STATS_DIR" \
+    AIDD_STATS_CHECK_MARKER_FILE="$MARKER" \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+reset_env() {
+  rm -f "$SKELETON" "$MARKER" "$STATS_DIR/$STATS_KEY.json"
+  setup_transcript
+}
+
+echo "=== scenario 1: skeletonログ無し → 沈黙 ==="
+reset_env
+rm -f "$SKELETON"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: このセッションのwf_イベント無し（非Workflowイベントのみ） → 沈黙 ==="
+reset_env
+non_wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 3: 別セッションのwf_イベントのみ（sessionId不一致） → 沈黙 ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$OTHER_SESSION" > "$SKELETON"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 4: wf_イベントあり・statsファイル無し → 警告＋マーカー作成 ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（block不可）"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "start" "start記録に関する警告が含まれる"
+assert_contains "$OUT" "issue #495" "issue番号が含まれる"
+assert_eq "$([ -f "$MARKER" ] && echo yes || echo no)" "yes" "警告済みマーカーが作成される"
+
+echo "=== scenario 5: 警告済みマーカーあり（同一セッション） → 2回目は沈黙 ==="
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "2回目の出力は空である"
+
+echo "=== scenario 6: マーカーは別セッションのもの → 警告する ==="
+jq -n --arg sid "$OTHER_SESSION" '{sessionId: $sid}' > "$MARKER"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "別セッションのマーカーでは抑止されない"
+
+echo "=== scenario 7: statsのstart時刻が前セッションの残骸（セッション開始より古い） → 警告 ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+jq -n --argjson at "$((SESSION_START_EPOCH - 7200))" '{session_start_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "古いstart記録は残骸として警告される"
+
+echo "=== scenario 8: statsのstart時刻がセッション開始以降 → 沈黙 ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+jq -n --argjson at "$((SESSION_START_EPOCH + 300))" '{session_start_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "start記録済みなら沈黙する"
+
+echo "=== scenario 9: session_start_atは無いがphase1_start_atが今セッション → 沈黙（フォールバック） ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+jq -n --argjson at "$((SESSION_START_EPOCH + 300))" '{phase1_start_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "phase1_start_atフォールバックで沈黙する"
+
+echo "=== scenario 10: transcriptが読めない → 沈黙（fail-open） ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+rm -f "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "判定不能時は沈黙する"
+
+echo "=== scenario 11: transcript先頭行にtimestampが無い → 沈黙（fail-open） ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+printf '{"type":"summary"}\n' > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "timestamp欠損時は沈黙する"
+
+echo "=== scenario 12: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+READONLY_DIR="$WORK_DIR/readonly"
+mkdir -p "$READONLY_DIR"
+chmod 555 "$READONLY_DIR"
+set +e
+OUT="$(AIDD_STATS_CHECK_SESSION_ID="$SESSION" \
+  AIDD_STATS_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+  AIDD_STATS_CHECK_SKELETON_LOG="$SKELETON" \
+  AIDD_STATS_CHECK_STATS_DIR="$STATS_DIR" \
+  AIDD_STATS_CHECK_MARKER_FILE="$READONLY_DIR/marker.json" \
+  bash "$SCRIPT" < /dev/null 2>&1)"
+EXIT_CODE=$?
+set -e
+chmod 755 "$READONLY_DIR"
+assert_eq "$EXIT_CODE" "0" "exit 0（クラッシュしない・block不可の絶対要件）"
+assert_contains "$OUT" "systemMessage" "マーカーが書けなくても警告は出る"
+
+echo "=== scenario 13: skeletonログに壊れた行が混在 → 後続の正当なwf_イベントを見失わず警告する ==="
+reset_env
+{
+  printf '{broken json line\n'
+  wf_event "$SESSION_START_ISO" "$SESSION"
+} > "$SKELETON"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "壊れた行があっても後続イベントで警告できる"
+
+echo "=== scenario 14: 別キーのstatsファイルに今セッションのstart記録（cwdドリフト） → 沈黙 ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+jq -n --argjson at "$((SESSION_START_EPOCH + 100))" '{session_start_at: $at}' > "$STATS_DIR/otherkey0000000000.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "別キーでも今セッションのstartがあれば誤警告しない"
+rm -f "$STATS_DIR/otherkey0000000000.json"
+
+echo "=== scenario 15: transcriptのtimestampがZ以外（オフセット付き） → 沈黙（fail-open） ==="
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+printf '{"type":"user","timestamp":"2026-07-22T13:00:00.123+09:00"}\n' > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "UTC(Z)以外の形式は信頼せず沈黙する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #495

## 作業サマリ
- 変更した目的: AIDD stats書き出し（`~/write_aidd_stats.sh start`）の呼び忘れを機械検知し、棚卸し表の第3層ルール（検知手段なし）を削減する。呼び忘れの主因は長時間セッションのコンテキスト圧縮による指示喪失であり、モデル世代によらず構造的に再発しうるため機械検知が必要（issue #495の分析どおり）
- 変更した範囲:
  - 新規 `scripts/check-aidd-stats-recorded.sh`（Stop hook本体）: `logs/subagent-skeleton.jsonl`（SubagentStart/Stop hookの機械強制記録・issue #423）から現在セッション（sessionId一致）のWorkflow経由サブエージェント実行（`wf_`配下）の形跡を検出し、statsファイル（`~/.claude/aidd-session-stats/<sha256(cwd)先頭16桁>.json`）に今セッションのstart記録（`session_start_at`/`phase1_start_at`がセッション開始時刻以降）が無ければsystemMessageで警告する。警告はセッションにつき1回（`.aidd/`のatomicマーカーで抑止）・全経路exit 0・fail-open（判定材料が取れなければ沈黙）
  - 新規 `scripts/check-aidd-stats-recorded.test.sh`: フェイク注入方式の15シナリオ
  - `.claude/settings.json`: Stop hooksに登録（timeout 15）
  - `docs/agents/common.md`: 棚卸し表の「AIDD stats書き出し」行を「start検知済み（リンク付き）・phase単位のみ未検知として残す」形に更新、重要ファイル表に行追加
  - ルート`CLAUDE.md`: 検知hookの存在を注記
- 触っていない範囲: DB・migration・RLS・`src/`配下すべて。`~/write_aidd_stats.sh`・`~/aidd_session_report.sh`（ホーム側）は不変更（issueの設計案1が指す「既存のstatsレポートhook」はリポジトリ外の`~/aidd_session_report.sh`と確認したため、#488と同じ理由でリポジトリ内新規hookに変更）

## 検証済み
- 実行したコマンド: `bash scripts/check-aidd-stats-recorded.test.sh`（15シナリオ ALL PASSED、レビュー修正後に再実行）/ `npm test`（161ファイル・1240件pass）/ `npm run lint`（0 errors、既存warning 1件のみ）
- 確認した画面: なし（UI非接触）
- 確認したDB/RLS: なし（DB・RLS非接触）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（facility境界に非接触）

## AIDDフロー実行記録
- Phase 1: aidd-phase1-router → aidd-phase1（4軸Sweep、本issue関連の指摘なし）。gap check（agent-progress 4/4）は**#488で導入したStop hookが本セッションで実際に自動実行**して確認（#488機構の実機発火の初確認を兼ねる）
- 停止①: 仕様承認済み（レビュー指摘「マーカー書き込みの同時書き込み安全性の明記」をSPECへ反映）
- Phase 3〜5: 本タスク類型（scripts/配下のみ）はaidd-phase2の5ロール編成で2連続blockedの実績があるため、最初からオーケストレーター実装＋Agentツール4観点並列レビュー（正しさ／仕様カバレッジ／hook安全性／ドキュメント整合）で実施
- レビュー指摘は全件修正済み:
  - **critical**（正しさ）: skeletonログの壊れた行1つでjqが打ち切られ検知が丸ごと沈黙 → `jq -R fromjson?`の行単位パースに変更
  - **High**（hook安全性）: マーカー書き込み不可環境でexit 1クラッシュが毎ターン再発・警告も出ない → 書き込み失敗を握って警告は出す（全経路exit 0維持）
  - important: cwdドリフト（EnterWorktree後にcwdが静かに戻る既知障害）でstatsキーがズレて誤警告 → statsディレクトリ全体走査のフォールバックで沈黙側に倒す
  - Medium: skeletonログ無ローテーション肥大の恒久コスト → 走査を末尾2000行に限定
  - ほかLow/minor 6件（チェック順序・$HOME未設定・非Zタイムスタンプ不信頼・SPEC記述乖離・棚卸し表の比喩・python3依存の記載）
  - 各修正に対応する回帰テストを追加（12〜15番シナリオ）
- 停止②: 構造化レビュー承認済み

## 既知の未対応・限界
- 検知できるのはstartの呼び忘れのみ。phase単位の呼び忘れは棚卸し表に残置（startさえあればレポート生成は機能するため最小バーとして妥当）
- cwdドリフト対策の全ディレクトリ走査は、他worktreeの並行セッションが直近にstartを呼んだ場合に本worktreeの呼び忘れを見逃すトレードオフあり（誤警告によるオオカミ少年化の回避を優先。スクリプトコメントに明記）
- AIDDフロー以外のWorkflow実行（research系等）も形跡として拾い誤検知しうる（issue記載どおりwarning-onlyで許容）
- 同一ディレクトリで複数セッション同時実行時はマーカーが上書きし合い警告が重複しうる（worktree分離運用が既定のため許容）
- **新hookの実セッションでの発火は未確認**（settings.jsonはセッション開始時読み込みのため。#488は本セッションで実機発火を確認済みで、同型パターンの前例あり）

## 後任AIへの注意
- この実装で壊してはいけない前提: Stop hookは全セッション・毎ターン発火する。skeletonログ不在時（AIDD未使用）の最頻経路はサブプロセス起動ゼロで即exit 0。exit 2（block）は絶対に返さない
- 似ているが別物の用語: `check-aidd-stats-recorded.sh`（start呼び忘れ検知・issue #495）と`check-gap-check-state.sh`（gap check自動実行・issue #488）は別のStop hook。前者はstats、後者は観測ログ件数が対象
- 勝手にリファクタしない場所: statsキー計算（`sha256(cwd)先頭16桁`）は`~/write_aidd_stats.sh`と同一ロジックであることが前提。片方だけ変えると検知が静かに壊れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
