### PR TITLE
eval:workflows実行ルールの義務化と実行痕跡のCI警告(issue #496)

### DIFF
--- a/.github/workflows/eval-runs-freshness-check.yml
+++ b/.github/workflows/eval-runs-freshness-check.yml
@@ -1,0 +1,26 @@
+# WHY: issue #496。.claude/workflows/*.js（プロンプト正本のlib/prompts/配下を含む）を
+# 変更したPRで、docs/agents/eval-runs.jsonl（eval実行完了時にeval-workflow-prompts.sh /
+# eval-sweep-recall.shが自動追記する実行痕跡）の更新が抜けていないかを機械的に警告する
+# (.github/workflows/agent-baseline-check.ymlと同型)。まずはwarningのみで、マージを
+# ブロックしない。実evalそのものをCIで自動実行することはしない（実エージェント呼び出しの
+# 課金コストで見送り済みの判断は変えない。issue本文の注意点参照）。
+
+name: Eval Runs Freshness Check
+
+on:
+  pull_request:
+    paths:
+      - '.claude/workflows/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check eval-runs.jsonl freshness
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: bash scripts/check-eval-runs-freshness.sh "origin/$BASE_REF" HEAD

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -619,7 +619,10 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 - `--setting-sources ""` は `.claude/agents/*.md` のファイル探索によるカスタムagent型解決も同時に無効化してしまうため（`--agent implementer` が `not found` になる）、実際の `claude -p` 呼び出しでは `.claude/agents/<agentType>.md` のYAML frontmatterを除いた本文を `--agents` フラグで明示的に注入している（`scripts/lib/build-eval-agent-json.mjs`）。`--setting-sources ""` を弱めずにこの問題を回避するための組み合わせであり、削るとevalの実エージェント呼び出しが全滅する load-bearing な仕組みなので、harnessを触る際は要注意。
 - モデルは意図的に安価なモデルへ差し替えていない（実際のdb-impl実行時と同じsonnet）。安いモデルでevalすると「本番で実際に動くもの」と異なる挙動をテストすることになり、モックが実環境の挙動を隠す典型的な落とし穴に陥るため。
 - プロンプト本文のドリフト対策として、db-implプロンプトの正本を `.claude/workflows/lib/prompts/db-impl.js` に切り出し、`aidd-phase2.js` 側のインライン複製との一字一句の一致を `.claude/workflows/lib/__tests__/workflow-prompt-sync.test.js` が機械的に検証する（`npm test`に含まれる）。
-- **運用ルール（検知手段なし）**: `.claude/workflows/*.js` のプロンプト文言を変更したPRは、マージ前に `npm run eval:workflows <対応するfixtureセット>` を手動実行することが望ましい。CI化（PR時の自動実行）は実エージェント呼び出しの課金コストを理由に見送った。**この運用ルール自体、実行し忘れても気づく機械的な手段が無い**（下記「検知手段のないルールの棚卸し」参照）。将来案として、`.claude/workflows/*.js` が変更されたPRに対し、evalが最近実行された形跡（タイムスタンプファイル等）の有無だけを軽量にチェックするgit hookを検討したが、今回は見送った。
+- **運用ルール（義務化・検知機構あり、issue #496）**: `.claude/workflows/*.js` のプロンプト文言を変更したPRでは、マージ前に `npm run eval:workflows <対応するfixtureセット>`（sweep系のプロンプト変更は `scripts/eval-sweep-recall.sh <layer>`）を実行し、結果を引き継ぎメモの「検証済み」欄へ記載すること（未実施の場合はその旨と理由を明記する）。CI化（PR時の自動実行）は引き続き実エージェント呼び出しの課金コストを理由に見送っている。
+  - 両スクリプトは実行完了時（pass/fail問わず）に `docs/agents/eval-runs.jsonl`（git管理。`logs/`はgitignoreでbefore消失の前例があるため対象外にした。issue #429と同じ理由）へ日時・fixtureセット名・合否件数を1行追記する。呼び出し側の自己申告ではなくeval script自身が書くため、記録そのものの呼び忘れは起きない（issue #411原則: 起動トリガーは機械）
+  - `.github/workflows/eval-runs-freshness-check.yml`（`scripts/check-eval-runs-freshness.sh`、`agent-baseline-check.yml`と同型）が、PRに `.claude/workflows/*.js` の差分があるのに `docs/agents/eval-runs.jsonl` の更新が含まれていない場合に `::warning::` を出す（block ではなく warning のみ）
+  - **既知の限界**: 上記が保証するのは「evalスクリプトが最後まで実行されたこと」の痕跡のみであり、実行そのものを強制するものではない（実行し忘れて何もコミットしなければ警告が出るだけで、PRの作成・マージ自体は妨げない）。また記録内容の正しさ（本当にそのfixtureセットに対して実行したか、pass/fail件数が改ざんされていないか）までは検証しない
 
 ## 引き継ぎフォーマット
 
@@ -673,7 +676,6 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（上記「AIDD stats書き出しのphase単位」行と同型。Workflow DSLがfilesystem API不可のため自己申告依存が残る） |
 | seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | per-edit層で部分検知（`.claude/security-patterns.json`の`possible_real_facility_name`、issue #440）。ただし`/plugin install security-guidance@claude-plugins-official`の実機有効性は未確認、かつスクリーンショット・issue添付・E2E失敗ログは検知対象外 |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
-| `.claude/workflows/*.js` 変更時の`npm run eval:workflows`手動実行 | 本ファイル「AIDDワークフロープロンプトのeval」 | CI化は実エージェント呼び出しの課金コストで見送り。実行し忘れに気づく手段は無い（issue #391） |
 
 ## fault injection訓練の実施タイミング（issue #395）
 

--- a/scripts/check-eval-runs-freshness.sh
+++ b/scripts/check-eval-runs-freshness.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# issue #496: .claude/workflows/*.js に差分があるのに、同じ差分(コミット範囲)に
+# docs/agents/eval-runs.jsonl(scripts/eval-workflow-prompts.sh / scripts/eval-sweep-recall.sh
+# が実行完了時に自動追記するJSONL)の更新が含まれていない場合に警告する。
+# scripts/check-agent-baseline-freshness.sh(issue #429)と同型。まずはblockではなく
+# warning(exit 0)で開始する。
+#
+# 使い方: scripts/check-eval-runs-freshness.sh <base-ref> <head-ref>
+#   例: scripts/check-eval-runs-freshness.sh origin/main HEAD
+
+BASE_REF="${1:-}"
+HEAD_REF="${2:-HEAD}"
+
+if [ -z "$BASE_REF" ]; then
+  echo "usage: $0 <base-ref> [head-ref]" >&2
+  exit 1
+fi
+
+CHANGED_FILES="$(git diff --name-only "$BASE_REF" "$HEAD_REF")"
+
+WORKFLOWS_CHANGED="false"
+WORKFLOWS_DETAIL=""
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  case "$file" in
+    .claude/workflows/*.js)
+      WORKFLOWS_CHANGED="true"
+      WORKFLOWS_DETAIL="$WORKFLOWS_DETAIL
+- $file"
+      ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+if [ "$WORKFLOWS_CHANGED" = "false" ]; then
+  echo "check-eval-runs-freshness: .claude/workflows/*.js の変更は検知されませんでした。"
+  exit 0
+fi
+
+EVAL_RUNS_CHANGED="$(echo "$CHANGED_FILES" | grep -c '^docs/agents/eval-runs\.jsonl$' || true)"
+
+if [ "$EVAL_RUNS_CHANGED" -eq 0 ]; then
+  echo "::warning::.claude/workflows/*.js が変更されていますが、docs/agents/eval-runs.jsonlの更新が含まれていません。マージ前にnpm run eval:workflows（またはsweep系の変更ならscripts/eval-sweep-recall.sh）を実行し、実行痕跡を記録することを検討してください(issue #496)。変更箇所:$WORKFLOWS_DETAIL"
+  exit 0
+fi
+
+echo "check-eval-runs-freshness: .claude/workflows/*.js の変更とdocs/agents/eval-runs.jsonlの更新が両方含まれています。OK。"
+exit 0

--- a/scripts/check-eval-runs-freshness.test.sh
+++ b/scripts/check-eval-runs-freshness.test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# WHY: issue #496向けの機械トリガー(scripts/check-eval-runs-freshness.sh)の回帰テスト。
+# 一時gitリポジトリでworkflows変更のみのコミット・eval-runs.jsonl同時更新のコミットを作り、
+# 期待通りに警告が出る/出ないことを確認する。check-agent-baseline-freshness.test.shと同型。
+#
+# 実行: bash scripts/check-eval-runs-freshness.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-eval-runs-freshness.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  NG: $label (見つかってはいけない文字列が見つかった)"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+
+TMP_REPO="$(mktemp -d)"
+cd "$TMP_REPO"
+git init --quiet
+git config user.email "test@example.com"
+git config user.name "test"
+
+mkdir -p .claude/workflows docs/agents
+cat > .claude/workflows/aidd-phase2.js <<'EOF'
+export const meta = { name: "aidd-phase2" }
+EOF
+echo "[]" > docs/agents/eval-runs.jsonl
+git add .
+git commit --quiet -m "base"
+
+echo "=== scenario 1: workflowsのみ変更 → warning ==="
+cat >> .claude/workflows/aidd-phase2.js <<'EOF'
+// prompt change
+EOF
+git add .
+git commit --quiet -m "change workflow prompt"
+OUT="$(bash "$SCRIPT" HEAD~1 HEAD)"
+assert_contains "$OUT" "::warning::" "警告が出る"
+
+echo "=== scenario 2: workflows変更 + eval-runs.jsonl更新を同時コミット → OKのみ ==="
+cat >> .claude/workflows/aidd-phase2.js <<'EOF'
+// another change
+EOF
+echo '{"timestamp":"2026-07-23T00:00:00Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}' >> docs/agents/eval-runs.jsonl
+git add .
+git commit --quiet -m "change workflow prompt + record eval run"
+OUT="$(bash "$SCRIPT" HEAD~1 HEAD)"
+assert_not_contains "$OUT" "::warning::" "警告が出ない（eval-runs.jsonl同時更新済み）"
+
+echo "=== scenario 3: workflowsに無関係な変更のみ → 何も出ない ==="
+echo "# unrelated" >> README.md
+git add .
+git commit --quiet -m "unrelated doc change"
+OUT="$(bash "$SCRIPT" HEAD~1 HEAD)"
+assert_not_contains "$OUT" "::warning::" "警告が出ない（workflows変更なし）"
+
+echo "=== scenario 4: .claude/workflows/lib/配下(プロンプト正本の切り出し先)の変更も対象になる ==="
+mkdir -p .claude/workflows/lib/prompts
+echo "export const x = 1" > .claude/workflows/lib/prompts/db-impl.js
+git add .
+git commit --quiet -m "change prompt source of truth in lib/"
+OUT="$(bash "$SCRIPT" HEAD~1 HEAD)"
+assert_contains "$OUT" "::warning::" "警告が出る（lib/prompts/配下もプロンプト正本のため検知対象）"
+
+cd - > /dev/null
+rm -rf "$TMP_REPO"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL"
+  exit 1
+fi
+echo "PASS"

--- a/scripts/eval-sweep-recall.sh
+++ b/scripts/eval-sweep-recall.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 # いずれか1つが両方含まれていればヒット(見落としなし)とする決定的判定。LLM judgeは
 # 使わない(判定器自体が非決定になると回帰テストの意味が薄れるため。issue本文の設計判断)。
 #
+# 実行が最後まで完了すると(hit/miss問わず)、$REPO_DIR/docs/agents/eval-runs.jsonl に
+# 実行痕跡(日時・layer名・合否件数)を1行追記する(issue #496。eval-workflow-prompts.shと同型)。
+#
 # 使い方: scripts/eval-sweep-recall.sh <layer>（例: sweep-ui）
 #
 # 環境変数（テスト容易性のため上書き可能。scripts/eval-workflow-prompts.shと同じパターン）:
@@ -191,6 +194,12 @@ fi
 echo ""
 echo "=== eval-sweep-recall: $LAYER ==="
 echo "recall: $HIT_COUNT / $TOTAL"
+
+EVAL_RUNS_FILE="$REPO_DIR/docs/agents/eval-runs.jsonl"
+mkdir -p "$(dirname "$EVAL_RUNS_FILE")"
+printf '{"timestamp":"%s","script":"eval-sweep-recall","fixtureSet":"%s","pass":%d,"total":%d}\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$LAYER" "$HIT_COUNT" "$TOTAL" >> "$EVAL_RUNS_FILE"
+
 if [ -n "$MISS_LINES" ]; then
   echo "$MISS_LINES"
   exit 1

--- a/scripts/eval-workflow-prompts.sh
+++ b/scripts/eval-workflow-prompts.sh
@@ -15,6 +15,11 @@ set -euo pipefail
 # 各fixtureは本体リポジトリを汚さないよう、一時ディレクトリへのlocal clone上で実行する
 # （fixtureによっては実際にsupabase/migrations/へファイルを書こうとするため）。
 #
+# 実行が最後まで完了すると(pass/fail問わず)、$REPO_DIR/docs/agents/eval-runs.jsonl に
+# 実行痕跡(日時・fixtureセット名・合否件数)を1行追記する(issue #496)。呼び忘れ検知が
+# 効かなかったこと自体への対策のため、eval scriptが自分で書く(呼び出し側の自己申告に
+# 依存しない)。
+#
 # サーキットブレーカー・hooks非継承・セッション非永続化は、verify-claims.shが2026-07-14に
 # 経験したStop hook再帰暴走と同型の事故を未然に防ぐため、初回コミットから組み込んでいる。
 #
@@ -222,6 +227,15 @@ fi
 echo ""
 echo "=== eval-workflow-prompts: $FIXTURE_SET ==="
 echo "$PASS_COUNT / $TOTAL 件 合格"
+
+# issue #496: 実行完了の痕跡をgit管理下のJSONLへ残す。実行有無の機械検知
+# (scripts/check-eval-runs-freshness.sh)がこのファイルの更新有無を見るため、
+# pass/fail問わず(=ループが最後まで到達した場合は常に)1行追記する。
+EVAL_RUNS_FILE="$REPO_DIR/docs/agents/eval-runs.jsonl"
+mkdir -p "$(dirname "$EVAL_RUNS_FILE")"
+printf '{"timestamp":"%s","script":"eval-workflow-prompts","fixtureSet":"%s","pass":%d,"total":%d}\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$FIXTURE_SET" "$PASS_COUNT" "$TOTAL" >> "$EVAL_RUNS_FILE"
+
 if [ -n "$FAIL_LINES" ]; then
   echo "$FAIL_LINES"
   exit 1

--- a/scripts/eval-workflow-prompts.test.sh
+++ b/scripts/eval-workflow-prompts.test.sh
@@ -289,6 +289,28 @@ echo "=== scenario 9: タイムアウト時にプロセスグループごとkill
 RUN_AGENT_WITH_TIMEOUT_BLOCK="$(awk '/^run_agent_with_timeout\(\)/,/^}/' "$SCRIPT")"
 assert_contains "$RUN_AGENT_WITH_TIMEOUT_BLOCK" 'kill -- "-$pid"' "タイムアウト時にプロセスグループ全体をkillする実装になっている(単一PIDのkillに退行するとimplementerの子プロセスが停止せず残る)"
 
+echo "=== scenario 10: 実行完了時に \$REPO_DIR/docs/agents/eval-runs.jsonlへ実行痕跡を追記する(issue #496) ==="
+rm -f "$MOCK_CALL_LOG"
+rm -f "$DUMMY_REPO/docs/agents/eval-runs.jsonl"
+echo '{ "status": "pass" }' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_eq "$EXIT_CODE" "0" "全fixture合格でexit 0(前提の再確認)"
+EVAL_RUNS_LINE="$(tail -n 1 "$DUMMY_REPO/docs/agents/eval-runs.jsonl" 2>/dev/null || echo "")"
+assert_contains "$EVAL_RUNS_LINE" '"script":"eval-workflow-prompts"' "eval-runs.jsonlにscript名が記録される"
+assert_contains "$EVAL_RUNS_LINE" '"fixtureSet":"sample"' "eval-runs.jsonlにfixtureSet名が記録される"
+assert_contains "$EVAL_RUNS_LINE" '"pass":2,"total":2' "eval-runs.jsonlに合否件数が記録される"
+
+echo "=== scenario 11: 1件失敗(NG)でも実行完了時にeval-runs.jsonlへ追記される(pass/fail問わず記録) ==="
+rm -f "$MOCK_CALL_LOG"
+rm -f "$DUMMY_REPO/docs/agents/eval-runs.jsonl"
+echo '{ "status": "blocked" }' > "$FIXTURES_DIR/sample/case-b/expected.json"
+echo '{ "status": "pass" }' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_eq "$EXIT_CODE" "1" "1件不一致でexit 1(前提の再確認)"
+EVAL_RUNS_LINE="$(tail -n 1 "$DUMMY_REPO/docs/agents/eval-runs.jsonl" 2>/dev/null || echo "")"
+assert_contains "$EVAL_RUNS_LINE" '"pass":1,"total":2' "失敗ケースを含んでいてもeval-runs.jsonlへ追記される"
+echo '{ "status": "pass" }' > "$FIXTURES_DIR/sample/case-b/expected.json"
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
## Summary
- `.claude/workflows/*.js` のプロンプト文言変更PRで `npm run eval:workflows` 実行が「望ましい」という弱い勧奨に留まり、実行し忘れの検知手段が無かった問題を解消(issue #429の`agent-baseline-check`と同型)
- `eval-workflow-prompts.sh` / `eval-sweep-recall.sh` が実行完了時(pass/fail問わず)に `docs/agents/eval-runs.jsonl`(git管理)へ日時・fixtureセット名・合否件数を1行追記するようにした
- `.github/workflows/eval-runs-freshness-check.yml` + `scripts/check-eval-runs-freshness.sh` を新設し、`.claude/workflows/*.js` の差分があるのに `docs/agents/eval-runs.jsonl` の更新が含まれないPRに `::warning::` を出す
- `docs/agents/common.md` の該当箇所を義務化文言に強化し、棚卸し表から該当行を削除

Closes #496

## Test plan
- [x] `bash scripts/eval-workflow-prompts.test.sh`
- [x] `bash scripts/check-eval-runs-freshness.test.sh`
- [x] `bash scripts/check-agent-baseline-freshness.test.sh`(既存回帰確認)
- [x] `npm test`(161ファイル/1240件 全通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)