### PR TITLE
aidd-phase2.js Reviewリトライで前回attemptの修正内容を次のimplementer-retryへ引き継ぐ(issue #490)

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -410,10 +410,27 @@ function classifyReviewRound(results, dimensions, attempt, maxRetries) {
   return { done: false, blocked: false, failingDimensions, blockedDimensions: [] }
 }
 
+// issue #490: Reviewリトライのたびに新規implementerへ指摘の文字列のみを渡していたため、
+// 前回attemptで何をどう修正したかが引き継がれず、各attemptがゼロから修正対象を再発見して
+// いた（同じ修正の繰り返し・矛盾する修正のリスク）。次のretryプロンプトに直近2attempt分の
+// 「指摘→修正報告」履歴を含めることで軽減する。
+// 正本: .claude/workflows/lib/review-retry-history.js（buildRetryHistorySection）。
+// Workflow DSLはrequire不可のためインライン複製している。
+const MAX_RETRY_HISTORY_ENTRIES = 2
+function buildRetryHistorySection(retryHistory) {
+  if (!Array.isArray(retryHistory) || retryHistory.length === 0) return ''
+  const recent = retryHistory.slice(-MAX_RETRY_HISTORY_ENTRIES)
+  const entries = recent
+    .map(({ attempt, findings, detail }) => `### attempt ${attempt}\n指摘:\n${findings}\n\n修正報告:\n${detail ?? '(報告なし)'}`)
+    .join('\n\n')
+  return `\n\n## 前回までの修正履歴\n${entries}`
+}
+
 const MAX_REVIEW_RETRIES = 3
 let reviewResults
 let reviewAttempt = 0
 let reviewRetryAgentCount = 0
+const retryHistory = []
 
 while (true) {
   reviewAttempt++
@@ -475,8 +492,10 @@ while (true) {
     .map(({ dim, result }) => `## ${dim.label}\n${result.detail}`)
     .join('\n\n')
 
-  await agent(
-    `まず ${specPath} を Read ツールで読んでください。\n以下はコードレビューで検出された指摘です。該当箇所を修正してください（修正のみ、レビューはしない）。\n\n${retryFindings}${guide(
+  const retryHistorySection = buildRetryHistorySection(retryHistory)
+
+  const retryResult = await agent(
+    `まず ${specPath} を Read ツールで読んでください。\n以下はコードレビューで検出された指摘です。該当箇所を修正してください（修正のみ、レビューはしない）。\n\n${retryFindings}${retryHistorySection}${guide(
       '指摘箇所をすべて修正できた',
       '修正を試みたが解決できない指摘が残る',
       '指摘内容から修正対象・該当ファイルが特定できない'
@@ -486,6 +505,7 @@ while (true) {
   countLoggable('implementer')
   countProgressLoggable('implementer')
   reviewRetryAgentCount++
+  retryHistory.push({ attempt: reviewAttempt, findings: retryFindings, detail: retryResult?.detail })
 }
 
 const implResults = [contractResult, dbResult, dataResult, apiResult, uiResult]

--- a/.claude/workflows/lib/__tests__/review-retry-history.test.js
+++ b/.claude/workflows/lib/__tests__/review-retry-history.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { buildRetryHistorySection } from '../review-retry-history.js'
+
+describe('buildRetryHistorySection', () => {
+  it('履歴が空なら空文字列を返す(1回目のretryではセクションを追加しない)', () => {
+    expect(buildRetryHistorySection([])).toBe('')
+    expect(buildRetryHistorySection(undefined)).toBe('')
+    expect(buildRetryHistorySection(null)).toBe('')
+  })
+
+  it('1件の履歴からattempt番号・指摘・修正報告を含むセクションを生成する', () => {
+    const section = buildRetryHistorySection([
+      { attempt: 1, findings: '## 正しさ\n境界条件のバグ', detail: '境界条件を修正しました' },
+    ])
+    expect(section).toContain('## 前回までの修正履歴')
+    expect(section).toContain('### attempt 1')
+    expect(section).toContain('境界条件のバグ')
+    expect(section).toContain('境界条件を修正しました')
+  })
+
+  it('修正報告(detail)が無い場合は「(報告なし)」と表示する', () => {
+    const section = buildRetryHistorySection([{ attempt: 1, findings: '指摘A', detail: undefined }])
+    expect(section).toContain('(報告なし)')
+  })
+
+  it('プロンプト肥大対策として直近2件のみを含め、それより古い履歴は含めない', () => {
+    const section = buildRetryHistorySection([
+      { attempt: 1, findings: '指摘1', detail: '修正1' },
+      { attempt: 2, findings: '指摘2', detail: '修正2' },
+      { attempt: 3, findings: '指摘3', detail: '修正3' },
+    ])
+    expect(section).not.toContain('attempt 1')
+    expect(section).toContain('attempt 2')
+    expect(section).toContain('attempt 3')
+  })
+
+  it('複数attemptを古い順に並べる', () => {
+    const section = buildRetryHistorySection([
+      { attempt: 1, findings: '指摘1', detail: '修正1' },
+      { attempt: 2, findings: '指摘2', detail: '修正2' },
+    ])
+    expect(section.indexOf('attempt 1')).toBeLessThan(section.indexOf('attempt 2'))
+  })
+})

--- a/.claude/workflows/lib/review-retry-history.js
+++ b/.claude/workflows/lib/review-retry-history.js
@@ -1,0 +1,27 @@
+// aidd-phase2.js のReviewリトライループ（issue #490）向け、前回attemptの修正履歴を
+// 次のimplementer-retryプロンプトへ引き継ぐための純粋関数。
+//
+// 背景: 従来はReviewリトライのたびに新規のimplementerエージェントを起動し、レビュー指摘の
+// 文字列のみを渡していた。前回のretryで何をどう修正したかの情報が引き継がれないため、
+// 各attemptがゼロから修正対象を再発見しており、同じ修正の繰り返しや矛盾する修正のリスクが
+// あった（2026-07-21レビュー指摘4-1。Fable 5公式ガイドは「サブタスク間でコンテキストを
+// 保持する長寿命のサブエージェント」を推奨しているが、Workflow DSLにエージェント継続APIが
+// 無い制約下では、プロンプトへの履歴引き渡しで軽減する）。
+//
+// エージェント呼び出しを含まない純粋関数のため、LLM呼び出し無しで決定的にテストできる。
+// aidd-phase2.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+const MAX_RETRY_HISTORY_ENTRIES = 2
+
+// retryHistory: [{ attempt, findings, detail }, ...]（蓄積順。attemptは1始まりのReviewラウンド番号）
+// プロンプト肥大対策として直近MAX_RETRY_HISTORY_ENTRIES件のみ含める。
+// 履歴が空の場合は空文字列を返す（1回目のretryではプロンプトへセクション自体を追加しない）。
+export function buildRetryHistorySection(retryHistory) {
+  if (!Array.isArray(retryHistory) || retryHistory.length === 0) return ''
+  const recent = retryHistory.slice(-MAX_RETRY_HISTORY_ENTRIES)
+  const entries = recent
+    .map(({ attempt, findings, detail }) => `### attempt ${attempt}\n指摘:\n${findings}\n\n修正報告:\n${detail ?? '(報告なし)'}`)
+    .join('\n\n')
+  return `\n\n## 前回までの修正履歴\n${entries}`
+}

--- a/docs/agents/eval-runs.jsonl
+++ b/docs/agents/eval-runs.jsonl
@@ -1,1 +1,2 @@
 {"timestamp":"2026-07-23T01:44:03Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
+{"timestamp":"2026-07-23T02:48:29Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}


### PR DESCRIPTION
## Summary
- `aidd-phase2.js` のReviewリトライループは、毎回新規のimplementerエージェントを起動し、レビュー指摘の文字列のみを渡していた。前回のretryで何をどう修正したかの情報が引き継がれないため、各attemptがゼロから修正対象を再発見していた
- `retryHistory` 配列にattempt番号・指摘内容・修正報告を蓄積し、次回リトライのプロンプトへ「## 前回までの修正履歴」セクション(直近2attempt分に制限)を追加するようにした
- 純粋関数`buildRetryHistorySection`を `.claude/workflows/lib/review-retry-history.js` に切り出し、vitestでユニットテストできる形にした(Workflow DSL側は同一ロジックをインライン複製)
- `classifyReviewRound`（review-retry.jsの正本ロジック）・`reviewRetryAgentCount`/countLoggable系のカウントロジックは変更していない

Closes #490

## Test plan
- [x] `npm test`(162ファイル/1245件 全通過。新規ユニットテスト5件含む)
- [x] `npm run eval:workflows db-impl`(4/4合格。db-implプロンプトは不変のため結果不変を確認。`docs/agents/eval-runs.jsonl`に実行痕跡を記録)
- [ ] 実際のAIDDフロー実行での「2回目以降のimplementer-retryプロンプトに前回の修正報告が含まれる」実測確認は未実施(コード・ユニットテストでの保証のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)