### PR TITLE
.claude/agents/*.mdの進捗ログbash実例・自明手順を圧縮する(issue #489)

### DIFF
--- a/.claude/agents/adversarial-verify.md
+++ b/.claude/agents/adversarial-verify.md
@@ -17,9 +17,7 @@ effort: xhigh
 - 検証対象の指摘（finding）：ファイル・行番号・問題の概要
 
 ## 検証手順
-1. 指摘されたファイル・行を実際に読む
-2. 反論の根拠を探す（例：別の場所でバリデーション済み・型が実は安全・コードが存在しない等）
-3. 根拠があれば `refuted: true`、なければ `refuted: false`
+指摘されたファイル・行を実際に読み、反論の根拠（例：別の場所でバリデーション済み・型が実は安全・コードが存在しない等）があれば `refuted: true`、なければ `refuted: false` とする。
 
 ## 出力形式
 ```
@@ -29,9 +27,4 @@ evidence: [コードを読んで確認した根拠。refuted=falseの場合は�
 ```
 
 ## 進捗報告（issue #18）
-検証開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は検証対象の機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent adversarial-verify --feature "<feature名>" --status running --note "反証検証中..."
-# ...検証...
-scripts/log-agent-progress.sh --agent adversarial-verify --feature "<feature名>" --status done --note "検証完了"
-```
+検証開始時に`--status running`、出力を返す直前に`--status done`で、`scripts/log-agent-progress.sh --agent adversarial-verify --feature <検証対象の機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/completeness-critic.md
+++ b/.claude/agents/completeness-critic.md
@@ -37,9 +37,4 @@ model: sonnet
 **重要**: この2択以外の形式で返さないこと。前置き文・まとめ・補足説明は不要。
 
 ## 進捗報告（issue #18）
-評価開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は評価対象の機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent completeness-critic --feature "<feature名>" --status running --note "網羅性評価中..."
-# ...評価...
-scripts/log-agent-progress.sh --agent completeness-critic --feature "<feature名>" --status done --note "評価完了"
-```
+評価開始時に`--status running`、出力を返す直前に`--status done`で、`scripts/log-agent-progress.sh --agent completeness-critic --feature <評価対象の機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/contract-writer.md
+++ b/.claude/agents/contract-writer.md
@@ -21,11 +21,7 @@ model: sonnet
 - 既存の型を無断でrename・削除すること
 
 ## 作業手順
-1. SPEC.md Part 2の「実装セット一覧・並列グループ宣言」を読む
-2. 既存 `src/types/` を確認し、重複・衝突を把握する
-3. 新規または変更が必要な型定義を書く
-4. `npm run lint -- --max-warnings=0` でlintエラーがないことを確認する
-5. `npx tsc --noEmit` で型エラーがないことを確認する
+SPEC.md Part 2の「実装セット一覧・並列グループ宣言」をもとに、既存 `src/types/` との重複・衝突を確認したうえで型定義を書く。`npm run lint -- --max-warnings=0` と `npx tsc --noEmit` がともに0エラーであることを確認してから完了報告すること。
 
 ## 完了報告形式（後続implementerへの入力になる）
 ```
@@ -37,9 +33,4 @@ TSC: 0 errors
 ```
 
 ## 進捗報告（issue #18）
-作業開始時に `--status running`、完了報告の直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` はSPEC.mdの機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent contract-writer --feature "<feature名>" --status running --note "型定義作成中..."
-# ...型定義作成...
-scripts/log-agent-progress.sh --agent contract-writer --feature "<feature名>" --status done --note "契約定義完了"
-```
+作業開始時に`--status running`、完了報告の直前に`--status done`で、`scripts/log-agent-progress.sh --agent contract-writer --feature <SPEC.mdの機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -10,12 +10,7 @@ contract-writer が確定した `src/types/` の型定義を「契約」とし�
 型定義自体を変更・追加することは禁止です（変更が必要な場合は報告して止まる）。
 
 ## 進捗報告（issue #18）
-作業開始時に一度、`--status running` で `scripts/log-agent-progress.sh` を呼ぶこと。`--agent` は自分が担当する実装セット名（例: `implementer-<グループ名>`）、`--feature` はSPEC.mdの機能名（無ければ `unknown`）。長時間かかる場合は主要な区切り（実装セット完了ごと等）で再度 `--status running` を呼び直して更新するとよい。全セット完了時・または3回修正しても通らず報告する時に、`--status done`（成功）または `--status failed`（要報告）を1回呼んで締める。
-```bash
-scripts/log-agent-progress.sh --agent "implementer-<グループ名>" --feature "<SPEC.mdの機能名>" --status running --note "実装中..."
-# ...実装...
-scripts/log-agent-progress.sh --agent "implementer-<グループ名>" --feature "<SPEC.mdの機能名>" --status done --note "実装完了"
-```
+開始時に一度`--status running`、全セット完了時または3回修正しても通らず報告する時に`--status done`（成功）/`--status failed`（要報告）で、`scripts/log-agent-progress.sh --agent <自分が担当する実装セット名（例: implementer-<グループ名>）> --feature <SPEC.mdの機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと（長時間かかる場合は区切りごとにrunningを呼び直してよい）。
 
 ## 実装前に読むべきドキュメント
 実装対象が facility / tenant / organization / inventory / RLS / policy / auth のいずれかのドメインに関わる場合、実装に入る前に必ず `docs/agents/domain.md`（ドメイン用語の定義）と `docs/agents/decisions.md`（なぜその設計にしたかの理由）を読むこと。特に `is_facility_member` によるRLS施設分離の仕組みを理解せずに新しいテーブル・エンドポイントを実装すると、施設間のデータ越境を許してしまう危険がある。
@@ -28,71 +23,18 @@ scripts/log-agent-progress.sh --agent "implementer-<グループ名>" --feature 
 5. 失敗したら自分で直す。3回直して通らなければ報告。
 
 ## 自己修正ループのログ記録
-実装セットごとに、テストを実行するたびに `scripts/log-loop-observability.sh` を呼び出し、1回の試行につき1レコードを記録すること。「実装セットの進め方」のステップ4（テスト通過を確認）とステップ5（自己修正の再試行）の両方で、テストを実行した直後に呼ぶ。
-
-例（1回目のテストが失敗し、2回目の修正で通った場合）:
-```bash
-scripts/log-loop-observability.sh \
-  --agent implementer \
-  --feature "<SPEC.mdのタスク名>" \
-  --attempt 1 \
-  --model sonnet \
-  --intent "<何を実装しようとしたか、1文>" \
-  --scenario "<実行したテストの内容、1文>" \
-  --result fail \
-  --reason "<失敗理由、1文>"
-
-scripts/log-loop-observability.sh \
-  --agent implementer \
-  --feature "<SPEC.mdのタスク名>" \
-  --attempt 2 \
-  --model sonnet \
-  --intent "<何を実装しようとしたか、1文>" \
-  --scenario "<実行したテストの内容、1文>" \
-  --result pass \
-  --reason "<通った理由、1文>"
-```
-
-- `--model` には自分が実行されているモデル名（例: `sonnet`、`opus`）を書く。
-- 3回修正しても通らず人間に報告する場合も、3回目の試行として `--result fail` を記録してから報告すること。
+「実装セットの進め方」のステップ4（テスト通過を確認）・ステップ5（自己修正の再試行）でテストを実行した直後に毎回、`scripts/log-loop-observability.sh --agent implementer --feature "<SPEC.mdのタスク名>" --attempt <試行回数> --model "<自分が実行されているモデル名>" --intent "<何を実装しようとしたか、1文>" --scenario "<実行したテストの内容、1文>" --result pass|fail --reason "<理由、1文>"` を呼び、1回の試行につき1レコード記録すること（`docs/agents/common.md`「loop-observabilityログの記録漏れ検知」参照）。3回修正しても通らず人間に報告する場合も、3回目の試行としてfailを記録してから報告すること。
 
 ## 最新ドキュメント参照（Context7 MCP）
-実装対象のライブラリ・フレームワーク（Next.js、Supabaseクライアント、その他外部パッケージ）の名称やバージョンが不確かな場合は、実装（GREEN）に入る前に `mcp__context7__resolve-library-id` でライブラリを特定すること。
+実装対象のライブラリ・フレームワーク（Next.js、Supabaseクライアント、その他外部パッケージ）の名称やバージョンが不確かな場合は、実装（GREEN）に入る前に `mcp__context7__resolve-library-id` でライブラリを特定すること。参照した場合は上記と同じ形式で `--intent "Context7 MCPでライブラリを特定"` としてログを1件追加する（既に確実に知っている一般的なAPIで参照不要と判断した実装セットでは書かない）。
 
 ※ `mcp__context7__query-docs`（ドキュメント本文取得）はサブエージェントのツール可視性の制約により現状呼び出せない（deferredなツールをロードする`ToolSearch`がサブエージェントに提供されないため）。環境側の仕様が変わるまでは`resolve-library-id`によるライブラリ特定のみを行うこと。
 
-- 参照した場合、`scripts/log-loop-observability.sh` に以下を追加で呼び出し、利用したことをログに残す。
-  ```bash
-  scripts/log-loop-observability.sh \
-    --agent implementer \
-    --feature "<SPEC.mdのタスク名>" \
-    --attempt <試行回数> \
-    --model sonnet \
-    --intent "Context7 MCPでライブラリを特定" \
-    --scenario "<特定したライブラリ・確認した内容、1文>" \
-    --result pass \
-    --reason "<参照した理由、1文>"
-  ```
-- 既に確実に知っている一般的なAPI（言語標準機能など）で参照が不要と判断した実装セットでは、このログを書かない（実際に参照した場合のみ記録する）。
-
 ## ブラウザ確認（Playwright MCP）
-実装したUI・画面挙動をブラウザで目視確認する必要がある場合は、`curl` や推測ではなく Playwright MCP（`mcp__playwright__browser_*` ツール）を使って実際にブラウザを操作し確認すること。
+実装したUI・画面挙動をブラウザで目視確認する必要がある場合は、`curl` や推測ではなく Playwright MCP（`mcp__playwright__browser_*` ツール）を使って実際にブラウザを操作し確認すること。確認した場合は上記と同じ形式で `--intent "Playwright MCPでブラウザ確認"` としてログを1件追加する（確認しなかった実装セットでは書かない）。
 
 - 認証が必要な画面を確認する前に、まず `e2e/.auth/user.json` が存在するか確認する。存在しなければ `npm run e2e:auth` を実行してログイン済みセッションを生成してから確認に進むこと（Playwright MCPサーバーはこのファイルを `--storage-state` として読み込むため、ファイルが無いとログイン状態で開けない）。
 - ファイルが存在していても中身のセッションが期限切れの場合がある。ブラウザ確認中に想定外に `/login` へリダイレクトされたら、セッション切れとみなして `npm run e2e:auth` を再実行し、1回だけ確認をやり直すこと。再実行後も `/login` にリダイレクトされる場合は、セッション切れ以外の原因（実装側のバグ等）を疑い、無限に再試行しない。
-- 確認したら `scripts/log-loop-observability.sh` に以下を追加で呼び出し、利用したことをログに残す。
-  ```bash
-  scripts/log-loop-observability.sh \
-    --agent implementer \
-    --feature "<SPEC.mdのタスク名>" \
-    --attempt <試行回数> \
-    --model sonnet \
-    --intent "Playwright MCPでブラウザ確認" \
-    --scenario "<確認した画面・操作の内容、1文>" \
-    --result <pass|fail> \
-    --reason "<確認結果の理由、1文>"
-  ```
-- ブラウザ確認をしなかった実装セットでは、このログを書かない（実際に使った場合のみ記録する）。
 
 ## 絶対にやってはいけないこと
 - テストを削除・無効化して「通った」ことにする

--- a/.claude/agents/integrator.md
+++ b/.claude/agents/integrator.md
@@ -8,12 +8,7 @@ model: sonnet
 あなたはPhase 4の統合担当です。並列実装（Phase 3）で各implementerが書いたコードを**結線**し、アプリケーション全体として動作させてください。
 
 ## 進捗報告（issue #18）
-作業開始時に `--status running`、完了報告の直前に `--status done`（3回修正しても通らず報告する場合は `--status failed`）で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は対象の機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent integrator --feature "<feature名>" --status running --note "統合作業中..."
-# ...結線・テスト・lint...
-scripts/log-agent-progress.sh --agent integrator --feature "<feature名>" --status done --note "統合完了"
-```
+作業開始時に`--status running`、完了報告の直前に`--status done`（3回修正しても通らず報告する場合は`--status failed`）で、`scripts/log-agent-progress.sh --agent integrator --feature <対象の機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。
 
 ## あなたの担当範囲
 - **共有ファイルを触るのはあなただけ**（Phase 3の各implementerは自分のファイルしか触っていない）
@@ -21,12 +16,7 @@ scripts/log-agent-progress.sh --agent integrator --feature "<feature名>" --stat
 - 競合・重複・命名衝突の解消
 
 ## 作業手順
-1. 各implementerの成果ファイルを確認する
-2. 結線に必要な共有ファイルを特定する
-3. 最小限の変更で結線する（Phase 3実装を書き直さない）
-4. `npm test` を実行 → 失敗があれば修正（3回まで）
-5. `npm run lint` を実行 → 失敗があれば修正
-6. 全テスト・lint緑を確認して報告
+各implementerの成果ファイルを確認し、結線に必要な共有ファイルのみ最小限の変更で結線する（Phase 3実装は書き直さない）。`npm test`・`npm run lint` を実行し、失敗があれば修正（3回まで）、全テスト・lint緑を確認してから報告すること。
 
 ## 絶対にやってはいけないこと
 - Phase 3で実装済みの機能を勝手に書き直す

--- a/.claude/agents/judge-panel.md
+++ b/.claude/agents/judge-panel.md
@@ -58,9 +58,4 @@ scripts/log-loop-observability.sh \
 - `--agent` は必ず `judge-panel` を使う（`human` は使わない）。
 
 ## 進捗報告（issue #18）
-評価開始時に `--status running`、出力を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は評価対象の機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent judge-panel --feature "<feature名>" --status running --note "評価中..."
-# ...評価...
-scripts/log-agent-progress.sh --agent judge-panel --feature "<feature名>" --status done --note "評価完了"
-```
+評価開始時に`--status running`、出力を返す直前に`--status done`で、`scripts/log-agent-progress.sh --agent judge-panel --feature <評価対象の機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -8,12 +8,7 @@ model: sonnet
 あなたはシニアレビュアーです。読み取り専用で、指摘のみを箇条書きで返します（自動修正はしない）。
 
 ## 進捗報告（issue #18）
-レビュー開始時に `--status running`、指摘一覧を返す直前に `--status done` で `scripts/log-agent-progress.sh` を呼ぶこと。`--agent` は担当次元がわかる名前（例: `reviewer-correctness`）、`--feature` はレビュー対象の機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent "reviewer-<担当次元>" --feature "<feature名>" --status running --note "レビュー中..."
-# ...レビュー...
-scripts/log-agent-progress.sh --agent "reviewer-<担当次元>" --feature "<feature名>" --status done --note "レビュー完了"
-```
+レビュー開始時に`--status running`、指摘一覧を返す直前に`--status done`で、`scripts/log-agent-progress.sh --agent <担当次元がわかる名前（例: reviewer-correctness）> --feature <レビュー対象の機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。
 
 ## 既知の失敗パターン（必ず機械的にチェックする）
 `docs/agents/known-failure-patterns.md` を読み、そこに載っている各パターンが
@@ -21,19 +16,7 @@ scripts/log-agent-progress.sh --agent "reviewer-<担当次元>" --feature "<feat
 見落とされ再発した実例があるため、レビューフェーズでの機械チェックが必須。
 
 ## 守られているべき品質規約（実装が違反していないか確認する）
-
-### 実装セットの進め方（RED → GREEN → REFACTOR）
-1. テストを先に書く（RED）
-2. 通す最小限の実装を書く（GREEN）
-3. リファクタ（REFACTOR）
-4. テスト通過を確認 → 次のセットへ
-5. 失敗したら自分で直す。3回直して通らなければ報告。
-
-### 絶対にやってはいけないこと（違反を検出する）
-- テストを削除・無効化して「通った」ことにする
-- テストの期待値（アサーション）をこっそり緩めて通す
-- 失敗を無視して次に進む
-- 毎回「どうしますか？」と人間に丸投げする
+implementerの品質規約（`.claude/agents/implementer.md`のTDD手順RED→GREEN→REFACTOR・3回修正しても通らなければ報告、およびテスト削除/無効化・アサーション改竄・失敗の握りつぶし・人間への丸投げの禁止）への違反を検出すること。
 
 ## レビュー観点（Phase 5：呼び出し時に指定された次元を担当する）
 - 正しさ（バグ・境界条件）

--- a/.claude/agents/sweep-data.md
+++ b/.claude/agents/sweep-data.md
@@ -36,9 +36,4 @@ effort: low
 - 問題がなければ「指摘なし」と返す
 
 ## 進捗報告（issue #18）
-調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent sweep-data --feature "<feature名>" --status running --note "データ取得層調査中..."
-# ...調査...
-scripts/log-agent-progress.sh --agent sweep-data --feature "<feature名>" --status done --note "データ取得層調査完了"
-```
+調査開始時に`--status running`、終了時に`--status done`で、`scripts/log-agent-progress.sh --agent sweep-data --feature <呼び出し元から与えられた機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/sweep-db.md
+++ b/.claude/agents/sweep-db.md
@@ -29,9 +29,4 @@ effort: low
 - 問題がなければ「指摘なし」と返す
 
 ## 進捗報告（issue #18）
-調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent sweep-db --feature "<feature名>" --status running --note "DB層調査中..."
-# ...調査...
-scripts/log-agent-progress.sh --agent sweep-db --feature "<feature名>" --status done --note "DB層調査完了"
-```
+調査開始時に`--status running`、終了時に`--status done`で、`scripts/log-agent-progress.sh --agent sweep-db --feature <呼び出し元から与えられた機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/sweep-types.md
+++ b/.claude/agents/sweep-types.md
@@ -30,9 +30,4 @@ effort: low
 - 問題がなければ「指摘なし」と返す
 
 ## 進捗報告（issue #18）
-調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent sweep-types --feature "<feature名>" --status running --note "型整合性調査中..."
-# ...調査...
-scripts/log-agent-progress.sh --agent sweep-types --feature "<feature名>" --status done --note "型整合性調査完了"
-```
+調査開始時に`--status running`、終了時に`--status done`で、`scripts/log-agent-progress.sh --agent sweep-types --feature <呼び出し元から与えられた機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/.claude/agents/sweep-ui.md
+++ b/.claude/agents/sweep-ui.md
@@ -34,9 +34,4 @@ effort: low
 - 問題がなければ「指摘なし」と返す
 
 ## 進捗報告（issue #18）
-調査開始時と終了時に `scripts/log-agent-progress.sh` を呼ぶこと。`--feature` は呼び出し元から与えられた機能名（無ければ `unknown`）。
-```bash
-scripts/log-agent-progress.sh --agent sweep-ui --feature "<feature名>" --status running --note "UI層調査中..."
-# ...調査...
-scripts/log-agent-progress.sh --agent sweep-ui --feature "<feature名>" --status done --note "UI層調査完了"
-```
+調査開始時に`--status running`、終了時に`--status done`で、`scripts/log-agent-progress.sh --agent sweep-ui --feature <呼び出し元から与えられた機能名。無ければunknown> --status <状態> --note <一言>` を呼ぶこと。

--- a/docs/agents/eval-runs.jsonl
+++ b/docs/agents/eval-runs.jsonl
@@ -1,2 +1,4 @@
 {"timestamp":"2026-07-23T01:44:03Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
 {"timestamp":"2026-07-23T02:48:29Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
+{"timestamp":"2026-07-23T03:13:53Z","script":"eval-sweep-recall","fixtureSet":"sweep-ui","pass":1,"total":1}
+{"timestamp":"2026-07-23T03:14:21Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}


### PR DESCRIPTION
## Summary
- 進捗ログ指示ブロック（bash実例込み）が10ファイルに複製、implementer.mdは観測ログのbash実例だけで約50行、reviewer.mdにはimplementer向けTDD手順がそのままコピーされていた問題を解消
- 進捗ログ指示を全11ファイルで統一: bash実例を削除し「開始時running/終了時done(failed)で`scripts/log-agent-progress.sh`を1回ずつ呼ぶ」規約(1〜2文)へ圧縮
- implementer.mdの`log-loop-observability.sh`実例3箇所(`--model sonnet`ハードコード含む)を引数規約1文+`docs/agents/common.md`参照へ圧縮
- reviewer.mdのTDD手順コピー(RED→GREEN→REFACTORの5ステップ)を「implementerの品質規約への違反を検出する」参照形式へ変更
- adversarial-verify.md(検証手順3ステップ)・contract-writer.md(作業手順5ステップ)・integrator.md(作業手順6ステップ)の自明な手順列挙を完了条件のみに圧縮

## 変更していないもの
- 固定文字列出力(「指摘なし」「新規指摘なし」「refuted: true/false」)
- known-failure-patterns.md参照(reviewer/sweep-data/sweep-ui)・facility/RLS境界の警告(implementer)・「3回で止まる」系サーキットブレーカー・責務境界の明文
- sweep系4種の観点・パス列挙
- frontmatterの`model:`/`effort:`行

Closes #489

## Test plan
- [x] `npm test`(162ファイル/1245件 全通過)
- [x] `bash scripts/eval-sweep-recall.sh sweep-ui`(recall 1/1、圧縮後も検出できることを確認)
- [x] `npm run eval:workflows db-impl`(4/4合格、圧縮後も結果不変を確認。`docs/agents/eval-runs.jsonl`に実行痕跡を記録)

🤖 Generated with [Claude Code](https://claude.com/claude-code)