### PR TITLE
ローカルmainの鮮度警告をSessionStart hookに追加する(issue #499)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -152,6 +152,11 @@
           },
           {
             "type": "command",
+            "command": "scripts/check-local-main-freshness.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "scripts/check-otel-collector-status.sh",
             "timeout": 5
           },

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -97,6 +97,10 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
     **「別issueの未マージPRが乗っている」ケース（マージ前の分岐）はこのhookの検知対象外**で、引き続き人手の確認に依存する。
 - **`git checkout -b <new-branch> main` の前に、必ず `git fetch origin main` してから最新の `origin/main` を起点にする**（`git checkout -b <new-branch> origin/main`、または直前に`git merge origin/main`でローカルmainを追従させる）。
   ローカルの`main`ブランチ参照は自動更新されない（`gh pr merge`はリモートを更新するだけで、ローカルの別ブランチにいる間はローカル`main`が古いまま）。古いローカル`main`から新しいブランチを切ると、直近でマージされたPRの変更が丸ごと欠落した状態で作業が進んでしまい、後から気づいて`origin/main`をマージし直す手戻りが発生する
+  - **このルールは、SessionStart hook（`scripts/check-local-main-freshness.sh`、issue #499）が部分的に機械検知する。**
+    FETCH_HEADの更新時刻が既定24時間（`LOCAL_MAIN_STALE_HOURS`で変更可）より古いか、`git rev-list --count main..origin/main`が1以上（ローカルmainがorigin/mainより遅れている）のいずれかに該当すると、セッション開始時に警告メッセージを出す（block不可・warningのみ、fetch自体はhook内で実行しないためネットワークアクセス無し・オフラインでも動作する）。
+    worktree環境では`.git`がファイルでありFETCH_HEADの実体がworktree固有パスにあるため、`git rev-parse --git-path FETCH_HEAD`で実パスを解決している（`.git/FETCH_HEAD`と決め打ちすると存在しないパスを見て誤判定する）。
+    **これは近似判定であり、実際にリモートで何が起きているかまでは見ていない**（前回fetch時点の情報を基準にするため、fetch直後に他者がpushした場合は検知できない）。
 
 ## loop-observabilityログの記録漏れ検知
 
@@ -669,7 +673,7 @@ issue #419のような設定変更（effort/model）に対して「精度が落�
 | ルール | 所在 | 備考 |
 |---|---|---|
 | 引き継ぎフォーマットの実施 | 本ファイル「引き継ぎフォーマット」 | 既存Stop hook（`ai-check-suggest.sh`等）の拡張候補（優先度3候補） |
-| ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースのみ`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。「別issueの未マージPRが乗っている」ケースと`origin/main`起点確認自体は未検知のまま |
+| ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースは`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。**`origin/main`起点確認自体もissue #499で部分検知済み**（`scripts/check-local-main-freshness.sh`。FETCH_HEAD鮮度・ローカルmainの遅れコミット数による近似判定、fetchはhook内で実行しないため取りこぼしうる）。「別issueの未マージPRが乗っている」ケース（マージ前の分岐）は引き続き未検知のまま |
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | issue #441で検知手段を調査したが、「`/goal`が設定されているか」を外部から機械的に問い合わせるAPI/hookは公式に存在しないと判明（実機確認済み）。条件テンプレート化・役割分担の明文化（Workflow内部retryとの切り分け）は完了したが、呼び忘れ自体の検知は依然できないままこの表に残る |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
 | AIDD stats書き出しのうち**phase単位**の呼び出し（`write_aidd_stats.sh` phase1/phase2等） | ルートの`CLAUDE.md` | **start呼び忘れはissue #495でStop hook検知済み**（`scripts/check-aidd-stats-recorded.sh`。Workflow実行の形跡があるのにstart記録が無ければ警告）。phase単位の呼び忘れ検知は未実装のままこの表に残る |

--- a/scripts/check-local-main-freshness.sh
+++ b/scripts/check-local-main-freshness.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# issue #499: docs/agents/common.md「ブランチ運用ルール」のうち、
+# 「git checkout -b の前に必ず git fetch origin main してから origin/main 起点にする」
+# ルールは未検知のまま棚卸し表（issue #339）に残っていた。過去に古いローカルmain起点で
+# branch作成し、直近マージPRの変更が丸ごと欠落した状態で作業が進む手戻りが実際に発生
+# している。2026-07-21レビューで「ローカルmainが古いという環境状態に気づけない」ことが
+# 原因であり、モデルの指示追従力では解決しない型と判定され、SessionStart hookでの
+# 機械検知（check-branch-pr-status.shと同型・block不可・warningのみ）を追加した。
+#
+# ローカルmainの鮮度を、以下いずれかで近似判定する（fetchはこのhook自身では実行しない。
+# SessionStartでのネットワークアクセス・起動遅延を避けるため。オフラインでも動作する）:
+#   1. FETCH_HEADの更新時刻が既定24時間（LOCAL_MAIN_STALE_HOURSで変更可）より古い
+#   2. git rev-list --count main..origin/main が1以上（ローカル追跡refベースの近似判定。
+#      前回fetch時点のorigin/mainより、ローカルmainが遅れているかを見る。実際の
+#      リモート最新とは限らない＝近似）
+#
+# worktree環境での注意（過去の落とし穴）: worktreeでは`.git`がディレクトリではなく
+# ファイルであり、FETCH_HEADの実体は`.git/worktrees/<name>/FETCH_HEAD`という
+# worktree固有のパスにある（`.git/FETCH_HEAD`と決め打ちすると存在しないパスを見て
+# 誤判定する）。`git rev-parse --git-path FETCH_HEAD`で実パスを解決することで対応した。
+
+STALE_HOURS="${LOCAL_MAIN_STALE_HOURS:-24}"
+if ! [[ "$STALE_HOURS" =~ ^[0-9]+$ ]]; then
+  STALE_HOURS=24
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+FETCH_HEAD_PATH="$(git rev-parse --git-path FETCH_HEAD 2>/dev/null || true)"
+
+STALE_FETCH="false"
+AGE_HOURS=""
+if [ -n "$FETCH_HEAD_PATH" ] && [ -f "$FETCH_HEAD_PATH" ]; then
+  # mtime取得: macOS(BSD stat)とLinux(GNU stat)で-fオプション互換性が無いため、
+  # 他スクリプト（check-blocked-issues-staleness.sh等）と同様python3経由で秒数を得る。
+  MTIME_EPOCH="$(python3 -c "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" "$FETCH_HEAD_PATH" 2>/dev/null || echo "")"
+  if [ -n "$MTIME_EPOCH" ]; then
+    NOW_EPOCH="$(date +%s)"
+    AGE_HOURS=$(( (NOW_EPOCH - MTIME_EPOCH) / 3600 ))
+    if [ "$AGE_HOURS" -ge "$STALE_HOURS" ]; then
+      STALE_FETCH="true"
+    fi
+  fi
+else
+  # FETCH_HEADが無い＝このworktreeで一度もfetchしていない可能性が高いため古いとみなす。
+  STALE_FETCH="true"
+fi
+
+BEHIND_COUNT="$(git rev-list --count main..origin/main 2>/dev/null || echo 0)"
+if ! [[ "$BEHIND_COUNT" =~ ^[0-9]+$ ]]; then
+  BEHIND_COUNT=0
+fi
+
+if [ "$STALE_FETCH" = "false" ] && [ "$BEHIND_COUNT" = "0" ]; then
+  exit 0
+fi
+
+if [ -n "$AGE_HOURS" ]; then
+  FETCH_DETAIL="前回fetchから約${AGE_HOURS}時間経過（既定${STALE_HOURS}時間）"
+else
+  FETCH_DETAIL="このworktreeでのfetch記録が見つかりません"
+fi
+
+MSG="ローカルmainが古い可能性があります（${FETCH_DETAIL}、ローカルmainはorigin/mainより${BEHIND_COUNT}コミット遅れています）。新しいブランチを作成する前に \`git fetch origin main\` してから \`git checkout -b <new-branch> origin/main\` してください（docs/agents/common.md「ブランチ運用ルール」参照）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-local-main-freshness.test.sh
+++ b/scripts/check-local-main-freshness.test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# WHY: scripts/check-local-main-freshness.sh(SessionStart hook、issue #499)の回帰テスト。
+# 実物のgit/ネットワークに依存させず、フェイクgitスクリプトをPATHの先頭に注入して
+# 決定的に検証する（check-branch-pr-status.test.shと同型）。
+#
+# 実行: bash scripts/check-local-main-freshness.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-local-main-freshness.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+FAKE_BIN="$WORKDIR/bin"
+mkdir -p "$FAKE_BIN"
+trap 'rm -rf "$WORKDIR"' EXIT
+BASH_BIN="$(command -v bash)"
+
+cat > "$FAKE_BIN/git" <<'EOF'
+#!/bin/bash
+if [ "$1" = "rev-parse" ] && [ "$2" = "--is-inside-work-tree" ]; then
+  if [ "${FAKE_GIT_IS_REPO:-1}" = "0" ]; then
+    exit 1
+  fi
+  echo "true"
+  exit 0
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ] && [ "$3" = "FETCH_HEAD" ]; then
+  echo "${FAKE_FETCH_HEAD_PATH:-}"
+  exit 0
+fi
+if [ "$1" = "rev-list" ] && [ "$2" = "--count" ]; then
+  echo "${FAKE_BEHIND_COUNT:-0}"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/git"
+
+run_hook() {
+  set +e
+  OUT="$(PATH="$FAKE_BIN:$PATH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: fetch直近・behind=0 → 何も出力しない ==="
+FRESH_FETCH_HEAD="$WORKDIR/fresh-fetch-head"
+touch "$FRESH_FETCH_HEAD"
+FAKE_FETCH_HEAD_PATH="$FRESH_FETCH_HEAD" FAKE_BEHIND_COUNT=0 run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: fetchが既定24時間より古い・behind=0 → 警告を出す ==="
+STALE_FETCH_HEAD="$WORKDIR/stale-fetch-head"
+touch "$STALE_FETCH_HEAD"
+# 30時間前のmtimeにする(macOS/Linux両対応のためpython3で設定)
+python3 -c "
+import os, time
+path = '$STALE_FETCH_HEAD'
+old = time.time() - 30 * 3600
+os.utime(path, (old, old))
+"
+FAKE_FETCH_HEAD_PATH="$STALE_FETCH_HEAD" FAKE_BEHIND_COUNT=0 run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "ローカルmainが古い可能性があります" "警告メッセージが含まれる"
+
+echo "=== scenario 3: fetch直近・behind>0 → 警告を出す ==="
+FAKE_FETCH_HEAD_PATH="$FRESH_FETCH_HEAD" FAKE_BEHIND_COUNT=5 run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "5コミット遅れています" "遅れコミット数が含まれる"
+
+echo "=== scenario 4: FETCH_HEADファイルが存在しない(一度もfetchしていない) → 警告を出す ==="
+FAKE_FETCH_HEAD_PATH="$WORKDIR/no-such-file" FAKE_BEHIND_COUNT=0 run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "fetch記録が見つかりません" "fetch未実施の旨が含まれる"
+
+echo "=== scenario 5: gitリポジトリでない環境 → 何も出力しない ==="
+FAKE_GIT_IS_REPO=0 FAKE_FETCH_HEAD_PATH="$STALE_FETCH_HEAD" FAKE_BEHIND_COUNT=5 run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 6: LOCAL_MAIN_STALE_HOURSで閾値を変更できる ==="
+# 30時間前のfetchは既定(24時間)では古いが、閾値を48時間に上げれば古くない
+python3 -c "
+import os, time
+path = '$STALE_FETCH_HEAD'
+old = time.time() - 30 * 3600
+os.utime(path, (old, old))
+"
+set +e
+OUT="$(PATH="$FAKE_BIN:$PATH" FAKE_FETCH_HEAD_PATH="$STALE_FETCH_HEAD" FAKE_BEHIND_COUNT=0 LOCAL_MAIN_STALE_HOURS=48 "$BASH_BIN" "$SCRIPT" < /dev/null)"
+EXIT_CODE=$?
+set -e
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "閾値を緩めると警告が出ない"
+
+echo "=== scenario 7: ネットワークアクセスを行わない(静的確認: git fetchをコマンドとして実行する行が無い) ==="
+# メッセージ文中の案内(git fetch origin main してから...)は許容し、コマンドとしての
+# 呼び出し(行頭または;/&&の後にgit fetchが来る形)が無いことだけを確認する。
+FETCH_INVOCATIONS="$(grep -nE '(^|[;&|]) *git fetch' "$SCRIPT" || true)"
+assert_empty "$FETCH_INVOCATIONS" "git fetchをコマンドとして呼び出す行が無い"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- `docs/agents/common.md`「ブランチ運用ルール」の`origin/main`起点確認は自然言語指示のみで検知手段が無く、過去に古いローカル`main`起点でbranch作成し直近マージPRの変更が欠落する手戻りが実際に発生していた
- `scripts/check-branch-pr-status.sh`と同型のSessionStart hook（`scripts/check-local-main-freshness.sh`）を追加し、以下いずれかに該当したら警告する（block不可・warningのみ）
  - FETCH_HEADの更新時刻が既定24時間（`LOCAL_MAIN_STALE_HOURS`で変更可）より古い
  - `git rev-list --count main..origin/main` が1以上（ローカルmainがorigin/mainより遅れている）
- hook内で`git fetch`は実行しないため、ネットワークアクセス無し・オフラインでも動作する
- worktree環境では`.git`がファイルでFETCH_HEADの実体がworktree固有パスにあるため、`git rev-parse --git-path FETCH_HEAD`で実パスを解決（`.git/FETCH_HEAD`決め打ちだと誤判定する）。実際にこのworktree上で動作確認し、ローカルmainがorigin/mainより5コミット遅れている状態を正しく検知できることを確認済み
- `.claude/settings.json`のSessionStart hooksに登録
- `docs/agents/common.md`の「検知手段のないルールの棚卸し」表の該当行を部分検知済みに更新

Closes #499

## Test plan
- [x] `bash scripts/check-local-main-freshness.test.sh`(フェイクgit注入による7シナリオ、全通過)
- [x] `npm test`(162ファイル/1245件 全通過)
- [x] 実機確認: このworktree上で実行し、ローカルmainが5コミット遅れている状態を正しく警告することを確認
- [x] `jq empty .claude/settings.json` でJSON妥当性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)