### PR TITLE
fix: aidd-phase1.jsのsweep失敗を偽の指摘なしにせず可視化する(issue #521)

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -394,6 +394,11 @@ const proposals = await parallel(
 )
 
 const validProposals = proposals.filter(Boolean)
+// issue #521: agent()失敗(null)による間引きは、件数を明示しないと「3案生成」が
+// 静かに「1〜2案生成」に減っていることに気づけない（偽の完全性）。
+if (validProposals.length < proposals.length) {
+  log(`Judge Panel: 提案生成でagent()失敗が${proposals.length - validProposals.length}件あり、${validProposals.length}/${proposals.length}案で続行します`)
+}
 
 // 設計判断が実質同じ提案しかない場合は採点パネル（3案 x 3観点 = 9エージェント）を省略する。
 // 品質ゲート: .claude/workflows/lib/judge-panel.js の computeDivergence と同一ロジック
@@ -444,12 +449,19 @@ if (hasDivergence) {
         ))
       ).then(scores => {
         const validScores = scores.filter(Boolean)
+        if (validScores.length < scores.length) {
+          log(`Judge Panel: "${proposal.name}"の採点でagent()失敗が${scores.length - validScores.length}件あり、${validScores.length}/${scores.length}観点の平均で採点します`)
+        }
         const avgTotal = validScores.reduce((s, sc) => s + sc.total, 0) / (validScores.length || 1)
         return { proposal, scores: validScores, avgScore: avgTotal }
       })
     )
   )
-  validScored = scoredProposals.filter(Boolean).sort((a, b) => b.avgScore - a.avgScore)
+  const validScoredProposals = scoredProposals.filter(Boolean)
+  if (validScoredProposals.length < scoredProposals.length) {
+    log(`Judge Panel: 採点処理でagent()失敗が${scoredProposals.length - validScoredProposals.length}件あり、${validScoredProposals.length}/${scoredProposals.length}案で続行します`)
+  }
+  validScored = validScoredProposals.sort((a, b) => b.avgScore - a.avgScore)
   log(`Judge Panel: 設計判断の分岐を検出（重複率${Math.round(divergenceRatio * 100)}%）→ 採点パネルを実行`)
 } else {
   validScored = validProposals.map(proposal => ({ proposal, scores: [], avgScore: null }))

--- a/.claude/workflows/aidd-phase1.js
+++ b/.claude/workflows/aidd-phase1.js
@@ -85,6 +85,33 @@ log('Sweep 完了')
 
 const results = [uiResult, dataResult, dbResult, typesResult]
 
+// 正本: .claude/workflows/lib/phase1-result-classification.js。Workflow DSLはrequire不可のため
+// インライン複製している。同期は phase1-result-classification-sync.test.js が検証する（issue #521）。
+function describeSweepResult(result) {
+  if (result === null) return '(実行失敗: エージェントが結果を返しませんでした。手動で再実行してください)'
+  return result.detail ?? '指摘なし'
+}
+
+function classifyPhase1Results(results) {
+  return {
+    findingCount: results.filter(r => r?.status === 'pass' && r?.detail !== '指摘なし').length,
+    blockedCount: results.filter(r => r?.status === 'blocked').length,
+    failedCount:  results.filter(r => r === null).length,
+  }
+}
+
+const { findingCount, blockedCount, failedCount } = classifyPhase1Results(results)
+
+// issue #521: 4体全てがagent()自体の失敗(null。致命的APIエラー等でstatus/detailを
+// 自己申告できなかったケース。agent自身が返すstatus:'blocked'とは別物)だった場合、
+// findingsを「指摘なし」で埋めた偽の正常完了を返さないよう明示的に中断する。
+if (failedCount === results.length) {
+  throw new Error('Sweep全4体(ui/data/db/types)がagent()の実行失敗(null)を返しました。findingCount: 0の偽の正常完了を返さないため中断します。手動で再実行してください。')
+}
+if (failedCount > 0) {
+  log(`警告: Sweep ${failedCount}件の軸でagent()自体が実行失敗しました(status/detailを自己申告できず)。該当軸のfindingsは「実行失敗」と表示されます`)
+}
+
 const baseCommit = providedBaseCommit ?? (baseCommitRaw?.trim().match(BASE_COMMIT_PATTERN)?.[0] ?? null)
 if (!baseCommit) {
   log('警告: baseCommitの取得に失敗しました。Run Manifestのbase_commitは手動で埋めてください。')
@@ -92,18 +119,21 @@ if (!baseCommit) {
 
 return {
   findings: {
-    ui:    uiResult?.detail    ?? '指摘なし',
-    data:  dataResult?.detail  ?? '指摘なし',
-    db:    dbResult?.detail    ?? '指摘なし',
-    types: typesResult?.detail ?? '指摘なし',
+    ui:    describeSweepResult(uiResult),
+    data:  describeSweepResult(dataResult),
+    db:    describeSweepResult(dbResult),
+    types: describeSweepResult(typesResult),
   },
   stats: {
     phase: 'phase1',
     agents: 4,
     rounds: 1,
     // findingCount: 完遂できた調査のうち、実際に指摘が見つかった本数(status/detailの2軸判定。docs/agents/agent-result-schema.md参照)
-    findingCount: results.filter(r => r?.status === 'pass' && r?.detail !== '指摘なし').length,
-    blockedCount: results.filter(r => r?.status === 'blocked').length,
+    findingCount,
+    blockedCount,
+    // failedCount: agent()自体が実行失敗しnullを返した軸の数(issue #521)。blockedCount
+    // (エージェント自身がstatus:'blocked'を自己申告した数)とは別カウント
+    failedCount,
     // issue #339: sweep-ui/data/db/typesの4体は全てdocs/agents/common.md「サブエージェント進捗の
     // 可視化」の進捗記録対象agentType（.claude/workflows/lib/agent-progress-expectation.js参照）。
     // capture-base-commitは対象外のため含めない。

--- a/.claude/workflows/lib/__tests__/phase1-result-classification-sync.test.js
+++ b/.claude/workflows/lib/__tests__/phase1-result-classification-sync.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKFLOW_FILE = path.resolve(__dirname, '../../aidd-phase1.js')
+const LIB_FILE = path.resolve(__dirname, '../phase1-result-classification.js')
+
+// aidd-phase1.js（Workflow DSL、require不可）内にインライン複製されたSweep結果分類ロジックが、
+// lib/phase1-result-classification.js の正本と一字一句ドリフトしていないかを検証する
+// （issue #521。router-risk-sync.test.js / workflow-prompt-sync.test.js と同型のガード）。
+const DECLARATIONS = ['describeSweepResult', 'classifyPhase1Results']
+
+describe('aidd-phase1.jsのSweep結果分類ロジック同期(issue #521)', () => {
+  const workflowSource = readFileSync(WORKFLOW_FILE, 'utf-8')
+  const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+  for (const name of DECLARATIONS) {
+    it(`${name} がaidd-phase1.jsとlib/phase1-result-classification.jsで一致する`, () => {
+      const workflowDecl = extractDeclaration(workflowSource, name)
+      const libDecl = extractDeclaration(libSource, name)
+      expect(workflowDecl).toBe(libDecl)
+    })
+  }
+})

--- a/.claude/workflows/lib/__tests__/phase1-result-classification.test.js
+++ b/.claude/workflows/lib/__tests__/phase1-result-classification.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { describeSweepResult, classifyPhase1Results } from '../phase1-result-classification.js'
+
+describe('describeSweepResult', () => {
+  it('null（agent()自体の実行失敗）は実行失敗の文言を返す', () => {
+    expect(describeSweepResult(null)).toBe('(実行失敗: エージェントが結果を返しませんでした。手動で再実行してください)')
+  })
+
+  it('detailが「指摘なし」ならそのまま返す', () => {
+    expect(describeSweepResult({ status: 'pass', detail: '指摘なし' })).toBe('指摘なし')
+  })
+
+  it('detailに指摘本文があればそのまま返す', () => {
+    expect(describeSweepResult({ status: 'pass', detail: '型不整合が1件あります' })).toBe('型不整合が1件あります')
+  })
+
+  it('status:blocked（agent自身の自己申告）でもdetailをそのまま返す（実行失敗とは区別する）', () => {
+    expect(describeSweepResult({ status: 'blocked', detail: '対象コードが存在しません' })).toBe('対象コードが存在しません')
+  })
+})
+
+describe('classifyPhase1Results', () => {
+  it('全結果がpassかつ指摘ありならfindingCountに計上される', () => {
+    const results = [
+      { status: 'pass', detail: 'UI指摘' },
+      { status: 'pass', detail: '指摘なし' },
+      { status: 'pass', detail: 'DB指摘' },
+      { status: 'pass', detail: '指摘なし' },
+    ]
+    expect(classifyPhase1Results(results)).toEqual({ findingCount: 2, blockedCount: 0, failedCount: 0 })
+  })
+
+  it('status:blockedはblockedCountに計上され、findingCountには計上されない', () => {
+    const results = [
+      { status: 'blocked', detail: '対象コードなし' },
+      { status: 'pass', detail: '指摘なし' },
+    ]
+    expect(classifyPhase1Results(results)).toEqual({ findingCount: 0, blockedCount: 1, failedCount: 0 })
+  })
+
+  it('issue #521: nullはfailedCountに計上され、blockedCount・findingCountのどちらにも計上されない', () => {
+    const results = [null, { status: 'pass', detail: '指摘なし' }]
+    expect(classifyPhase1Results(results)).toEqual({ findingCount: 0, blockedCount: 0, failedCount: 1 })
+  })
+
+  it('issue #521: 4体全滅(全てnull)でもfindingCount:0を装わずfailedCountで実態を表す', () => {
+    const results = [null, null, null, null]
+    expect(classifyPhase1Results(results)).toEqual({ findingCount: 0, blockedCount: 0, failedCount: 4 })
+  })
+
+  it('pass/blocked/failed/指摘ありが混在するケース', () => {
+    const results = [
+      { status: 'pass', detail: 'UI指摘' },
+      { status: 'blocked', detail: '権限不足' },
+      null,
+      { status: 'pass', detail: '指摘なし' },
+    ]
+    expect(classifyPhase1Results(results)).toEqual({ findingCount: 1, blockedCount: 1, failedCount: 1 })
+  })
+})

--- a/.claude/workflows/lib/phase1-result-classification.js
+++ b/.claude/workflows/lib/phase1-result-classification.js
@@ -1,0 +1,22 @@
+// docs/agents/agent-result-schema.md 参照。
+// Sweep結果（status: 'pass'|'blocked'、またはagent()自体が失敗した場合のnull）を分類する。
+// nullは、権限不足・対象コード不在等でagent自身がstatus:'blocked'と自己申告した場合とは異なり、
+// エージェント呼び出し自体が致命的エラー・スキップで結果を返せなかったケースを指す
+// （Workflowツールの仕様。agent()はretry後の致命的APIエラー・ユーザースキップ時にnullを返す）。
+// 従来はnullも`?? '指摘なし'`で丸められ、Sweepが全滅してもfindingCount:0の偽の正常完了に
+// 見えていた（issue #521）。
+// aidd-phase1.js（Workflow DSL、require不可）にも同一ロジックをインラインで複製している。
+// このファイルはvitestでの単体テスト用の正本。
+
+export function describeSweepResult(result) {
+  if (result === null) return '(実行失敗: エージェントが結果を返しませんでした。手動で再実行してください)'
+  return result.detail ?? '指摘なし'
+}
+
+export function classifyPhase1Results(results) {
+  return {
+    findingCount: results.filter(r => r?.status === 'pass' && r?.detail !== '指摘なし').length,
+    blockedCount: results.filter(r => r?.status === 'blocked').length,
+    failedCount:  results.filter(r => r === null).length,
+  }
+}


### PR DESCRIPTION
Closes #521

## 作業サマリ
- 変更した目的: issue #521。`.claude/workflows/aidd-phase1.js`で`agent()`自体の実行失敗(null)が`?? '指摘なし'`で丸められ、Sweep 4体(ui/data/db/types)が全滅しても`findingCount: 0`という偽の正常完了を返していた。issue #420のplugin検証(2026-07-16)で発見された「エラーなく完了したように見える偽の指摘なし」と同型のバグが、plugin化前の本体リポジトリ側に既に存在していたことを確認した。
- 変更した範囲:
  - `.claude/workflows/aidd-phase1.js`: `status:'blocked'`（エージェント自身の自己申告）と`null`（致命的APIエラー等で結果自体を返せなかったケース）を区別。`stats.failedCount`を追加し、該当軸のfindingsは「実行失敗」の文言で表示する。Sweep 4体全滅時はfindingCount:0を装わず`throw`して偽の正常完了を防ぐ。
  - 分類ロジックを`.claude/workflows/lib/phase1-result-classification.js`に切り出し（`describeSweepResult`/`classifyPhase1Results`）、単体テスト11ケースと、Workflow DSL側インライン複製とのsync test（既存の`router-risk-sync.test.js`と同型）を追加。
  - `.claude/workflows/aidd-1-1-deep-task.js`: 3箇所の`filter(Boolean)`（提案生成・採点処理）による間引きが無言だったため、間引き件数を`log()`で明示するよう追加（issue本文で明示された対象箇所）。
- 触っていない範囲:
  - `.claude/workflows/aidd-phase2.js`は横展開確認のみ実施。`shouldBlock`のdeny-by-defaultゲートが既にnullを含む非pass結果で早期returnする設計のため、最終returnの`implResults.filter(...)`集計に到達する時点でnullは混入し得ないことを確認済み（同種の脆弱性なし、コード変更なし）。
  - `.claude/workflows/aidd-phase1-router.js`はmetaルートで`agent()`を直接呼ばない（`workflow()`経由で委譲するのみ）ため対象外（コード変更なし）。
  - `.claude/workflows/aidd-1-1-deep-task.js`の`roundSummary`内の`?? '指摘なし'`（138〜141行）は変更していない。直前に`lastRoundBlockedAxes`の警告ログが既に出る設計のため、silent化ではないと判断した。

## 検証済み
- 実行したコマンド: `npm test`（全164ファイル・1256テストgreen）、`npm run lint`（0 errors, 既存無関係箇所に警告1件のみ）。`npm run ai:check`は本プロジェクトに存在しないため未実行（`npm test`・`npm run lint`が該当するチェック）。
- 確認した画面: 該当なし（ワークフロー定義ファイルのみの変更、UIコード非対象）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/RLS等のプロダクトコードは一切変更していない。TRI/RISK機械判定でメタ改修ルートに分類されることを`aidd-phase1-router` Workflow実行で確認済み）。
- `npm run eval:workflows`は未実行。理由: 変更はプロンプト文言ではなく、Sweep結果の集計・return値ロジックのみ（`STATUS_GUIDE`等のエージェント向けプロンプト文字列は無変更）。対応する`scripts/eval-fixtures/`にaidd-phase1用のfixtureも存在しないため対象外と判断した。

## 既知の未対応
- 今回あえて対応しなかったこと: 実際にSweepエージェントを故意に失敗させて`throw`が発火することを、ライブのWorkflow実行では確認していない（コストの高い実agent呼び出しが必要なため）。単体テスト（`phase1-result-classification.test.js`）で分類ロジック自体（4体全null→failedCount:4等）は検証済みだが、実行時に本当に`throw`されてWorkflowが異常終了することの実機確認は未実施。
- 理由: 4〜5エージェントを故意に失敗させるfault injectionの仕組みが本ワークフロー向けに未整備（issue #395のfault injection訓練はaidd-phase2.jsのSpec/Manifest Check専用）。
- 次に触るなら見る場所: 実機確認をしたい場合、`.claude/workflows/aidd-phase1.js`のsweepAgentsを一時的に存在しないagentTypeに差し替えて`Workflow({name: "aidd-phase1"})`を実行すると、issue #420のplugin検証と同じ`agent type not found`エラーでnullが返る状況を再現できる。

## 後任AIへの注意
- この実装で壊してはいけない前提: `describeSweepResult`/`classifyPhase1Results`は`aidd-phase1.js`と`lib/phase1-result-classification.js`で一字一句同期している。`aidd-phase1.js`側のみ変更すると`phase1-result-classification-sync.test.js`が落ちる（意図的なガード）。
- 似ているが別物の用語: `stats.blockedCount`（エージェント自身が`status:'blocked'`と自己申告した数）と`stats.failedCount`（`agent()`呼び出し自体が失敗しnullが返った数）は別物。混同しないこと。
- 勝手にリファクタしない場所: `aidd-1-1-deep-task.js`の`shouldContinueSweepLoop`・`classifyRoute`等、本PRで触れていない既存ロジックは無変更のまま。

## 関連
- issue #521
- issue #420（2026-07-16のplugin検証コメントで同型バグを発見した経緯）

🤖 Generated with [Claude Code](https://claude.com/claude-code)