### PR TITLE
feat: hook拡張第3弾 引き継ぎフォーマット・AIDD stats phase単位の呼び忘れを検知する(issue #524)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -249,6 +249,18 @@
             "command": "scripts/check-aidd-stats-recorded.sh",
             "timeout": 15,
             "statusMessage": "AIDD stats記録の有無を確認中(issue #495)..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-aidd-phase-stats-recorded.sh",
+            "timeout": 15,
+            "statusMessage": "AIDD stats phase単位の記録漏れを確認中(issue #524)..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-handoff-format.sh",
+            "timeout": 15,
+            "statusMessage": "PR引き継ぎフォーマットの有無を確認中(issue #524)..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,10 @@ stats JSON は標準入力ではなく**第4引数**で渡す（パイプ・リ�
 ```
 ※ start を呼び忘れた場合は phase1_start_at がフォールバックで使われる
 ※ start の呼び忘れは Stop hook（`scripts/check-aidd-stats-recorded.sh`、issue #495）が
-  Workflow実行の形跡と突き合わせて機械検知し警告する（セッションにつき1回・warningのみ。
-  phase単位の呼び忘れは検知対象外）
+  Workflow実行の形跡と突き合わせて機械検知し警告する（セッションにつき1回・warningのみ）
+※ phase1/phase2 の呼び忘れは Stop hook（`scripts/check-aidd-phase-stats-recorded.sh`、
+  issue #524）が、Workflow実行記録（wf_*.json）内のphase1/phase2形跡と突き合わせて機械検知し
+  警告する（セッションにつき1回・warningのみ。近似判定のため過検知を許容する設計）
 
 ## gap check state 記録ルール（issue #488）
 AIDDフロー実行時は、上記statsと合わせて以下も呼ぶ（gap check本体はStop hookが自動実行する。

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -202,6 +202,10 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 - auth/facility/tenant/organization/inventory/RLS/policy に触れた変更は、「検証済み」の
   他テナントIDアクセス確認を省略しない（Issue #24再発防止。チェック観点は
   [`known-failure-patterns.md`](./known-failure-patterns.md) 参照）
+- PR本文経由での引き継ぎ（`gh pr create`/`gh pr edit`）は、Stop hook
+  （`scripts/check-handoff-format.sh`、issue #524）が「## 作業サマリ」「## 検証済み」の
+  2見出しの有無を機械検知し、無ければ警告する（PRにつき1回・warningのみ。セッション終了報告・
+  `docs/sessions/`経由の引き継ぎは検知対象外）
 
 ## 検知手段のないルールの棚卸し（issue #339）
 
@@ -214,12 +218,10 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 
 | ルール | 所在 | 備考 |
 |---|---|---|
-| 引き継ぎフォーマットの実施 | 本ファイル「引き継ぎフォーマット」 | 既存Stop hook（`ai-check-suggest.sh`等）の拡張候補（優先度3候補） |
 | ブランチ運用ルール（`origin/main`起点でのbranch作成） | 本ファイル「ブランチ運用ルール」 | 過去に古いローカル`main`起点でbranch作成し手戻りが発生した実績あり。着手前PR確認のうち「マージ済みPRが乗っている」ケースは`scripts/check-branch-pr-status.sh`（SessionStart hook）で検知済み。**`origin/main`起点確認自体もissue #499で部分検知済み**（`scripts/check-local-main-freshness.sh`。FETCH_HEAD鮮度・ローカルmainの遅れコミット数による近似判定、fetchはhook内で実行しないため取りこぼしうる）。「別issueの未マージPRが乗っている」ケース（マージ前の分岐）は引き続き未検知のまま |
 | サーキットブレーカー（`/goal`設定・テスト修正3回まで・フロー全体上限） | ルートの`CLAUDE.md` | issue #441で検知手段を調査したが、「`/goal`が設定されているか」を外部から機械的に問い合わせるAPI/hookは公式に存在しないと判明（実機確認済み）。条件テンプレート化・役割分担の明文化（Workflow内部retryとの切り分け）は完了したが、呼び忘れ自体の検知は依然できないままこの表に残る |
 | 停止①②以外で止まらず自律進行すること | ルートの`CLAUDE.md`「絶対ルール」 | |
-| AIDD stats書き出しのうち**phase単位**の呼び出し（`write_aidd_stats.sh` phase1/phase2等） | ルートの`CLAUDE.md` | **start呼び忘れはissue #495でStop hook検知済み**（`scripts/check-aidd-stats-recorded.sh`。Workflow実行の形跡があるのにstart記録が無ければ警告）。phase単位の呼び忘れ検知は未実装のままこの表に残る |
-| gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（上記「AIDD stats書き出しのphase単位」行と同型。Workflow DSLがfilesystem API不可のため自己申告依存が残る） |
+| gap check stateの記録（`record-gap-check-state.sh` before/expectedの呼び出し） | ルートの`CLAUDE.md`「gap check state 記録ルール」 | gap check本体の実行はissue #488でStop hookに機械化済み。ただしこの記録呼び出し自体の呼び忘れ検知は無い（Workflow DSLがfilesystem API不可のため自己申告依存が残る。AIDD statsのphase単位呼び出しと同型の限界だったが、そちらはissue #524で検知済みになった） |
 | seed・スクリーンショットに実在施設名を使わない | 本ファイル「テスト環境・データ衛生ルール」 | per-edit層で部分検知（`.claude/security-patterns.json`の`possible_real_facility_name`、issue #440）。ただし`/plugin install security-guidance@claude-plugins-official`の実機有効性は未確認、かつスクリーンショット・issue添付・E2E失敗ログは検知対象外 |
 | `aidd-phase2.js`のSpec Check/Manifest Check関連プロンプトを変更した際のfault injection訓練の実施自体 | 本ファイル「fault injection訓練の実施タイミング（issue #395）」 | 訓練の手順・fixture・setup/teardownスクリプトは用意した（[`fault-injection-drill.md`](./fault-injection-drill.md)）が、「変更時に必ず訓練を実施すること」自体を機械的に強制する手段（例: 該当プロンプト変更を検知してブロックするpre-commit等）は無い。実施記録の記入漏れにも気づく仕組みが無い |
 
@@ -278,6 +280,8 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 | `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
 | `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |
 | `scripts/check-aidd-stats-recorded.sh` | Stop hookによるAIDD stats start呼び忘れの機械検知（issue #495） |
+| `scripts/check-aidd-phase-stats-recorded.sh` | Stop hookによるAIDD stats phase1/phase2呼び忘れの機械検知（issue #524） |
+| `scripts/check-handoff-format.sh` | Stop hookによるPR本文の引き継ぎフォーマット必須見出し欠如の機械検知（issue #524） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/scripts/check-aidd-phase-stats-recorded.sh
+++ b/scripts/check-aidd-phase-stats-recorded.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #524（issue #495の後続。#444「hook拡張第2弾」と同型のhook拡張第3弾）。
+# ~/write_aidd_stats.sh の呼び忘れのうち、「セッション全体のstart呼び忘れ」は
+# check-aidd-stats-recorded.sh（issue #495）が検知済みだが、「phase単位（phase1/phase2）の
+# 呼び忘れ」はdocs/agents/common.md「検知手段のないルールの棚卸し」表の第3層ルールとして
+# 残っていた。
+# このスクリプトはStop hookとして毎ターン終了時に発火し、このセッションで
+# aidd-phase1系（aidd-phase1 / aidd-1-1-deep-task / aidd-phase1-router経由での委譲）または
+# aidd-phase2 のWorkflow実行の形跡があるのに、対応するphase1/phase2のstats記録
+# （~/write_aidd_stats.sh phase1/phase2）が無い場合にsystemMessageで警告する
+# （block不可・warningのみ）。
+#
+# 検知ロジック:
+# 1. Workflowツールはラン毎に <transcript配置ディレクトリ>/<session_id>/workflows/wf_*.json
+#    という実行記録ファイルを生成する（issue #524調査で判明。SubagentStart/Stop hookの
+#    共有skeletonログ[logs/subagent-skeleton.jsonl、issue #423]とは別の、セッション固有の
+#    ファイル）。このディレクトリ配下の全wf_*.jsonを走査する
+# 2. 各ファイルの`.result`フィールド（Workflowの実際の返却値。ソースコード文字列である
+#    `.script`フィールドは意図的に除外し誤検知を避ける）を再帰的に走査し、
+#    "phase1"で始まる文字列値（phase1 / phase1-meta / phase1-needs-confirmation。
+#    aidd-phase1.js・aidd-phase1-router.jsのstats.phase）と、"phase2"に完全一致する
+#    文字列値（aidd-phase2.jsのstats.phase）の有無を判定する
+#    （route自体の判定[deep/light/meta/confirm]に関わらず、Phase1調査の入り口を通過した
+#    形跡があれば「phase1相当の作業をした」とみなす近似判定でよい。confirmルート等での
+#    過検知は許容する。issue本文の方針どおり）
+# 3. phase1形跡があるのに、statsファイルのphase1_end_atがセッション開始以降で記録されて
+#    いなければ警告対象に加える（phase2/phase2_end_atも同様）
+#
+# 設計方針:
+# - fail-open: 判定材料が取れないケース（jq/python3不在・ディレクトリ不在等）はすべて沈黙する
+# - 警告は同一セッションにつき1回のみ（phase1/phase2をまとめて1つのマーカーで抑止）
+# - 全経路 exit 0（blockしない）
+# - check-aidd-stats-recorded.sh（issue #495）本体は改修せず、独立したスクリプト・
+#   独立したhook登録として追加する（既存の複雑なfail-open分岐へ手を入れるリスクを避けるため）
+#
+# 既知の限界:
+# - 「Workflow実行の形跡」の判定はwf_*.json内の文字列走査による近似判定であり、
+#   route='confirm'（実際には調査に着手していない）でもphase1形跡ありと扱われうる
+# - agentType不明のresultフィールド構造が将来変わった場合、この文字列走査は追従しない
+#   （sync testの対象外。プロンプト文字列ではなくWorkflowツールの実行記録フォーマットに
+#   依存するため）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   AIDD_PHASE_STATS_CHECK_SESSION_ID       hook stdinのsession_idの代替
+#   AIDD_PHASE_STATS_CHECK_TRANSCRIPT_PATH  hook stdinのtranscript_pathの代替
+#   AIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR    workflows記録ディレクトリの代替
+#   AIDD_PHASE_STATS_CHECK_STATS_DIR        statsディレクトリ（既定 ~/.claude/aidd-session-stats）
+#   AIDD_PHASE_STATS_CHECK_MARKER_FILE      警告済みマーカー（既定 .aidd/aidd-phase-stats-warning-shown.json）
+
+cd "$(dirname "$0")/.."
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+MARKER_FILE="${AIDD_PHASE_STATS_CHECK_MARKER_FILE:-.aidd/aidd-phase-stats-warning-shown.json}"
+
+if [ -n "${AIDD_PHASE_STATS_CHECK_STATS_DIR:-}" ]; then
+  STATS_DIR="$AIDD_PHASE_STATS_CHECK_STATS_DIR"
+elif [ -n "${HOME:-}" ]; then
+  STATS_DIR="$HOME/.claude/aidd-session-stats"
+else
+  exit 0
+fi
+
+HOOK_INPUT=""
+if [ -z "${AIDD_PHASE_STATS_CHECK_SESSION_ID:-}" ] || [ -z "${AIDD_PHASE_STATS_CHECK_TRANSCRIPT_PATH:-}" ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+fi
+SESSION_ID="${AIDD_PHASE_STATS_CHECK_SESSION_ID:-$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)}"
+TRANSCRIPT_PATH="${AIDD_PHASE_STATS_CHECK_TRANSCRIPT_PATH:-$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)}"
+
+[ -n "$SESSION_ID" ] || exit 0
+
+# 警告済みマーカー: 同一セッションでは2回目以降沈黙
+if [ -f "$MARKER_FILE" ]; then
+  WARNED_SESSION="$(jq -r '.sessionId // empty' "$MARKER_FILE" 2>/dev/null || true)"
+  if [ "$WARNED_SESSION" = "$SESSION_ID" ]; then
+    exit 0
+  fi
+fi
+
+# 1. workflows実行記録ディレクトリを特定
+if [ -n "${AIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR:-}" ]; then
+  WORKFLOWS_DIR="$AIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR"
+else
+  [ -n "$TRANSCRIPT_PATH" ] || exit 0
+  PROJECT_DIR="$(dirname "$TRANSCRIPT_PATH")"
+  WORKFLOWS_DIR="$PROJECT_DIR/$SESSION_ID/workflows"
+fi
+[ -d "$WORKFLOWS_DIR" ] || exit 0
+
+PHASE1_SEEN=0
+PHASE2_SEEN=0
+shopt -s nullglob
+for wf_file in "$WORKFLOWS_DIR"/wf_*.json; do
+  [ -f "$wf_file" ] || continue
+  MATCHES="$(jq -r '[.result | .. | strings] | .[]' "$wf_file" 2>/dev/null || true)"
+  if printf '%s\n' "$MATCHES" | grep -q '^phase1'; then
+    PHASE1_SEEN=1
+  fi
+  if printf '%s\n' "$MATCHES" | grep -q '^phase2$'; then
+    PHASE2_SEEN=1
+  fi
+done
+shopt -u nullglob
+
+if [ "$PHASE1_SEEN" -eq 0 ] && [ "$PHASE2_SEEN" -eq 0 ]; then
+  exit 0
+fi
+
+# 2. セッション開始時刻（transcript先頭行timestamp。末尾ZのUTC表記のみ信頼する。
+# check-aidd-stats-recorded.shと同一パターン）
+SESSION_START_EPOCH=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+  case "$FIRST_TS" in
+    *Z)
+      SESSION_START_EPOCH="$(python3 -c "
+import sys, datetime
+try:
+    ts = sys.argv[1][:19]
+    dt = datetime.datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=datetime.timezone.utc)
+    print(int(dt.timestamp()))
+except Exception:
+    pass
+" "$FIRST_TS" 2>/dev/null || true)"
+      ;;
+  esac
+fi
+[ -n "$SESSION_START_EPOCH" ] || exit 0
+
+# 3. statsファイル（write_aidd_stats.shと同一のcwdハッシュキー）のphase1_end_at/phase2_end_at
+STATS_KEY="$(python3 -c 'import hashlib, os; print(hashlib.sha256(os.getcwd().encode()).hexdigest()[:16])' 2>/dev/null || true)"
+[ -n "$STATS_KEY" ] || exit 0
+STATS_FILE="$STATS_DIR/$STATS_KEY.json"
+
+get_recorded_at() {
+  local key="$1"
+  local val=""
+  if [ -f "$STATS_FILE" ]; then
+    val="$(jq -r --arg k "$key" '.[$k] // empty' "$STATS_FILE" 2>/dev/null || true)"
+  fi
+  case "$val" in
+    *[!0-9]*) val="" ;;
+  esac
+  printf '%s' "$val"
+}
+
+PHASE1_RECORDED=0
+if [ "$PHASE1_SEEN" -eq 1 ]; then
+  AT="$(get_recorded_at phase1_end_at)"
+  if [ -n "$AT" ] && [ "$AT" -ge $((SESSION_START_EPOCH - 60)) ]; then
+    PHASE1_RECORDED=1
+  fi
+fi
+
+PHASE2_RECORDED=0
+if [ "$PHASE2_SEEN" -eq 1 ]; then
+  AT="$(get_recorded_at phase2_end_at)"
+  if [ -n "$AT" ] && [ "$AT" -ge $((SESSION_START_EPOCH - 60)) ]; then
+    PHASE2_RECORDED=1
+  fi
+fi
+
+MISSING=""
+if [ "$PHASE1_SEEN" -eq 1 ] && [ "$PHASE1_RECORDED" -eq 0 ]; then
+  MISSING="${MISSING}phase1 "
+fi
+if [ "$PHASE2_SEEN" -eq 1 ] && [ "$PHASE2_RECORDED" -eq 0 ]; then
+  MISSING="${MISSING}phase2"
+fi
+
+[ -n "$MISSING" ] || exit 0
+
+# マーカー書き込み失敗時もクラッシュせず警告は出す
+# （check-aidd-stats-recorded.shと同一パターン。Stop hookの「全経路exit 0」が絶対要件）
+write_marker() {
+  local dir tmp
+  dir="$(dirname "$MARKER_FILE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(mktemp "$dir/.aidd-phase-stats-warning.XXXXXX" 2>/dev/null)" || return 1
+  jq -n --arg sid "$SESSION_ID" '{sessionId: $sid}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  return 0
+}
+set +e
+write_marker
+set -e
+
+MSG="このセッションはaidd-phase1系/aidd-phase2のWorkflow実行の形跡がありますが、対応するphase単位のAIDD stats記録（~/write_aidd_stats.sh ${MISSING}）が見当たりません（issue #524）。CLAUDE.md「AIDD stats 書き出しルール」の該当フェーズの手順で今からでも記録してください（この警告はセッションにつき1回のみ表示されます）。"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+
+exit 0

--- a/scripts/check-aidd-phase-stats-recorded.test.sh
+++ b/scripts/check-aidd-phase-stats-recorded.test.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# WHY: scripts/check-aidd-phase-stats-recorded.sh（issue #524のStop hook）の回帰テスト。
+# 実workflows記録ディレクトリ・実statsファイル・実transcriptに依存させず、一時ディレクトリの
+# フェイクファイル群を環境変数で注入して決定的に検証する
+# （check-aidd-stats-recorded.test.shと同じパターン）。
+#
+# 実行: bash scripts/check-aidd-phase-stats-recorded.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-aidd-phase-stats-recorded.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+WORKFLOWS_DIR="$WORK_DIR/workflows"
+STATS_DIR="$WORK_DIR/stats"
+MARKER="$WORK_DIR/marker.json"
+TRANSCRIPT="$WORK_DIR/transcript.jsonl"
+mkdir -p "$STATS_DIR"
+
+SESSION="session-aaa"
+
+# セッション開始時刻: 2026-07-22T04:00:00Z = epoch 1784692800
+SESSION_START_ISO="2026-07-22T04:00:00.123Z"
+SESSION_START_EPOCH=1784692800
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATS_KEY="$(cd "$REPO_ROOT" && python3 -c 'import hashlib, os; print(hashlib.sha256(os.getcwd().encode()).hexdigest()[:16])')"
+
+setup_transcript() {
+  printf '{"type":"user","timestamp":"%s"}\n' "$SESSION_START_ISO" > "$TRANSCRIPT"
+}
+
+write_wf_result() {
+  # $1: ファイル名, $2: phaseの値（jq経由で.result.stats.phaseに埋め込む）
+  jq -n --arg phase "$2" '{result: {stats: {phase: $phase}}}' > "$WORKFLOWS_DIR/$1"
+}
+
+run_hook() {
+  set +e
+  OUT="$(AIDD_PHASE_STATS_CHECK_SESSION_ID="$SESSION" \
+    AIDD_PHASE_STATS_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+    AIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR="$WORKFLOWS_DIR" \
+    AIDD_PHASE_STATS_CHECK_STATS_DIR="$STATS_DIR" \
+    AIDD_PHASE_STATS_CHECK_MARKER_FILE="$MARKER" \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+reset_env() {
+  rm -rf "$WORKFLOWS_DIR"
+  mkdir -p "$WORKFLOWS_DIR"
+  rm -f "$MARKER" "$STATS_DIR/$STATS_KEY.json"
+  setup_transcript
+}
+
+echo "=== scenario 1: workflowsディレクトリ無し → 沈黙 ==="
+reset_env
+rm -rf "$WORKFLOWS_DIR"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: workflowsディレクトリは空 → 沈黙 ==="
+reset_env
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 3: phase1/phase2に無関係なwf_*.json → 沈黙 ==="
+reset_env
+jq -n '{result: {route: "something-else"}}' > "$WORKFLOWS_DIR/wf_unrelated.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 4: phase1形跡ありでstats記録無し → 警告＋マーカー作成 ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（block不可）"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "phase1" "phase1に関する警告が含まれる"
+assert_contains "$OUT" "issue #524" "issue番号が含まれる"
+assert_eq "$([ -f "$MARKER" ] && echo yes || echo no)" "yes" "警告済みマーカーが作成される"
+
+echo "=== scenario 5: 警告済みマーカーあり（同一セッション） → 2回目は沈黙 ==="
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "2回目の出力は空である"
+
+echo "=== scenario 6: マーカーは別セッションのもの → 警告する ==="
+jq -n --arg sid "other-session" '{sessionId: $sid}' > "$MARKER"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "別セッションのマーカーでは抑止されない"
+
+echo "=== scenario 7: phase1-metaルートでも文字列一致でphase1形跡ありと判定される ==="
+reset_env
+write_wf_result "wf_a.json" "phase1-meta"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "phase1-metaも近似判定でphase1扱いになる"
+
+echo "=== scenario 8: phase1_end_atがセッション開始以降で記録済み → 沈黙 ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+jq -n --argjson at "$((SESSION_START_EPOCH + 300))" '{phase1_end_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "記録済みなら沈黙する"
+
+echo "=== scenario 9: phase1_end_atが前セッションの残骸（セッション開始より古い） → 警告 ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+jq -n --argjson at "$((SESSION_START_EPOCH - 7200))" '{phase1_end_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "古い記録は残骸として警告される"
+
+echo "=== scenario 10: phase2形跡ありでstats記録無し → 警告 ==="
+reset_env
+write_wf_result "wf_a.json" "phase2"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "phase2" "phase2に関する警告が含まれる"
+
+echo "=== scenario 11: phase1は記録済み・phase2は未記録 → phase2のみ警告に含まれる ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+write_wf_result "wf_b.json" "phase2"
+jq -n --argjson at "$((SESSION_START_EPOCH + 300))" '{phase1_end_at: $at}' > "$STATS_DIR/$STATS_KEY.json"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "phase2" "phase2の警告が含まれる"
+
+echo "=== scenario 12: transcriptが読めない → 沈黙（fail-open） ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+rm -f "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "判定不能時は沈黙する"
+
+echo "=== scenario 13: transcriptのtimestampがZ以外 → 沈黙（fail-open） ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+printf '{"type":"user","timestamp":"2026-07-22T13:00:00.123+09:00"}\n' > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "UTC(Z)以外の形式は信頼せず沈黙する"
+
+echo "=== scenario 14: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
+reset_env
+write_wf_result "wf_a.json" "phase1"
+READONLY_DIR="$WORK_DIR/readonly"
+mkdir -p "$READONLY_DIR"
+chmod 555 "$READONLY_DIR"
+set +e
+OUT="$(AIDD_PHASE_STATS_CHECK_SESSION_ID="$SESSION" \
+  AIDD_PHASE_STATS_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+  AIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR="$WORKFLOWS_DIR" \
+  AIDD_PHASE_STATS_CHECK_STATS_DIR="$STATS_DIR" \
+  AIDD_PHASE_STATS_CHECK_MARKER_FILE="$READONLY_DIR/marker.json" \
+  bash "$SCRIPT" < /dev/null 2>&1)"
+EXIT_CODE=$?
+set -e
+chmod 755 "$READONLY_DIR"
+assert_eq "$EXIT_CODE" "0" "exit 0（クラッシュしない・block不可の絶対要件）"
+assert_contains "$OUT" "systemMessage" "マーカーが書けなくても警告は出る"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/check-handoff-format.sh
+++ b/scripts/check-handoff-format.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #524（#444「hook拡張第2弾」の後続、issue #495と同型のStop hook）。
+# docs/agents/common.md「引き継ぎフォーマット」の実施（PR本文・セッション終了報告・
+# docs/sessions/への記録のいずれかに作業サマリ・検証済み・既知の未対応・後任AIへの注意の
+# 4見出しを残すこと）は、「検知手段のないルールの棚卸し」表の第3層ルールだった
+# （自然言語指示のみに依存し、破られても機械的に気づけなかった）。
+# このスクリプトはStop hookとして毎ターン終了時に発火し、このセッションで
+# `gh pr create`/`gh pr edit`の形跡があるのに、対応するPRの本文に必須見出しが無い場合に
+# systemMessageで警告する（block不可・warningのみ）。
+#
+# 検知ロジック:
+# 1. transcript_pathを軽くgrepし、このセッションで`gh pr create`/`gh pr edit`が呼ばれた
+#    形跡があるかを確認する。無ければ「PR操作なしセッション」として沈黙する
+#    （最頻経路。gh呼び出し自体を避けてコストを抑える）
+# 2. 形跡があれば、現在のブランチに紐づく直近のPR（`gh pr list --head <branch>`）を取得する
+# 3. PR本文に「## 作業サマリ」「## 検証済み」の2見出しが含まれるかを確認する
+#    （4見出し中、最も本質的な2つに絞った近似判定。厳密なMarkdown見出しレベル一致ではなく
+#    部分文字列一致で緩く判定する。誤検知よりも取りこぼしを許容する）
+# 4. 揃っていなければ警告する
+#
+# 設計方針:
+# - fail-open: 判定材料が取れないケース（gh/jq不在・git repo外・ネットワーク不通・
+#   PR未検出等）はすべて沈黙する
+# - 警告は同一セッション・同一PR番号につき1回のみ
+# - 全経路 exit 0（blockしない）
+#
+# 既知の限界:
+# - セッション終了報告・docs/sessions/への記録のみで完結し、PRを一切作らない作業フローは
+#   検知対象外（この警告はPR本文経由の引き継ぎのみをカバーする）
+# - 見出し文言の部分文字列一致のため、別の文脈で偶然「作業サマリ」「検証済み」という語が
+#   PR本文に含まれていれば見出しが無くても素通りしうる（fail-openの範囲内として許容）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   HANDOFF_CHECK_SESSION_ID       hook stdinのsession_idの代替
+#   HANDOFF_CHECK_TRANSCRIPT_PATH  hook stdinのtranscript_pathの代替
+#   HANDOFF_CHECK_MARKER_FILE      警告済みマーカー（既定 .aidd/handoff-format-warning-shown.json）
+#   HANDOFF_CHECK_GH_CMD           `gh`コマンドの代替（テスト用フェイク）
+#   HANDOFF_CHECK_GIT_BRANCH       現在ブランチの代替
+
+cd "$(dirname "$0")/.."
+
+MARKER_FILE="${HANDOFF_CHECK_MARKER_FILE:-.aidd/handoff-format-warning-shown.json}"
+GH_CMD="${HANDOFF_CHECK_GH_CMD:-gh}"
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v "$GH_CMD" >/dev/null 2>&1 || exit 0
+
+HOOK_INPUT=""
+if [ -z "${HANDOFF_CHECK_SESSION_ID:-}" ] || [ -z "${HANDOFF_CHECK_TRANSCRIPT_PATH:-}" ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+fi
+SESSION_ID="${HANDOFF_CHECK_SESSION_ID:-$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)}"
+TRANSCRIPT_PATH="${HANDOFF_CHECK_TRANSCRIPT_PATH:-$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)}"
+
+[ -n "$SESSION_ID" ] || exit 0
+[ -n "$TRANSCRIPT_PATH" ] || exit 0
+[ -f "$TRANSCRIPT_PATH" ] || exit 0
+
+# 1. PR作成/更新の形跡が無ければ沈黙（最頻経路。gh呼び出し自体を避ける）
+if ! grep -qF -e '"command":"gh pr create' -e '"command":"gh pr edit' "$TRANSCRIPT_PATH" 2>/dev/null; then
+  exit 0
+fi
+
+# 2. 現在のブランチに紐づく直近PRを取得
+BRANCH="${HANDOFF_CHECK_GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)}"
+[ -n "$BRANCH" ] || exit 0
+
+PR_JSON="$("$GH_CMD" pr list --head "$BRANCH" --state all --json number,body --limit 1 2>/dev/null || true)"
+[ -n "$PR_JSON" ] || exit 0
+
+PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)"
+PR_BODY="$(printf '%s' "$PR_JSON" | jq -r '.[0].body // empty' 2>/dev/null || true)"
+[ -n "$PR_NUMBER" ] || exit 0
+
+# 警告済みマーカー: 同一セッション・同一PR番号では2回目以降沈黙
+if [ -f "$MARKER_FILE" ]; then
+  WARNED_KEY="$(jq -r '.key // empty' "$MARKER_FILE" 2>/dev/null || true)"
+  if [ "$WARNED_KEY" = "${SESSION_ID}:${PR_NUMBER}" ]; then
+    exit 0
+  fi
+fi
+
+HAS_SUMMARY=0
+if printf '%s' "$PR_BODY" | grep -qF '作業サマリ'; then
+  HAS_SUMMARY=1
+fi
+HAS_VERIFIED=0
+if printf '%s' "$PR_BODY" | grep -qF '検証済み'; then
+  HAS_VERIFIED=1
+fi
+
+if [ "$HAS_SUMMARY" -eq 1 ] && [ "$HAS_VERIFIED" -eq 1 ]; then
+  exit 0
+fi
+
+write_marker() {
+  local dir tmp
+  dir="$(dirname "$MARKER_FILE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(mktemp "$dir/.handoff-format-warning.XXXXXX" 2>/dev/null)" || return 1
+  jq -n --arg key "${SESSION_ID}:${PR_NUMBER}" '{key: $key}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  return 0
+}
+set +e
+write_marker
+set -e
+
+MSG="PR #${PR_NUMBER} の本文に、docs/agents/common.md「引き継ぎフォーマット」の必須見出し（## 作業サマリ / ## 検証済み）が見当たりません。作業完了報告には引き継ぎフォーマット（作業サマリ・検証済み・既知の未対応・後任AIへの注意）を含めてください（この警告はこのPRにつき1回のみ表示されます）。"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+
+exit 0

--- a/scripts/check-handoff-format.test.sh
+++ b/scripts/check-handoff-format.test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# WHY: scripts/check-handoff-format.sh（issue #524のStop hook）の回帰テスト。
+# 実PR・実ghコマンドに依存させず、フェイクの`gh`実行可能ファイルと一時ディレクトリの
+# フェイクファイル群を環境変数で注入して決定的に検証する
+# （check-aidd-stats-recorded.test.shと同じパターン）。
+#
+# 実行: bash scripts/check-handoff-format.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-handoff-format.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+MARKER="$WORK_DIR/marker.json"
+TRANSCRIPT="$WORK_DIR/transcript.jsonl"
+FAKE_GH="$WORK_DIR/fake-gh.sh"
+PR_RESPONSE_FILE="$WORK_DIR/pr-response.json"
+
+SESSION="session-aaa"
+BRANCH="feature/test-branch"
+
+# フェイクgh: `gh pr list ...`が呼ばれたら $PR_RESPONSE_FILE の中身をそのまま返す。
+# ファイルが存在しない場合は空配列を返す（PR未検出を模す）。
+cat > "$FAKE_GH" <<'EOF'
+#!/bin/bash
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  if [ -f "$PR_RESPONSE_FILE" ]; then
+    cat "$PR_RESPONSE_FILE"
+  else
+    echo "[]"
+  fi
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$FAKE_GH"
+export PR_RESPONSE_FILE
+
+pr_command_transcript() {
+  printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"gh pr create --title x --body y"}}]}}\n' > "$TRANSCRIPT"
+}
+no_pr_command_transcript() {
+  printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"git status"}}]}}\n' > "$TRANSCRIPT"
+}
+set_pr_response() {
+  # $1: PR番号, $2: PR本文
+  jq -n --argjson num "$1" --arg body "$2" '[{number: $num, body: $body}]' > "$PR_RESPONSE_FILE"
+}
+
+run_hook() {
+  set +e
+  OUT="$(HANDOFF_CHECK_SESSION_ID="$SESSION" \
+    HANDOFF_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+    HANDOFF_CHECK_MARKER_FILE="$MARKER" \
+    HANDOFF_CHECK_GH_CMD="$FAKE_GH" \
+    HANDOFF_CHECK_GIT_BRANCH="$BRANCH" \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+reset_env() {
+  rm -f "$MARKER" "$PR_RESPONSE_FILE"
+}
+
+echo "=== scenario 1: PR作成/更新コマンドの形跡が無い → 沈黙 ==="
+reset_env
+no_pr_command_transcript
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: PR作成の形跡はあるがgh pr listが空配列（PR未検出） → 沈黙 ==="
+reset_env
+pr_command_transcript
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 3: PR本文に必須見出しが両方揃っている → 沈黙 ==="
+reset_env
+pr_command_transcript
+set_pr_response 100 $'## 作業サマリ\n内容\n\n## 検証済み\n内容'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "見出しが揃っていれば沈黙する"
+
+echo "=== scenario 4: PR本文に必須見出しが両方とも無い → 警告＋マーカー作成 ==="
+reset_env
+pr_command_transcript
+set_pr_response 101 'Summary: something\n\nTest plan: something'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（block不可）"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "PR #101" "PR番号が含まれる"
+assert_contains "$OUT" "作業サマリ" "作業サマリへの言及が含まれる"
+assert_eq "$([ -f "$MARKER" ] && echo yes || echo no)" "yes" "警告済みマーカーが作成される"
+
+echo "=== scenario 5: 警告済みマーカーあり（同一セッション・同一PR） → 2回目は沈黙 ==="
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "2回目の出力は空である"
+
+echo "=== scenario 6: 別PR番号 → 警告する ==="
+set_pr_response 102 'Summary only'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "PR #102" "別PR番号では抑止されない"
+
+echo "=== scenario 7: 片方の見出しのみ（作業サマリのみ） → 警告する ==="
+reset_env
+pr_command_transcript
+set_pr_response 103 $'## 作業サマリ\n内容のみ'
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "片方のみでは警告される"
+
+echo "=== scenario 8: transcriptが読めない → 沈黙（fail-open） ==="
+reset_env
+rm -f "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "判定不能時は沈黙する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #524

## 作業サマリ
- 変更した目的: issue #524。docs/agents/common.md「検知手段のないルールの棚卸し」表に残っていた7項目のうち、機械検知が技術的に可能と判断した2項目（引き継ぎフォーマット実施・AIDD stats phase単位の呼び忘れ）を機械検知化する（issue #444「hook拡張第2弾」・issue #495の後続）。
- 変更した範囲:
  - scripts/check-handoff-format.sh（新規）: Stop hookとして毎ターン終了時に発火。transcriptを軽くgrepしこのセッションでgh pr create/gh pr editが呼ばれた形跡があるかを確認（無ければ最頻経路として即沈黙・ghコマンド自体呼ばない）。形跡があれば現在ブランチの直近PRをgh pr listで取得し、本文に「## 作業サマリ」「## 検証済み」の2見出し（4見出し中最も本質的な2つ）があるか確認。無ければ警告する。
  - scripts/check-aidd-phase-stats-recorded.sh（新規）: 同じくStop hook。調査の過程で、Workflowツールがラン毎に<transcript配置ディレクトリ>/<session_id>/workflows/wf_*.jsonという実行記録ファイルを生成すること（logs/subagent-skeleton.jsonlとは別の、セッション固有のファイル）を発見し、これを検知の土台にした。各wf_*.jsonの.resultフィールド（ソースコード文字列の.scriptは誤検知回避のため除外）を再帰走査し、aidd-phase1系（route='meta'/'confirm'含む近似判定）・aidd-phase2のWorkflow実行形跡と、対応するwrite_aidd_stats.sh phase1/phase2記録の有無を突き合わせる。
  - .claude/settings.json: 上記2スクリプトをStop hook配列に追加登録（既存のcheck-aidd-stats-recorded.shと同じ並び）。
  - CLAUDE.md「AIDD stats 書き出しルール」・docs/agents/common.md「引き継ぎフォーマット」に検知手段への言及を追記。
  - docs/agents/common.md「検知手段のないルールの棚卸し」表から該当2行を削除し、gap check state行の相互参照文言も追従させた。「重要ファイルへのパス」表に新規2スクリプトを追加。
- 触っていない範囲: 既存のscripts/check-aidd-stats-recorded.sh（issue #495、start呼び忘れ検知）は無変更。複雑なfail-open分岐に手を入れるリスクを避け、独立したスクリプト・独立したhook登録として追加する設計を選んだ。「検知手段のないルールの棚卸し」表に残る他5項目（ブランチ運用ルール・サーキットブレーカー・停止①②遵守・実在施設名混入・fault injection訓練実施自体）には触れていない。

## 検証済み
- 実行したコマンド: npm test（全164ファイル・1256テストgreen、既存JS側への影響なし）、npm run lint（0 errors）、bash scripts/check-aidd-phase-stats-recorded.test.sh（14シナリオ全passed）、bash scripts/check-handoff-format.test.sh（8シナリオ全passed）、settings.jsonのJSON構文検証（python3）。
- 確認した画面: 該当なし（hookスクリプト・設定ファイルのみの変更、UIコード非対象）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/RLS等のプロダクトコードは一切変更していない）。

## 既知の未対応
- 今回あえて対応しなかったこと: 実際のStop hook発火（実セッションでのgh pr create後・Workflow実行後にhookが本当に発火すること）は、フェイク注入によるshellテストでのみ検証しており、ライブでの発火は未確認。
- 理由: このPR自体を作成するgh pr createの後、このセッションの次のStop hookでcheck-handoff-format.shが実際に発火するはず（本PR本文には作業サマリ・検証済み見出しを含めているため警告は出ない想定）だが、それはこのPRの作成後に判明する。
- 次に触るなら見る場所: もし実際のセッションで想定通りに警告が出ない場合、まずAIDD_PHASE_STATS_CHECK_WORKFLOWS_DIR/HANDOFF_CHECK_TRANSCRIPT_PATHの実際のパス解決（dirname "$TRANSCRIPT_PATH"配下に session_id/workflows という構造がある前提）が実環境と一致しているかを確認すること。この構造は本PR作成にあたり実際のセッションディレクトリを調査して確認したもの（issue #524本文には無かった発見）。

## 後任AIへの注意
- この実装で壊してはいけない前提: check-aidd-phase-stats-recorded.shは.resultフィールドのみを走査し、.scriptフィールド（ワークフロー定義の全ソースコードが文字列として埋め込まれている）は意図的に除外している。ここを全体再帰に変更すると、ソースコード中のphase1という文字列破片を誤検知する可能性がある。
- 似ているが別物の用語: logs/subagent-skeleton.jsonl（check-aidd-stats-recorded.shが使う、全セッション共有のSubagentStart/Stop記録）と、<session>/workflows/wf_*.json（check-aidd-phase-stats-recorded.shが使う、セッション固有のWorkflow実行記録）は別物。混同しないこと。
- 勝手にリファクタしない場所: check-aidd-stats-recorded.sh本体は今回意図的に無変更のまま。同じstart検知ロジックを持つが、phase単位検知とは別スクリプトとして独立させている設計判断（コミットメッセージ・本PR説明に理由あり）を尊重すること。

## 関連
- issue #524
- issue #444（hook拡張第2弾。同型のStop hook追加パターン）
- issue #495（check-aidd-stats-recorded.sh。start呼び忘れ検知の先行実装）

Generated with Claude Code
