### PR TITLE
feat: find-av-precisionログ記録漏れをStop hookで検知する(issue #522)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -261,6 +261,12 @@
             "command": "scripts/check-handoff-format.sh",
             "timeout": 15,
             "statusMessage": "PR引き継ぎフォーマットの有無を確認中(issue #524)..."
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-find-av-precision-recorded.sh",
+            "timeout": 15,
+            "statusMessage": "find-av-precisionログ記録の有無を確認中(issue #522)..."
           }
         ]
       }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -282,6 +282,7 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 | `scripts/check-aidd-stats-recorded.sh` | Stop hookによるAIDD stats start呼び忘れの機械検知（issue #495） |
 | `scripts/check-aidd-phase-stats-recorded.sh` | Stop hookによるAIDD stats phase1/phase2呼び忘れの機械検知（issue #524） |
 | `scripts/check-handoff-format.sh` | Stop hookによるPR本文の引き継ぎフォーマット必須見出し欠如の機械検知（issue #524） |
+| `scripts/check-find-av-precision-recorded.sh` | Stop hookによるfind-av-precisionログ記録漏れの機械検知（issue #522） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/docs/agents/observability-internals.md
+++ b/docs/agents/observability-internals.md
@@ -304,8 +304,16 @@ security/ux/performance5軸の再発見）の指摘であり、Sweepフェーズ
   filesystem API不可のため、フロー完了後にオーケストレーター（Claude Code）が
   `scripts/log-find-av-precision.sh --feature "<feature名>" '<findAvPrecisionのJSON>'`を
   呼んで`logs/find-av-precision.jsonl`へ永続化する必要がある。これは人/エージェント起動の
-  第3層ルールであり、呼び忘れを機械的に検知する手段は無い（issue #411原則に照らし、
-  今回は機械検知までは実装していない）
+  第3層ルールであり、呼び忘れを機械的に検知する手段は無かった
+- **issue #522で判明した実態**: 品質ゲートの許容誤判定率（precision/recall閾値）を数値で
+  定義しようとbaselineを集計したところ、`logs/find-av-precision.jsonl`（gitignore対象）への
+  記録が実際には一度も残っていないことが判明した（呼び忘れが常態化していた）。**呼び忘れは
+  Stop hook（`scripts/check-find-av-precision-recorded.sh`、issue #522）が機械検知するように
+  なった**（Workflowの実行記録`wf_*.json`内の`findAvPrecision.verifiedCount`と、ログの最新
+  timestampを突き合わせる。セッションにつき1回・warningのみ）。ただし記録データ自体は
+  `logs/`配下でgitignore対象のため、warning-only運用だけでは長期的な蓄積は保証されない
+  （`docs/agents/eval-runs.jsonl`のように意図的にgit管理下へ移す設計変更は未実施のまま）。
+  数値での閾値確定はこのデータが十分に蓄積されてから別issueで行う方針とした
 - `npm run find-av-precision-summary`（実体は`scripts/summarize-find-av-precision.sh`）で
   feature別・lens別の生存率を集計できる
 - **限界**: AV自体もLLM判定でありground truthではない（AVが正しい指摘を誤って棄却する

--- a/scripts/check-find-av-precision-recorded.sh
+++ b/scripts/check-find-av-precision-recorded.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #522（issue #432の後続）。品質ゲートの許容誤判定率（precision/recall閾値）を
+# 数値で確定させる作業に着手する前に、baselineデータを実際に集計したところ、
+# `logs/find-av-precision.jsonl`（Find→Adversarial Verify生存率。issue #432で仕組みは
+# 作られていた）への記録が一度も残っていないことが判明した。原因は、この記録が
+# `scripts/log-find-av-precision.sh`という「Workflow DSLがfilesystem API不可のため、
+# フロー完了後にオーケストレーター（Claude Code）が戻り値を渡して呼ぶ」人/エージェント起動の
+# 第3層ルールであり、呼び忘れを機械的に検知する手段が無かったため（issue #411原則に照らし、
+# issue #432起票時は機械検知まで実装していなかった）。
+# 数値で閾値を決めるには実データの蓄積が先決のため、まずこの記録漏れをStop hookで検知する
+# （check-aidd-phase-stats-recorded.sh、issue #524と同型のパターン）。
+#
+# 検知ロジック:
+# 1. Workflowツールがラン毎に生成する <transcript配置ディレクトリ>/<session_id>/workflows/
+#    wf_*.json（issue #524調査で判明した構造）を走査し、aidd-1-1-deep-taskの`.result`に
+#    `findAvPrecision.verifiedCount`が1以上の値で存在するランがあるかを確認する
+#    （verifiedCount=0＝そもそも検証対象が無かった回は記録すべきデータが無いため対象外）
+# 2. あれば、logs/find-av-precision.jsonl の最新エントリのtimestampがセッション開始以降か
+#    どうかを確認する
+# 3. 記録が無い、またはセッション開始より古ければ警告する
+#
+# 設計方針:
+# - fail-open: 判定材料が取れないケースはすべて沈黙する
+# - 警告は同一セッションにつき1回のみ
+# - 全経路 exit 0（blockしない）
+# - check-aidd-phase-stats-recorded.sh・check-aidd-stats-recorded.shとは独立したスクリプト・
+#   独立したhook登録として追加する（既存スクリプトへ手を入れるリスクを避けるため）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   FIND_AV_PRECISION_CHECK_SESSION_ID       hook stdinのsession_idの代替
+#   FIND_AV_PRECISION_CHECK_TRANSCRIPT_PATH  hook stdinのtranscript_pathの代替
+#   FIND_AV_PRECISION_CHECK_WORKFLOWS_DIR    workflows記録ディレクトリの代替
+#   FIND_AV_PRECISION_CHECK_LOG_FILE         find-av-precisionログの代替（既定 logs/find-av-precision.jsonl）
+#   FIND_AV_PRECISION_CHECK_MARKER_FILE      警告済みマーカー（既定 .aidd/find-av-precision-warning-shown.json）
+
+cd "$(dirname "$0")/.."
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+LOG_FILE="${FIND_AV_PRECISION_CHECK_LOG_FILE:-logs/find-av-precision.jsonl}"
+MARKER_FILE="${FIND_AV_PRECISION_CHECK_MARKER_FILE:-.aidd/find-av-precision-warning-shown.json}"
+
+HOOK_INPUT=""
+if [ -z "${FIND_AV_PRECISION_CHECK_SESSION_ID:-}" ] || [ -z "${FIND_AV_PRECISION_CHECK_TRANSCRIPT_PATH:-}" ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+fi
+SESSION_ID="${FIND_AV_PRECISION_CHECK_SESSION_ID:-$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)}"
+TRANSCRIPT_PATH="${FIND_AV_PRECISION_CHECK_TRANSCRIPT_PATH:-$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)}"
+
+[ -n "$SESSION_ID" ] || exit 0
+
+# 警告済みマーカー: 同一セッションでは2回目以降沈黙
+if [ -f "$MARKER_FILE" ]; then
+  WARNED_SESSION="$(jq -r '.sessionId // empty' "$MARKER_FILE" 2>/dev/null || true)"
+  if [ "$WARNED_SESSION" = "$SESSION_ID" ]; then
+    exit 0
+  fi
+fi
+
+# 1. workflows実行記録ディレクトリを特定
+if [ -n "${FIND_AV_PRECISION_CHECK_WORKFLOWS_DIR:-}" ]; then
+  WORKFLOWS_DIR="$FIND_AV_PRECISION_CHECK_WORKFLOWS_DIR"
+else
+  [ -n "$TRANSCRIPT_PATH" ] || exit 0
+  PROJECT_DIR="$(dirname "$TRANSCRIPT_PATH")"
+  WORKFLOWS_DIR="$PROJECT_DIR/$SESSION_ID/workflows"
+fi
+[ -d "$WORKFLOWS_DIR" ] || exit 0
+
+HAS_VERIFIED_DATA=0
+shopt -s nullglob
+for wf_file in "$WORKFLOWS_DIR"/wf_*.json; do
+  [ -f "$wf_file" ] || continue
+  VERIFIED_COUNT="$(jq -r '[.. | objects | select(has("findAvPrecision")) | .findAvPrecision.verifiedCount] | max // 0' "$wf_file" 2>/dev/null || echo 0)"
+  case "$VERIFIED_COUNT" in
+    ''|*[!0-9]*) VERIFIED_COUNT=0 ;;
+  esac
+  if [ "$VERIFIED_COUNT" -gt 0 ]; then
+    HAS_VERIFIED_DATA=1
+  fi
+done
+shopt -u nullglob
+
+[ "$HAS_VERIFIED_DATA" -eq 1 ] || exit 0
+
+# 2. セッション開始時刻（transcript先頭行timestamp。末尾ZのUTC表記のみ信頼する）
+SESSION_START_EPOCH=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+  case "$FIRST_TS" in
+    *Z)
+      SESSION_START_EPOCH="$(python3 -c "
+import sys, datetime
+try:
+    ts = sys.argv[1][:19]
+    dt = datetime.datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=datetime.timezone.utc)
+    print(int(dt.timestamp()))
+except Exception:
+    pass
+" "$FIRST_TS" 2>/dev/null || true)"
+      ;;
+  esac
+fi
+[ -n "$SESSION_START_EPOCH" ] || exit 0
+
+# 3. logs/find-av-precision.jsonlの最新エントリがセッション開始以降か
+RECORDED=0
+if [ -f "$LOG_FILE" ]; then
+  LAST_TS="$(tail -n 50 "$LOG_FILE" 2>/dev/null | jq -R -r 'fromjson? | .timestamp // empty' 2>/dev/null | tail -n 1 || true)"
+  case "$LAST_TS" in
+    *Z)
+      LAST_EPOCH="$(python3 -c "
+import sys, datetime
+try:
+    ts = sys.argv[1][:19]
+    dt = datetime.datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=datetime.timezone.utc)
+    print(int(dt.timestamp()))
+except Exception:
+    pass
+" "$LAST_TS" 2>/dev/null || true)"
+      if [ -n "${LAST_EPOCH:-}" ] && [ "$LAST_EPOCH" -ge $((SESSION_START_EPOCH - 60)) ]; then
+        RECORDED=1
+      fi
+      ;;
+  esac
+fi
+
+[ "$RECORDED" -eq 0 ] || exit 0
+
+write_marker() {
+  local dir tmp
+  dir="$(dirname "$MARKER_FILE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(mktemp "$dir/.find-av-precision-warning.XXXXXX" 2>/dev/null)" || return 1
+  jq -n --arg sid "$SESSION_ID" '{sessionId: $sid}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  return 0
+}
+set +e
+write_marker
+set -e
+
+MSG="このセッションはaidd-1-1-deep-taskでFind→Adversarial Verifyの検証（findAvPrecision）を実行した形跡がありますが、logs/find-av-precision.jsonlへの記録（scripts/log-find-av-precision.sh）が見当たりません（issue #522）。品質ゲートの許容誤判定率を決めるにはこのデータの蓄積が前提のため、今からでも記録してください（この警告はセッションにつき1回のみ表示されます）。"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+
+exit 0

--- a/scripts/check-find-av-precision-recorded.test.sh
+++ b/scripts/check-find-av-precision-recorded.test.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# WHY: scripts/check-find-av-precision-recorded.sh（issue #522のStop hook）の回帰テスト。
+# 実workflows記録ディレクトリ・実ログファイル・実transcriptに依存させず、一時ディレクトリの
+# フェイクファイル群を環境変数で注入して決定的に検証する
+# （check-aidd-phase-stats-recorded.test.shと同じパターン）。
+#
+# 実行: bash scripts/check-find-av-precision-recorded.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-find-av-precision-recorded.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+WORKFLOWS_DIR="$WORK_DIR/workflows"
+MARKER="$WORK_DIR/marker.json"
+TRANSCRIPT="$WORK_DIR/transcript.jsonl"
+LOG_FILE="$WORK_DIR/find-av-precision.jsonl"
+mkdir -p "$WORKFLOWS_DIR"
+
+SESSION="session-aaa"
+
+# セッション開始時刻: 2026-07-22T04:00:00Z = epoch 1784692800
+SESSION_START_ISO="2026-07-22T04:00:00.123Z"
+SESSION_START_EPOCH=1784692800
+
+setup_transcript() {
+  printf '{"type":"user","timestamp":"%s"}\n' "$SESSION_START_ISO" > "$TRANSCRIPT"
+}
+
+write_wf_with_precision() {
+  # $1: ファイル名, $2: verifiedCount
+  jq -n --argjson vc "$2" '{result: {findAvPrecision: {verifiedCount: $vc}}}' > "$WORKFLOWS_DIR/$1"
+}
+
+run_hook() {
+  set +e
+  OUT="$(FIND_AV_PRECISION_CHECK_SESSION_ID="$SESSION" \
+    FIND_AV_PRECISION_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+    FIND_AV_PRECISION_CHECK_WORKFLOWS_DIR="$WORKFLOWS_DIR" \
+    FIND_AV_PRECISION_CHECK_LOG_FILE="$LOG_FILE" \
+    FIND_AV_PRECISION_CHECK_MARKER_FILE="$MARKER" \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+reset_env() {
+  rm -rf "$WORKFLOWS_DIR"
+  mkdir -p "$WORKFLOWS_DIR"
+  rm -f "$MARKER" "$LOG_FILE"
+  setup_transcript
+}
+
+echo "=== scenario 1: workflowsディレクトリが空 → 沈黙 ==="
+reset_env
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: verifiedCount=0のみ（検証対象が無かった） → 沈黙 ==="
+reset_env
+write_wf_with_precision "wf_a.json" 0
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 3: verifiedCount>0でログ記録無し → 警告＋マーカー作成 ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（block不可）"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "issue #522" "issue番号が含まれる"
+assert_eq "$([ -f "$MARKER" ] && echo yes || echo no)" "yes" "警告済みマーカーが作成される"
+
+echo "=== scenario 4: 警告済みマーカーあり（同一セッション） → 2回目は沈黙 ==="
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "2回目の出力は空である"
+
+echo "=== scenario 5: マーカーは別セッションのもの → 警告する ==="
+jq -n --arg sid "other-session" '{sessionId: $sid}' > "$MARKER"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "別セッションのマーカーでは抑止されない"
+
+echo "=== scenario 6: ログがセッション開始以降に記録済み → 沈黙 ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+RECENT_ISO="2026-07-22T04:10:00Z"
+printf '{"timestamp":"%s","feature":"x"}\n' "$RECENT_ISO" > "$LOG_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "記録済みなら沈黙する"
+
+echo "=== scenario 7: ログが前セッションの残骸（セッション開始より古い） → 警告 ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+OLD_ISO="2026-07-22T02:00:00Z"
+printf '{"timestamp":"%s","feature":"x"}\n' "$OLD_ISO" > "$LOG_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "古い記録は残骸として警告される"
+
+echo "=== scenario 8: transcriptが読めない → 沈黙（fail-open） ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+rm -f "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "判定不能時は沈黙する"
+
+echo "=== scenario 9: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+READONLY_DIR="$WORK_DIR/readonly"
+mkdir -p "$READONLY_DIR"
+chmod 555 "$READONLY_DIR"
+set +e
+OUT="$(FIND_AV_PRECISION_CHECK_SESSION_ID="$SESSION" \
+  FIND_AV_PRECISION_CHECK_TRANSCRIPT_PATH="$TRANSCRIPT" \
+  FIND_AV_PRECISION_CHECK_WORKFLOWS_DIR="$WORKFLOWS_DIR" \
+  FIND_AV_PRECISION_CHECK_LOG_FILE="$LOG_FILE" \
+  FIND_AV_PRECISION_CHECK_MARKER_FILE="$READONLY_DIR/marker.json" \
+  bash "$SCRIPT" < /dev/null 2>&1)"
+EXIT_CODE=$?
+set -e
+chmod 755 "$READONLY_DIR"
+assert_eq "$EXIT_CODE" "0" "exit 0（クラッシュしない・block不可の絶対要件）"
+assert_contains "$OUT" "systemMessage" "マーカーが書けなくても警告は出る"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #522

## 作業サマリ
- 変更した目的: issue #522。当初の計画は「品質ゲートの許容誤判定率(precision/recall)を数値で確定する」ことだったが、baseline集計（Step 1）を実施したところ、`docs/agents/eval-runs.jsonl`（git管理）の実績はdb-implプロンプトeval 4/4件×3回・sweep-uiのrecall 1/1件のみで、find-av-precision（issue #432で仕組みは作成済み）に至っては記録が0件（一度も記録されたことがない）と判明した。ユーザーに確認したところ「データ蓄積を先に固める」方針で合意を得た（AskUserQuestionで確認済み）ため、本PRのスコープはfind-av-precisionのログ記録漏れ検知の実装までとし、数値の確定は別issueへ切り出した。
- 変更した範囲:
  - `scripts/check-find-av-precision-recorded.sh`（新規、Stop hook）: 調査時にissue #524（PR #526）で発見したWorkflowツールの実行記録構造（`<transcript配置ディレクトリ>/<session_id>/workflows/wf_*.json`）を再利用し、`aidd-1-1-deep-task`の`.result.findAvPrecision.verifiedCount`が1以上のランがあるのに、対応する`logs/find-av-precision.jsonl`への記録（`scripts/log-find-av-precision.sh`呼び出し）がセッション開始以降に無ければ警告する。`check-aidd-phase-stats-recorded.sh`（issue #524）と同型のパターン。
  - `.claude/settings.json`: Stop hook配列に追加登録。
  - `docs/agents/observability-internals.md`「Find→Adversarial Verify precision記録（issue #432）」に、今回判明した「記録0件」の実態と検知手段追加の経緯を追記。
  - `docs/agents/common.md`「重要ファイルへのパス」表に新規スクリプトを追加。
  - 数値確定タスクは新規issueとして切り出し済み（このPRには含まない。着手ゲート条件＝最低データ件数を明記した）。
- 触っていない範囲: `scripts/log-find-av-precision.sh`・`scripts/summarize-find-av-precision.sh`本体は無変更（記録の仕組み自体はissue #432で既に実装済みのため、今回は「呼び忘れの検知」のみを追加）。閾値の数値そのものはこのPRでは一切決めていない。

## 検証済み
- 実行したコマンド: `npm test`（全164ファイル・1256テストgreen）、`npm run lint`（0 errors、既存無関係箇所の警告1件のみ）、`bash scripts/check-find-av-precision-recorded.test.sh`（9シナリオ全passed）、settings.jsonのJSON構文検証（python3）。
- 確認した画面: 該当なし（hookスクリプト・ドキュメントのみの変更）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/RLS等のプロダクトコードは一切変更していない）。

## 既知の未対応
- 今回あえて対応しなかったこと: 品質ゲートの誤判定率の数値確定そのもの（元issue #522の主目的）。
- 理由: n=1〜4件という統計的に意味のないサンプルサイズで数値を確定させることを避けるため。ユーザーとの合意（AskUserQuestion）に基づき、データ蓄積を先に固める方針とした。
- 次に触るなら見る場所: 数値確定は新規issue（本PRのマージ後にpending_issues.jsonl経由で自動作成される想定）で行う。着手ゲート条件（find-av-precision verifiedCount合計20件以上、またはsweep-recallが4層×3回以上）を満たしてから着手すること。

## 後任AIへの注意
- この実装で壊してはいけない前提: `check-find-av-precision-recorded.sh`は`verifiedCount > 0`の場合のみ警告対象とする（0件は「検証対象が無かった正常系」であり記録漏れではない）。この条件を外すと、Find指摘が1件も無かった正常な回まで警告してしまう。
- 似ているが別物の用語: `logs/find-av-precision.jsonl`（Find→Adversarial Verify生存率、issue #432）と`docs/agents/eval-runs.jsonl`（db-impl/sweep-recall eval、issue #496・git管理）は別物。前者はgitignore対象で今回もその方針は変更していない。
- 勝手にリファクタしない場所: `logs/`をgit管理下に移す設計変更（`eval-runs.jsonl`のように）は今回のスコープ外。observability-internals.mdにその旨明記済み。

## 関連
- issue #522
- issue #432（find-av-precision計測の仕組み。本PRが検知を追加した対象）
- issue #524（PR #526。wf_*.json実行記録構造の発見元、同型のhookパターン）

Generated with Claude Code
