### PR TITLE
feat: 検知後の自動復旧閉ループ(recovery-queue方式)を実装する(issue #523)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -174,6 +174,11 @@
             "type": "command",
             "command": "scripts/check-fault-injection-drill-staleness.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "scripts/check-recovery-queue.sh",
+            "timeout": 10
           }
         ]
       }

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -283,6 +283,9 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 | `scripts/check-aidd-phase-stats-recorded.sh` | Stop hookによるAIDD stats phase1/phase2呼び忘れの機械検知（issue #524） |
 | `scripts/check-handoff-format.sh` | Stop hookによるPR本文の引き継ぎフォーマット必須見出し欠如の機械検知（issue #524） |
 | `scripts/check-find-av-precision-recorded.sh` | Stop hookによるfind-av-precisionログ記録漏れの機械検知（issue #522） |
+| [`docs/agents/recovery-queue.md`](./recovery-queue.md) | 検知後の自動復旧閉ループの設計・スコープ・既知の未対応（issue #523） |
+| `scripts/queue-recovery-task.sh` | 検知hookから呼ばれ`.aidd/recovery-queue.jsonl`へ復旧タスクを登録する（issue #523） |
+| `scripts/check-recovery-queue.sh` | SessionStart hookによる未対応の復旧タスクのcontext注入（issue #523） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/docs/agents/recovery-queue.md
+++ b/docs/agents/recovery-queue.md
@@ -1,0 +1,62 @@
+# 検知後の自動復旧閉ループ（recovery-queue、issue #523）
+
+## 背景
+
+既存の検知hook群（gap check・AIDD stats呼び忘れ・引き継ぎフォーマット等）はすべて
+「検知して警告」までで、検知後の立て直しは人間がsystemMessageを読んで指示する前提だった。
+長時間の自律実行（3ヶ月の反復実証を想定）では、警告→人間対応待ちがスループットの律速になる。
+
+## 設計
+
+- 検知hookは、警告を出すのと同時に `scripts/queue-recovery-task.sh` を呼び、
+  `.aidd/recovery-queue.jsonl`（gitignore対象、`.aidd/`配下）へ1エントリ追記する
+  （`{id, timestamp, type, detail, status: "pending"}`）
+- 次回セッション開始時、SessionStart hook（`scripts/check-recovery-queue.sh`）が
+  `status: "pending"` のエントリを読み、セッション冒頭のcontextへ注入する
+  （`systemMessage`。同時に`status`を`"surfaced"`へ書き換え、同一エントリを毎セッション
+  繰り返し表示しないようにする）
+- 実際の復旧作業は、contextへ注入された内容を見てセッション自身が自律的に行う。
+  hookスクリプト自体は復旧作業を一切実行しない
+
+## 第一弾の対象type
+
+- `gap-check-followup`: `scripts/check-gap-check-state.sh` がgap警告を出したときに登録される。
+  対応する記録漏れの原因調査・issue化が復旧内容
+
+## 未実装のtype（Workflow中断→resumeFromRunId再開）
+
+issue #523の起票時点では「復旧手順が既に明文化されている2種」として、Workflow中断からの
+`resumeFromRunId`再開（[`workflow-resume-runbook.md`](./workflow-resume-runbook.md)）も
+第一弾の対象に含める想定だった。しかし実装検討の結果、**このPRでは見送った**。
+
+理由: 「Workflowが中断された」ことを機械的に検知する信頼できる手段が無いため。
+Workflowツールは実行ごとに `<transcript配置ディレクトリ>/<session_id>/workflows/wf_*.json`
+という実行記録ファイルを生成し（issue #524調査で判明）、少なくとも正常完了時は`status`フィールドに
+`"completed"`が入ることを実機で確認した。しかし、
+
+- 中断時にこのファイルが「存在するが`status`が`"completed"`でない」状態になるのか、
+  それとも「そもそもファイルが存在しない」状態になるのか、実際に中断を起こして検証していない
+- 仮に前者だとしても、同一worktreeで複数セッションが並行してWorkflowを実行しているケース
+  （他ワーカーが正当に実行中のもの）と、本当に中断されたケースを、ファイルの中身だけから
+  確実に区別できるかが未検証
+
+を、実際に確認しないまま「検知できる」と主張してshipすることは避けた
+（このリポジトリの一貫した方針：不確かな検知能力を実装済みと詐称しない）。
+
+## 今後この機能を拡張する場合
+
+1. まず実際にWorkflow実行を中断させ、`wf_*.json`の実際の状態（存在有無・statusフィールドの値）を
+   実機観測する
+2. 観測結果をもとに、誤検知（正当に実行中のものを中断扱いする）を避けられる判定条件を設計する
+3. `scripts/queue-recovery-task.sh --type workflow-interrupted` を呼ぶ新しいhook
+   （SessionStart推奨。前セッションの残骸を見つけるため）を追加する
+4. 復旧内容の`detail`には、対象の`runId`と`docs/agents/workflow-resume-runbook.md`への
+   参照を含める
+
+## 安全上の制約
+
+- 停止①②（仕様レビュー・構造化レビュー）を自動復旧でスキップしない
+- サーキットブレーカー（`/goal`・budgetガード）を復旧ループが迂回しない
+- 復旧キュー自体の記録漏れ・処理漏れの検知手段は今回未実装のまま
+  （issue #339の原則どおり、この限界を明記しておく。`status: "surfaced"`から
+  `"resolved"`への遷移は自動化されておらず、対応後は手動でキューから該当行を削除する運用）

--- a/scripts/check-gap-check-state.sh
+++ b/scripts/check-gap-check-state.sh
@@ -112,6 +112,12 @@ rm -f "$STATE_FILE"
 MSG=""
 if [ -n "$GAP_WARNINGS" ]; then
   MSG="AIDDフローの観測ログに記録漏れ（またはズレ）の可能性があります（Stop hookによる自動gap check、issue #488）。issue化するか原因を調査してください（docs/agents/common.md「loop-observabilityログの記録漏れ検知」参照）:${GAP_WARNINGS}"
+  # issue #523: 検知して終わりにせず、次回SessionStart時に確実に思い出せるようキューへ
+  # 登録する（scripts/check-recovery-queue.sh参照）。失敗してもこのhook自体の警告出力は
+  # 継続する（fail-open。キュー登録はベストエフォート）
+  bash scripts/queue-recovery-task.sh --type "gap-check-followup" \
+    --detail "$(jq -n --arg warnings "$GAP_WARNINGS" '{gapWarnings: $warnings}')" \
+    >/dev/null 2>&1 || true
 fi
 if [ -n "$EXEC_FAILURES" ]; then
   if [ -n "$MSG" ]; then

--- a/scripts/check-gap-check-state.test.sh
+++ b/scripts/check-gap-check-state.test.sh
@@ -74,8 +74,12 @@ EOF
 run_hook() {
   rm -f "$LOOP_CALLED" "$PROGRESS_CALLED"
   set +e
+  # RECOVERY_QUEUE_FILE: issue #523でcheck-gap-check-state.shがhasGap時に
+  # scripts/queue-recovery-task.shを呼ぶようになったため、実リポジトリの
+  # .aidd/recovery-queue.jsonlを汚さないよう一時ディレクトリへ隔離する
   OUT="$(GAP_CHECK_STATE_FILE="$STATE" GAP_CHECK_LOOP_CMD="$LOOP_CMD" \
     GAP_CHECK_PROGRESS_CMD="$PROGRESS_CMD" GAP_CHECK_NOW_EPOCH=2000000 \
+    RECOVERY_QUEUE_FILE="$WORK_DIR/recovery-queue.jsonl" \
     bash "$SCRIPT" < /dev/null 2>&1)"
   EXIT_CODE=$?
   set -e
@@ -125,6 +129,7 @@ assert_contains "$OUT" "記録漏れ" "記録漏れ警告が含まれる"
 assert_contains "$OUT" "loop-observability" "どのログのgapかが含まれる"
 assert_contains "$OUT" "hasGap" "gap check出力が引用されている"
 assert_eq "$([ -f "$STATE" ] && echo kept || echo removed)" "removed" "stateファイルがクリアされている"
+assert_contains "$(cat "$WORK_DIR/recovery-queue.jsonl" 2>/dev/null || true)" "gap-check-followup" "issue #523: gap警告がrecovery-queueへ登録される"
 
 echo "=== scenario 6: agent-progressのexpectedのみ記録 → loop checkは呼ばれない ==="
 jq -n '{beforeLoopObservability: 5, beforeAgentProgress: 19, recordedAt: 1999000, expectedAgentProgress: 4}' > "$STATE"

--- a/scripts/check-recovery-queue.sh
+++ b/scripts/check-recovery-queue.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #523。.aidd/recovery-queue.jsonl（scripts/queue-recovery-task.shが追記する）に
+# status="pending"のエントリが溜まっていないかをSessionStart時に確認し、あればcontextへ
+# 注入する。人間がwarningを読んで指示するのを待たず、次のセッション開始時点で自動的に
+# 「何を復旧すべきか」が目の前に出てくることで、検知→復旧の閉ループを1段階前進させる。
+#
+# 設計方針:
+# - このhook自体は復旧作業を実行しない（自律実行はセッション本体が行う）。役割は
+#   「pendingエントリの存在をセッション冒頭のcontextへ確実に届けること」に限定する
+# - 注入時にstatusを"pending"から"surfaced"へ書き換える（同一エントリを毎セッション
+#   繰り返し表示しないため）。"surfaced"→"resolved"への遷移は今回のスコープ外
+#   （docs/agents/recovery-queue.md「既知の未対応」参照。人間・エージェントいずれかが
+#   対応後に手動でキューから該当行を削除する運用を暫定とする）
+# - fail-open: 判定材料が取れないケース（jq不在・キューファイル無し等）はすべて沈黙する
+# - 全経路 exit 0（block不可）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   RECOVERY_QUEUE_FILE  キューファイルパス（既定 .aidd/recovery-queue.jsonl）
+
+cd "$(dirname "$0")/.."
+
+QUEUE_FILE="${RECOVERY_QUEUE_FILE:-.aidd/recovery-queue.jsonl}"
+
+command -v jq >/dev/null 2>&1 || exit 0
+[ -f "$QUEUE_FILE" ] || exit 0
+
+PENDING_COUNT="$(jq -R -r 'fromjson? | select(.status == "pending")' "$QUEUE_FILE" 2>/dev/null | jq -s 'length' 2>/dev/null || echo 0)"
+case "$PENDING_COUNT" in
+  ''|*[!0-9]*) PENDING_COUNT=0 ;;
+esac
+
+[ "$PENDING_COUNT" -gt 0 ] || exit 0
+
+SUMMARY="$(jq -R -r 'fromjson? | select(.status == "pending") | "- [\(.type)] \(.timestamp): \(.detail | tostring)"' "$QUEUE_FILE" 2>/dev/null || true)"
+
+# statusを"pending"→"surfaced"に書き換えて再書き込みする（他行は無変更）。
+# 書き込みに失敗しても（disk full・read-only等）クラッシュせず、次回もpendingのまま
+# 再表示されるだけで実害は軽微なため、fail-openでそのまま進める
+TMP_FILE="$(mktemp "$(dirname "$QUEUE_FILE")/.recovery-queue.XXXXXX" 2>/dev/null || true)"
+if [ -n "$TMP_FILE" ]; then
+  if jq -R -r 'fromjson? | if .status == "pending" then (.status = "surfaced") else . end | tostring' "$QUEUE_FILE" > "$TMP_FILE" 2>/dev/null; then
+    mv "$TMP_FILE" "$QUEUE_FILE" 2>/dev/null || rm -f "$TMP_FILE"
+  else
+    rm -f "$TMP_FILE"
+  fi
+fi
+
+MSG="未対応の復旧タスクが${PENDING_COUNT}件あります（.aidd/recovery-queue.jsonl、issue #523）。停止①②・サーキットブレーカーを迂回しない範囲で、内容を確認し対応してください（対応後はキューから該当行を削除してください。自動クローズは未実装）:
+${SUMMARY}"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+
+exit 0

--- a/scripts/check-recovery-queue.test.sh
+++ b/scripts/check-recovery-queue.test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# WHY: scripts/check-recovery-queue.sh（issue #523のSessionStart hook）の回帰テスト。
+# 実キューファイルに依存させず、一時ディレクトリのフェイクファイルで決定的に検証する。
+#
+# 実行: bash scripts/check-recovery-queue.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-recovery-queue.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+QUEUE_FILE="$WORK_DIR/recovery-queue.jsonl"
+
+run_hook() {
+  set +e
+  OUT="$(RECOVERY_QUEUE_FILE="$QUEUE_FILE" bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: キューファイル無し → 沈黙 ==="
+rm -f "$QUEUE_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: pendingエントリが1件 → 警告し内容を含む ==="
+jq -nc '{id: "a", timestamp: "2026-07-23T00:00:00Z", type: "gap-check-followup", detail: {gapWarnings: "x"}, status: "pending"}' > "$QUEUE_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "1件" "件数が含まれる"
+assert_contains "$OUT" "gap-check-followup" "typeが含まれる"
+assert_contains "$OUT" "issue #523" "issue番号が含まれる"
+
+echo "=== scenario 3: 1回表示後はstatusがsurfacedに書き換わる ==="
+STATUS="$(jq -r '.status' "$QUEUE_FILE")"
+assert_eq "$STATUS" "surfaced" "statusがsurfacedになっている"
+
+echo "=== scenario 4: surfaced済みエントリのみ → 2回目は沈黙 ==="
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "surfaced済みは再表示しない"
+
+echo "=== scenario 5: pending・surfacedが混在 → pendingのみ対象になる ==="
+{
+  jq -nc '{id: "a", timestamp: "2026-07-23T00:00:00Z", type: "gap-check-followup", detail: {}, status: "surfaced"}'
+  jq -nc '{id: "b", timestamp: "2026-07-23T00:01:00Z", type: "gap-check-followup", detail: {}, status: "pending"}'
+} > "$QUEUE_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "1件" "pending1件のみが件数に数えられる"
+
+echo "=== scenario 6: 壊れた行が混在 → クラッシュせず正当な行だけ処理する ==="
+{
+  printf '{broken json\n'
+  jq -nc '{id: "c", timestamp: "2026-07-23T00:02:00Z", type: "gap-check-followup", detail: {}, status: "pending"}'
+} > "$QUEUE_FILE"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0（クラッシュしない）"
+assert_contains "$OUT" "systemMessage" "壊れた行があっても正当な行は処理される"
+
+echo "=== scenario 7: jq不在 → 沈黙（fail-open） ==="
+FAKE_BIN_DIR="$WORK_DIR/fake-bin-no-jq"
+mkdir -p "$FAKE_BIN_DIR"
+for bin in bash cat mktemp rm mv dirname; do
+  real="$(command -v "$bin")"
+  ln -sf "$real" "$FAKE_BIN_DIR/$bin"
+done
+jq -nc '{id: "a", timestamp: "2026-07-23T00:00:00Z", type: "x", detail: {}, status: "pending"}' > "$QUEUE_FILE"
+set +e
+OUT="$(PATH="$FAKE_BIN_DIR" RECOVERY_QUEUE_FILE="$QUEUE_FILE" bash "$SCRIPT" < /dev/null 2>&1)"
+EXIT_CODE=$?
+set -e
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "jq不在時は沈黙する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/queue-recovery-task.sh
+++ b/scripts/queue-recovery-task.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #523。既存の検知hook群（gap check・AIDD stats等）はすべてwarning-onlyで、
+# 検知後の立て直しは人間がsystemMessageを読んで指示する前提だった。長時間の自律実行では
+# 警告→人間対応待ちがスループットの律速になる。このスクリプトは汎用ヘルパーとして、
+# 検知hookから呼ばれ .aidd/recovery-queue.jsonl に1エントリ追記する。
+# 追記されたエントリは次回SessionStart時に scripts/check-recovery-queue.sh が読み、
+# セッション冒頭のcontextへ注入する。実際の復旧作業はセッション自身が自律的に行う
+# （このスクリプト自体は復旧を実行しない。キューへの登録のみ）。
+#
+# 第一弾の対象type: gap-check-followup（gap check警告からの記録漏れ調査）。
+# 詳細な設計・スコープ（Workflow中断→resumeFromRunId再開を未実装とした理由を含む）は
+# docs/agents/recovery-queue.md 参照。
+#
+# 使い方（パイプ・stdinは使わない。detail JSONは第4引数相当のオプションで渡す）:
+#   scripts/queue-recovery-task.sh --type TYPE --detail '<JSON>' [--queue-file PATH]
+
+QUEUE_FILE="${RECOVERY_QUEUE_FILE:-.aidd/recovery-queue.jsonl}"
+TYPE=""
+DETAIL=""
+
+usage() {
+  echo "Usage: $0 --type TYPE --detail '<JSON>' [--queue-file PATH]" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type) TYPE="$2"; shift 2 ;;
+    --detail) DETAIL="$2"; shift 2 ;;
+    --queue-file) QUEUE_FILE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$TYPE" || -z "$DETAIL" ]]; then
+  usage
+fi
+
+if ! printf '%s' "$DETAIL" | jq empty 2>/dev/null; then
+  echo "Invalid JSON for --detail: $DETAIL" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$QUEUE_FILE")"
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+ID="${TIMESTAMP}-$$"
+
+jq -nc \
+  --arg id "$ID" \
+  --arg timestamp "$TIMESTAMP" \
+  --arg type "$TYPE" \
+  --argjson detail "$DETAIL" \
+  '{id: $id, timestamp: $timestamp, type: $type, detail: $detail, status: "pending"}' \
+  >> "$QUEUE_FILE"

--- a/scripts/queue-recovery-task.test.sh
+++ b/scripts/queue-recovery-task.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# WHY: scripts/queue-recovery-task.sh（issue #523）の回帰テスト。
+# 実キューファイルに依存させず、一時ディレクトリのフェイクファイルで決定的に検証する。
+#
+# 実行: bash scripts/queue-recovery-task.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/queue-recovery-task.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+QUEUE_FILE="$WORK_DIR/recovery-queue.jsonl"
+
+echo "=== scenario 1: 正常な呼び出し → 1行追記される ==="
+rm -f "$QUEUE_FILE"
+bash "$SCRIPT" --type "gap-check-followup" --detail '{"foo":"bar"}' --queue-file "$QUEUE_FILE"
+assert_eq "$(wc -l < "$QUEUE_FILE" | tr -d ' ')" "1" "1行追記されている"
+LINE="$(cat "$QUEUE_FILE")"
+assert_contains "$LINE" '"type":"gap-check-followup"' "typeが記録される"
+assert_contains "$LINE" '"status":"pending"' "statusはpendingで記録される"
+assert_contains "$LINE" '"foo":"bar"' "detailが記録される"
+
+echo "=== scenario 2: 複数回呼び出し → 追記される（既存行は消えない） ==="
+bash "$SCRIPT" --type "another-type" --detail '{"x":1}' --queue-file "$QUEUE_FILE"
+assert_eq "$(wc -l < "$QUEUE_FILE" | tr -d ' ')" "2" "2行になっている"
+
+echo "=== scenario 3: --typeが無い → エラー終了 ==="
+set +e
+bash "$SCRIPT" --detail '{"x":1}' --queue-file "$QUEUE_FILE" > /dev/null 2>&1
+CODE=$?
+set -e
+assert_eq "$CODE" "1" "--type無しはexit 1"
+
+echo "=== scenario 4: --detailが不正なJSON → エラー終了 ==="
+set +e
+bash "$SCRIPT" --type "x" --detail 'not-json' --queue-file "$QUEUE_FILE" > /dev/null 2>&1
+CODE=$?
+set -e
+assert_eq "$CODE" "1" "不正JSONはexit 1"
+
+echo "=== scenario 5: キューファイルの親ディレクトリが無い → 自動作成される ==="
+NESTED_QUEUE="$WORK_DIR/nested/dir/recovery-queue.jsonl"
+bash "$SCRIPT" --type "x" --detail '{}' --queue-file "$NESTED_QUEUE"
+assert_eq "$([ -f "$NESTED_QUEUE" ] && echo yes || echo no)" "yes" "親ディレクトリが自動作成されファイルが書ける"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #523

## 作業サマリ
- 変更した目的: issue #523。既存の検知hook群はすべてwarning-onlyで、検知後の立て直しは人間がsystemMessageを読んで指示する前提だった。長時間の自律実行ではこれがスループットの律速になるため、検知→復旧の閉ループを1段階前進させる。ユーザーに設計案（recovery-queue方式、第一弾2種、停止①②・サーキットブレーカーを迂回しない制約）を提示しAskUserQuestionで承認を得た（「この設計で実装に進む」）。
- 変更した範囲:
  - `scripts/queue-recovery-task.sh`（新規）: 検知hookから呼ばれ`.aidd/recovery-queue.jsonl`（gitignore対象）へ`{id, timestamp, type, detail, status: "pending"}`形式で1エントリ追記する汎用ヘルパー。
  - `scripts/check-recovery-queue.sh`（新規、SessionStart hook）: `status: "pending"`のエントリを読み、セッション冒頭のcontextへ`systemMessage`として注入する。注入と同時に`status`を`"surfaced"`へ書き換え、同一エントリの毎セッション再表示を防ぐ。
  - `scripts/check-gap-check-state.sh`: hasGap時に`queue-recovery-task.sh --type gap-check-followup`を呼ぶよう最小限の追加（既存の複雑な分岐構造は変更していない）。
  - `scripts/check-gap-check-state.test.sh`: 新規呼び出しが実リポジトリの`.aidd/recovery-queue.jsonl`を汚さないよう`RECOVERY_QUEUE_FILE`を一時ディレクトリへ隔離するテスト修正＋新規アサーション追加。
  - `docs/agents/recovery-queue.md`（新規）: 設計・スコープ・安全上の制約・**未実装としたWorkflow中断→resumeFromRunId再開の理由**を文書化。
  - `.claude/settings.json`: `check-recovery-queue.sh`をSessionStart hook配列に追加登録。
  - `docs/agents/common.md`「重要ファイルへのパス」表に新規3ファイルを追加。
- 触っていない範囲: 第一弾の対象typeは`gap-check-followup`の1種のみ。当初issue本文が想定していた「Workflow中断→resumeFromRunId再開」は**このPRでは実装していない**（詳細は「既知の未対応」参照）。`check-aidd-stats-recorded.sh`・`check-aidd-phase-stats-recorded.sh`・`check-handoff-format.sh`・`check-find-av-precision-recorded.sh`（既存の検知hook群）へのrecovery-queue統合も未実施（gap-check-state.shのみ先行実装）。

## 検証済み
- 実行したコマンド: `npm test`（全164ファイル・1256テストgreen）、`npm run lint`（0 errors）、`bash scripts/queue-recovery-task.test.sh`（5シナリオ全passed）、`bash scripts/check-recovery-queue.test.sh`（7シナリオ全passed）、`bash scripts/check-gap-check-state.test.sh`（8シナリオ全passed、新規追加分含む）、settings.jsonのJSON構文検証（python3）。
- 確認した画面: 該当なし（hookスクリプト・ドキュメントのみの変更）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/RLS等のプロダクトコードは一切変更していない）。
- **実装中に発見した実害**: `check-gap-check-state.test.sh`にqueue呼び出しの隔離設定を入れ忘れた状態で一度テストを実行し、実リポジトリの`.aidd/recovery-queue.jsonl`にテスト用フェイクデータが書き込まれる事故を起こした。気づいて即座に削除し、テスト側を修正済み（`RECOVERY_QUEUE_FILE`を一時ディレクトリへ向ける）。後任AIが新しいhook統合を追加する際、同種の汚染に注意すること。

## 既知の未対応
- 今回あえて対応しなかったこと: 「Workflow中断→resumeFromRunId再開」の自動検知・復旧キュー登録。
- 理由: Workflowツールが生成する`wf_*.json`実行記録は、正常完了時に`status: "completed"`が入ることは実機確認できたが、①中断時に実際どういう状態（ファイル不在／status別値）になるかを実際に中断を起こして検証していない、②正当に並行実行中のWorkflowと本当に中断されたものを確実に区別できるかも未検証、という2点が未解決のまま。不確かな検知能力を実装済みと主張してshipすることを避けた（`docs/agents/recovery-queue.md`に詳細と再開手順を明記）。
- 次に触るなら見る場所: `docs/agents/recovery-queue.md`「今後この機能を拡張する場合」に、実機観測から始める具体的な手順を残した。

## 後任AIへの注意
- この実装で壊してはいけない前提: `check-recovery-queue.sh`は復旧作業そのものは実行しない（contextへの注入のみ）。実際の復旧はセッション自身が停止①②・サーキットブレーカーを尊重しながら自律的に行う設計であり、hookスクリプト側に自動修正ロジックを追加しないこと。
- 似ているが別物の用語: `status: "pending"`（未表示）→`"surfaced"`（表示済み）の2状態のみ実装済み。`"resolved"`（対応完了）への遷移は自動化されておらず、対応後は手動でキューから該当行を削除する運用が前提（誤って「resolvedへの自動遷移がある」と思い込まないこと）。
- 勝手にリファクタしない場所: `check-gap-check-state.sh`本体の既存分岐（stale判定・EXEC_FAILURES区別等）は無変更。recovery-queue呼び出しは`GAP_WARNINGS`が非空の場合のみ発火する1箇所への追加のみ。

## 関連
- issue #523
- issue #442（`docs/agents/workflow-resume-runbook.md`。Workflow中断時の手動再開手順。今回の自動検知は見送ったが手動手順は既存のまま有効）
- issue #488（`check-gap-check-state.sh`本体。今回統合した既存hook）

Generated with Claude Code
