### PR TITLE
fix: agent-progress件数の恒常的+1ズレとimplementer no-op時の記録漏れを修正(issue #509)

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -25,6 +25,8 @@ contract-writer が確定した `src/types/` の型定義を「契約」とし�
 ## 自己修正ループのログ記録
 「実装セットの進め方」のステップ4（テスト通過を確認）・ステップ5（自己修正の再試行）でテストを実行した直後に毎回、`scripts/log-loop-observability.sh --agent implementer --feature "<SPEC.mdのタスク名>" --attempt <試行回数> --model "<自分が実行されているモデル名>" --intent "<何を実装しようとしたか、1文>" --scenario "<実行したテストの内容、1文>" --result pass|fail --reason "<理由、1文>"` を呼び、1回の試行につき1レコード記録すること（`docs/agents/common.md`「loop-observabilityログの記録漏れ検知」参照）。3回修正しても通らず人間に報告する場合も、3回目の試行としてfailを記録してから報告すること。
 
+担当範囲を確認した結果、実装作業が一切不要（該当なし）と判断してテストを1つも実行せず`status: pass`のみを返す場合も、テストを実行していないため上記の記録トリガー（ステップ4・5）が発火しない。この場合は記録漏れとして検知されるのを防ぐため、`--attempt 1 --intent "担当範囲の実装要否を確認" --scenario "実装不要と判断" --result pass --reason "<不要と判断した根拠、1文>"`で1件だけ記録すること（issue #509）。
+
 ## 最新ドキュメント参照（Context7 MCP）
 実装対象のライブラリ・フレームワーク（Next.js、Supabaseクライアント、その他外部パッケージ）の名称やバージョンが不確かな場合は、実装（GREEN）に入る前に `mcp__context7__resolve-library-id` でライブラリを特定すること。参照した場合は上記と同じ形式で `--intent "Context7 MCPでライブラリを特定"` としてログを1件追加する（既に確実に知っている一般的なAPIで参照不要と判断した実装セットでは書かない）。
 

--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -153,7 +153,10 @@ const specCheck = await agent(
 )
 
 countLoggable('reviewer')
-countProgressLoggable('reviewer')
+// issue #509: Spec Checkのプロンプトは「それ以外は何もしないでください」と明示しており、
+// log-agent-progress.sh呼び出し（Bash実行）と構造的に矛盾するため、agent-progress側の
+// 期待件数（countProgressLoggable）からは除外する。loop-observability側（countLoggable）は
+// 実測でSpec Checkが記録できていることを確認済みのため対象外にしない（issue #509参照）。
 log(`Spec Check完了: status=${specCheck?.status ?? 'なし'}, actualPath=${specCheck?.actualPath ?? 'なし'}`)
 
 // issue #399: Workflowツール側の非対称バグにより、最初のagent()呼び出し（Spec Check）だけが


### PR DESCRIPTION
Closes #509

## 作業サマリ
- 変更した目的: issue #509。issue #493のフロー実行後のgap checkで、agent-progressが常に+1ズレ、loop-observabilityが5件不足するという2種類の記録漏れを検知していた。issue本文で原因が既に特定されていたため、その修正方針に従った。
- 変更した範囲:
  - `.claude/workflows/aidd-phase2.js`: Spec Checkの`countProgressLoggable('reviewer')`呼び出しを削除。Spec Checkのプロンプトが「それ以外は何もしないでください」と明示しており、log-agent-progress.sh呼び出し（Bash実行）と構造的に矛盾するため、期待件数の算出から除外した。loop-observability側（`countLoggable`）は実測で記録できていることが確認されているため、そちらは対象外にしなかった（issue本文の診断どおり）。
  - `.claude/agents/implementer.md`: 「実装セットの進め方」ステップ4/5（テスト実行直後）にのみ記録がトリガーされる設計のため、担当範囲に実装が不要と判断してテストを1つも実行せず`pass`のみ返すケースでは`log-loop-observability.sh`が一度も呼ばれなかった。この場合も1件記録する指示を追加した。
- 触っていない範囲: Manifest Check・Review phase等、他のreviewer/implementer呼び出しは無変更（Spec Checkの1箇所のみが構造的に矛盾していたため）。`model:`/`effort:`のfrontmatterは変更していないため、agent baseline freshness checkの対象外（確認済み）。

## 検証済み
- 実行したコマンド: `npm test`（全166ファイル・1264テストgreen）、`npm run lint`（0 errors）。
- 確認した画面: 該当なし（ワークフロー定義・エージェント定義ファイルのみの変更）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/RLS等のプロダクトコードは一切変更していない）。
- `npm run eval:workflows`は対象外と判断: `implementer.md`は`.claude/workflows/*.js`ではなくエージェント定義ファイルであり、common.mdのeval義務化ルール（`.claude/workflows/*.js`のプロンプト文言変更が対象）には該当しない。また修正内容が「Bash呼び出しの有無」という副作用の検証であり、既存のeval harness（status/detailのJSON schemaのみ判定）では検証できない種類の変更のため、ライブ検証は次回実際のAIDDフロー実行時のgap check結果で確認する方針とした。

## 既知の未対応
- 今回あえて対応しなかったこと: 修正の実効性を実際のAIDDフロー実行で確認すること。
- 理由: 数十エージェント規模のフルフロー実行が必要でコストが高いため、次回実際にaidd-phase2.jsを実行する機会に、gap checkの結果（agent-progress/loop-observabilityの実測ズレ）で確認する。
- 次に触るなら見る場所: issue #509本文が触れている「恒久対応（issue #423のsubagent-skeleton機械記録層への一本化、gap check群自体の廃止検討）」は今回のスコープ外。

## 後任AIへの注意
- この実装で壊してはいけない前提: `countProgressLoggable('reviewer')`はManifest Check・Review phaseの呼び出しでは引き続き必要（Spec Check呼び出しのみが例外）。他のreviewer呼び出しから誤って削除しないこと。
- 似ているが別物の用語: `countLoggable`（loop-observability期待件数）と`countProgressLoggable`（agent-progress期待件数）は別カウンタ。Spec Checkは前者は対象、後者は対象外という非対称な扱いになっている。

## 関連
- issue #509
- issue #493（発見の経緯となったフロー実行）
- issue #18（agent-progress記録の可視化本体）・issue #488（loop-observability gap checkの自動実行）

Generated with Claude Code
