### PR TITLE
fix: worktree作成時の.env.local欠落を恒久対応

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -101,6 +101,9 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
     FETCH_HEADの更新時刻が既定24時間（`LOCAL_MAIN_STALE_HOURS`で変更可）より古いか、`git rev-list --count main..origin/main`が1以上（ローカルmainがorigin/mainより遅れている）のいずれかに該当すると、セッション開始時に警告メッセージを出す（block不可・warningのみ、fetch自体はhook内で実行しないためネットワークアクセス無し・オフラインでも動作する）。
     worktree環境では`.git`がファイルでありFETCH_HEADの実体がworktree固有パスにあるため、`git rev-parse --git-path FETCH_HEAD`で実パスを解決している（`.git/FETCH_HEAD`と決め打ちすると存在しないパスを見て誤判定する）。
     **これは近似判定であり、実際にリモートで何が起きているかまでは見ていない**（前回fetch時点の情報を基準にするため、fetch直後に他者がpushした場合は検知できない）。
+- **新しいworktreeを手動で作る場合は`git worktree add`を直接叩かず`scripts/create-worktree.sh <branch-name> [base-branch]`を使う**（issue発生源: supabase-env-config-325893セッション）。
+  `git worktree`はgit管理外ファイル（`.env.local`・`.env.test`等、`.gitignore`対象）を新規worktreeへ引き継がないため、素の`git worktree add`だけで作ると`NEXT_PUBLIC_SUPABASE_URL`等が欠落しRuntime Errorになる。このスクリプトは`git fetch origin main`→`origin/main`起点でのbranch作成（上記ルール）と`.env.local`/`.env.test`の自動コピーをまとめて行う。
+  **既知の限界**: Claude Code本体のEnterWorktreeツール経由でworktreeを作った場合はこのスクリプトを経由しないため、同じ欠落が起きうる（ツール内部の挙動でありこのリポジトリ側からは制御できない）。その場合は引き続き手動で`.env.local`/`.env.test`をコピーする必要がある
 
 ## loop-observabilityログの記録漏れ検知
 
@@ -274,6 +277,7 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 | `src/components/` | UI コンポーネント |
 | `src/lib/supabase/` | Supabase クライアント・データ取得層 |
 | `supabase/migrations/` | DBマイグレーション |
+| `scripts/create-worktree.sh` | worktree作成 + `.env.local`/`.env.test`自動コピー（「ブランチ運用ルール」参照） |
 | [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |
 | `scripts/log-agent-progress.sh` / `scripts/show-agent-status.sh` | サブエージェント進捗の記録・一覧表示（issue #18） |
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# WHY: git worktreeはgit管理外ファイル（.env.local等）を新規worktreeへ引き継がないため、
+# 新しいworktreeを作るたびにSupabase接続情報が欠落しRuntime Errorになっていた(issue発生源:
+# supabase-env-config-325893セッション)。worktree作成をこのスクリプト経由に一本化し、
+# .env.local/.env.testの手動コピー漏れを構造的に防ぐ。
+# あわせてdocs/agents/common.md「ブランチ運用ルール」(origin/main起点でのbranch作成)も
+# 機械的に強制する。
+#
+# Usage: scripts/create-worktree.sh <branch-name> [base-branch]
+#   branch-name: 例 claude/my-feature。既存ローカルブランチがあればそれを使う、無ければ
+#                base-branchから新規作成する
+#   base-branch: 省略時 origin/main
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <branch-name> [base-branch]" >&2
+  exit 1
+fi
+
+BRANCH_NAME="$1"
+BASE_BRANCH="${2:-origin/main}"
+WORKTREE_BASENAME="${BRANCH_NAME##*/}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="$REPO_ROOT/.claude/worktrees/$WORKTREE_BASENAME"
+
+if [ -e "$WORKTREE_DIR" ]; then
+  echo "Error: $WORKTREE_DIR は既に存在します" >&2
+  exit 1
+fi
+
+echo "Fetching origin/main..."
+git fetch origin main
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  echo "既存ローカルブランチ $BRANCH_NAME を使用します"
+  git worktree add "$WORKTREE_DIR" "$BRANCH_NAME"
+else
+  echo "$BASE_BRANCH から新規ブランチ $BRANCH_NAME を作成します"
+  git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" "$BASE_BRANCH"
+fi
+
+for f in .env.local .env.test; do
+  if [ -f "$REPO_ROOT/$f" ]; then
+    cp "$REPO_ROOT/$f" "$WORKTREE_DIR/$f"
+    echo "Copied $f -> $WORKTREE_DIR/$f"
+  else
+    echo "Warning: $REPO_ROOT/$f が見つからないためコピーをスキップしました" >&2
+  fi
+done
+
+echo "Worktree ready: $WORKTREE_DIR (branch: $BRANCH_NAME)"

--- a/scripts/create-worktree.test.sh
+++ b/scripts/create-worktree.test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# WHY: create-worktree.shの回帰テスト。git worktree自体の実動作を検証したいため、
+# 他の*.test.shのようなフェイクgit注入ではなく、一時ディレクトリに実物のgitリポジトリ
+# (bare origin + working copy)を作って統合的に検証する。
+#
+# 実行: bash scripts/create-worktree.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/create-worktree.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+assert_file_exists() {
+  local path="$1" label="$2"
+  if [ -f "$path" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (not found: $path)"
+    fail=1
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ORIGIN="$TMP/origin.git"
+WORK="$TMP/work"
+
+git init --bare -q "$ORIGIN"
+
+git init -q "$WORK"
+git -C "$WORK" config user.email "test@example.com"
+git -C "$WORK" config user.name "Test"
+git -C "$WORK" checkout -q -b main
+echo "readme" > "$WORK/README.md"
+git -C "$WORK" add README.md
+git -C "$WORK" commit -q -m "init"
+git -C "$WORK" remote add origin "$ORIGIN"
+git -C "$WORK" push -q -u origin main
+
+# git管理外ファイル(.env.local相当)。worktree作成後にコピーされることを検証する対象
+echo "NEXT_PUBLIC_SUPABASE_URL=dummy" > "$WORK/.env.local"
+echo "NEXT_PUBLIC_SUPABASE_URL=dummy-test" > "$WORK/.env.test"
+
+run_script() {
+  set +e
+  OUT="$(cd "$WORK" && "$SCRIPT" "$@" 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: 新規ブランチ作成 + .env.local/.env.testが自動コピーされる ==="
+run_script "feature/new-thing"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "Worktree ready" "完了メッセージが出る"
+assert_file_exists "$WORK/.claude/worktrees/new-thing/.env.local" ".env.localがworktreeにコピーされている"
+assert_file_exists "$WORK/.claude/worktrees/new-thing/.env.test" ".env.testがworktreeにコピーされている"
+assert_eq "$(git -C "$WORK" branch --list "feature/new-thing" | tr -d ' *+')" "feature/new-thing" "新規ブランチが作成されている"
+
+echo "=== scenario 2: 既存ローカルブランチを指定 → 新規作成せずそのまま使う ==="
+git -C "$WORK" branch existing-branch main
+run_script "existing-branch"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "既存ローカルブランチ" "既存ブランチ使用メッセージが出る"
+assert_file_exists "$WORK/.claude/worktrees/existing-branch/.env.local" ".env.localがコピーされている"
+
+echo "=== scenario 3: 既に同名worktreeディレクトリがある → エラーで停止 ==="
+run_script "feature/new-thing"
+assert_eq "$EXIT_CODE" "1" "exit 1"
+assert_contains "$OUT" "既に存在します" "重複エラーメッセージが出る"
+
+echo "=== scenario 4: .env.local/.env.testが無い環境 → 警告のみでworktree作成自体は成功 ==="
+rm "$WORK/.env.local" "$WORK/.env.test"
+run_script "feature/no-env"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "見つからないためコピーをスキップ" "警告メッセージが出る"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- 新規worktreeで`npm run dev`するとSupabaseクライアント初期化が失敗する（`NEXT_PUBLIC_SUPABASE_URL`等が未定義）Runtime Errorが発生していた
- 原因: `git worktree`はgit管理外ファイル（`.env.local`/`.env.test`、`.gitignore`対象）を新規worktreeへコピーしない仕様
- `scripts/create-worktree.sh`を追加し、`git fetch origin main`→`origin/main`起点でのbranch作成（既存の「ブランチ運用ルール」準拠）と`.env.local`/`.env.test`の自動コピーを一本化した
- `docs/agents/common.md`の「ブランチ運用ルール」に追記し、既知の限界（EnterWorktreeツール経由の場合はこのスクリプトを通らない）も明記した

## 作業サマリ
- 変更した目的: worktreeごとの`.env.local`手動コピー漏れによるRuntime Errorを構造的に防ぐ
- 変更した範囲: `scripts/create-worktree.sh`（新規）、`scripts/create-worktree.test.sh`（新規）、`docs/agents/common.md`（ルール追記）
- 触っていない範囲: アプリケーションコード（`src/`配下）・DBスキーマ・RLS

## 検証済み
- 実行したコマンド: `bash scripts/create-worktree.test.sh`（全4シナリオPASS。一時gitリポジトリ上で新規ブランチ作成/既存ブランチ使用/重複エラー/.env欠如時の警告を検証）
- 確認した画面: 本件はスクリプト・ドキュメントのみの変更のためUI確認は対象外。ただし発端となったRuntime Errorは、対象worktreeに`.env.local`を手動配置後、devサーバー再起動でログインページが正常表示されることを確認済み
- 確認したDB/RLS: 対象外
- 他テナントIDアクセス確認: 対象外（auth/facility/RLS等には触れていない）

## Test plan
- [x] `bash scripts/create-worktree.test.sh` が全PASSすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)