### PR TITLE
feat: DBスキーマ変更ルールをpath-scoped ruleとして.claude/rules/へ切り出す(issue #445)

### DIFF
--- a/.claude/rules/db-schema.md
+++ b/.claude/rules/db-schema.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "supabase/migrations/**"
+---
+
+# DBスキーマ変更ルール
+
+- **DBスキーマ変更は必ず `supabase/migrations/` 配下のマイグレーションファイル経由で行う。**
+  `execute_sql` 等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）。
+  `supabase db execute`・`psql`直接実行、およびMCP経由のexecute_sql系ツール呼び出しは
+  PreToolUse hook（`scripts/check-direct-ddl-execution.sh`、issue #444）で機械的にdenyされる
+  （`db push`/`db reset`等の正規のmigration適用手段は対象外）
+- マイグレーション外で本番/リモートDBに存在するスキーマ変更（トリガー・関数等）を発見した場合は、
+  差分をキャッチアップ用マイグレーションとして必ず記録してから作業を進める
+- 理由（過去のスキーマドリフト事例）は [`../../docs/agents/decisions/db-rls.md`](../../docs/agents/decisions/db-rls.md#なぜdbスキーマ変更をmigrationファイル経由に限定し直接ddl実行を禁止したか) を参照
+- **publicスキーマのテーブルを追加/削除するmigrationは、末尾で`SELECT refresh_schema_baseline_snapshot('<そのmigrationのタイムスタンプ>');`を呼ぶ**（issue #305のスキーマドリフト検知が使うbaselineスナップショットを更新するため）。
+  呼ばないと、正規のPRレビュー済み変更であっても`table_added`/`table_removed`ドリフトとして恒久的に誤検知され続け、対応するGitHub Issueが自動クローズされなくなる

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -75,16 +75,7 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
 
 ## DBスキーマ変更ルール
 
-- **DBスキーマ変更は必ず `supabase/migrations/` 配下のマイグレーションファイル経由で行う。**
-  `execute_sql` 等による直接実行・直接DDL適用は禁止（ローカル・リモート問わず）。
-  `supabase db execute`・`psql`直接実行、およびMCP経由のexecute_sql系ツール呼び出しは
-  PreToolUse hook（`scripts/check-direct-ddl-execution.sh`、issue #444）で機械的にdenyされる
-  （`db push`/`db reset`等の正規のmigration適用手段は対象外）
-- マイグレーション外で本番/リモートDBに存在するスキーマ変更（トリガー・関数等）を発見した場合は、
-  差分をキャッチアップ用マイグレーションとして必ず記録してから作業を進める
-- 理由（過去のスキーマドリフト事例）は [`decisions/db-rls.md`](./decisions/db-rls.md#なぜdbスキーマ変更をmigrationファイル経由に限定し直接ddl実行を禁止したか) を参照
-- **publicスキーマのテーブルを追加/削除するmigrationは、末尾で`SELECT refresh_schema_baseline_snapshot('<そのmigrationのタイムスタンプ>');`を呼ぶ**（issue #305のスキーマドリフト検知が使うbaselineスナップショットを更新するため）。
-  呼ばないと、正規のPRレビュー済み変更であっても`table_added`/`table_removed`ドリフトとして恒久的に誤検知され続け、対応するGitHub Issueが自動クローズされなくなる
+`supabase/migrations/`配下のファイルをRead/Editする際にのみ [`.claude/rules/db-schema.md`](../../.claude/rules/db-schema.md) が自動ロードされる（issue #445。path-scoped rules化により、DB作業をしないセッションでは常時のコンテキストコストを払わない）。
 
 ## ブランチ運用ルール
 


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: `docs/agents/common.md`は`@include`で毎セッション全量がロードされ、DB作業をしないセッションでも固定コンテキストコストを払っていた。issue #445の設計案①②に従い、DBスキーマ変更ルールをpath-scoped ruleとして切り出しコンテキストコストを削減する
- 変更した範囲: `.claude/rules/db-schema.md`を新規作成（`paths: supabase/migrations/**`）。`docs/agents/common.md`の該当セクションを短いポインタに置き換え
- 触っていない範囲: e2e/**・eval関連の切り出し（issue本文に「1ルールずつ」の方針があるため別コミットで対応予定）。`scripts/check-direct-ddl-execution.sh`等の機械強制フック本体（このPRでは触れていない。ルールのプロセス移動のみで機械強制は元々hook側にある）

## 検証済み
- 実行したコマンド: `npm test`(166ファイル/1264件 全green)
- 確認した画面: なし
- 確認したDB/RLS: 該当なし（DBスキーマ自体は変更していない。ルール文書の置き場所変更のみ）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし

## 実装前ゲート確認（issue本文の必須条件）
公式ドキュメント（code.claude.com/docs/en/memory・context-window）で`paths:`フロントマター仕様とcompaction時の挙動を確認済み（詳細はissue #445のコメント参照）。設計案③「Compact Instructions追加」は存在しない機能を前提にしていたため、issue本文・コメントで訂正済み（本PRのスコープからは除外）。

## 既知の未対応
- 今回あえて対応しなかったこと: `paths:`フロントマターが実際にこの環境でロード（lazy-load）されるかどうかの実機確認
- 理由: 非対話セッション内では、path-scoped ruleがロードされたことを示す通知を観測する手段がなかった。外部のGitHub issue（anthropics/claude-code#17204）で「`paths:`がサイレント失敗し`globs:`のみ効く」という報告があり、当時のバージョンのバグだった可能性がある（公式ドキュメントにはv2.1.198/v2.1.207/v2.1.217での`paths`関連修正履歴が明記されており、その後修正済みと見られるが未確認）
- 次に触るなら見る場所: マージ後、対話セッションで`supabase/migrations/`配下のファイルをRead → `/context`を実行し、「Memory files」欄に`db-schema.md`が表示されるか確認する。表示されなければ`paths:`を`globs:`に変更する必要がある

## 後任AIへの注意
- この実装で壊してはいけない前提: `scripts/check-direct-ddl-execution.sh`によるDB直接実行のPreToolUse denyは、このPRの変更と無関係に既に有効（ルール文書の移動は機械強制のhookに一切影響しない）
- 似ているが別物の用語: 「`.claude/rules/`のpath-scoped rule」（本PRで導入。読み込み時のみロード）と「CLAUDE.mdのimport（`@path`構文）」（起動時に必ずロード）は別の仕組み
- 勝手にリファクタしない場所: 停止①②・TRI/RISK判定等の「絶対ルール」はcompaction後も生き残る必要があるため、path-scoped rule化せずCLAUDE.md/common.md本体に残すこと（issue #445の設計方針）