### PR TITLE
feat: テスト衛生ルール・eval実行義務をpath-scoped ruleへ切り出す(issue #445)

### DIFF
--- a/.claude/rules/e2e-test-hygiene.md
+++ b/.claude/rules/e2e-test-hygiene.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "e2e/**"
+---
+
+# テスト環境・データ衛生ルール
+
+- **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。
+  `NODE_ENV=test` のため `.env.local`（本番）は読み込まれず、さらに `e2e/env-guard.ts` が
+  許可ホスト以外（＝本番URL・本番service role実行）を**即失敗**させる
+- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/e2e.yml`）。
+  BSG（ローカルゲート）ではチェックしない方針
+- **seed・スクリーンショット・E2E失敗ログ・issue添付に実在施設名・実データを入れない。**
+  施設名・ユーザー名・在庫品目などはすべてダミー（例: `テスト施設A`、`e2e-test-user@example.com`）を使う

--- a/.claude/rules/workflow-eval-requirement.md
+++ b/.claude/rules/workflow-eval-requirement.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - ".claude/workflows/**"
+---
+
+# AIDDワークフロープロンプトのeval実行義務（issue #496）
+
+`.claude/workflows/*.js` のプロンプト文言を変更したPRでは、マージ前に `npm run eval:workflows <対応するfixtureセット>`
+（sweep系のプロンプト変更は `scripts/eval-sweep-recall.sh <layer>`）を実行し、結果を引き継ぎメモの
+「検証済み」欄へ記載すること（未実施の場合はその旨と理由を明記する）。実行完了時に
+`docs/agents/eval-runs.jsonl` へ自動記録され、未更新のPRは `.github/workflows/eval-runs-freshness-check.yml` が警告する。
+
+詳細・経緯は [`../../docs/agents/observability-internals.md`](../../docs/agents/observability-internals.md#aiddワークフロープロンプトのevalissue-391) を参照。

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -65,13 +65,7 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
 
 ## テスト環境・データ衛生ルール
 
-- **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。
-  `NODE_ENV=test` のため `.env.local`（本番）は読み込まれず、さらに `e2e/env-guard.ts` が
-  許可ホスト以外（＝本番URL・本番service role実行）を**即失敗**させる
-- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/e2e.yml`）。
-  BSG（ローカルゲート）ではチェックしない方針
-- **seed・スクリーンショット・E2E失敗ログ・issue添付に実在施設名・実データを入れない。**
-  施設名・ユーザー名・在庫品目などはすべてダミー（例: `テスト施設A`、`e2e-test-user@example.com`）を使う
+`e2e/`配下のファイルをRead/Editする際にのみ [`.claude/rules/e2e-test-hygiene.md`](../../.claude/rules/e2e-test-hygiene.md) が自動ロードされる（issue #445）。
 
 ## DBスキーマ変更ルール
 
@@ -150,7 +144,7 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 - agents設定変更時のbaselineスナップショット機械強制（issue #429）
 - Find→Adversarial Verify precision記録（issue #432）
 - Sweep recallベンチマーク（issue #431）
-- AIDDワークフロープロンプトのeval（issue #391）— **運用ルール（義務化、issue #496）だけは下記に残す**: `.claude/workflows/*.js` のプロンプト文言を変更したPRでは、マージ前に `npm run eval:workflows <対応するfixtureセット>`（sweep系のプロンプト変更は `scripts/eval-sweep-recall.sh <layer>`）を実行し、結果を引き継ぎメモの「検証済み」欄へ記載すること（未実施の場合はその旨と理由を明記する）。実行完了時に `docs/agents/eval-runs.jsonl` へ自動記録され、未更新のPRは `.github/workflows/eval-runs-freshness-check.yml` が警告する。
+- AIDDワークフロープロンプトのeval（issue #391）— 運用ルール（義務化、issue #496）は`.claude/workflows/`配下のファイルをRead/Editする際に [`.claude/rules/workflow-eval-requirement.md`](../../.claude/rules/workflow-eval-requirement.md) として自動ロードされる（issue #445）
 
 ## ツール・機能導入可否の判断記録への参照
 


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: issue #445の残り2件のルール切り出し。PR #539(DBスキーマ変更ルール)に続き、テスト衛生ルールとeval実行義務ルールをpath-scoped rule化しコンテキストコストを削減する
- 変更した範囲: `.claude/rules/e2e-test-hygiene.md`(新規、`paths: e2e/**`)、`.claude/rules/workflow-eval-requirement.md`(新規、`paths: .claude/workflows/**`)を作成。`docs/agents/common.md`の該当2箇所を短いポインタに置き換え
- 触っていない範囲: `.claude/security-patterns.json`の`possible_real_facility_name`パターン(common.mdの見出し自体は残しているため参照は引き続き有効、変更不要と判断)

## 検証済み
- 実行したコマンド: `npm test`(166ファイル/1264件 全green)
- 確認した画面: なし
- 確認したDB/RLS: 該当なし(ルール文書の置き場所変更のみ、DBスキーマ自体は無変更)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし

## issue本文からの意図的な逸脱
eval関連ルール(issue #496の運用ルール)のpath scopeを、issue本文が候補としていた`scripts/eval-fixtures/**`ではなく`.claude/workflows/**`にした。実際のルール本文を確認したところ発火条件は「`.claude/workflows/*.js`のプロンプト文言を変更した場合」であり、fixtureファイルを読むタイミングではなく`.claude/workflows/`配下を読み書きするタイミングでこそ必要なリマインダーだったため、候補パスをそのまま採用せず実際の発火条件に合わせて変更した。

## 既知の未対応
- 今回あえて対応しなかったこと: `paths:`フロントマターが実際にこの環境でロードされるかどうかの実機確認(PR #539と同様の既知の限界)。/doctor実行(issue #445設計案④)
- 理由: 非対話セッション内では実機確認ができない。/doctorは対話コマンドのためユーザー側での実施が必要
- 次に触るなら見る場所: PR #539のコメント参照。マージ後、対話セッションで`e2e/`または`.claude/workflows/`配下のファイルをRead → `/context`で「Memory files」欄を確認する

## 後任AIへの注意
- この実装で壊してはいけない前提: `.claude/security-patterns.json`の`possible_real_facility_name`パターンが参照する「テスト環境・データ衛生ルール」見出しはcommon.mdに残したまま(中身だけポインタに置換)。見出し自体を消さないこと
- 似ているが別物の用語: issue本文の「候補パス」と実際に採用したpathは一致しない箇所がある(eval関連、上記参照)。issue本文を鵜呑みにせず実際のルール内容の発火条件を優先すること
- 勝手にリファクタしない場所: これでissue #445のルール切り出し(DB/e2e/eval)は完了。残るのは/doctor実行のみで、issueはまだクローズしないこと