### PR TITLE
feat: logs/の書き込み先をworktree横断で単一ディレクトリへ集約する(issue #546)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -210,6 +210,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | `scripts/create-worktree.sh` | worktree作成 + `.env.local`/`.env.test`自動コピー（「ブランチ運用ルール」参照） |
 | [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |
 | `scripts/log-agent-progress.sh` / `scripts/show-agent-status.sh` | サブエージェント進捗の記録・一覧表示（issue #18） |
+| `scripts/lib/resolve-log-dir.sh` | `logs/`の書き込み先をworktree横断で単一のディレクトリ（メインworktree直下）に解決する。全`log-*.sh`/`check-*.sh`/`summarize-*.sh`が参照する（issue #546。従来は各worktreeが起動時のカレントディレクトリ相対で別々の`logs/`に書き込み、観測記録の約半数が死蔵していた） |
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |
 | `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
 | `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |

--- a/scripts/check-agent-progress-gap.sh
+++ b/scripts/check-agent-progress-gap.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/agent-progress.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/agent-progress.jsonl"
 BEFORE_COUNT=""
 EXPECTED_COUNT=""
 
@@ -32,6 +35,5 @@ else
 fi
 
 ACTUAL_COUNT=$(( AFTER_COUNT - BEFORE_COUNT ))
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 npx -y tsx "$SCRIPT_DIR/../.claude/workflows/lib/agent-progress-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"

--- a/scripts/check-loop-observability-gap.sh
+++ b/scripts/check-loop-observability-gap.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/loop-observability.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
 BEFORE_COUNT=""
 EXPECTED_COUNT=""
 
@@ -32,6 +35,5 @@ else
 fi
 
 ACTUAL_COUNT=$(( AFTER_COUNT - BEFORE_COUNT ))
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 npx -y tsx "$SCRIPT_DIR/../.claude/workflows/lib/loop-observability-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"

--- a/scripts/gate-effectiveness-monthly-check.sh
+++ b/scripts/gate-effectiveness-monthly-check.sh
@@ -12,9 +12,11 @@ set -euo pipefail
 # logs/loop-observability.jsonlに記録されないため、この集計には現れない
 # （scripts/log-loop-observability.shの--resultはpass|failのみ受け付ける。issue #412コメント参照）。
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+cd "$SCRIPT_DIR/.."
 
-LOG_FILE="logs/loop-observability.jsonl"
+LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
 if [ ! -f "$LOG_FILE" ]; then
   echo '{"systemMessage": ""}'
   exit 0

--- a/scripts/gate-effectiveness-monthly-check.test.sh
+++ b/scripts/gate-effectiveness-monthly-check.test.sh
@@ -43,9 +43,10 @@ assert_file_exists() {
 
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
-mkdir -p "$SANDBOX/scripts" "$SANDBOX/logs" "$SANDBOX/.claude"
+mkdir -p "$SANDBOX/scripts/lib" "$SANDBOX/logs" "$SANDBOX/.claude"
 cp "$SCRIPT_DIR/gate-effectiveness-monthly-check.sh" "$SANDBOX/scripts/"
 cp "$SCRIPT_DIR/summarize-loop-observability.sh" "$SANDBOX/scripts/"
+cp "$SCRIPT_DIR/lib/resolve-log-dir.sh" "$SANDBOX/scripts/lib/"
 
 STATE_FILE="$SANDBOX/.claude/.gate-effectiveness-state/last-summary-at"
 LOG_FILE="$SANDBOX/logs/loop-observability.jsonl"

--- a/scripts/lib/resolve-log-dir.sh
+++ b/scripts/lib/resolve-log-dir.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 全worktreeで共有される logs/ ディレクトリの絶対パスを解決する（issue #546）。
+#
+# 背景: git worktreeは`.git`は共有するが、`logs/`は各scripts/log-*.sh・check-*.sh・
+# summarize-*.shが自身の起動時カレントディレクトリ相対（"logs/xxx.jsonl"）で作るため、
+# worktreeごとに別々の logs/ へ書き込んでいた。2026-07-26のOpus設計評価（issue #546の元）で
+# 実測したところ、観測記録全319件中156件（49%）が6つのworktreeに死蔵しており、
+# 新しいworktreeでは月次サマリ（gate-effectiveness-monthly-check.sh）が恒久的に無言になる
+# 事象も確認された。
+#
+# `git rev-parse --git-common-dir` は同一リポジトリの全worktreeで共通の.gitディレクトリ
+# （メインworktree側の実体）を指すため、その親ディレクトリをlogs/の基準にする。
+# gitリポジトリでない場合（*.test.shのサンドボックス等）は、従来どおり呼び出し側の
+# カレントディレクトリ相対の"logs"にフォールバックする（挙動を変えない）。
+#
+# 使い方: sourceしてから resolve_log_dir を呼ぶ（末尾スラッシュ無しのディレクトリパスを
+# 1行返す。存在しなくてもよい。ディレクトリの作成は呼び出し側の責務のまま）。
+#   source ".../lib/resolve-log-dir.sh"
+#   LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
+#
+# AIDD_LOG_DIR環境変数が設定されている場合は、git解決より優先してそれを返す
+# （テスト・手動検証での明示的な差し替え用）。
+
+resolve_log_dir() {
+  if [[ -n "${AIDD_LOG_DIR:-}" ]]; then
+    echo "$AIDD_LOG_DIR"
+    return 0
+  fi
+
+  local common_git_dir
+  if common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+    echo "$(dirname "$common_git_dir")/logs"
+    return 0
+  fi
+
+  echo "logs"
+}

--- a/scripts/lib/resolve-log-dir.test.sh
+++ b/scripts/lib/resolve-log-dir.test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# WHY: scripts/lib/resolve-log-dir.sh（logs/集約、issue #546）の回帰テスト。
+# 実物のgit worktree構成を一時ディレクトリに作って決定的に検証する。
+#
+# 実行: bash scripts/lib/resolve-log-dir.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/resolve-log-dir.sh"
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+echo "=== scenario 1: AIDD_LOG_DIR環境変数が最優先される ==="
+OUT="$(cd "$SANDBOX" && AIDD_LOG_DIR="/tmp/explicit-override" bash -c "source '$LIB'; resolve_log_dir")"
+assert_eq "$OUT" "/tmp/explicit-override" "環境変数の値をそのまま返す"
+
+echo "=== scenario 2: gitリポジトリでない場合は相対'logs'にフォールバックする ==="
+NON_GIT_DIR="$SANDBOX/plain"
+mkdir -p "$NON_GIT_DIR"
+OUT="$(cd "$NON_GIT_DIR" && bash -c "source '$LIB'; resolve_log_dir")"
+assert_eq "$OUT" "logs" "gitでない環境では従来どおり相対'logs'を返す"
+
+echo "=== scenario 3: メインworktreeとlinked worktreeが同じlogsディレクトリに解決される ==="
+REPO="$SANDBOX/main-repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "test"
+echo "placeholder" > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -q -m "init"
+
+WORKTREE="$SANDBOX/linked-worktree"
+git -C "$REPO" worktree add -q -b feature-branch "$WORKTREE" >/dev/null 2>&1
+
+FROM_MAIN="$(cd "$REPO" && bash -c "source '$LIB'; resolve_log_dir")"
+FROM_WORKTREE="$(cd "$WORKTREE" && bash -c "source '$LIB'; resolve_log_dir")"
+REPO_PHYSICAL="$(cd "$REPO" && pwd -P)"
+assert_eq "$FROM_MAIN" "$REPO_PHYSICAL/logs" "メインworktreeではリポジトリ直下のlogsに解決される"
+assert_eq "$FROM_WORKTREE" "$FROM_MAIN" "linked worktreeもメインworktreeと同じlogsディレクトリに解決される"
+
+echo "=== scenario 4: linked worktreeのサブディレクトリからでも同じ結果になる ==="
+mkdir -p "$WORKTREE/scripts/nested"
+FROM_NESTED="$(cd "$WORKTREE/scripts/nested" && bash -c "source '$LIB'; resolve_log_dir")"
+assert_eq "$FROM_NESTED" "$FROM_MAIN" "サブディレクトリからでもメインworktree基準のlogsに解決される"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/log-agent-progress.sh
+++ b/scripts/log-agent-progress.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/agent-progress.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/agent-progress.jsonl"
 AGENT=""
 FEATURE=""
 STATUS=""

--- a/scripts/log-find-av-precision.sh
+++ b/scripts/log-find-av-precision.sh
@@ -12,7 +12,10 @@ set -euo pipefail
 # 使い方（fourth-argument経由でJSONを渡す。パイプ・stdinは使わない）:
 #   scripts/log-find-av-precision.sh --feature "<feature名>" '<findAvPrecisionのJSON>'
 
-LOG_FILE="logs/find-av-precision.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/find-av-precision.jsonl"
 FEATURE=""
 
 usage() {

--- a/scripts/log-loop-observability.sh
+++ b/scripts/log-loop-observability.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/loop-observability.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
 LOOP="agentic"
 AGENT=""
 FEATURE=""

--- a/scripts/log-subagent-hook-skeleton.sh
+++ b/scripts/log-subagent-hook-skeleton.sh
@@ -26,7 +26,10 @@ set -euo pipefail
 # grepし、規約行を抽出できた場合のみベストエフォートでintentフィールドに追記する
 # （②feature/attempt層。抽出できなくてもhook自体は失敗させない＝欠落は許容する）。
 
-LOG_FILE="${SUBAGENT_HOOK_SKELETON_LOG_FILE:-logs/subagent-skeleton.jsonl}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="${SUBAGENT_HOOK_SKELETON_LOG_FILE:-$(resolve_log_dir)/subagent-skeleton.jsonl}"
 
 PAYLOAD="$(cat)"
 

--- a/scripts/show-agent-status.sh
+++ b/scripts/show-agent-status.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/agent-progress.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/agent-progress.jsonl"
 STALE_SECONDS=180
 NOW_EPOCH=""
 

--- a/scripts/summarize-find-av-precision.sh
+++ b/scripts/summarize-find-av-precision.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # lens別・feature別に集計する。Find指摘のAdversarial Verify生存率であり、Sweep指摘の
 # precisionではない点に注意（.claude/workflows/lib/find-av-precision.jsのコメント参照）。
 
-LOG_FILE="logs/find-av-precision.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/find-av-precision.jsonl"
 OUT=""
 
 usage() {

--- a/scripts/summarize-loop-observability.sh
+++ b/scripts/summarize-loop-observability.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="logs/loop-observability.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
 OUT=""
 
 usage() {

--- a/scripts/update-loop-observability-usage.sh
+++ b/scripts/update-loop-observability-usage.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_FILE="${1:-logs/loop-observability.jsonl}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="${1:-$(resolve_log_dir)/loop-observability.jsonl}"
 PROJECTS_ROOT="${2:-$HOME/.claude/projects}"
 
-npx -y tsx scripts/lib/aggregate-loop-observability-usage.ts "$LOG_FILE" "$PROJECTS_ROOT"
+npx -y tsx "$SCRIPT_DIR/lib/aggregate-loop-observability-usage.ts" "$LOG_FILE" "$PROJECTS_ROOT"

--- a/scripts/verify-agent-progress-transcript.sh
+++ b/scripts/verify-agent-progress-transcript.sh
@@ -11,9 +11,10 @@ usage() {
 }
 
 ARGS=()
+LOG_FILE_GIVEN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --log-file) ARGS+=(--log-file "$2"); shift 2 ;;
+    --log-file) ARGS+=(--log-file "$2"); LOG_FILE_GIVEN=1; shift 2 ;;
     --project-dir) ARGS+=(--project-dir "$2"); shift 2 ;;
     --json) ARGS+=(--json); shift ;;
     -h|--help) usage ;;
@@ -22,5 +23,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+# issue #546: --log-fileが明示されなかった場合は、TS側のcwd相対デフォルト
+# （'logs/agent-progress.jsonl'）に頼らず、worktree横断で共有されるlogs/を渡す。
+if [[ "$LOG_FILE_GIVEN" -eq 0 ]]; then
+  ARGS=(--log-file "$(resolve_log_dir)/agent-progress.jsonl" "${ARGS[@]}")
+fi
 
 npx -y tsx "$SCRIPT_DIR/lib/verify-agent-progress-transcript.ts" "${ARGS[@]}"

--- a/scripts/verify-claims.sh
+++ b/scripts/verify-claims.sh
@@ -31,7 +31,10 @@ set -euo pipefail
 # 同時に生きている検証プロセス数を機械的に頭打ちにすることで被害を抑える。
 # 設計: docs/superpowers/specs/2026-07-14-verification-subagent-design.md の「サーキットブレーカー」節
 
-REPO_DIR="${VERIFY_CLAIMS_REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+REPO_DIR="${VERIFY_CLAIMS_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 cd "$REPO_DIR"
 
 STATE_DIR="${VERIFY_CLAIMS_STATE_DIR:-.claude/.verify-state}"
@@ -40,7 +43,7 @@ TIMEOUT_SECONDS="${VERIFY_CLAIMS_TIMEOUT_SECONDS:-60}"
 MODEL="${VERIFY_CLAIMS_MODEL:-claude-haiku-4-5-20251001}"
 LOCK_DIR="${VERIFY_CLAIMS_LOCK_DIR:-.claude/.verify-lock}"
 MAX_CONCURRENT="${VERIFY_CLAIMS_MAX_CONCURRENT:-4}"
-OBS_LOG_FILE="${VERIFY_CLAIMS_OBSERVABILITY_LOG:-logs/verify-claims-observability.jsonl}"
+OBS_LOG_FILE="${VERIFY_CLAIMS_OBSERVABILITY_LOG:-$(resolve_log_dir)/verify-claims-observability.jsonl}"
 
 mkdir -p "$STATE_DIR" "$LOCK_DIR"
 


### PR DESCRIPTION
close #546

## 作業サマリ
- 変更した目的: `logs/`（loop-observability・agent-progress・subagent-skeleton・find-av-precision・verify-claims-observability）が各worktreeの起動時カレントディレクトリ相対で書き込まれ、worktreeごとに分散・死蔵していた問題を解消する。2026-07-26のOpus設計評価で実測: 全319件中156件(49%)が6つのworktreeに死蔵、新worktreeでは月次サマリ(`gate-effectiveness-monthly-check.sh`)が恒久的に無言になる事象を確認。
- 変更した範囲: `scripts/lib/resolve-log-dir.sh`（新設。`git rev-parse --git-common-dir`でメインworktree基準のlogs/ディレクトリを解決する共通関数）と、それを呼び出すよう既定値を置き換えた12スクリプト（log-loop-observability.sh / log-agent-progress.sh / log-subagent-hook-skeleton.sh / log-find-av-precision.sh / summarize-loop-observability.sh / summarize-find-av-precision.sh / show-agent-status.sh / gate-effectiveness-monthly-check.sh / check-loop-observability-gap.sh / check-agent-progress-gap.sh / verify-agent-progress-transcript.sh / verify-claims.sh / update-loop-observability-usage.sh）。あわせて`gate-effectiveness-monthly-check.test.sh`のサンドボックスに新規依存ファイルのコピーを追加し、`docs/agents/common.md`の重要ファイル表に1行追記した。
- 触っていない範囲: `logs/`ディレクトリの物理的な統合（既存worktreeに分散済みのログファイル自体のマージ）はissue #557（worktree棚卸し）側のスコープとして残している。specPath存在チェック(#547)・spec-check.jsのendsWithバグ(#548)・sync test追加(#549)・costUsd欠損(#550)・未配線スクリプト(#551)・自己評価ドキュメント陳腐化(#552)以降の他issueには着手していない。ドメイン層(src/)・DB(supabase/migrations/)には一切触れていない。

## 検証済み
- 実行したコマンド: `npm test`（166ファイル・1264テスト全pass、変更前後で件数一致）、`npm run lint`（0エラー、既存の無関係ファイルの警告2件のみ）、`bash scripts/lib/resolve-log-dir.test.sh`（新規、4シナリオ全pass）、`bash scripts/gate-effectiveness-monthly-check.test.sh`（サンドボックス更新後、4シナリオ全pass）、`bash scripts/log-subagent-hook-skeleton.test.sh` / `log-find-av-precision.test.sh` / `show-agent-status.test.sh` / `verify-claims.test.sh`（既存27シナリオ含め全pass）、`npx vitest run scripts/lib/verify-agent-progress-transcript.test.ts`（24件pass）。`npm run ai:check`は未実行（このリポジトリに該当コマンドが存在しないため対象外）。
- 確認した画面: 該当なし（フレームワーク層のスクリプト変更のみ、UIへの影響なし）。
- 確認したDB/RLS: 該当なし（DB/RLSに触れる変更ではない）。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/organization/inventory/RLS/policyのいずれにも触れていない）。
- 実地検証: このworktree（`pr-529-scope-review-4eff3f`）から`scripts/log-agent-progress.sh`を実行し、メインworktree(`/Users/masanori/medical-inventory-vkumai`)側の`logs/agent-progress.jsonl`に書き込まれることを確認した（このworktree自体の`logs/`は更新されなかった）。検証用に追記したレコードはテスト後に削除済み。

## 既知の未対応
- 今回あえて対応しなかったこと: 既存worktree（24個）に既に分散しているログファイル自体のマージ・回収は行っていない。
- 理由: それはissue #557（worktree棚卸し）のスコープであり、本issueは「今後の書き込み先を一本化する」ことに閉じた。既存データのマージは`jq -s`等で機械的にできるが、レコードの重複除去方針（同一timestampの扱い等）は別途検討が要るため分離した。
- 次に触るなら見る場所: `scripts/lib/resolve-log-dir.sh`のフォールバック（gitでない場合は相対"logs"）。CI環境やテストサンドボックスなど、意図せずgit外で実行されるケースが増えた場合はこのフォールバックが再びworktree/CWD依存の分散を生む可能性がある。

## 後任AIへの注意
- この実装で壊してはいけない前提: `resolve_log_dir`は「AIDD_LOG_DIR環境変数 > git共通ディレクトリ基準 > 相対'logs'」の優先順位。既存の`--log-file`引数・各スクリプト固有の環境変数（`VERIFY_CLAIMS_OBSERVABILITY_LOG`・`SUBAGENT_HOOK_SKELETON_LOG_FILE`）は変更しておらず、これらは`resolve_log_dir`の結果より優先される。この優先順位を崩すと、既存の`*.test.sh`が明示的に`--log-file`/環境変数で上書きしている前提が壊れる。
- 似ているが別物の用語: 「logs/の集約」（本PR、書き込み先の一本化）と「observability記録漏れ検知」（`check-*-gap.sh`、記録件数の突合）は別レイヤー。本PRは後者の検知ロジック自体には触れていない。
- 勝手にリファクタしない場所: 各スクリプトの`SCRIPT_DIR`定義位置。`gate-effectiveness-monthly-check.sh`と`verify-claims.sh`は`cd`前にsourceする必要があるため、他のスクリプト（cdしないもの）とわずかにパターンが異なる。統一しようとして`cd`前後の順序を変えると、`$0`相対のsource解決が壊れる。