### PR TITLE
fix: Spec Checkの経路一致ガードがファイル名の部分一致ですり抜けるバグを修正(issue #548)

### DIFF
--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -182,11 +182,18 @@ log(`Spec Check完了: status=${specCheck?.status ?? 'なし'}, actualPath=${spe
 // 根本原因はWorkflowツール側にある可能性が高く本スクリプトでは修正できないため、当面の防御として
 // 「実際にReadした絶対パス」を自己申告させ、指定specPathとの文字列一致をここで機械検証する。
 // 判定ロジックの正本・テストは .claude/workflows/lib/spec-check.js の isSpecCheckPathMismatch。
-// Workflow DSLはrequire不可のためインライン複製している（プロンプト文言を変更した場合は
+// Workflow DSLはrequire不可のためインライン複製している（判定ロジックを変更した場合は
 // spec-check.js側も手動で追従させること。自動では同期されない）。
-const specCheckPathMismatch = specCheck?.status === 'pass'
-  && typeof specCheck?.actualPath === 'string'
-  && !specCheck.actualPath.endsWith(specPath)
+// issue #548: 単純なendsWithだと'DRAFT-SPEC.md'.endsWith('SPEC.md')のようなファイル名の部分
+// 一致まで「一致」と誤判定するため、一致箇所の直前がパス区切り('/')であることまで確認する。
+let specCheckPathMismatch = false
+if (specCheck?.status === 'pass' && typeof specCheck?.actualPath === 'string') {
+  const actualPath = specCheck.actualPath
+  if (actualPath !== specPath) {
+    specCheckPathMismatch = !actualPath.endsWith(specPath)
+      || actualPath.charAt(actualPath.length - specPath.length - 1) !== '/'
+  }
+}
 
 if (specCheckPathMismatch) {
   log(`品質ゲート: Spec Checkが指定specPath(${specPath})ではなく別ファイル(${specCheck.actualPath})を読んだため中断（issue #399）`)

--- a/.claude/workflows/lib/__tests__/spec-check.test.js
+++ b/.claude/workflows/lib/__tests__/spec-check.test.js
@@ -34,4 +34,31 @@ describe('isSpecCheckPathMismatch', () => {
     const specCheck = { status: 'pass', detail: 'ok' }
     expect(isSpecCheckPathMismatch(specCheck, 'SPEC.md')).toBe(false)
   })
+
+  it('ファイル名の部分一致(DRAFT-SPEC.md)をendsWithだけで誤って一致扱いしない（issue #548）', () => {
+    const specCheck = {
+      status: 'pass',
+      detail: 'ok',
+      actualPath: '/repo/docs/specs/DRAFT-SPEC.md',
+    }
+    expect(isSpecCheckPathMismatch(specCheck, 'SPEC.md')).toBe(true)
+  })
+
+  it('サブディレクトリのspecPathに対してもファイル名の部分一致を弾く（issue #548）', () => {
+    const specCheck = {
+      status: 'pass',
+      detail: 'ok',
+      actualPath: '/repo/docs/specs/NOT-docs/specs/SPEC.md',
+    }
+    expect(isSpecCheckPathMismatch(specCheck, 'docs/specs/SPEC.md')).toBe(true)
+  })
+
+  it('specPathとactualPathが完全一致（絶対パス運用の推奨形）であればfalse', () => {
+    const specCheck = {
+      status: 'pass',
+      detail: 'ok',
+      actualPath: '/repo/docs/specs/issue-999-example.md',
+    }
+    expect(isSpecCheckPathMismatch(specCheck, '/repo/docs/specs/issue-999-example.md')).toBe(false)
+  })
 })

--- a/.claude/workflows/lib/spec-check.js
+++ b/.claude/workflows/lib/spec-check.js
@@ -14,8 +14,27 @@
 
 // specCheck: Spec Checkエージェントの返り値 { status, detail, actualPath }
 // specPath: 今回のAIDD実行に指定されたSPEC.mdのパス
+//
+// issue #548: 単純な endsWith(specPath) だと、'DRAFT-SPEC.md'.endsWith('SPEC.md') === true の
+// ように「ファイル名の部分一致」まで「一致」として誤判定し、指定specPath以外のファイルを
+// 読んだ非対称バグ（issue #399）への防御が最も必要な相対パス運用時にすり抜けていた
+// （nodeで実行して実証済み）。一致箇所の直前がパス区切り('/')であることまで確認することで、
+// ファイル名の部分一致を弾く。
+// Workflow DSL側は`path`モジュールをrequireできないため、pathモジュールに頼らず文字列操作
+// のみで判定できる形にしている（aidd-phase2.js内のインライン複製と同じ書き方に揃えるため）。
+//
+// 既知の限界: specPathが相対パスの場合、実際のリポジトリルートを知らないまま「末尾一致＋
+// 直前がパス区切り」だけで判定するため、たまたま同じ相対サブパスを持つ別のサブツリー
+// （例: specPath='docs/specs/SPEC.md'に対しactualPath='/repo/other/docs/specs/SPEC.md'）を
+// 区別できない。この限界はspecPathを絶対パスで渡すことで解消される
+// （呼び出し側規約として既に推奨されている。issue #507のコメント参照）。絶対パスの場合は
+// 下のexact一致で判定が確定するため、この限界の影響を受けない。
 export function isSpecCheckPathMismatch(specCheck, specPath) {
   if (specCheck?.status !== 'pass') return false
   if (typeof specCheck?.actualPath !== 'string') return false
-  return !specCheck.actualPath.endsWith(specPath)
+  const actualPath = specCheck.actualPath
+  if (actualPath === specPath) return false
+  if (!actualPath.endsWith(specPath)) return true
+  const boundaryChar = actualPath.charAt(actualPath.length - specPath.length - 1)
+  return boundaryChar !== '/'
 }


### PR DESCRIPTION
close #548

## 作業サマリ
- 変更した目的: `lib/spec-check.js`の`isSpecCheckPathMismatch`が単純な`endsWith(specPath)`で判定しており、`'DRAFT-SPEC.md'.endsWith('SPEC.md')`のようにファイル名の部分一致まで「一致」と誤判定していた（nodeで実行して実証済み）。issue #399で追加された「指定specPath以外を読んでpassの根拠にする非対称バグ」への防御が、specPathが相対パスかつデフォルト値`'SPEC.md'`の場合（＝最も必要な場面）にすり抜けていた。
- 変更した範囲: 正本`.claude/workflows/lib/spec-check.js`の`isSpecCheckPathMismatch`と、Workflow DSLがrequire不可のためインライン複製されている`.claude/workflows/aidd-phase2.js`の該当箇所（`specCheckPathMismatch`の算出部分）を同じロジックに揃えた。テストを3件追加。
- 触っていない範囲: Spec Checkプロンプト文言自体（`lib/prompts/spec-check.js`）・`shouldBlock`等の他の品質ゲートロジックには触れていない。issue #547（specPath存在チェック）は別issueとして解決済み(#313)であることを確認済みでdupe close済み、本PRとは無関係。

## 検証済み
- 実行したコマンド: `npm run ai:check`は該当なし（本リポジトリに存在しないコマンド）。`npx vitest run .claude/workflows/lib/__tests__/spec-check.test.js`（8件全pass、新規3件含む）、`npm test`（166ファイル・1267テスト全pass。修正前は1264件だったので追加した3件のみ増加、他は無影響）、`npm run lint`（0エラー、既存の無関係ファイルの警告2件のみ）。
- 確認した画面: 該当なし（Workflow DSLのロジック変更のみ、UIへの影響なし）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/organization/inventory/RLS/policyのいずれにも触れていない。AIDDパイプライン自体のメタ改修）。
- 実地検証: 修正前後で同一のnodeスクリプト（issue発見時に使った再現スクリプト）を実行し、`specPath='SPEC.md'`・`actualPath='/repo/docs/specs/DRAFT-SPEC.md'`のケースが「検知=false（すり抜け）」から「検知=true（正しく検知）」に変わったことを確認した。

## 既知の未対応
- 今回あえて対応しなかったこと: specPathが相対パスの場合、「実際のリポジトリルートを知らないため、同じ相対サブパスを持つ別のサブツリー（例: specPath='docs/specs/SPEC.md'に対しactualPath='/repo/other/docs/specs/SPEC.md'）を区別できない」という限界が残る。
- 理由: Workflow DSLは`path`モジュール・`fs`にアクセスできず、真のリポジトリルートを渡す仕組みも無いため、文字列操作だけでこのケースを完全に解消することはできない。根本的にはspecPathを絶対パスで渡すことでしか解消しない構造で、これは既にissue #507で呼び出し側規約として推奨されている。
- 次に触るなら見る場所: `lib/spec-check.js`のコード内コメントに既知の限界として明記した。将来specPathを必須の絶対パスとして強制するようになれば、この限界自体が意味を持たなくなる。

## 後任AIへの注意
- この実装で壊してはいけない前提: `isSpecCheckPathMismatch`とaidd-phase2.js側のインライン複製は同一ロジックを維持すること（sync testは無いため、変更時は両方を手動で更新する必要がある。この非同期はissue #548調査時に見つかった既存の設計上のギャップで、本PRのスコープ外）。
- 似ているが別物の用語: 「Spec Checkの経路一致ガード」（本PR、`actualPath`と`specPath`の一致判定）と「Spec Check自体のblocked判定」（`shouldBlock([specCheck])`、ファイルが存在するかどうかの判定）は別レイヤー。本PRは前者のみ変更した。
- 勝手にリファクタしない場所: `actualPath === specPath`の完全一致チェックを先に行っている順序。これを省いて`endsWith`＋境界チェックだけにすると、specPathが絶対パスで両者が完全一致する通常ケースの可読性が落ちる（動作は変わらないが意図が読み取りにくくなる）。