### PR TITLE
test: quality-gate/severity/review-retry-history/find-av-precisionのsync testを追加(issue #549)

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -305,6 +305,7 @@ log(`Adversarial Verify完了: critical/important ${toVerify.length}件検証 �
 function computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvivedMinor) {
   const survivedFromVerify = toVerify.filter((_, i) => !verdicts[i]?.refuted)
   const survived = [...survivedFromVerify, ...autoSurvivedMinor]
+
   const byLens = {}
   toVerify.forEach((f, i) => {
     const lens = f?.lens ?? 'unknown'
@@ -312,6 +313,7 @@ function computeFindAvPrecision(dedupedFindings, toVerify, verdicts, autoSurvive
     byLens[lens].verified++
     if (!verdicts[i]?.refuted) byLens[lens].survived++
   })
+
   return {
     findCount: dedupedFindings.length,
     verifiedCount: toVerify.length,

--- a/.claude/workflows/lib/__tests__/find-av-precision-sync.test.js
+++ b/.claude/workflows/lib/__tests__/find-av-precision-sync.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKFLOW_FILE = path.resolve(__dirname, '../../aidd-1-1-deep-task.js')
+const LIB_FILE = path.resolve(__dirname, '../find-av-precision.js')
+
+// aidd-1-1-deep-task.js（Workflow DSL、require不可）内にインライン複製されたFind-AV
+// precision集計ロジックが、lib/find-av-precision.js の正本と一字一句ドリフトしていないかを
+// 検証する（issue #549。router-risk-sync.test.js と同型のガード）。
+describe('aidd-1-1-deep-task.jsのFind-AV precision集計ロジック同期(issue #549)', () => {
+  const workflowSource = readFileSync(WORKFLOW_FILE, 'utf-8')
+  const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+  it('computeFindAvPrecision がaidd-1-1-deep-task.jsとlib/find-av-precision.jsで一致する', () => {
+    const workflowDecl = extractDeclaration(workflowSource, 'computeFindAvPrecision')
+    const libDecl = extractDeclaration(libSource, 'computeFindAvPrecision')
+    expect(workflowDecl).toBe(libDecl)
+  })
+})

--- a/.claude/workflows/lib/__tests__/quality-gate-severity-sync.test.js
+++ b/.claude/workflows/lib/__tests__/quality-gate-severity-sync.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKFLOW_FILE = path.resolve(__dirname, '../../aidd-phase2.js')
+const SEVERITY_FILE = path.resolve(__dirname, '../severity.js')
+const QUALITY_GATE_FILE = path.resolve(__dirname, '../quality-gate.js')
+
+// aidd-phase2.js（Workflow DSL、require不可）内にインライン複製された品質ゲート判定ロジックが、
+// lib/severity.js・lib/quality-gate.js の正本と一字一句ドリフトしていないかを検証する
+// （issue #549。router-risk-sync.test.js / phase1-result-classification-sync.test.js と同型のガード）。
+//
+// 背景: これら2関数はaidd-phase2.js内の5箇所すべてのdeny-by-defaultゲート
+// （Spec Check・Manifest Check・Contract+DB・Implement・Coverage Check・Integrate・Review）が
+// 依存する中核ロジックだが、2026-07-26のOpus設計評価まで同期テストが存在しなかった
+// （router-risk等と同じ「正本・テストはlib側」という体裁でありながら、実際には同期を
+// 検証する仕組みが無いという不一致があった）。
+describe('aidd-phase2.jsの品質ゲート判定ロジック同期(issue #549)', () => {
+  const workflowSource = readFileSync(WORKFLOW_FILE, 'utf-8')
+  const severitySource = readFileSync(SEVERITY_FILE, 'utf-8')
+  const qualityGateSource = readFileSync(QUALITY_GATE_FILE, 'utf-8')
+
+  it('isMinorOnlyFailure がaidd-phase2.jsとlib/severity.jsで一致する', () => {
+    const workflowDecl = extractDeclaration(workflowSource, 'isMinorOnlyFailure')
+    const libDecl = extractDeclaration(severitySource, 'isMinorOnlyFailure')
+    expect(workflowDecl).toBe(libDecl)
+  })
+
+  it('shouldBlock がaidd-phase2.jsとlib/quality-gate.jsで一致する', () => {
+    const workflowDecl = extractDeclaration(workflowSource, 'shouldBlock')
+    const libDecl = extractDeclaration(qualityGateSource, 'shouldBlock')
+    expect(workflowDecl).toBe(libDecl)
+  })
+})

--- a/.claude/workflows/lib/__tests__/review-retry-history-sync.test.js
+++ b/.claude/workflows/lib/__tests__/review-retry-history-sync.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKFLOW_FILE = path.resolve(__dirname, '../../aidd-phase2.js')
+const LIB_FILE = path.resolve(__dirname, '../review-retry-history.js')
+
+// aidd-phase2.js（Workflow DSL、require不可）内にインライン複製されたReviewリトライ履歴の
+// 組み立てロジックが、lib/review-retry-history.js の正本と一字一句ドリフトしていないかを
+// 検証する（issue #549。router-risk-sync.test.js と同型のガード）。
+//
+// MAX_RETRY_HISTORY_ENTRIES（スカラー定数）はextractDeclarationの対象外
+// （関数・配列宣言のみ対応。extract-declaration.jsのコメント参照）のため、
+// buildRetryHistorySection関数本体のみを比較する。
+describe('aidd-phase2.jsのReviewリトライ履歴組み立てロジック同期(issue #549)', () => {
+  const workflowSource = readFileSync(WORKFLOW_FILE, 'utf-8')
+  const libSource = readFileSync(LIB_FILE, 'utf-8')
+
+  it('buildRetryHistorySection がaidd-phase2.jsとlib/review-retry-history.jsで一致する', () => {
+    const workflowDecl = extractDeclaration(workflowSource, 'buildRetryHistorySection')
+    const libDecl = extractDeclaration(libSource, 'buildRetryHistorySection')
+    expect(workflowDecl).toBe(libDecl)
+  })
+})


### PR DESCRIPTION
close #549

## 作業サマリ
- 変更した目的: Workflow DSL（require不可）内にインライン複製された判定ロジックのうち、`router-risk-sync.test.js`等と異なりsync testが存在しなかった4関数（`isMinorOnlyFailure`・`shouldBlock`・`buildRetryHistorySection`・`computeFindAvPrecision`）にドリフト検知を追加する。特に`isMinorOnlyFailure`/`shouldBlock`は`aidd-phase2.js`内の5箇所全てのdeny-by-defaultゲート（Spec Check・Manifest Check・Contract+DB・Implement・Coverage Check・Integrate・Review）が依存する中核ロジックであるにもかかわらず、正本(lib側)とWorkflow DSL側の一致を保証する仕組みが無かった。
- 変更した範囲: 新規テスト3ファイル（`quality-gate-severity-sync.test.js`・`review-retry-history-sync.test.js`・`find-av-precision-sync.test.js`）。既存の`extractDeclaration`ヘルパーをそのまま利用し、新しいユーティリティは追加していない。あわせて`aidd-1-1-deep-task.js`の`computeFindAvPrecision`複製に、`lib/find-av-precision.js`側とだけ食い違っていた空行2箇所を追加した（機能的な差分はゼロ、書式のみ）。
- 触っていない範囲: `phase2-done.js`・`judge-panel.js`・`budget-guard.js`はDSL側とlib側で構造そのものが既に異なっており（オブジェクト引数 vs 位置引数、関数名の展開など）、`extractDeclaration`による単純な文字列比較を適用する前にリファクタが必要なため対象外とした（issue #549の元issue本文にもその旨明記）。ゲート判定のロジック自体（`shouldBlock`・`isMinorOnlyFailure`の中身）は一切変更していない。

## 検証済み
- 実行したコマンド: `npm run ai:check`は該当なし（本リポジトリに存在しないコマンド）。`npx vitest run <新規3ファイル>`（4件全pass）、`npm test`（169ファイル・1268テスト全pass。修正前は166ファイル・1264テストだったので新規3ファイル・4テストの増分のみ、既存テストは無影響）、`npm run lint`（0エラー、既存の無関係ファイルの警告2件のみ）。
- 確認した画面: 該当なし（テスト追加のみ、UIへの影響なし）。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし（auth/facility/tenant/organization/inventory/RLS/policyのいずれにも触れていない。AIDDパイプライン自体のメタ改修）。
- 追加検証: `lib/severity.js`の`isMinorOnlyFailure`を一時的に書き換え（`return false`→`return true`）、`quality-gate-severity-sync.test.js`が実際にドリフトを検知して失敗することを確認した後、元に戻した（この一時変更はコミットに含めていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: `phase2-done.js`（`computeDone`）・`judge-panel.js`（`computeDivergence`）・`budget-guard.js`（`isBudgetExhausted`/`shouldContinueLoop`）のsync test追加。
- 理由: これら3つはDSL側とlib側で構造そのものが既に分岐している（`phase2-done.js`はlib側が`function`宣言・DSL側は`const`直書き、`judge-panel.js`はDSL側で`computeDivergence`という名前の宣言自体が存在せず`toBigrams`/`decisionSimilarity`に展開、`budget-guard.js`はオブジェクト引数と位置引数で既にインターフェースが分岐）。`extractDeclaration`は生テキストの一字一句比較のため、先に構造を揃えるリファクタが必要で、本PRのスコープ（sync test追加のみ）を超える。
- 次に触るなら見る場所: 上記3ファイルにsync testを追加したい場合は、まずDSL側の構造をlib側に揃える（またはlib側をDSL側に揃える）リファクタをPRを分けて行うこと。

## 後任AIへの注意
- この実装で壊してはいけない前提: `extractDeclaration`は`const`/`function`宣言かつ本体が`{`または`[`で始まるものにしか対応しない。`MAX_RETRY_HISTORY_ENTRIES = 2`のようなスカラー定数には使えない（`review-retry-history-sync.test.js`にコメントで明記済み）。新しくsync testを足す際にこの制約を忘れると、誤って無関係な宣言を抽出してテストが意味をなさなくなる。
- 似ているが別物の用語: 「sync test」（正本とインライン複製の一致検証、本PR）と「lib/配下の関数が本番実行時に評価されるか」は別の話。本PRで追加した4関数はいずれもsync testはあるが、実行時に評価されるのはDSL側のインライン複製であり、lib側は単体テスト用の参照実装のまま（既存の設計、本PRでは変更していない）。
- 勝手にリファクタしない場所: `aidd-1-1-deep-task.js`に追加した2つの空行。cosmeticに見えるが、これが無いとsync testが（機能的には同一なのに）falseに壊れる。削除しないこと。