### PR TITLE
chore: .claude/.doc-suggest-state/をgitignoreに追加(issue #557)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ e2e/.auth/*.json
 /.claude/.ai-check-suggest-state/
 /.claude/.verify-state/
 /.claude/.gate-effectiveness-state/
+/.claude/.doc-suggest-state/
 
 # AIDD Run Manifest（フロー実行ごとに生成される一時状態。スキーマはdocs/agents/run-manifest.md参照）
 /.aidd/


### PR DESCRIPTION
close #557

## 作業サマリ
- 変更した目的: issue #557（worktree棚卸し）の実施中に、24個のworktreeのうち大半で`.claude/.doc-suggest-state/`が未追跡ファイルとして残存していることを発見した。他のStop hook状態ディレクトリと同様`.gitignore`に追加すべきだった漏れ。
- 変更した範囲: `.gitignore`に1行追加のみ。
- 触っていない範囲: `.claude/launch.json`も同様に未追跡ノイズとして複数worktreeに残っていたが、これが意図的に個人ローカル管理とされているのか根拠が薄いため、本PRでは対応せず現状維持とした。

## 検証済み
- 実行したコマンド: `npm run ai:check`は該当なし。`npm test`（169ファイル・1271テスト全pass、`.gitignore`のみの変更のためテスト内容への影響なし）。
- 確認した画面: 該当なし。
- 確認したDB/RLS: 該当なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし。

## worktree棚卸しの実施結果（本PRとは別に、リポジトリ外の作業として実施済み）
issue #546（logs/集約、PR #558）のマージ完了を確認した上で、以下を実施した:

1. **観測ログの回収**: 24個のworktreeに分散していた`loop-observability.jsonl`（110→137件）・`agent-progress.jsonl`（53→192件）・`subagent-skeleton.jsonl`（217→891件）・`verify-claims-observability.jsonl`（21→590件）を、完全一致行の重複除去をした上でメインリポジトリの`logs/`へ集約した。マージ後は全てjqで妥当なJSONLであることを検証済み。
2. **worktreeの削除**: `gh pr list --state merged`でブランチ名が実際にマージ済みPRと一致することを確認し、かつ各worktreeの`git status --porcelain`で実質的な未コミット内容（既知の空テンプレセッションレポート・内部状態ディレクトリ以外）が無いことを確認した19個のworktreeを削除した（24個中）。
3. **削除しなかったもの**: `objective-einstein-213ea6`（`loan-returns-rls-idor.integration.test.ts`という、origin/mainに存在しない未マージのRLS/IDOR統合テストを含んでいたため保持）と`remaining-issues-320c09`（`main`ブランチ自体を保持する特殊worktreeのため対象外）は削除していない。

## 既知の未対応
- 今回あえて対応しなかったこと: `objective-einstein-213ea6`に残っている未コミットのRLS/IDOR統合テスト作業（`loan-returns-rls-idor.integration.test.ts`）の扱い。
- 理由: このテストが意図的に未完成なのか、PR化を忘れているだけなのかがコード読解だけでは判断できないため、削除・PR化のいずれも私の判断で進めるべきではないと考えた。
- 次に触るなら見る場所: `.claude/worktrees/objective-einstein-213ea6/supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts`（新規ファイル）と`seed-rls-idor.ts`への47行の追加差分。内容を確認し、価値があればPR化、不要なら削除を検討すること。

## 後任AIへの注意
- この実装で壊してはいけない前提: `logs/`集約先（`scripts/lib/resolve-log-dir.sh`、issue #546）は既にmainにマージ済みで、今回の観測ログ回収作業もこの集約先に対して行った。今後worktreeを削除する際は、削除前に`logs/`が既にこの集約先経由で書き込まれていることを確認してから削除すること（今回のような手動回収が不要になっているはず）。
- 似ているが別物の用語: 「worktree削除」（本作業、`git worktree remove`）と「ローカルブランチ削除」（`git branch -D`）は別操作。後者は本リポジトリのpermissions denyリストで機械的にブロックされており、削除したworktreeに対応するローカルブランチ参照の一部（squash-merge済みで通常の`-d`祖先チェックが通らないもの）は意図的に残したまま。実害は無い（ディスク容量を消費するだけの空ブランチ参照）。
- 勝手にリファクタしない場所: なし（本PRの変更は.gitignore1行のみ）。