### PR TITLE
test: loan_returnsのRLS/IDOR統合テストを追加

### DIFF
--- a/supabase/__tests__/integration/helpers/seed-rls-idor.ts
+++ b/supabase/__tests__/integration/helpers/seed-rls-idor.ts
@@ -360,3 +360,50 @@ export async function seedOrdersRlsIdorFixtures(): Promise<SeedOrdersRlsIdorFixt
 export async function cleanupOrdersRlsIdorFixtures(fixtures: SeedOrdersRlsIdorFixtures): Promise<void> {
   await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
 }
+
+export interface SeedLoanReturnsRlsIdorFixtures {
+  facilityA: { id: string; name: string }
+  facilityB: { id: string; name: string }
+  userA: SeededUser
+  userB: SeededUser
+  loanReturnA: { id: string }
+}
+
+/**
+ * 施設A・施設B、ユーザーA（施設Aのみ）・ユーザーB（施設Bのみ）、
+ * 施設Aに紐づく loan_returns 1件を作成する（loan_orders/case_orders/
+ * consumable_ordersと同様の横展開。facility_member_or_admin RLSポリシーの
+ * テーブル単体検証がloan_returnsだけ欠落していたため追加）。
+ */
+export async function seedLoanReturnsRlsIdorFixtures(): Promise<SeedLoanReturnsRlsIdorFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facilityA = await createFacility(serviceClient, `テスト施設A-${runId}`)
+  const facilityB = await createFacility(serviceClient, `テスト施設B-${runId}`)
+
+  const userA = await createSeededUser(serviceClient, 'rls-idor-loan-return-user-a', facilityA.id)
+  const userB = await createSeededUser(serviceClient, 'rls-idor-loan-return-user-b', facilityB.id)
+
+  // シード用の1件は service role client（RLSをバイパスする）で直接作成する。
+  const { data: loanReturn, error: loanReturnError } = await serviceClient
+    .from('loan_returns')
+    .insert({ facility_id: facilityA.id, return_datetime: new Date().toISOString() })
+    .select('id')
+    .single()
+  if (loanReturnError || !loanReturn) {
+    throw new Error(`[seed-rls-idor] loan_returns シード作成失敗: ${loanReturnError?.message}`)
+  }
+
+  return {
+    facilityA,
+    facilityB,
+    userA,
+    userB,
+    loanReturnA: { id: loanReturn.id as string },
+  }
+}
+
+export async function cleanupLoanReturnsRlsIdorFixtures(fixtures: SeedLoanReturnsRlsIdorFixtures): Promise<void> {
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
+}

--- a/supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts
@@ -1,0 +1,81 @@
+// supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts
+// WHY: 施設A/施設Bという2つの本物のテスト施設と、それぞれに所属する本物の
+//      認証済みユーザーを使い、「施設Bのユーザーが施設Aの返却(loan_returns)に
+//      アクセスできない」ことをPostgREST/RPC越しに直接確認する。
+//      loan_returnsはloan_ordersと同じfacility_member_or_admin RLSポリシー
+//      （supabase/migrations/20260628010001_update_rls_admin.sql）で保護されて
+//      おり、src/lib/dashboard/loan-outstanding.tsのgetLoanOutstandingCountが
+//      このテーブルをクエリしているが、case_orders/consumable_orders/loan_orders
+//      にはあるテーブル単体のRLS/IDOR統合テストがloan_returnsだけ欠落していた
+//      （docs/agents/known-failure-patterns.md「RLS/テナント分離層」チェックリスト）。
+//      モック・静的SQL検証ではなく、本物のローカルSupabaseへの接続を伴う。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupLoanReturnsRlsIdorFixtures,
+  seedLoanReturnsRlsIdorFixtures,
+  type SeedLoanReturnsRlsIdorFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('loan_returns RLS/IDOR', () => {
+  let fixtures: SeedLoanReturnsRlsIdorFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedLoanReturnsRlsIdorFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupLoanReturnsRlsIdorFixtures(fixtures)
+    }
+  })
+
+  it('ユーザーBは施設Aのloan_returnsを1件も取得できない', async () => {
+    const { data, error } = await fixtures.userB.client
+      .from('loan_returns')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).toEqual([])
+  })
+
+  it('ユーザーBは施設Aに対してcreate_loan_return_atomicを呼ぶと拒否される', async () => {
+    const { data, error } = await fixtures.userB.client.rpc('create_loan_return_atomic', {
+      p_header: {
+        facility_id: fixtures.facilityA.id,
+        return_datetime: new Date().toISOString(),
+      },
+      p_items: [],
+    })
+
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+  })
+
+  it('ユーザーAは自分の施設Aのloan_returnsを取得でき、シード済みの1件が含まれる', async () => {
+    const { data, error } = await fixtures.userA.client
+      .from('loan_returns')
+      .select('*')
+      .eq('facility_id', fixtures.facilityA.id)
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data!.length).toBeGreaterThanOrEqual(1)
+    expect(data!.some((row) => row.id === fixtures.loanReturnA.id)).toBe(true)
+  })
+
+  it('ユーザーAは自分の施設Aに対してcreate_loan_return_atomicを呼ぶと成功する', async () => {
+    const { data, error } = await fixtures.userA.client.rpc('create_loan_return_atomic', {
+      p_header: {
+        facility_id: fixtures.facilityA.id,
+        return_datetime: new Date().toISOString(),
+      },
+      p_items: [],
+    })
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect((data as { facility_id?: string })?.facility_id).toBe(fixtures.facilityA.id)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: `case_orders`・`consumable_orders`・`loan_orders`にはある、テーブル単体のRLS/IDOR統合テストが`loan_returns`だけ欠落していた。`loan_returns`は`loan_orders`と同じ`facility_member_or_admin`RLSポリシーで保護されており、ダッシュボードの`getLoanOutstandingCount`がこのテーブルを直接クエリしているにもかかわらず、他施設ユーザーからのアクセス拒否を検証するテストが無かった。この抜け漏れを埋める。本作業は、8日前（2026-07-18）に別worktree（`objective-einstein-213ea6`）で着手されたまま未コミット・未PR化だった作業を、最新originから引き継いで仕上げたもの。
- 変更した範囲: `supabase/__tests__/integration/helpers/seed-rls-idor.ts`に`seedLoanReturnsRlsIdorFixtures`/`cleanupLoanReturnsRlsIdorFixtures`を追加（既存の`case_orders`/`consumable_orders`版と同じ構成）。新規`supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts`を追加（既存の`loan-orders-rls-idor.integration.test.ts`と同じパターン）。
- 触っていない範囲: マイグレーション・RPC定義（`create_loan_return_atomic`）自体は変更していない（既存のシグネチャ`(p_header JSONB, p_items JSONB)`をそのまま利用）。他のRLS/IDORテストファイルには触れていない。

## 検証済み
- 実行したコマンド: `npm run ai:check`は実行していない（e2eを含み時間がかかるため、個別に`typecheck`/`lint`/`test`/`test:integration`を実行）。`npx vitest run --config vitest.integration.config.ts supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts`（新規4テスト全pass、本物のローカルSupabaseへの接続を伴う）。`npm run test:integration`（既存分含め6ファイル・22テスト全pass、既存テストへの影響なし）。`npm test`（169ファイル・1271テスト全pass）。`npm run lint`（0エラー、既存の無関係ファイルの警告2件のみ）。`npm run typecheck`は`scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/`配下で既存の無関係なエラーが出る（本PRの変更範囲外、eval用の意図的な壊れフィクスチャの可能性が高い。本PRの変更ファイルはそこに含まれない）。
- 確認した画面: 該当なし（テスト追加のみ、UIへの影響なし）。
- 確認したDB/RLS: `create_loan_return_atomic`のRLS判定（`is_facility_member`によるfacility_idチェック）を、実際のローカルSupabaseへの接続を伴う統合テストで確認した。
- 他テナントのIDでアクセスし、弾かれることを確認したか: **確認した**。施設Bのユーザーが施設Aの`loan_returns`をSELECTすると0件、`create_loan_return_atomic`を施設A宛に呼ぶとエラーになることをテストで検証している（このPRの主目的そのもの）。

## 既知の未対応
- 今回あえて対応しなかったこと: なし（スコープを`loan_returns`単体のRLS/IDORテスト追加に限定）。
- 理由: 元の未完成作業のスコープをそのまま踏襲した。
- 次に触るなら見る場所: 元の作業元だった`objective-einstein-213ea6`worktreeは削除せず残っているが、本PRで内容を引き継いだため、マージ後にworktree自体の削除を検討してよい。

## 後任AIへの注意
- この実装で壊してはいけない前提: `create_loan_return_atomic`のRPCシグネチャ`(p_header JSONB, p_items JSONB)`。既存の`loan-orders`版RPC（`create_loan_order_atomic`）とは引数の形が異なる（loan_ordersは個別パラメータ、loan_returnsはheader/itemsのJSONB）ため、コピー&ペーストでテストを書く際にこの違いを見落とさないこと。
- 似ているが別物の用語: 「loan_orders」（短貸発注）と「loan_returns」（貸出返却）は別テーブル・別RPC。テスト名・fixture名の接頭辞（`rls-idor-loan-return-user-*`）で区別している。
- 勝手にリファクタしない場所: `seed-rls-idor.ts`内の既存4つのfixtureパターン（`seedRlsIdorFixtures`・`seedCaseOrdersRlsIdorFixtures`・`seedConsumableOrdersRlsIdorFixtures`・`seedOrdersRlsIdorFixtures`）との構成の一貫性。今回追加した`seedLoanReturnsRlsIdorFixtures`もこれらと同じ命名・構造パターンに揃えており、崩さないこと。