### PR TITLE
fix: 意図的に壊れたeval fixtureをtsconfigのtypecheck対象から除外(issue #570)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts/eval-fixtures/**"]
 }


### PR DESCRIPTION
Closes #570

## 作業サマリ
- 変更した目的: tsconfig.jsonのincludeが`**/*.ts`と広範囲すぎて、eval-sweep-recall用に意図的に型エラーを仕込んだfixture(`scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/`)が製品のtypecheck/production buildを道連れに失敗させていた問題を修正
- 変更した範囲: `tsconfig.json`の`exclude`に`scripts/eval-fixtures/**`を追加のみ(1ファイル1行)
- 触っていない範囲: `eslint.config.mjs`(lintは元々0エラーだったため未変更)、eval-fixtures配下のfixture内容自体、`eval-sweep-recall.sh`等のeval実行スクリプト

## 検証済み
- 実行したコマンド: `npx tsc --noEmit -p tsconfig.json`(0エラーに復帰)、`npm run build`(成功・40ページ生成)、`npm run lint`(0エラー)、`npm test`(169 test files / 1271 tests 全passed)。`npm run ai:check`自体は実行していない(test:e2eはSupabase test環境が必要なため今回未実行。typecheck/lint/testの3つは個別実行しall green確認済み)
- 確認した画面: なし(tsconfig設定のみの変更でUI変更なし)
- 確認したDB/RLS: 対象外(DB/RLSに触れていない)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(auth/facility/tenant領域に触れていない、ビルド設定のみの変更)

## 既知の未対応
- 今回あえて対応しなかったこと: eslint側への同様の除外設定は追加していない
- 理由: 今回壊れていたのはtypecheck/production buildのみで、lintは既に0エラーだったため対象外
- 次に触るなら見る場所: 新しいeval fixture layer(sweep-ui/sweep-data等)を`scripts/eval-fixtures/`配下に追加する分にはこのexcludeで自動的にカバーされる。配置場所を変える場合のみ要再確認

## 後任AIへの注意
- この実装で壊してはいけない前提: `scripts/eval-fixtures/`配下は製品buildの対象外という前提。ここに製品コードから実際にimportされるファイルを置かないこと
- 似ているが別物の用語: 今回のeval-fixtures(sweep系エージェントのrecallベンチマーク用、意図的に壊れている)と、db-impl用のeval fixture(`scripts/eval-fixtures/db-impl/`、SPEC.md単体コピー方式で別スクリプト`eval-workflow-prompts.sh`が使う)は別物
- 勝手にリファクタしない場所: `tsconfig.json`の`include`自体(`**/*.ts`)は変更していない。`exclude`追加のみに留めた

🤖 Generated with [Claude Code](https://claude.com/claude-code)