### PR TITLE
fix: 短貸返却作成をatomic RPCへ一本化しorphan header混入を防ぐ(issue #572)

### DIFF
--- a/src/lib/loan-returns/__tests__/repository.test.ts
+++ b/src/lib/loan-returns/__tests__/repository.test.ts
@@ -36,26 +36,43 @@ function makeLoanOrderLookupTable(result: { data: unknown; error: unknown }) {
   return builder
 }
 
+// WHY: createLoanReturn は header+items を単一トランザクションのRPC
+//      (create_loan_return_atomic)経由でinsertする(architecture review 2026-07-26 issue #2、
+//      orphan header混入防止)。RPC呼び出しをモックするヘルパー(case-orders/loan-ordersの
+//      repository.test.tsと同じ規約)
+function makeMockRpcDb(rpcResult: { data: unknown; error: unknown }): { db: SupabaseClient; rpc: ReturnType<typeof vi.fn> } {
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+  const db = { rpc } as unknown as SupabaseClient
+  return { db, rpc }
+}
+
+function makeMockRpcDbWithLoanOrderLookup(
+  rpcResult: { data: unknown; error: unknown },
+  loanOrderLookupResult: { data: unknown; error: unknown }
+): { db: SupabaseClient; rpc: ReturnType<typeof vi.fn>; loanOrders: ReturnType<typeof makeLoanOrderLookupTable> } {
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+  const loanOrders = makeLoanOrderLookupTable(loanOrderLookupResult)
+  const db = {
+    rpc,
+    from: vi.fn((table: string) => {
+      if (table === 'loan_orders') return loanOrders
+    }),
+  } as unknown as SupabaseClient
+  return { db, rpc, loanOrders }
+}
+
 describe('createLoanReturn', () => {
-  const mockReturn = {
+  const mockRpcResult = {
     id: 'lr-1', facility_id: 'f-1', return_datetime: '2026-06-24T15:00:00Z',
     status: 'draft', created_at: '2026-06-24T00:00:00Z', updated_at: '2026-06-24T00:00:00Z',
+    loan_order_id: null,
+    items: [
+      { id: 'i-1', loan_return_id: 'lr-1', jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1, created_at: '2026-06-24T00:00:00Z' },
+    ],
   }
-  const mockItems = [
-    { id: 'i-1', loan_return_id: 'lr-1', jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1, created_at: '2026-06-24T00:00:00Z' },
-  ]
 
   it('ヘッダーと明細を作成してLoanReturnを返す', async () => {
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'loan_returns') {
-          return { insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: mockReturn, error: null }) })) })) }
-        }
-        if (table === 'loan_return_items') {
-          return { insert: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ data: mockItems, error: null }) })) }
-        }
-      }),
-    } as unknown as SupabaseClient
+    const { db } = makeMockRpcDb({ data: mockRpcResult, error: null })
 
     const result = await createLoanReturn(db, 'f-1', {
       returnDatetime: '2026-06-24T15:00:00Z',
@@ -66,43 +83,57 @@ describe('createLoanReturn', () => {
     expect(result.items[0].jan).toBe('490001')
   })
 
-  it('loanOrderIdを指定すると loan_returns の insert に loan_order_id として渡る（未返却誤判定バグの修正）', async () => {
-    const insertLoanReturns = vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { ...mockReturn, loan_order_id: 'lo-1' }, error: null }) })) }))
-    const loanOrders = makeLoanOrderLookupTable({ data: { id: 'lo-1' }, error: null })
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'loan_orders') return loanOrders
-        if (table === 'loan_returns') {
-          return { insert: insertLoanReturns }
-        }
-        if (table === 'loan_return_items') {
-          return { insert: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ data: mockItems, error: null }) })) }
-        }
-      }),
-    } as unknown as SupabaseClient
+  it('header+itemsを単一のRPC呼び出しで作成する(2回INSERTによるorphan header混入を防ぐ)', async () => {
+    const { db, rpc } = makeMockRpcDb({ data: mockRpcResult, error: null })
+
+    await createLoanReturn(db, 'f-1', {
+      returnDatetime: '2026-06-24T15:00:00Z',
+      items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+    })
+
+    expect(rpc).toHaveBeenCalledWith('create_loan_return_atomic', expect.objectContaining({
+      p_header: expect.objectContaining({ facility_id: 'f-1', return_datetime: '2026-06-24T15:00:00Z' }),
+      p_items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+    }))
+  })
+
+  it('RPCがエラーを返した場合は例外を投げる(headerのみ孤児で残ることはない)', async () => {
+    const { db } = makeMockRpcDb({ data: null, error: { message: 'insert failed' } })
+
+    await expect(
+      createLoanReturn(db, 'f-1', {
+        returnDatetime: '2026-06-24T15:00:00Z',
+        items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+      })
+    ).rejects.toThrow('insert failed')
+  })
+
+  it('loanOrderIdを指定すると RPC の p_header.loan_order_id として渡る（未返却誤判定バグの修正）', async () => {
+    const { db, rpc, loanOrders } = makeMockRpcDbWithLoanOrderLookup(
+      { data: { ...mockRpcResult, loan_order_id: 'lo-1' }, error: null },
+      { data: { id: 'lo-1' }, error: null }
+    )
 
     const result = await createLoanReturn(db, 'f-1', {
       returnDatetime: '2026-06-24T15:00:00Z',
       items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
     }, 'lo-1')
 
-    // WHY: 他施設のloan_orderへの紐付けを防ぐため、insert前にfacilityId込みで存在確認する
-    //      （issue #20 レビュー指摘: critical テナント境界チェック）
+    // WHY: 他施設のloan_orderへの紐付けを防ぐため、RPC呼び出し前にfacilityId込みで存在確認する
+    //      （issue #20 レビュー指摘: critical テナント境界チェック。RPC側では再検証しない）
     expect(loanOrders.eq).toHaveBeenCalledWith('id', 'lo-1')
     expect(loanOrders.eq).toHaveBeenCalledWith('facility_id', 'f-1')
-    expect(insertLoanReturns).toHaveBeenCalledWith(expect.objectContaining({ loan_order_id: 'lo-1' }))
+    expect(rpc).toHaveBeenCalledWith('create_loan_return_atomic', expect.objectContaining({
+      p_header: expect.objectContaining({ loan_order_id: 'lo-1' }),
+    }))
     expect(result.loanOrderId).toBe('lo-1')
   })
 
-  it('loanOrderIdが自施設に存在しない場合（他施設のIDを指定した場合を含む）はエラーを投げてinsertしない', async () => {
-    const insertLoanReturns = vi.fn()
-    const loanOrders = makeLoanOrderLookupTable({ data: null, error: null })
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'loan_orders') return loanOrders
-        if (table === 'loan_returns') return { insert: insertLoanReturns }
-      }),
-    } as unknown as SupabaseClient
+  it('loanOrderIdが自施設に存在しない場合（他施設のIDを指定した場合を含む）はエラーを投げてRPCを呼ばない', async () => {
+    const { db, rpc } = makeMockRpcDbWithLoanOrderLookup(
+      { data: mockRpcResult, error: null },
+      { data: null, error: null }
+    )
 
     await expect(
       createLoanReturn(db, 'f-1', {
@@ -110,41 +141,24 @@ describe('createLoanReturn', () => {
         items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
       }, 'other-facility-lo')
     ).rejects.toThrow(LOAN_ORDER_NOT_FOUND_ERROR)
-    expect(insertLoanReturns).not.toHaveBeenCalled()
+    expect(rpc).not.toHaveBeenCalled()
   })
 
-  it('loanOrderIdを指定しない場合は loan_order_id: null で insert される（既存呼び出し元互換）', async () => {
-    const insertLoanReturns = vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: mockReturn, error: null }) })) }))
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'loan_returns') {
-          return { insert: insertLoanReturns }
-        }
-        if (table === 'loan_return_items') {
-          return { insert: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ data: mockItems, error: null }) })) }
-        }
-      }),
-    } as unknown as SupabaseClient
+  it('loanOrderIdを指定しない場合は p_header.loan_order_id: null でRPCが呼ばれる（既存呼び出し元互換）', async () => {
+    const { db, rpc } = makeMockRpcDb({ data: mockRpcResult, error: null })
 
     await createLoanReturn(db, 'f-1', {
       returnDatetime: '2026-06-24T15:00:00Z',
       items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
     })
 
-    expect(insertLoanReturns).toHaveBeenCalledWith(expect.objectContaining({ loan_order_id: null }))
+    expect(rpc).toHaveBeenCalledWith('create_loan_return_atomic', expect.objectContaining({
+      p_header: expect.objectContaining({ loan_order_id: null }),
+    }))
   })
 
   it('DBのstatusが想定外の値の場合はdraftにフォールバックする', async () => {
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'loan_returns') {
-          return { insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { ...mockReturn, status: 'invalid' }, error: null }) })) })) }
-        }
-        if (table === 'loan_return_items') {
-          return { insert: vi.fn(() => ({ select: vi.fn().mockResolvedValue({ data: mockItems, error: null }) })) }
-        }
-      }),
-    } as unknown as SupabaseClient
+    const { db } = makeMockRpcDb({ data: { ...mockRpcResult, status: 'invalid' }, error: null })
 
     const result = await createLoanReturn(db, 'f-1', {
       returnDatetime: '2026-06-24T15:00:00Z',

--- a/src/lib/loan-returns/repository.ts
+++ b/src/lib/loan-returns/repository.ts
@@ -120,35 +120,31 @@ export async function createLoanReturn(db: SupabaseClient, facilityId: string, i
     if (!loanOrder) throw new Error(LOAN_ORDER_NOT_FOUND_ERROR)
   }
 
-  const { data: ret, error: retError } = await db
-    .from('loan_returns')
-    .insert({ facility_id: facilityId, return_datetime: input.returnDatetime, loan_order_id: loanOrderId ?? null })
-    .select(LOAN_RETURN_COLUMNS)
-    .single()
-  if (retError) throw new Error(retError.message)
-  if (!ret) throw new Error('loan_returns の作成に失敗しました')
+  // WHY: header/itemsを別々にINSERTすると、items失敗時にheaderだけが孤児レコードとして
+  //      残るリスクがある(architecture review 2026-07-26 issue #2)。既存のatomic RPC
+  //      (supabase/migrations/20260629000002_loan_return_atomic_rpc.sql)で単一トランザクションに
+  //      統一する。loanOrderIdのテナント境界検証は上記で完了済みのため、RPC側では再検証しない
+  const { data, error } = await db.rpc('create_loan_return_atomic', {
+    p_header: { facility_id: facilityId, return_datetime: input.returnDatetime, loan_order_id: loanOrderId ?? null },
+    p_items: input.items.map(item => ({
+      jan: item.jan,
+      lot: item.lot ?? null,
+      ubd: item.ubd ?? null,
+      quantity: item.quantity,
+    })),
+  })
+  if (error) throw new Error(error.message)
+  if (!data) throw new Error('loan_returns の作成に失敗しました')
 
-  const r = ret as LoanReturnRow
-  const itemRows = input.items.map(item => ({
-    loan_return_id: r.id,
-    jan: item.jan,
-    lot: item.lot ?? null,
-    ubd: item.ubd ?? null,
-    quantity: item.quantity,
-  }))
-
-  const { data: items, error: itemsError } = await db
-    .from('loan_return_items')
-    .insert(itemRows)
-    .select(LOAN_RETURN_ITEM_COLUMNS)
-  if (itemsError) throw new Error(itemsError.message)
+  const r = data as LoanReturnRow & { items?: unknown }
+  const itemRows = Array.isArray(r.items) ? (r.items as LoanReturnItemRow[]) : []
 
   return {
     id: asString(r.id),
     facilityId: asString(r.facility_id),
     returnDatetime: asString(r.return_datetime),
     status: asEnum(r.status, STATUSES, 'draft'),
-    items: (items as LoanReturnItemRow[]).map(mapItem),
+    items: itemRows.map(mapItem),
     createdAt: asString(r.created_at),
     updatedAt: asString(r.updated_at),
     loanOrderId: asOptionalString(r.loan_order_id),

--- a/supabase/migrations/20260726120000_add_loan_order_id_to_loan_return_atomic_rpc.sql
+++ b/supabase/migrations/20260726120000_add_loan_order_id_to_loan_return_atomic_rpc.sql
@@ -1,0 +1,50 @@
+-- supabase/migrations/20260726120000_add_loan_order_id_to_loan_return_atomic_rpc.sql
+-- WHY: create_loan_return_atomic(issue #20 Set A以前に追加)はheader+itemsのみをINSERTし、
+--      loan_order_id(未返却判定用のFK)を扱えなかった。そのためproduction caller
+--      (src/lib/loan-returns/repository.ts)はRPCを使わずheader/items別々の2回INSERTのままで、
+--      orphan header混入リスクが残っていた(architecture review 2026-07-26 issue #2)。
+--      テナント境界チェック(loan_order_idが呼び出し施設に属するか)はJS側で既に検証済み
+--      (issue #20 レビュー指摘: critical)であり、このRPCでは再検証せずそのままinsertする。
+
+CREATE OR REPLACE FUNCTION create_loan_return_atomic(
+  p_header JSONB,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_facility_id UUID := (p_header->>'facility_id')::UUID;
+  v_loan_order_id UUID := NULLIF(p_header->>'loan_order_id', '')::UUID;
+  v_return loan_returns%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT is_facility_member(v_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO loan_returns (facility_id, return_datetime, loan_order_id)
+  VALUES (v_facility_id, (p_header->>'return_datetime')::TIMESTAMPTZ, v_loan_order_id)
+  RETURNING * INTO v_return;
+
+  INSERT INTO loan_return_items (loan_return_id, jan, lot, ubd, quantity)
+  SELECT
+    v_return.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM loan_return_items i
+  WHERE i.loan_return_id = v_return.id;
+
+  RETURN to_jsonb(v_return) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_loan_return_atomic(JSONB, JSONB) TO authenticated;

--- a/supabase/migrations/__tests__/add_loan_order_id_to_loan_return_atomic_rpc.test.ts
+++ b/supabase/migrations/__tests__/add_loan_order_id_to_loan_return_atomic_rpc.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(architecture review 2026-07-26 issue #2)を
+//      満たすかを静的に検証することで、回帰テストとして固定する
+//      (add_unit_price_snapshot_to_order_rpcs.test.tsと同じ静的検証パターン)
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_loan_order_id_to_loan_return_atomic_rpc.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_loan_order_id_to_loan_return_atomic_rpc.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('既存migrationを追記せず、CREATE OR REPLACE FUNCTIONでcreate_loan_return_atomicを再定義する', () => {
+    expect(n).toContain('create or replace function create_loan_return_atomic(')
+  })
+
+  it('is_facility_memberチェックを維持している（施設境界チェックの退行防止）', () => {
+    const occurrences = n.match(/if not is_facility_member\(v_facility_id\) then/g) ?? []
+    expect(occurrences.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('loan_returnsのinsertにloan_order_idを含む(未返却誤判定バグの修正がRPC側にも反映されている)', () => {
+    expect(n).toContain('insert into loan_returns (facility_id, return_datetime, loan_order_id)')
+  })
+
+  it('v_loan_order_idはp_headerから取得している(JS側で検証済みの値をそのまま使う)', () => {
+    expect(n).toContain("v_loan_order_id uuid := nullif(p_header->>'loan_order_id', '')::uuid;")
+  })
+})


### PR DESCRIPTION
Closes #572

## 作業サマリ
- 変更した目的: `createLoanReturn`がheader/itemsを別々にINSERTしており、items INSERT失敗時にheaderだけ孤児レコードとして残るリスクがあった問題を修正
- 変更した範囲: `supabase/migrations/`に新規migration追加(既存の`create_loan_return_atomic` RPCへ`loan_order_id`列のinsertを追加)、`src/lib/loan-returns/repository.ts`の`createLoanReturn`をRPC呼び出しに置き換え、対応するunit test・migration静的検証testを更新
- 触っていない範囲: loanOrderIdのテナント境界検証ロジック自体(JS側の既存チェックをそのまま維持し、RPC内では再検証していない)。`listLoanReturns`・route.ts・他のorder系repository

## 検証済み
- 実行したコマンド: `npx tsc --noEmit`(このブランチ単体では issue #570 由来の既知エラーのみ、新規エラーなしを確認済み)、`npm run lint`(0エラー)、`npm test`(170 test files / 1278 tests 全passed)。`npm run ai:check`自体は実行していない(test:e2eは今回未実行)
- 確認した画面: なし(API/DB層のみの変更)
- 確認したDB/RLS: `create_loan_return_atomic`はSECURITY DEFINERのまま、既存の`is_facility_member`チェックを変更せず維持(migration静的テストで退行防止を検証)
- 他テナントのIDでアクセスし、弾かれることを確認したか: はい。`repository.test.ts`に「他施設のloan_order_idを指定した場合はLOAN_ORDER_NOT_FOUND_ERRORを投げてRPCを呼ばない」テストがあり、green

## 既知の未対応
- 今回あえて対応しなかったこと: loanOrderIdのテナント境界検証をRPC内に移動する案は見送った
- 理由: 既にissue #20で「critical」指摘を受けレビュー済みのロジックであり、RPC内に移動すると挙動(エラー文言のexact match等)を変える必要が出てリスクが増すため、JS側の既存チェックをそのまま活かす最小差分にした
- 次に触るなら見る場所: 同種の2回INSERTパターンが他のrepositoryに残っていないか横展開の余地はあるかもしれない(未調査)

## 後任AIへの注意
- この実装で壊してはいけない前提: loanOrderId指定時のテナント境界チェック(`repository.ts`のRPC呼び出し前のブロック)は、他施設のloan_orderへの紐付け防止という「critical」なセキュリティ要件。RPC側に検証が無いことを理由に消してはいけない
- 似ているが別物の用語: `create_loan_return_atomic`(今回拡張)と`create_case_order_atomic`/`create_loan_order_atomic`/`create_consumable_order_atomic`(こちらは`20260627010001_update_order_rpcs.sql`で定義、対象テーブルが異なる別RPC)は同じパターンだが別物
- 勝手にリファクタしない場所: `LOAN_RETURN_COLUMNS`/`LOAN_RETURN_ITEM_COLUMNS`は`listLoanReturns`がまだ使用しているため削除しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)