### PR TITLE
fix: raw DBエラーのクライアント漏洩を防ぐClientVisibleError方式を導入(issue #566)

### DIFF
--- a/src/__tests__/api-order-error-handling.test.ts
+++ b/src/__tests__/api-order-error-handling.test.ts
@@ -40,7 +40,22 @@ describe('consumable-orders エラーハンドリング', () => {
     expect(res.status).toBe(500)
     const body = await res.json()
     expect(typeof body.error).toBe('string')
-    expect(body.error).toBe('DB エラー')
+  })
+
+  // WHY: 生のリポジトリ/DBエラーはClientVisibleErrorでない限りクライアントへ漏らさず
+  //      fallbackメッセージのみ返す(architecture review 2026-07-26 issue #3の回帰テスト)
+  it('ClientVisibleErrorでない例外はメッセージを漏らさずfallbackを返す', async () => {
+    vi.mocked(createConsumableOrder).mockRejectedValue(new Error('relation "consumable_orders" does not exist'))
+    const res = await consumableOrderPOST(
+      makeRequest('/api/consumable-orders', {
+        facilityId: 'f1',
+        items: [{ name: 'A', quantity: 1 }],
+      })
+    )
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('発注に失敗しました')
+    expect(body.error).not.toContain('consumable_orders')
   })
 })
 

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { isValidDateString } from '@/lib/jst-date-range'
 import { fetchOrderAmountReport } from '@/lib/reports/repository'
 import type {
@@ -68,6 +68,6 @@ export async function GET(
     if (message.includes('permission denied')) {
       return reportsApiError('権限がありません', 403)
     }
-    return reportsApiError(message || '発注金額レポートの取得に失敗しました')
+    return reportsApiError(toClientErrorMessage(error, '発注金額レポートの取得に失敗しました'))
   }
 }

--- a/src/app/api/admin/user-facilities/route.ts
+++ b/src/app/api/admin/user-facilities/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createAdminSupabase } from '@/lib/supabase/server'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { requireAdmin } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
       { onConflict: 'user_id,facility_id' }
     )
 
-  if (error) return apiError(error.message)
+  if (error) return apiError(toClientErrorMessage(error, '施設の割り当てに失敗しました'))
 
   return NextResponse.json({ message: '施設を割り当てました' })
 }
@@ -54,7 +54,7 @@ export async function DELETE(request: NextRequest) {
     .delete()
     .eq('user_id', userId)
     .eq('facility_id', facilityId)
-  if (error) return apiError(error.message)
+  if (error) return apiError(toClientErrorMessage(error, '施設の割り当て解除に失敗しました'))
 
   return NextResponse.json({ message: '施設の割り当てを解除しました' })
 }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createAdminSupabase } from '@/lib/supabase/server'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { requireAdmin } from '@/lib/admin-auth'
 import { asEnum } from '@/lib/mapping'
 import type { AdminUser } from '@/types/admin'
@@ -11,7 +11,7 @@ export async function GET() {
 
   const admin = createAdminSupabase()
   const { data, error } = await admin.auth.admin.listUsers()
-  if (error) return apiError(error.message)
+  if (error) return apiError(toClientErrorMessage(error, 'ユーザー一覧の取得に失敗しました'))
 
   const userIds = data.users.map(u => u.id)
 
@@ -21,7 +21,7 @@ export async function GET() {
     .select('user_id, facility_id, role')
     .in('user_id', userIds)
 
-  if (facilityError) return apiError(facilityError.message)
+  if (facilityError) return apiError(toClientErrorMessage(facilityError, 'ユーザー一覧の取得に失敗しました'))
 
   // Group by user_id in memory
   const facilityMap = new Map<string, { id: string; role: 'admin' | 'staff' }[]>()
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
 
   const admin = createAdminSupabase()
   const { error } = await admin.auth.admin.inviteUserByEmail(email)
-  if (error) return apiError(error.message)
+  if (error) return apiError(toClientErrorMessage(error, '招待メールの送信に失敗しました'))
 
   return NextResponse.json({ message: `${email} に招待メールを送信しました` })
 }
@@ -77,7 +77,7 @@ export async function DELETE(request: NextRequest) {
 
   const admin = createAdminSupabase()
   const { error } = await admin.auth.admin.deleteUser(userId)
-  if (error) return apiError(error.message)
+  if (error) return apiError(toClientErrorMessage(error, 'ユーザーの削除に失敗しました'))
 
   return NextResponse.json({ message: 'ユーザーを削除しました' })
 }

--- a/src/app/api/case-orders/route.ts
+++ b/src/app/api/case-orders/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listCaseOrders, createCaseOrder } from '@/lib/case-orders/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parsePagination } from '@/lib/api-pagination'
 import type { CaseOrderInput } from '@/types/order'
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const orders = await listCaseOrders(db, facilityId!, limit, offset)
     return NextResponse.json({ orders })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '発注一覧の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '発注一覧の取得に失敗しました'))
   }
 }
 
@@ -71,6 +71,6 @@ export async function POST(request: NextRequest) {
     const order = await createCaseOrder(db, body.facilityId, input)
     return NextResponse.json({ order }, { status: 201 })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '発注に失敗しました')
+    return apiError(toClientErrorMessage(error, '発注に失敗しました'))
   }
 }

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listCategories, createCategory } from '@/lib/categories/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { CategoryInput } from '@/types/category'
 
 export async function GET() {
@@ -13,7 +13,7 @@ export async function GET() {
     const categories = await listCategories(db)
     return NextResponse.json({ categories })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : 'カテゴリの取得に失敗しました')
+    return apiError(toClientErrorMessage(error, 'カテゴリの取得に失敗しました'))
   }
 }
 
@@ -41,6 +41,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message.includes('既に使用されています')) {
       return apiError('カテゴリ名が重複しています', 409)
     }
-    return apiError(error instanceof Error ? error.message : 'カテゴリの作成に失敗しました')
+    return apiError(toClientErrorMessage(error, 'カテゴリの作成に失敗しました'))
   }
 }

--- a/src/app/api/compat/[id]/route.ts
+++ b/src/app/api/compat/[id]/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { deleteCompatibility } from '@/lib/compatibilities/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { RouteContext } from '@/types/route'
 
 // WHY: idはDB上uuid型のため、不正形式のまま渡すとPostgres側の生のパースエラーが
@@ -35,6 +35,6 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
 
     return NextResponse.json({ success: true })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '互換品の削除に失敗しました')
+    return apiError(toClientErrorMessage(error, '互換品の削除に失敗しました'))
   }
 }

--- a/src/app/api/compat/products/route.ts
+++ b/src/app/api/compat/products/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { listProductsInCategory } from '@/lib/compatibilities/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 
 // WHY: category_id はDB上uuid型のためAPI層で形式チェックしておくと不正値による
 // 無駄なクエリ発行を防げる（SPEC Part2 Set D参照）
@@ -22,6 +22,6 @@ export async function GET(request: NextRequest) {
     const products = await listProductsInCategory(db, categoryId)
     return NextResponse.json({ products })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '製品候補の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '製品候補の取得に失敗しました'))
   }
 }

--- a/src/app/api/compat/route.ts
+++ b/src/app/api/compat/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listCompatibilities, createCompatibility, listProductsInCategory, categoryExists } from '@/lib/compatibilities/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { ProductCompatibilityInput } from '@/types/compatibility'
 
 // WHY: category_id/product_id_1/product_id_2 はDB上uuid型のためAPI層で形式チェックしておくと
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     const compatibilities = await listCompatibilities(db, { categoryId, keyword })
     return NextResponse.json({ compatibilities })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '互換品の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '互換品の取得に失敗しました'))
   }
 }
 
@@ -114,6 +114,6 @@ export async function POST(request: NextRequest) {
       throw error
     }
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '互換品の登録に失敗しました')
+    return apiError(toClientErrorMessage(error, '互換品の登録に失敗しました'))
   }
 }

--- a/src/app/api/consumable-orders/route.ts
+++ b/src/app/api/consumable-orders/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listConsumableOrders, createConsumableOrder } from '@/lib/consumable-orders/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parsePagination } from '@/lib/api-pagination'
 import type { ConsumableOrderInput } from '@/types/order'
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const orders = await listConsumableOrders(db, facilityId!, limit, offset)
     return NextResponse.json({ orders })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '消耗品発注一覧の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '消耗品発注一覧の取得に失敗しました'))
   }
 }
 
@@ -52,6 +52,6 @@ export async function POST(request: NextRequest) {
     const order = await createConsumableOrder(db, body.facilityId, { items: body.items })
     return NextResponse.json({ order }, { status: 201 })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '発注に失敗しました')
+    return apiError(toClientErrorMessage(error, '発注に失敗しました'))
   }
 }

--- a/src/app/api/consumables/route.ts
+++ b/src/app/api/consumables/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listConsumablesByFacility, createConsumable } from '@/lib/consumables/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { ConsumableInput } from '@/types/order'
 
 export async function GET(request: NextRequest) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     const consumables = await listConsumablesByFacility(db, facilityId!)
     return NextResponse.json({ consumables })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '消耗品の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '消耗品の取得に失敗しました'))
   }
 }
 
@@ -54,6 +54,6 @@ export async function POST(request: NextRequest) {
     })
     return NextResponse.json({ consumable }, { status: 201 })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '消耗品の作成に失敗しました')
+    return apiError(toClientErrorMessage(error, '消耗品の作成に失敗しました'))
   }
 }

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -5,7 +5,7 @@ import { listUserFacilities } from '@/lib/user-facilities/repository'
 import { getFacilityOrderSummary } from '@/lib/dashboard/facility-summary'
 import { getLoanOutstandingCount } from '@/lib/dashboard/loan-outstanding'
 import { listRecentPriceHistories } from '@/lib/price-histories/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { DashboardData, DashboardFacilitySummary, LoanOutstandingSummary } from '@/types/dashboard'
 
 export async function GET() {
@@ -69,6 +69,6 @@ export async function GET() {
 
     return NextResponse.json(data)
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : 'ダッシュボードの取得に失敗しました')
+    return apiError(toClientErrorMessage(error, 'ダッシュボードの取得に失敗しました'))
   }
 }

--- a/src/app/api/distributor-products/route.ts
+++ b/src/app/api/distributor-products/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listDistributorProducts, createDistributorProduct } from '@/lib/distributor-products/repository'
-import { apiError, sanitizeDbError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parseKeyword } from '@/lib/api-keyword-query'
 import type {
   DistributorProductInput,
@@ -47,7 +47,7 @@ export async function GET(
     const items = await listDistributorProducts(db, query)
     return NextResponse.json({ items } satisfies DistributorProductsApiResponse)
   } catch (error) {
-    return distributorProductsApiError(sanitizeDbError(error, '販売店商品の取得に失敗しました'))
+    return distributorProductsApiError(toClientErrorMessage(error, '販売店商品の取得に失敗しました'))
   }
 }
 
@@ -75,6 +75,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message.includes('存在しません')) {
       return apiError(error.message, 404)
     }
-    return apiError(error instanceof Error ? error.message : 'ディーラー商品の作成に失敗しました')
+    return apiError(toClientErrorMessage(error, 'ディーラー商品の作成に失敗しました'))
   }
 }

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listFacilities, createFacility } from '@/lib/facilities/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { FacilityInput } from '@/types/facility'
 
 export async function GET() {
@@ -18,7 +18,7 @@ export async function GET() {
     const isAdmin = await resolveIsAdmin(db, user)
     return NextResponse.json({ facilities, isAdmin })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '施設の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '施設の取得に失敗しました'))
   }
 }
 
@@ -46,6 +46,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message.includes('既に使用されています')) {
       return apiError('施設名が重複しています', 409)
     }
-    return apiError(error instanceof Error ? error.message : '施設の作成に失敗しました')
+    return apiError(toClientErrorMessage(error, '施設の作成に失敗しました'))
   }
 }

--- a/src/app/api/hospital-prices/route.ts
+++ b/src/app/api/hospital-prices/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listHospitalPrices, createHospitalPrice } from '@/lib/hospital-prices/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { HospitalPriceInput } from '@/types/hospitalPrice'
 
 export async function GET(request: NextRequest) {
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     const prices = await listHospitalPrices(db, grantedFacilityId)
     return NextResponse.json({ prices })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '価格の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '価格の取得に失敗しました'))
   }
 }
 
@@ -61,8 +61,7 @@ export async function POST(request: NextRequest) {
       if (error.message.includes('存在しません')) {
         return apiError(error.message, 422)
       }
-      return apiError(error.message)
     }
-    return apiError('価格の作成に失敗しました')
+    return apiError(toClientErrorMessage(error, '価格の作成に失敗しました'))
   }
 }

--- a/src/app/api/loan-orders/route.ts
+++ b/src/app/api/loan-orders/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listLoanOrders, createLoanOrder } from '@/lib/loan-orders/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parsePagination } from '@/lib/api-pagination'
 import type { LoanOrderInput } from '@/types/order'
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const orders = await listLoanOrders(db, facilityId!, limit, offset)
     return NextResponse.json({ orders })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '短貸発注一覧の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '短貸発注一覧の取得に失敗しました'))
   }
 }
 
@@ -61,6 +61,6 @@ export async function POST(request: NextRequest) {
     const order = await createLoanOrder(db, body.facilityId, input)
     return NextResponse.json({ order }, { status: 201 })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '発注に失敗しました')
+    return apiError(toClientErrorMessage(error, '発注に失敗しました'))
   }
 }

--- a/src/app/api/loan-returns/route.ts
+++ b/src/app/api/loan-returns/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listLoanReturns, createLoanReturn, LOAN_ORDER_NOT_FOUND_ERROR } from '@/lib/loan-returns/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parsePagination } from '@/lib/api-pagination'
 import type { LoanReturnInput } from '@/types/order'
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const returns = await listLoanReturns(db, facilityId!, limit, offset)
     return NextResponse.json({ returns })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : '返却一覧の取得に失敗しました')
+    return apiError(toClientErrorMessage(error, '返却一覧の取得に失敗しました'))
   }
 }
 
@@ -68,6 +68,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message === LOAN_ORDER_NOT_FOUND_ERROR) {
       return apiError(LOAN_ORDER_NOT_FOUND_ERROR, 400)
     }
-    return apiError(error instanceof Error ? error.message : '返却に失敗しました')
+    return apiError(toClientErrorMessage(error, '返却に失敗しました'))
   }
 }

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listNewsFeed } from '@/lib/news/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 
 const DEFAULT_LIMIT = 20
 const DEFAULT_OFFSET = 0
@@ -53,6 +53,6 @@ export async function GET(request: NextRequest) {
     const items = await listNewsFeed(db, { facilityId: grantedFacilityId, limit, offset })
     return NextResponse.json({ items })
   } catch (error) {
-    return apiError(error instanceof Error ? error.message : 'ニュースの取得に失敗しました')
+    return apiError(toClientErrorMessage(error, 'ニュースの取得に失敗しました'))
   }
 }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
 import { listOrders } from '@/lib/orders/repository'
-import { apiError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parsePagination } from '@/lib/api-pagination'
 import { isValidDateString } from '@/lib/jst-date-range'
 import type { OrderKind, OrdersApiErrorResponse, OrdersApiQuery, OrdersApiResponse } from '@/types/order'
@@ -79,6 +79,6 @@ export async function GET(request: NextRequest): Promise<NextResponse<OrdersApiR
     const body: OrdersApiResponse = { orders }
     return NextResponse.json(body)
   } catch (error) {
-    return ordersApiError(error instanceof Error ? error.message : '発注履歴の取得に失敗しました')
+    return ordersApiError(toClientErrorMessage(error, '発注履歴の取得に失敗しました'))
   }
 }

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -3,7 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listProducts, createProduct } from '@/lib/products/repository'
-import { apiError, sanitizeDbError } from '@/lib/api-error'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { parseKeyword } from '@/lib/api-keyword-query'
 import type { ProductInput, ProductsApiErrorResponse, ProductsApiQuery, ProductsApiResponse } from '@/types/product'
 
@@ -31,7 +31,7 @@ export async function GET(
     const products = await listProducts(db, query)
     return NextResponse.json({ products } satisfies ProductsApiResponse)
   } catch (error) {
-    return productsApiError(sanitizeDbError(error, '製品の取得に失敗しました'))
+    return productsApiError(toClientErrorMessage(error, '製品の取得に失敗しました'))
   }
 }
 
@@ -63,6 +63,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error && error.message.includes('既に使用されています')) {
       return apiError('JAN または REF が重複しています', 409)
     }
-    return apiError(error instanceof Error ? error.message : '製品の作成に失敗しました')
+    return apiError(toClientErrorMessage(error, '製品の作成に失敗しました'))
   }
 }

--- a/src/lib/api-error.test.ts
+++ b/src/lib/api-error.test.ts
@@ -1,24 +1,42 @@
-import { describe, it, expect, vi } from 'vitest'
-import { sanitizeDbError } from './api-error'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { toClientErrorMessage } from './api-error'
+import { ClientVisibleError } from './client-visible-error'
 
-describe('sanitizeDbError', () => {
-  it('Errorインスタンスを渡してもfallbackMessageのみ返す', () => {
+describe('toClientErrorMessage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('ClientVisibleErrorのmessageはそのまま返す(repository層が安全と保証した翻訳済みメッセージ)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new ClientVisibleError('カテゴリ名が既に使用されています')
+    expect(toClientErrorMessage(error, 'fallback')).toBe('カテゴリ名が既に使用されています')
+  })
+
+  it('通常のErrorインスタンスを渡してもfallbackMessageのみ返す(生のDBエラー漏洩防止)', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = new Error('relation "products" does not exist')
-    expect(sanitizeDbError(error, '製品の取得に失敗しました')).toBe('製品の取得に失敗しました')
+    expect(toClientErrorMessage(error, '製品の取得に失敗しました')).toBe('製品の取得に失敗しました')
   })
 
   it('文字列を渡してもfallbackMessageのみ返す（元のmessageを含まない）', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    const result = sanitizeDbError('duplicate key value violates unique constraint "products_jan_key"', 'fallback')
+    const result = toClientErrorMessage('duplicate key value violates unique constraint "products_jan_key"', 'fallback')
     expect(result).toBe('fallback')
     expect(result).not.toContain('products_jan_key')
   })
 
-  it('console.errorにerror内容を記録する', () => {
+  it('ClientVisibleError以外はconsole.errorにerror内容を記録する', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = new Error('detail')
-    sanitizeDbError(error, 'fallback')
+    toClientErrorMessage(error, 'fallback')
     expect(spy).toHaveBeenCalledWith(error)
+  })
+
+  it('ClientVisibleErrorの場合はconsole.errorを呼ばない(想定内の業務エラーのためログ不要)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new ClientVisibleError('使用中のため削除できません')
+    toClientErrorMessage(error, 'fallback')
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { ClientVisibleError } from './client-visible-error'
 
 // WHY: 全 API のエラーレスポンスを { error: string } 形式に統一し、catch ごとの書きぶれを防ぐため
 export function apiError(message: string, status = 500) {
@@ -6,11 +7,12 @@ export function apiError(message: string, status = 500) {
 }
 
 // WHY: Supabase/Postgresの生エラーメッセージにはテーブル名・制約名が含まれうるため、
-//      クライアントに返す前に必ずこの関数を通してスキーマ情報の漏洩を防ぐ
-export function sanitizeDbError(error: unknown, fallbackMessage: string): string {
-  // 23505(unique_violation)・23503(foreign_key_violation)等、既存の個別コードハンドリングが
-  // ある呼び出し元(repository層)ではその判定結果(Error.message)がここに渡ってくる。
-  // ここでは生メッセージを返さずfallbackMessageのみ返す。詳細はconsole.errorでサーバ側ログにのみ記録する。
+//      クライアントに返す前に必ずこの関数を通してスキーマ情報の漏洩を防ぐ。
+//      ClientVisibleErrorのインスタンス(repository層が明示的に翻訳済みと保証した安全なメッセージ)
+//      だけをそのまま通し、それ以外は詳細をconsole.errorでサーバ側ログにのみ記録しfallbackを返す
+//      (architecture review 2026-07-26 issue #3: 25箇所のraw error.message漏洩の修正)
+export function toClientErrorMessage(error: unknown, fallbackMessage: string): string {
+  if (error instanceof ClientVisibleError) return error.message
   console.error(error)
   return fallbackMessage
 }

--- a/src/lib/categories/repository.ts
+++ b/src/lib/categories/repository.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asNullableString } from '@/lib/mapping'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { Category, CategoryInput } from '@/types/category'
 
 const CATEGORY_COLUMNS = 'id, name, description, created_at, updated_at'
@@ -51,7 +52,7 @@ export async function createCategory(db: SupabaseClient, input: CategoryInput): 
     .select(CATEGORY_COLUMNS)
     .single()
   if (error) {
-    if (error.code === '23505') throw new Error('カテゴリ名が既に使用されています')
+    if (error.code === '23505') throw new ClientVisibleError('カテゴリ名が既に使用されています')
     throw new Error(error.message)
   }
   return mapCategory(data)
@@ -65,8 +66,8 @@ export async function updateCategory(db: SupabaseClient, id: string, input: Cate
     .select(CATEGORY_COLUMNS)
     .single()
   if (error) {
-    if (error.code === 'PGRST116') throw new Error(`カテゴリID "${id}" は存在しません`)
-    if (error.code === '23505') throw new Error('カテゴリ名が既に使用されています')
+    if (error.code === 'PGRST116') throw new ClientVisibleError(`カテゴリID "${id}" は存在しません`)
+    if (error.code === '23505') throw new ClientVisibleError('カテゴリ名が既に使用されています')
     throw new Error(error.message)
   }
   return mapCategory(data)
@@ -78,7 +79,7 @@ export async function deleteCategory(db: SupabaseClient, id: string): Promise<vo
     .select('id', { count: 'exact', head: true })
     .eq('category_id', id)
   if (countError) throw new Error(countError.message)
-  if ((count ?? 0) > 0) throw new Error('使用中のため削除できません')
+  if ((count ?? 0) > 0) throw new ClientVisibleError('使用中のため削除できません')
 
   const { data, error } = await db
     .from('categories')
@@ -86,5 +87,5 @@ export async function deleteCategory(db: SupabaseClient, id: string): Promise<vo
     .eq('id', id)
     .select('id')
   if (error) throw new Error(error.message)
-  if (data.length === 0) throw new Error(`カテゴリID "${id}" は存在しません`)
+  if (data.length === 0) throw new ClientVisibleError(`カテゴリID "${id}" は存在しません`)
 }

--- a/src/lib/client-visible-error.ts
+++ b/src/lib/client-visible-error.ts
@@ -1,0 +1,5 @@
+// WHY: repository層が投げるErrorのうち「翻訳済みで安全にクライアントへ見せてよいメッセージ」だけを
+//      区別するためのマーカークラス。api-error.tsのtoClientErrorMessageはこのクラスのインスタンスの
+//      messageだけをそのまま返し、それ以外(生のPostgres/Supabaseエラー等)はサニタイズする
+//      (architecture review 2026-07-26 issue #3: raw error.messageのDBスキーマ情報漏洩対策)
+export class ClientVisibleError extends Error {}

--- a/src/lib/distributor-products/repository.ts
+++ b/src/lib/distributor-products/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asNumber, asNullableNumber } from '@/lib/mapping'
 import { buildIlikeValue } from '@/lib/search/like-pattern'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { DistributorProduct, DistributorProductInput, DistributorProductListFilter } from '@/types/distributorProduct'
 
 const DISTRIBUTOR_PRODUCT_COLUMNS =
@@ -84,7 +85,7 @@ export async function createDistributorProduct(db: SupabaseClient, input: Distri
     .select(DISTRIBUTOR_PRODUCT_COLUMNS)
     .single()
   if (error) {
-    if (error.code === '23503') throw new Error(`製品ID "${input.productId}" は存在しません`)
+    if (error.code === '23503') throw new ClientVisibleError(`製品ID "${input.productId}" は存在しません`)
     throw new Error(error.message)
   }
   return mapDistributorProduct(data)
@@ -106,8 +107,8 @@ export async function updateDistributorProduct(db: SupabaseClient, id: string, i
     .select(DISTRIBUTOR_PRODUCT_COLUMNS)
     .single()
   if (error) {
-    if (error.code === 'PGRST116') throw new Error(`代理店商品ID "${id}" は存在しません`)
-    if (error.code === '23503') throw new Error(`製品ID "${input.productId}" は存在しません`)
+    if (error.code === 'PGRST116') throw new ClientVisibleError(`代理店商品ID "${id}" は存在しません`)
+    if (error.code === '23503') throw new ClientVisibleError(`製品ID "${input.productId}" は存在しません`)
     throw new Error(error.message)
   }
   return mapDistributorProduct(data)
@@ -120,5 +121,5 @@ export async function deleteDistributorProduct(db: SupabaseClient, id: string): 
     .eq('id', id)
     .select('id')
   if (error) throw new Error(error.message)
-  if (data.length === 0) throw new Error(`代理店商品ID "${id}" は存在しません`)
+  if (data.length === 0) throw new ClientVisibleError(`代理店商品ID "${id}" は存在しません`)
 }

--- a/src/lib/facilities/repository.ts
+++ b/src/lib/facilities/repository.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString } from '@/lib/mapping'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { Facility, FacilityInput } from '@/types/facility'
 
 const FACILITY_COLUMNS = 'id, name, created_at, updated_at'
@@ -49,7 +50,7 @@ export async function createFacility(db: SupabaseClient, input: FacilityInput): 
     .select(FACILITY_COLUMNS)
     .single()
   if (error) {
-    if (error.code === '23505') throw new Error(`施設名 "${input.name}" は既に使用されています`)
+    if (error.code === '23505') throw new ClientVisibleError(`施設名 "${input.name}" は既に使用されています`)
     throw new Error(error.message)
   }
   return mapFacility(data)
@@ -63,8 +64,8 @@ export async function updateFacility(db: SupabaseClient, id: string, input: Faci
     .select(FACILITY_COLUMNS)
     .single()
   if (error) {
-    if (error.code === 'PGRST116') throw new Error(`施設ID "${id}" は存在しません`)
-    if (error.code === '23505') throw new Error(`施設名 "${input.name}" は既に使用されています`)
+    if (error.code === 'PGRST116') throw new ClientVisibleError(`施設ID "${id}" は存在しません`)
+    if (error.code === '23505') throw new ClientVisibleError(`施設名 "${input.name}" は既に使用されています`)
     throw new Error(error.message)
   }
   return mapFacility(data)
@@ -77,5 +78,5 @@ export async function deleteFacility(db: SupabaseClient, id: string): Promise<vo
     .eq('id', id)
     .select('id')
   if (error) throw new Error(error.message)
-  if (data.length === 0) throw new Error(`施設ID "${id}" は存在しません`)
+  if (data.length === 0) throw new ClientVisibleError(`施設ID "${id}" は存在しません`)
 }

--- a/src/lib/hospital-prices/repository.ts
+++ b/src/lib/hospital-prices/repository.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asNumber, asNullableNumber } from '@/lib/mapping'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { HospitalPrice, HospitalPriceInput } from '@/types/hospitalPrice'
 
 const HOSPITAL_PRICE_COLUMNS =
@@ -71,8 +72,8 @@ export async function createHospitalPrice(db: SupabaseClient, input: HospitalPri
     .select(HOSPITAL_PRICE_COLUMNS)
     .single()
   if (error) {
-    if (error.code === '23505') throw new Error('この代理店商品と施設の組み合わせは既に登録されています')
-    if (error.code === '23503') throw new Error('代理店商品または施設が存在しません')
+    if (error.code === '23505') throw new ClientVisibleError('この代理店商品と施設の組み合わせは既に登録されています')
+    if (error.code === '23503') throw new ClientVisibleError('代理店商品または施設が存在しません')
     throw new Error(error.message)
   }
   return mapHospitalPrice(data)
@@ -91,9 +92,9 @@ export async function updateHospitalPrice(db: SupabaseClient, id: string, input:
     .select(HOSPITAL_PRICE_COLUMNS)
     .single()
   if (error) {
-    if (error.code === 'PGRST116') throw new Error(`病院別価格ID "${id}" は存在しません`)
-    if (error.code === '23505') throw new Error('この代理店商品と施設の組み合わせは既に登録されています')
-    if (error.code === '23503') throw new Error('代理店商品または施設が存在しません')
+    if (error.code === 'PGRST116') throw new ClientVisibleError(`病院別価格ID "${id}" は存在しません`)
+    if (error.code === '23505') throw new ClientVisibleError('この代理店商品と施設の組み合わせは既に登録されています')
+    if (error.code === '23503') throw new ClientVisibleError('代理店商品または施設が存在しません')
     throw new Error(error.message)
   }
   return mapHospitalPrice(data)
@@ -106,5 +107,5 @@ export async function deleteHospitalPrice(db: SupabaseClient, id: string): Promi
     .eq('id', id)
     .select('id')
   if (error) throw new Error(error.message)
-  if (data.length === 0) throw new Error(`病院別価格ID "${id}" は存在しません`)
+  if (data.length === 0) throw new ClientVisibleError(`病院別価格ID "${id}" は存在しません`)
 }

--- a/src/lib/loan-returns/repository.ts
+++ b/src/lib/loan-returns/repository.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asOptionalString, asNumber, asEnum } from '@/lib/mapping'
 import { jstDayStart, jstDayEnd } from '@/lib/jst-date-range'
 import { KEYWORD_SCAN_LIMIT, type OrderRepositoryFilter } from '@/lib/orders/list-filter'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { LoanReturn, LoanReturnInput, LoanReturnItem } from '@/types/order'
 
 const STATUSES = ['draft', 'returned'] as const
@@ -117,7 +118,7 @@ export async function createLoanReturn(db: SupabaseClient, facilityId: string, i
       .eq('facility_id', facilityId)
       .maybeSingle()
     if (loanOrderError) throw new Error(loanOrderError.message)
-    if (!loanOrder) throw new Error(LOAN_ORDER_NOT_FOUND_ERROR)
+    if (!loanOrder) throw new ClientVisibleError(LOAN_ORDER_NOT_FOUND_ERROR)
   }
 
   const { data: ret, error: retError } = await db
@@ -126,7 +127,7 @@ export async function createLoanReturn(db: SupabaseClient, facilityId: string, i
     .select(LOAN_RETURN_COLUMNS)
     .single()
   if (retError) throw new Error(retError.message)
-  if (!ret) throw new Error('loan_returns の作成に失敗しました')
+  if (!ret) throw new ClientVisibleError('loan_returns の作成に失敗しました')
 
   const r = ret as LoanReturnRow
   const itemRows = input.items.map(item => ({

--- a/src/lib/products/repository.ts
+++ b/src/lib/products/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asNullableString, asString } from '@/lib/mapping'
 import { buildIlikeValue } from '@/lib/search/like-pattern'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import type { Product, ProductInput, ProductListFilter } from '@/types/product'
 
 const PRODUCT_COLUMNS = 'id, jan, ref, name, maker, created_at, updated_at'
@@ -68,7 +69,7 @@ export async function createProduct(db: SupabaseClient, input: ProductInput): Pr
     .select(PRODUCT_COLUMNS)
     .single()
   if (error) {
-    if (error.code === '23505') throw new Error('JAN または REF が既に使用されています')
+    if (error.code === '23505') throw new ClientVisibleError('JAN または REF が既に使用されています')
     throw new Error(error.message)
   }
   return mapProduct(data)
@@ -82,8 +83,8 @@ export async function updateProduct(db: SupabaseClient, id: string, input: Produ
     .select(PRODUCT_COLUMNS)
     .single()
   if (error) {
-    if (error.code === 'PGRST116') throw new Error(`製品ID "${id}" は存在しません`)
-    if (error.code === '23505') throw new Error('JAN または REF が既に使用されています')
+    if (error.code === 'PGRST116') throw new ClientVisibleError(`製品ID "${id}" は存在しません`)
+    if (error.code === '23505') throw new ClientVisibleError('JAN または REF が既に使用されています')
     throw new Error(error.message)
   }
   return mapProduct(data)
@@ -96,5 +97,5 @@ export async function deleteProduct(db: SupabaseClient, id: string): Promise<voi
     .eq('id', id)
     .select('id')
   if (error) throw new Error(error.message)
-  if (data.length === 0) throw new Error(`製品ID "${id}" は存在しません`)
+  if (data.length === 0) throw new ClientVisibleError(`製品ID "${id}" は存在しません`)
 }


### PR DESCRIPTION
Closes #566

## 作業サマリ
- 変更した目的: 17ファイル25箇所超のroute.tsが生のPostgres/Supabaseエラー(テーブル名・制約名を含みうる)をそのままクライアントへ返していた問題を修正
- 変更した範囲:
  - `src/lib/client-visible-error.ts`(新設): `ClientVisibleError`マーカークラス
  - `src/lib/api-error.ts`: `sanitizeDbError`を`toClientErrorMessage`に統合(ClientVisibleErrorのみmessageを通し、それ以外はconsole.error後にfallbackを返す)
  - `src/lib/{products,categories,facilities,hospital-prices,distributor-products,loan-returns}/repository.ts`: 翻訳済みで安全な業務エラー(JAN重複・カテゴリ名重複・施設名重複・IDが存在しない・使用中のため削除できない等、25箇所)を`ClientVisibleError`に変更
  - `src/app/api/**/route.ts`(17ファイル)・`admin/users`・`admin/user-facilities`: 生の`error.message`直接返却箇所を`toClientErrorMessage`経由に置き換え(既存の409/404等の特別分岐は維持)
- 触っていない範囲: `requireAuth`/`requireFacilityAccess`の認可フロー自体、`[id]/route.ts`系(PUT/DELETE)。これらは未知エラーを`throw error`でNext.jsの既定エラーハンドリングに委ねる別パターンで、クライアントへのraw message直接漏洩は無いため対象外と判断

## 検証済み
- 実行したコマンド: `npx tsc --noEmit`(既存issue #570由来の既知エラーのみ、新規エラーなし)、`npm run lint`(0エラー)、`npm test`(169 test files / 1274 tests 全passed)。`npm run ai:check`自体(test:e2e含む)は未実行
- 追加したテスト: `src/lib/api-error.test.ts`に`toClientErrorMessage`の単体テスト、`src/__tests__/api-order-error-handling.test.ts`に「ClientVisibleErrorでない例外はメッセージを漏らさずfallbackを返す」回帰テストを追加。既存の`api-order-error-handling.test.ts`の1テストは旧脆弱挙動(生メッセージがそのまま返ることを期待)を前提にしていたため、新しい安全な挙動を検証するテストとして追加(既存テスト自体は`typeof body.error === 'string'`のみ検証する形で維持)
- 確認した画面: なし(API層のみの変更、レスポンスの`{error: string}`形式自体は変えていない)
- 確認したDB/RLS: 変更なし(RLS/migrationには一切触れていない)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(認可ロジック自体は変更していない。requireAuth/requireFacilityAccessの呼び出し順序・挙動は不変)

## 既知の未対応
- 今回あえて対応しなかったこと: `[id]/route.ts`(PUT/DELETE、products/categories/facilities/distributor-products/hospital-prices)の`throw error`パターンへの手当て
- 理由: これらは生のraw messageをJSONで返してはおらず(Next.jsのフレームワーク既定エラーハンドリングに委ねている)、今回の「クライアントへのDBスキーマ情報漏洩」バグとは別種の問題(レスポンス形式の一貫性)であり、issueのスコープ外と判断
- 次に触るなら見る場所: 上記`[id]/route.ts`系のエラーレスポンス形式を統一したい場合は別issueとして起票する想定

## 後任AIへの注意
- この実装で壊してはいけない前提: `ClientVisibleError`は「repository層が翻訳済みで安全と保証したメッセージ」だけに使うこと。生のSupabase/Postgresエラーを安易に`ClientVisibleError`でラップしてはいけない(スキーマ情報漏洩の再発になる)
- 似ているが別物の用語: `ClientVisibleError`(今回新設、クライアントに見せてよい)と、`require-auth.ts`/`require-facility-access.ts`が投げる`'UNAUTHORIZED'`/`'FACILITY_ID_REQUIRED'`/`'FORBIDDEN'`(こちらは内部センチネル文字列で、route側が個別にexact matchして別の翻訳済みメッセージを返す。ClientVisibleErrorには変換していない)は別物
- 勝手にリファクタしない場所: `compat/route.ts`の`DUPLICATE_COMPATIBILITY_ERROR`/`CATEGORY_NOT_FOUND_ERROR`(compatibilities/repository.ts)は意図的に`ClientVisibleError`化していない。route側で`.toLowerCase().includes(...)`によるexact match変換が既にあり、二重の安全網として「その変換ロジックが将来壊れた場合に内部センチネル文字列がそのまま漏れない」ようにするための意図的な設計判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)