### PR TITLE
docs: 管理者判定decisions.mdの記述をADMIN_EMAILSブートストラップ仕様に合わせて修正(issue #567)

### DIFF
--- a/docs/agents/decisions/db-rls.md
+++ b/docs/agents/decisions/db-rls.md
@@ -13,15 +13,22 @@
 1つでもあれば他施設のデータが見えてしまう。RLSをDB層に置くことで、どのAPIルート・どのクエリ
 経路を通っても機械的に遮断される。
 
-## なぜ管理者判定をDB role（user_facilities.role）ベースにしたか
+## なぜ管理者判定をDB role（user_facilities.role）ベースにし、ADMIN_EMAILSは初回ブートストラップ専用に限定したか
 
-**結論: 管理者判定は環境変数ではなくDBの`user_facilities.role`に一本化する。**
+**結論: 管理者判定はDBの`user_facilities.role`を正とする。`ADMIN_EMAILS`環境変数は、DBにadminが1件も存在しない場合（＝初回デプロイ直後でまだ誰も管理者を割り当てられない状態）のみのブートストラップ用フォールバックとして残す。DBに1件でもadminが存在すれば、`ADMIN_EMAILS`は他の誰に対しても一切参照されない。**
 
 当初 `ADMIN_EMAILS` 環境変数によるフォールバックがあったが、`requireAdmin()` の判定を
 DBの `user_facilities.role = 'admin'` ベースに一本化した（`docs/specs/admin-role-migration.sql`）。
 
 環境変数ベースだと、デプロイ環境ごとに設定がずれる／環境変数の変更履歴がgit管理されない
 という問題があった。DBに判定根拠を置くことで、管理者の追加・削除がSQLとして履歴に残る。
+
+ただし新規デプロイ直後はDBにadminが1件も存在せず、誰もUIから管理者を割り当てられない
+「鶏と卵」問題が残る。issue #24対応（`src/lib/admin-status.ts`、`get_admin_status` RPC）で
+この初回ブートストラップ専用の用途に限定して`ADMIN_EMAILS`を復活させた。DBに1件でも
+adminが存在する場合は`db_has_admin`判定により`ADMIN_EMAILS`のチェック自体を行わないため、
+「一本化」の原則（判定根拠はDBが正）自体は崩していない。この設計は
+`src/lib/__tests__/admin-status.test.ts`のテストケースで固定されている。
 
 ## なぜprice_historiesはdistributor_product側の施設チェックを素通りさせるか
 


### PR DESCRIPTION
Closes #567

## 作業サマリ
- 変更した目的: `docs/agents/decisions/db-rls.md`が「管理者判定はDB roleへ一本化した」と無条件に書いており、`src/lib/admin-status.ts`の実装(ADMIN_EMAILSを初回ブートストラップ専用フォールバックとして意図的に残す設計)と食い違っていた記述を、実態に合わせて修正
- 変更した範囲: `docs/agents/decisions/db-rls.md`の該当セクションのみ
- 触っていない範囲: `src/lib/admin-status.ts`本体・関連テスト・DB migration(コード変更は無し)

## 調査結果(ユーザー確認済みの対応方針)
- 当初は「decisionsの決定通りコードを直す」対応も検討したが、`src/lib/__tests__/admin-status.test.ts`の7ケースを確認したところ、ADMIN_EMAILSは「DBにadminが1件も存在しない場合のみ」のブートストラップ専用フォールバックとして意図的に設計・テストされていることが分かった(issue #24対応、commit 5f4840a)
- DBに1件でもadminが存在すれば、ADMIN_EMAILSは他の誰に対しても一切参照されない(`db_has_admin`判定)。恒久的な並行認可経路ではない
- コードを変更してこの機能を削除すると、新規デプロイ時に最初の管理者を作る手段が無くなるため、ユーザーと相談の上「実装ではなくdecisions.mdの記述を実態に合わせて修正する」方針を選択した

## 検証済み
- 実行したコマンド: ドキュメントのみの変更のためnpm run ai:checkは対象外(コード変更が無いことをgit diffで確認済み)
- 確認した画面: なし
- 確認したDB/RLS: 変更なし
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(コード変更なし)

## 既知の未対応
- 今回あえて対応しなかったこと: `src/lib/admin-status.ts`のコード自体の変更
- 理由: 上記の通り、実装は意図通り正しく動作しておりテストで固定されているため、変更が必要なのは記述の方だった
- 次に触るなら見る場所: 将来的にADMIN_EMAILS自体を廃止したい場合は、新規デプロイ時の初回管理者作成の代替手段(seed migration等)を先に用意すること

## 後任AIへの注意
- この実装で壊してはいけない前提: `ADMIN_EMAILS`は「DBにadminが1件もいない場合のみ」有効という条件付きの設計。ここを「常時有効なフォールバック」と誤解して恒久的な認可経路として扱わないこと
- 似ているが別物の用語: 「管理者判定の一本化」は「DB roleを判定の正とする」という意味であり、「ADMIN_EMAILSを完全に廃止する」という意味ではない(今回decisions.mdの表現をこの区別が伝わるように修正した)
- 勝手にリファクタしない場所: `src/lib/admin-status.ts`の`db_has_admin`チェックとその順序(自分がadmin→DBに他のadminがいるか→いなければADMIN_EMAILS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)