### PR TITLE
AIDD実行記録をcanonical event moduleへ統合する(issue #569)

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -211,6 +211,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | [`docs/agents/run-manifest.md`](./run-manifest.md) | AIDDフローのspecHash/baseCommit突合用Run Manifestのスキーマ |
 | `scripts/log-agent-progress.sh` / `scripts/show-agent-status.sh` | サブエージェント進捗の記録・一覧表示（issue #18） |
 | `scripts/lib/resolve-log-dir.sh` | `logs/`の書き込み先をworktree横断で単一のディレクトリ（メインworktree直下）に解決する。全`log-*.sh`/`check-*.sh`/`summarize-*.sh`が参照する（issue #546。従来は各worktreeが起動時のカレントディレクトリ相対で別々の`logs/`に書き込み、観測記録の約半数が死蔵していた） |
+| `scripts/lib/canonical-event.ts` | hook/journal/agent-progress/loop-observabilityの4ログを正規化する読み取り専用Adapter層（issue #569） |
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |
 | `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
 | `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |

--- a/docs/agents/observability-internals.md
+++ b/docs/agents/observability-internals.md
@@ -60,6 +60,15 @@ loop-observabilityと同じ構造的限界を持つ：**エージェントへの
     （hooks非継承・セッション非永続化・同時実行数上限）を初回コミットから組み込んだ上でのみ
     着手する。issue本文に理由を明記済み。
 
+## canonical event moduleへの統合（issue #569）
+
+上記4つのログ（agent-progress/loop-observability/subagent-skeleton/journal）は`scripts/lib/canonical-event.ts`
+が読み取り専用Adapterとして正規化する。設計・突合アルゴリズム・実機検証結果（hookのagent_idと
+journal.jsonlのagentIdが同一空間であることを確認済み）は
+[`docs/superpowers/specs/2026-07-27-canonical-event-module-design.md`](../superpowers/specs/2026-07-27-canonical-event-module-design.md)参照。
+`verify-agent-progress-transcript.ts`は本モジュール経由の薄いラッパーに統合済み。既存gap check
+bashスクリプト（`check-loop-observability-gap.sh`等）・ログ書き込み側は無改修のまま。
+
 ## サブエージェント骨格記録の機械強制（issue #423）
 
 上記の`agent-progress.jsonl` / `loop-observability.jsonl`は、いずれもエージェントへの

--- a/docs/agents/observability-internals.md
+++ b/docs/agents/observability-internals.md
@@ -47,9 +47,8 @@ loop-observabilityと同じ構造的限界を持つ：**エージェントへの
   パース処理を再利用）のstatus/detailを機械比較し、食い違う行のみ検出する。LLM呼び出し不要。
   - agent-progress.jsonlはagentId/workflow実行IDを保持しないため、`--agent`名から既知
     agentType一覧への前方一致でagentTypeを復元し、同じagentType内で最も時刻が近い
-    transcriptに貪欲に対応付けるベストエフォート方式（`scripts/lib/
-    verify-agent-progress-transcript.ts`の`matchRecords`）。1:1のID突合ではないため、
-    高並行実行下では誤対応の可能性が残る。
+    transcriptに貪欲に対応付けるベストエフォート方式（`scripts/lib/canonical-event.ts`の
+    `correlateEvents`）。1:1のID突合ではないため、高並行実行下では誤対応の可能性が残る。
   - statusの食い違い（自己申告doneなのにtranscriptがfail等）は確定的な指摘として
     `mismatches` に、detailの低一致（文字bigramのJaccard類似度が閾値未満）は
     「要目視確認」の弱いシグナルとして `lowOverlapDetails` に分けて出力する
@@ -130,10 +129,10 @@ agentTranscriptPath?, lastAssistantMessage?}`形式で自動記録される。�
   `reconstructWorkflowDir`が`loadJournalResults`（`export`済み）でjournal.jsonlの構造化result
   （statusが`pass|fail|blocked`のもの）を優先し、無ければ従来のtranscriptパース結果へ
   フォールバックする
-- **verify側の組み込み（issue #493で実装済み）**: `verify-agent-progress-transcript.ts`の
-  `loadTranscripts`も同じ`loadJournalResults`を再利用し、`TranscriptRecord`の`status`/`detail`
-  をjournal.jsonl優先で取得する（`endTimestamp`はjournal.jsonlにタイムスタンプが無いため
-  引き続きtranscript側から取得し、`matchRecords`の時刻近接突合ロジックには影響しない）
+- **verify側の組み込み（issue #493で実装済み、issue #569でcanonical-event.tsへ再統合済み）**:
+  `canonical-event.ts`の`journalAdapter`が同じ`loadJournalResults`を再利用し、`CanonicalEvent`の
+  `status`/`detail`をjournal.jsonl優先で取得する（`endTimestamp`はjournal.jsonlにタイムスタンプが
+  無いため引き続きtranscript側から取得し、`correlateEvents`の時刻近接突合ロジックには影響しない）
 
 ## OpenTelemetryと自作JSONLの役割分担（issue #417）
 

--- a/docs/superpowers/plans/2026-07-27-canonical-event-module.md
+++ b/docs/superpowers/plans/2026-07-27-canonical-event-module.md
@@ -1,0 +1,1591 @@
+# Canonical Event Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** hook/journal/agent-progress/loop-observabilityの4つのAIDD実行ログを正規化する読み取り専用Adapterモジュール`scripts/lib/canonical-event.ts`を新設し、既存の`verify-agent-progress-transcript.ts`をそのモジュール経由の薄いラッパーへリファクタする。
+
+**Architecture:** 各ログを`CanonicalEvent`に正規化する4つのAdapter（`subagentSkeletonAdapter`/`agentProgressAdapter`/`loopObservabilityAdapter`/`journalAdapter`）と、それらを同一実行単位へ突合する`correlateEvents()`（Stage1: agentId厳密一致 → Stage2: agentType+30分窓の貪欲割当）を実装する。ログの書き込み側・既存gap check bashスクリプトは無改修。
+
+**Tech Stack:** TypeScript, vitest, Node.js `fs`/`path`標準モジュール
+
+**参照仕様書:** [`docs/superpowers/specs/2026-07-27-canonical-event-module-design.md`](../specs/2026-07-27-canonical-event-module-design.md)
+
+## Global Constraints
+
+- コード内コメントは日本語で書き、WHY（なぜその実装か）のみを書く。WHATは書かない（既存コードの規約に合わせる）
+- 既存のexport済み関数・型（`reconstruct-loop-observability.ts`の`pairAgentFiles`/`loadJournalResults`/`parseAgentTranscriptLines`等）は変更せず再利用する
+- `verify-agent-progress-transcript.ts`のexit codeロジックは無変更のまま維持する（CLI引数・出力フォーマットはTask 10で`selfEvent`/`anchorEvent`等の新フィールド名・新テキストへ変更する。唯一の外部消費者`scripts/verify-agent-progress-transcript.sh`は出力をパースせず素通しするため実害なしとユーザー承認済み、2026-07-27）
+- 全テストは`npm test`（vitest run）で実行できること。`vitest.config.ts`の`exclude`に該当しないファイル配置にする
+- gap check bashスクリプト（`check-loop-observability-gap.sh`/`check-agent-progress-gap.sh`）自体は変更しない
+
+---
+
+## File Structure
+
+- Create: `scripts/lib/canonical-event.ts` — 4 Adapter + `CanonicalEvent`型 + `correlateEvents()`
+- Create: `scripts/lib/canonical-event.test.ts` — Adapter単体・`correlateEvents()`のテスト
+- Create: `scripts/lib/canonical-event-gap-check-equivalence.test.ts` — 既存gap checkとの等価性テスト
+- Modify: `scripts/lib/verify-agent-progress-transcript.ts` — `canonical-event.ts`経由の薄いラッパーへリファクタ
+- Modify: `scripts/lib/verify-agent-progress-transcript.test.ts` — 新しい`buildReport`シグネチャに合わせて再配置
+- Modify: `docs/agents/observability-internals.md` — 統合の設計・実機検証結果を追記
+- Modify: `docs/agents/common.md` — 「重要ファイルへのパス」表に1行追加
+
+---
+
+### Task 1: CanonicalEvent型・eventIdヘルパー・agentTypeユーティリティ
+
+**Files:**
+- Create: `scripts/lib/canonical-event.ts`
+- Test: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Produces: `EventSource`, `EventStatus`, `CanonicalEvent`, `KNOWN_AGENT_TYPES`, `extractAgentType(selfAgentField: string): string | null`, `buildEventId(source: EventSource, agentType: string | null, timestamp: string, lineIndex: number): string`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts
+import { describe, expect, it } from 'vitest'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES } from './canonical-event'
+
+describe('KNOWN_AGENT_TYPES', () => {
+  it('12種類のagentTypeを含む', () => {
+    expect(KNOWN_AGENT_TYPES).toHaveLength(12)
+    expect(KNOWN_AGENT_TYPES).toContain('sweep-ui')
+    expect(KNOWN_AGENT_TYPES).toContain('implementer')
+  })
+})
+
+describe('extractAgentType', () => {
+  it('agentType単体の完全一致を認識する', () => {
+    expect(extractAgentType('reviewer')).toBe('reviewer')
+  })
+
+  it('役割サフィックス付き(reviewer-correctness)からagentTypeを復元する', () => {
+    expect(extractAgentType('reviewer-correctness')).toBe('reviewer')
+  })
+
+  it('既知agentTypeに前方一致しない場合はnullを返す', () => {
+    expect(extractAgentType('unknown-agent')).toBeNull()
+  })
+
+  it('sweep-uiとsweep-dataのように前方一致が紛らわしい場合でも正しく判定する', () => {
+    expect(extractAgentType('sweep-data-something')).toBe('sweep-data')
+  })
+})
+
+describe('buildEventId', () => {
+  it('source:agentType:timestamp:lineIndexの形式で組み立てる', () => {
+    expect(buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 0)).toBe(
+      'agent-progress:implementer:2026-07-27T00:00:00Z:0',
+    )
+  })
+
+  it('agentTypeがnullの場合はunknownを使う', () => {
+    expect(buildEventId('subagent-skeleton', null, '2026-07-27T00:00:00Z', 3)).toBe(
+      'subagent-skeleton:unknown:2026-07-27T00:00:00Z:3',
+    )
+  })
+
+  it('同一秒・同一agentTypeでもlineIndexが異なれば衝突しない', () => {
+    const a = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 0)
+    const b = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 1)
+    expect(a).not.toBe(b)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`./canonical-event`が存在しないためimportエラー）
+
+- [ ] **Step 3: 最小実装を書く**
+
+```ts
+// scripts/lib/canonical-event.ts
+export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
+export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'
+
+export interface CanonicalEvent {
+  eventId: string
+  agentId: string | null
+  agentType: string | null
+  feature: string | null
+  startTimestamp: string | null
+  endTimestamp: string | null
+  status: EventStatus | null
+  detail: string | null
+  intent: string | null
+  scenario: string | null
+  source: EventSource
+}
+
+// docs/agents/common.md「サブエージェント進捗の可視化（issue #18）」に列挙されている
+// 進捗記録対象agentType一覧。verify-agent-progress-transcript.tsから本モジュールへ移設（issue #569）。
+export const KNOWN_AGENT_TYPES = [
+  'sweep-db',
+  'sweep-ui',
+  'sweep-types',
+  'sweep-data',
+  'implementer',
+  'reviewer',
+  'integrator',
+  'judge-panel',
+  'proposer',
+  'adversarial-verify',
+  'completeness-critic',
+  'contract-writer',
+] as const
+
+// 自己申告jsonlの--agentは「reviewer-correctness」「implementer-groupA」のように
+// agentTypeへ役割サフィックスを付けた自由記述のため、既知agentType一覧との前方一致
+// （区切りは'-'または完全一致）で復元する。
+export function extractAgentType(selfAgentField: string): string | null {
+  const candidates = KNOWN_AGENT_TYPES.filter(
+    (type) => selfAgentField === type || selfAgentField.startsWith(`${type}-`),
+  )
+  if (candidates.length === 0) return null
+  return candidates.reduce((longest, current) => (current.length > longest.length ? current : longest))
+}
+
+// 各log-*.shは秒精度タイムスタンプ(date -u +"%Y-%m-%dT%H:%M:%SZ")しか書かないため、
+// 同一秒内の複数状態遷移がタイムスタンプだけでは衝突しうる。ログ生成側は無改修という前提のため、
+// ファイル内の出現順インデックス(lineIndex)をキーに含めて一意性を保証する。
+export function buildEventId(
+  source: EventSource,
+  agentType: string | null,
+  timestamp: string,
+  lineIndex: number,
+): string {
+  return `${source}:${agentType ?? 'unknown'}:${timestamp}:${lineIndex}`
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにCanonicalEvent型とagentTypeユーティリティを追加(issue #569)"
+```
+
+---
+
+### Task 2: subagentSkeletonAdapter
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: `CanonicalEvent`, `buildEventId` (Task 1)
+- Produces: `EventAdapter`, `subagentSkeletonAdapter(logFile: string): EventAdapter`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { subagentSkeletonAdapter } from './canonical-event'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+describe('subagentSkeletonAdapter', () => {
+  it('Start行はstartTimestamp、Stop行はendTimestampに割り当てる', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skeleton-test-'))
+    const logFile = join(dir, 'subagent-skeleton.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'a1', agentType: 'workflow-subagent' }),
+        line({
+          timestamp: '2026-07-27T00:00:02Z',
+          hookEvent: 'SubagentStop',
+          agentId: 'a1',
+          agentType: 'workflow-subagent',
+          lastAssistantMessage: 'ok',
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = subagentSkeletonAdapter(logFile).load()
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({ agentId: 'a1', startTimestamp: '2026-07-27T00:00:00Z', endTimestamp: null, source: 'subagent-skeleton' })
+    expect(events[1]).toMatchObject({ agentId: 'a1', startTimestamp: null, endTimestamp: '2026-07-27T00:00:02Z', detail: 'ok' })
+  })
+
+  it('ファイルが存在しない場合は空配列を返す', () => {
+    const events = subagentSkeletonAdapter('/tmp/does-not-exist-xyz.jsonl').load()
+    expect(events).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`subagentSkeletonAdapter`が未定義）
+
+- [ ] **Step 3: 実装する**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+import { readFileSync } from 'node:fs'
+
+export interface EventAdapter {
+  source: EventSource
+  load(): CanonicalEvent[]
+}
+
+interface SkeletonLine {
+  timestamp: string
+  hookEvent: string
+  agentId: string
+  agentType?: string
+  lastAssistantMessage?: string
+  intent?: string
+}
+
+function parseSkeletonLine(raw: string): SkeletonLine | null {
+  try {
+    return JSON.parse(raw) as SkeletonLine
+  } catch {
+    return null
+  }
+}
+
+export function subagentSkeletonAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'subagent-skeleton',
+    load(): CanonicalEvent[] {
+      let content: string
+      try {
+        content = readFileSync(logFile, 'utf-8')
+      } catch {
+        return []
+      }
+      const lines = content.split('\n').filter(Boolean)
+      const events: CanonicalEvent[] = []
+      lines.forEach((raw, lineIndex) => {
+        const parsed = parseSkeletonLine(raw)
+        if (!parsed) return
+        const isStart = parsed.hookEvent === 'SubagentStart'
+        const agentType = parsed.agentType ?? null
+        events.push({
+          eventId: buildEventId('subagent-skeleton', agentType, parsed.timestamp, lineIndex),
+          agentId: parsed.agentId,
+          agentType,
+          feature: null,
+          startTimestamp: isStart ? parsed.timestamp : null,
+          endTimestamp: isStart ? null : parsed.timestamp,
+          status: null,
+          detail: parsed.lastAssistantMessage ?? null,
+          intent: parsed.intent ?? null,
+          scenario: null,
+          source: 'subagent-skeleton',
+        })
+      })
+      return events
+    },
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにsubagentSkeletonAdapterを追加(issue #569)"
+```
+
+---
+
+### Task 3: agentProgressAdapter（全ステータス）
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: `CanonicalEvent`, `buildEventId`, `extractAgentType`, `EventAdapter` (Task 1-2)
+- Produces: `loadAllAgentProgressRecords(logFile: string): AgentProgressLine[]`, `agentProgressAdapter(logFile: string): EventAdapter`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { agentProgressAdapter } from './canonical-event'
+
+describe('agentProgressAdapter', () => {
+  it('全ステータス(starting/running/waiting/done/failed)を落とさずに出力する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-test-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'starting', note: 'n1' }),
+        line({ timestamp: '2026-07-27T00:01:00Z', agent: 'implementer', feature: 'f1', status: 'running', note: 'n2' }),
+        line({ timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n3' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events).toHaveLength(3)
+    expect(events.map((e) => e.status)).toEqual(['starting', 'running', 'done'])
+    expect(events[0].agentType).toBe('implementer')
+    expect(events[2]).toMatchObject({ feature: 'f1', endTimestamp: '2026-07-27T00:02:00Z', detail: 'n3', agentId: null, source: 'agent-progress' })
+  })
+
+  it('役割サフィックス付きagent(reviewer-correctness)からagentTypeを復元する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-test-suffix-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, line({ timestamp: '2026-07-27T00:00:00Z', agent: 'reviewer-correctness', feature: 'f1', status: 'done', note: 'n' }) + '\n', 'utf-8')
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events[0].agentType).toBe('reviewer')
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`agentProgressAdapter`が未定義）
+
+- [ ] **Step 3: 実装する**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+interface AgentProgressLine {
+  timestamp: string
+  agent: string
+  feature: string
+  status: string
+  note: string
+}
+
+export function loadAllAgentProgressRecords(logFile: string): AgentProgressLine[] {
+  let content: string
+  try {
+    content = readFileSync(logFile, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((raw) => JSON.parse(raw) as AgentProgressLine)
+}
+
+export function agentProgressAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'agent-progress',
+    load(): CanonicalEvent[] {
+      return loadAllAgentProgressRecords(logFile).map((record, lineIndex) => {
+        const agentType = extractAgentType(record.agent)
+        return {
+          eventId: buildEventId('agent-progress', agentType, record.timestamp, lineIndex),
+          agentId: null,
+          agentType,
+          feature: record.feature,
+          startTimestamp: null,
+          endTimestamp: record.timestamp,
+          status: record.status as EventStatus,
+          detail: record.note,
+          intent: null,
+          scenario: null,
+          source: 'agent-progress',
+        }
+      })
+    },
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにagentProgressAdapterを追加(issue #569)"
+```
+
+---
+
+### Task 4: loopObservabilityAdapter
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: 同上（Task 1-3）
+- Produces: `loadAllLoopObservabilityRecords(logFile: string): LoopObservabilityLine[]`, `loopObservabilityAdapter(logFile: string): EventAdapter`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { loopObservabilityAdapter } from './canonical-event'
+
+describe('loopObservabilityAdapter', () => {
+  it('1行=1イベントとして正規化する(result->status, reason->detail)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'loop-obs-test-'))
+    const logFile = join(dir, 'loop-observability.jsonl')
+    writeFileSync(
+      logFile,
+      line({
+        timestamp: '2026-07-27T00:00:00Z',
+        agent: 'implementer',
+        feature: 'f1',
+        intent: 'テスト実装',
+        scenario: '正常系',
+        result: 'pass',
+        reason: '全テスト成功',
+      }) + '\n',
+      'utf-8',
+    )
+
+    const events = loopObservabilityAdapter(logFile).load()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      agentType: 'implementer',
+      feature: 'f1',
+      endTimestamp: '2026-07-27T00:00:00Z',
+      status: 'pass',
+      detail: '全テスト成功',
+      intent: 'テスト実装',
+      scenario: '正常系',
+      agentId: null,
+      source: 'loop-observability',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`loopObservabilityAdapter`が未定義）
+
+- [ ] **Step 3: 実装する**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+interface LoopObservabilityLine {
+  timestamp: string
+  agent: string
+  feature: string
+  intent: string
+  scenario: string
+  result: string
+  reason: string
+}
+
+export function loadAllLoopObservabilityRecords(logFile: string): LoopObservabilityLine[] {
+  let content: string
+  try {
+    content = readFileSync(logFile, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((raw) => JSON.parse(raw) as LoopObservabilityLine)
+}
+
+export function loopObservabilityAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'loop-observability',
+    load(): CanonicalEvent[] {
+      return loadAllLoopObservabilityRecords(logFile).map((record, lineIndex) => {
+        const agentType = extractAgentType(record.agent)
+        return {
+          eventId: buildEventId('loop-observability', agentType, record.timestamp, lineIndex),
+          agentId: null,
+          agentType,
+          feature: record.feature,
+          startTimestamp: null,
+          endTimestamp: record.timestamp,
+          status: record.result as EventStatus,
+          detail: record.reason,
+          intent: record.intent,
+          scenario: record.scenario,
+          source: 'loop-observability',
+        }
+      })
+    },
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにloopObservabilityAdapterを追加(issue #569)"
+```
+
+---
+
+### Task 5: journalAdapter（既存loadTranscriptsロジックの再利用）
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: `pairAgentFiles`, `loadJournalResults`, `parseAgentTranscriptLines`（`./reconstruct-loop-observability`、無改修で再利用）、`CanonicalEvent`, `buildEventId`, `EventAdapter`
+- Produces: `journalAdapter(projectDir: string): EventAdapter`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { mkdirSync } from 'node:fs'
+import { journalAdapter } from './canonical-event'
+
+describe('journalAdapter', () => {
+  it('journal.jsonlの構造化resultがある場合はそちらのstatus/detailを優先する', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-adapter-test-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-a1.jsonl'),
+      [
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+        line({
+          type: 'assistant',
+          message: {
+            model: 'claude-sonnet-5',
+            content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status: 'fail', detail: 'transcript側(上書きされるはず)' } }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+          timestamp: '2026-07-27T00:00:01.000Z',
+        }),
+      ].join('\n'),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    writeFileSync(
+      join(wfDir, 'journal.jsonl'),
+      [
+        line({ type: 'started', key: 'v2:xxx', agentId: 'a1' }),
+        line({ type: 'result', key: 'v2:xxx', agentId: 'a1', result: { status: 'pass', detail: 'journal側のdetail' } }),
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      agentId: 'a1',
+      agentType: 'implementer',
+      status: 'pass',
+      detail: 'journal側のdetail',
+      endTimestamp: '2026-07-27T00:00:01.000Z',
+      source: 'journal',
+    })
+  })
+
+  it('複数のwf_*ディレクトリを横断して読む', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-adapter-multi-test-'))
+    for (const [wfName, agentId] of [['wf_1', 'a1'], ['wf_2', 'a2']] as const) {
+      const wfDir = join(projectDir, wfName)
+      mkdirSync(wfDir)
+      writeFileSync(
+        join(wfDir, `agent-${agentId}.jsonl`),
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+        'utf-8',
+      )
+      writeFileSync(join(wfDir, `agent-${agentId}.meta.json`), JSON.stringify({ agentType: 'reviewer' }), 'utf-8')
+    }
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`journalAdapter`が未定義）
+
+- [ ] **Step 3: 実装する**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadJournalResults, pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability'
+
+// 既存verify-agent-progress-transcript.tsのfindWorkflowDirsと同一ロジック。
+// wf_*という名前のディレクトリを再帰的に探索する。
+function findWorkflowDirs(projectDir: string): string[] {
+  const results: string[] = []
+  function walk(dir: string) {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry)
+      let stat
+      try {
+        stat = statSync(fullPath)
+      } catch {
+        continue
+      }
+      if (!stat.isDirectory()) continue
+      if (entry.startsWith('wf_')) {
+        results.push(fullPath)
+        continue
+      }
+      walk(fullPath)
+    }
+  }
+  walk(projectDir)
+  return results
+}
+
+export function journalAdapter(projectDir: string): EventAdapter {
+  return {
+    source: 'journal',
+    load(): CanonicalEvent[] {
+      const events: CanonicalEvent[] = []
+      let lineIndex = 0
+      for (const wfDir of findWorkflowDirs(projectDir)) {
+        const filenames = readdirSync(wfDir)
+        const pairs = pairAgentFiles(filenames)
+        const journalResults = loadJournalResults(wfDir, filenames)
+        for (const { agentId, jsonlFile, metaFile } of pairs) {
+          let agentType = 'unknown'
+          try {
+            const meta = JSON.parse(readFileSync(join(wfDir, metaFile), 'utf-8')) as { agentType?: string }
+            agentType = meta.agentType ?? 'unknown'
+          } catch {
+            continue
+          }
+          const lines = readFileSync(join(wfDir, jsonlFile), 'utf-8').split('\n').filter(Boolean)
+          const summary = parseAgentTranscriptLines(lines)
+          const journalResult = journalResults.get(agentId)
+          const status = journalResult ? journalResult.status : summary.status
+          const detail = journalResult ? journalResult.detail : summary.detail
+
+          events.push({
+            eventId: buildEventId('journal', agentType, summary.endTimestamp ?? 'unknown', lineIndex++),
+            agentId,
+            agentType,
+            feature: null,
+            startTimestamp: summary.startTimestamp,
+            endTimestamp: summary.endTimestamp,
+            status,
+            detail,
+            intent: null,
+            scenario: null,
+            source: 'journal',
+          })
+        }
+      }
+      return events
+    },
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにjournalAdapterを追加(issue #569)"
+```
+
+---
+
+### Task 6: loadAllEvents()
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: 4つのAdapter (Task 2-5)
+- Produces: `LoadAllEventsOptions`, `loadAllEvents(opts?: LoadAllEventsOptions): CanonicalEvent[]`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { loadAllEvents } from './canonical-event'
+
+describe('loadAllEvents', () => {
+  it('指定した4ソースのイベントをすべて結合する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'load-all-test-'))
+    const agentProgressLogFile = join(dir, 'agent-progress.jsonl')
+    const loopObservabilityLogFile = join(dir, 'loop-observability.jsonl')
+    writeFileSync(agentProgressLogFile, line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n' }) + '\n', 'utf-8')
+    writeFileSync(loopObservabilityLogFile, line({ timestamp: '2026-07-27T00:00:01Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }) + '\n', 'utf-8')
+
+    const events = loadAllEvents({ agentProgressLogFile, loopObservabilityLogFile })
+    expect(events).toHaveLength(2)
+    expect(events.map((e) => e.source).sort()).toEqual(['agent-progress', 'loop-observability'])
+  })
+
+  it('パスを指定しなかったソースは含めない', () => {
+    const events = loadAllEvents({})
+    expect(events).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`loadAllEvents`が未定義）
+
+- [ ] **Step 3: 実装する**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+export interface LoadAllEventsOptions {
+  subagentSkeletonLogFile?: string
+  agentProgressLogFile?: string
+  loopObservabilityLogFile?: string
+  projectDir?: string
+}
+
+export function loadAllEvents(opts: LoadAllEventsOptions = {}): CanonicalEvent[] {
+  const events: CanonicalEvent[] = []
+  if (opts.subagentSkeletonLogFile) events.push(...subagentSkeletonAdapter(opts.subagentSkeletonLogFile).load())
+  if (opts.agentProgressLogFile) events.push(...agentProgressAdapter(opts.agentProgressLogFile).load())
+  if (opts.loopObservabilityLogFile) events.push(...loopObservabilityAdapter(opts.loopObservabilityLogFile).load())
+  if (opts.projectDir) events.push(...journalAdapter(opts.projectDir).load())
+  return events
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: canonical-event.tsにloadAllEvents()を追加(issue #569)"
+```
+
+---
+
+### Task 7: correlateEvents() Stage 1（agentId厳密一致）
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: `CanonicalEvent` (Task 1)
+- Produces: `CorrelatedExecution`, `correlateEvents(events: CanonicalEvent[], toleranceMs?: number): CorrelatedExecution[]`（このタスクではStage 1のみ実装。Stage 2はTask 8）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+import { correlateEvents } from './canonical-event'
+
+describe('correlateEvents (Stage 1: agentId厳密一致)', () => {
+  it('同一agentIdを持つsubagent-skeletonとjournalのイベントを1つのCorrelatedExecutionにまとめる', () => {
+    const events: CanonicalEvent[] = [
+      { eventId: 'e1', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: '2026-07-27T00:00:00Z', endTimestamp: null, status: null, detail: null, intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e2', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02Z', status: null, detail: 'ok', intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e3', agentId: 'a1', agentType: 'implementer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02.000Z', status: 'pass', detail: 'journal detail', intent: null, scenario: null, source: 'journal' },
+    ]
+
+    const result = correlateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].agentId).toBe('a1')
+    expect(result[0].events).toHaveLength(3)
+  })
+
+  it('agentIdが異なれば別々のCorrelatedExecutionになる', () => {
+    const events: CanonicalEvent[] = [
+      { eventId: 'e1', agentId: 'a1', agentType: 'implementer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:00Z', status: 'pass', detail: null, intent: null, scenario: null, source: 'journal' },
+      { eventId: 'e2', agentId: 'a2', agentType: 'reviewer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:00Z', status: 'pass', detail: null, intent: null, scenario: null, source: 'journal' },
+    ]
+
+    const result = correlateEvents(events)
+    expect(result).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（`correlateEvents`が未定義）
+
+- [ ] **Step 3: 実装する（Stage 1のみ。自己申告イベントは全て単独扱いにする仮実装）**
+
+```ts
+// scripts/lib/canonical-event.ts に追記
+export interface CorrelatedExecution {
+  agentId: string
+  events: CanonicalEvent[]
+}
+
+const DEFAULT_TOLERANCE_MS = 30 * 60 * 1000
+
+export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_TOLERANCE_MS): CorrelatedExecution[] {
+  // Stage 1: agentIdを持つイベント(subagent-skeleton/journal)を厳密一致でグループ化する。
+  // 両者は同一agentId空間であることを実機検証済み(2026-07-27、docs/superpowers/specs/
+  // 2026-07-27-canonical-event-module-design.md参照)。
+  const executions = new Map<string, CorrelatedExecution>()
+  const selfReportEvents: CanonicalEvent[] = []
+
+  for (const event of events) {
+    if (event.agentId !== null) {
+      const existing = executions.get(event.agentId)
+      if (existing) {
+        existing.events.push(event)
+      } else {
+        executions.set(event.agentId, { agentId: event.agentId, events: [event] })
+      }
+    } else {
+      selfReportEvents.push(event)
+    }
+  }
+
+  // Stage 2は次のタスクで実装する。ここでは自己申告イベントを一旦すべて単独のCorrelatedExecutionにする。
+  for (const event of selfReportEvents) {
+    executions.set(event.eventId, { agentId: event.eventId, events: [event] })
+  }
+
+  return [...executions.values()]
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: correlateEvents()にStage1(agentId厳密一致)を実装(issue #569)"
+```
+
+---
+
+### Task 8: correlateEvents() Stage 2（agentType+時刻窓フォールバック）
+
+**Files:**
+- Modify: `scripts/lib/canonical-event.ts`
+- Modify: `scripts/lib/canonical-event.test.ts`
+
+**Interfaces:**
+- Consumes: Task 7の`correlateEvents`実装を置き換える
+- Produces: `correlateEvents`は変わらないシグネチャのまま、Stage 2ロジックを追加
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```ts
+// scripts/lib/canonical-event.test.ts に追記
+describe('correlateEvents (Stage 2: agentType+時刻窓フォールバック)', () => {
+  const anchor: CanonicalEvent = {
+    eventId: 'anchor1', agentId: 'a1', agentType: 'sweep-ui', feature: null,
+    startTimestamp: null, endTimestamp: '2026-07-27T00:00:10.000Z', status: 'pass', detail: 'anchor detail',
+    intent: null, scenario: null, source: 'journal',
+  }
+
+  it('agentIdを持たないagent-progress(done)を同一agentType・時刻窓内のアンカーへ対応付ける', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'done', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(1)
+    expect(result[0].events).toHaveLength(2)
+  })
+
+  it('agent-progressのrunning/waiting/startingは常に単独になる(突合対象外)', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'running', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+    const selfExec = result.find((r) => r.agentId === 'self1')
+    expect(selfExec?.events).toHaveLength(1)
+  })
+
+  it('許容誤差を超えるアンカーとは対応付けない', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T02:00:00.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+  })
+
+  it('同じアンカーにagent-progressとloop-observabilityの両方が対応付いても競合しない', () => {
+    const selfProgress: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.000Z', status: 'done', detail: 'd1',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+    const selfLoop: CanonicalEvent = {
+      eventId: 'self2', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.500Z', status: 'pass', detail: 'd2',
+      intent: 'i', scenario: 's', source: 'loop-observability',
+    }
+
+    const result = correlateEvents([anchor, selfProgress, selfLoop])
+    expect(result).toHaveLength(1)
+    expect(result[0].events).toHaveLength(3)
+  })
+
+  it('同一agentTypeが複数ある場合、それぞれ最も近いアンカーに1件ずつ割り当てる(使い回さない)', () => {
+    const anchor2: CanonicalEvent = { ...anchor, agentId: 'a2', endTimestamp: '2026-07-27T00:10:10.000Z' }
+    const self1: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+    const self2: CanonicalEvent = { ...self1, eventId: 'self2', endTimestamp: '2026-07-27T00:10:12.000Z' }
+
+    const result = correlateEvents([anchor, anchor2, self1, self2])
+    expect(result).toHaveLength(2)
+    expect(result.every((r) => r.events.length === 2)).toBe(true)
+    const assignedAgentIds = result.map((r) => r.agentId).sort()
+    expect(assignedAgentIds).toEqual(['a1', 'a2'])
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: FAIL（Stage 2未実装のため、自己申告イベントが常に単独扱いになりテストの期待と食い違う）
+
+- [ ] **Step 3: `correlateEvents`をStage 2対応に書き換える**
+
+```ts
+// scripts/lib/canonical-event.ts の correlateEvents を丸ごと置き換える
+const TERMINAL_AGENT_PROGRESS_STATUSES = new Set(['done', 'failed'])
+
+function toEpochMs(timestamp: string): number | null {
+  const ms = Date.parse(timestamp)
+  return Number.isNaN(ms) ? null : ms
+}
+
+// agent-progressの中間状態(starting/running/waiting)は突合対象にしない。
+// 既存loadSelfReports(verify-agent-progress-transcript.ts)がdone/failedのみを検証対象として
+// きたのを踏襲する意図的な仕様(docs/superpowers/specs/2026-07-27-canonical-event-module-design.md参照)。
+function isMatchTarget(event: CanonicalEvent): boolean {
+  if (event.source === 'agent-progress') return TERMINAL_AGENT_PROGRESS_STATUSES.has(event.status ?? '')
+  return true
+}
+
+export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_TOLERANCE_MS): CorrelatedExecution[] {
+  const executions = new Map<string, CorrelatedExecution>()
+  const selfReportEvents: CanonicalEvent[] = []
+
+  // Stage 1: agentIdを持つイベント(subagent-skeleton/journal)を厳密一致でグループ化する。
+  for (const event of events) {
+    if (event.agentId !== null) {
+      const existing = executions.get(event.agentId)
+      if (existing) {
+        existing.events.push(event)
+      } else {
+        executions.set(event.agentId, { agentId: event.agentId, events: [event] })
+      }
+    } else {
+      selfReportEvents.push(event)
+    }
+  }
+
+  // アンカー(agentId確定済みグループ)のagentType/endTimestamp代表値を算出する。
+  interface AnchorInfo {
+    agentId: string
+    agentType: string | null
+    endTimestamp: string | null
+  }
+  const anchorInfos: AnchorInfo[] = [...executions.entries()].map(([agentId, exec]) => {
+    const withEndTs = exec.events.find((e) => e.endTimestamp !== null)
+    return {
+      agentId,
+      agentType: withEndTs?.agentType ?? exec.events[0]?.agentType ?? null,
+      endTimestamp: withEndTs?.endTimestamp ?? null,
+    }
+  })
+
+  // Stage 2: ソースごとに独立した排他プールで、agentType一致・時刻窓内の最近傍アンカーへ貪欲割当する。
+  // 排他制御を「ソース×agentType」単位にスコープすることで、agent-progressとloop-observabilityの
+  // 両方が同じアンカーに対応付くこと自体は許容する(別ソースなので競合しない)。
+  const bySource = new Map<EventSource, CanonicalEvent[]>()
+  for (const event of selfReportEvents) {
+    if (!isMatchTarget(event)) continue
+    const bucket = bySource.get(event.source) ?? []
+    bucket.push(event)
+    bySource.set(event.source, bucket)
+  }
+
+  const matchedEventIds = new Set<string>()
+
+  for (const candidates of bySource.values()) {
+    const usedAgentIds = new Set<string>()
+    const sorted = [...candidates].sort((a, b) => (a.endTimestamp ?? '').localeCompare(b.endTimestamp ?? ''))
+
+    for (const candidate of sorted) {
+      if (candidate.agentType === null || candidate.endTimestamp === null) continue
+      const candidateEpoch = toEpochMs(candidate.endTimestamp)
+      if (candidateEpoch === null) continue
+
+      let bestAgentId: string | null = null
+      let bestDiff = Infinity
+      for (const anchor of anchorInfos) {
+        if (usedAgentIds.has(anchor.agentId)) continue
+        if (anchor.agentType !== candidate.agentType || anchor.endTimestamp === null) continue
+        const anchorEpoch = toEpochMs(anchor.endTimestamp)
+        if (anchorEpoch === null) continue
+        const diff = Math.abs(anchorEpoch - candidateEpoch)
+        if (diff <= toleranceMs && diff < bestDiff) {
+          bestDiff = diff
+          bestAgentId = anchor.agentId
+        }
+      }
+
+      if (bestAgentId !== null) {
+        usedAgentIds.add(bestAgentId)
+        executions.get(bestAgentId)!.events.push(candidate)
+        matchedEventIds.add(candidate.eventId)
+      }
+    }
+  }
+
+  // 突合対象外(中間状態)、または対応するアンカーが見つからなかった自己申告は単独扱いにする。
+  for (const event of selfReportEvents) {
+    if (matchedEventIds.has(event.eventId)) continue
+    executions.set(event.eventId, { agentId: event.eventId, events: [event] })
+  }
+
+  return [...executions.values()]
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add scripts/lib/canonical-event.ts scripts/lib/canonical-event.test.ts
+git commit -m "feat: correlateEvents()にStage2(agentType+時刻窓フォールバック)を実装(issue #569)"
+```
+
+---
+
+### Task 9: 等価性テスト
+
+**Files:**
+- Create: `scripts/lib/canonical-event-gap-check-equivalence.test.ts`
+
+**Interfaces:**
+- Consumes: `agentProgressAdapter`, `loopObservabilityAdapter`, `journalAdapter`, `subagentSkeletonAdapter`（Task 2-5）
+
+- [ ] **Step 1: テストを書く（この段階で全てPASSする想定。既存Adapterの動作を別の角度から確認する回帰テストのため、Red確認はスキップ可）**
+
+```ts
+// scripts/lib/canonical-event-gap-check-equivalence.test.ts
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { agentProgressAdapter, journalAdapter, loopObservabilityAdapter, subagentSkeletonAdapter } from './canonical-event'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+describe('loop-observability: 既存check-loop-observability-gap.sh(wc -l)との等価性', () => {
+  it('Adapter出力件数が生ファイルの行数と一致する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'loop-obs-equiv-'))
+    const logFile = join(dir, 'loop-observability.jsonl')
+    const rawLines = [
+      line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }),
+      line({ timestamp: '2026-07-27T00:01:00Z', agent: 'reviewer', feature: 'f1', intent: 'i', scenario: 's', result: 'fail', reason: 'r' }),
+      line({ timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }),
+    ]
+    writeFileSync(logFile, rawLines.join('\n') + '\n', 'utf-8')
+
+    const events = loopObservabilityAdapter(logFile).load()
+    expect(events).toHaveLength(rawLines.length) // = check-loop-observability-gap.shの`wc -l`相当
+  })
+})
+
+describe('agent-progress: 既存check-agent-progress-gap.shとの等価性', () => {
+  const rawRecords = [
+    { timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'starting', note: 'n' },
+    { timestamp: '2026-07-27T00:01:00Z', agent: 'implementer', feature: 'f1', status: 'running', note: 'n' },
+    { timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n' },
+    { timestamp: '2026-07-27T00:03:00Z', agent: 'reviewer', feature: 'f1', status: 'failed', note: 'n' },
+  ]
+
+  it('①fidelity: Adapter出力件数(全ステータス)が生ファイルの行数と一致する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-equiv-fidelity-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, rawRecords.map(line).join('\n') + '\n', 'utf-8')
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events).toHaveLength(rawRecords.length)
+  })
+
+  it('②既存jqフィルタ(status=="done" or "failed")との等価性(gap check本体)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-equiv-jq-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, rawRecords.map(line).join('\n') + '\n', 'utf-8')
+
+    // check-agent-progress-gap.shの
+    // `jq '[.[] | select(.status == "done" or .status == "failed")] | length'`をJSで再現した基準値
+    const jqEquivalentCount = rawRecords.filter((r) => r.status === 'done' || r.status === 'failed').length
+    expect(jqEquivalentCount).toBe(2)
+
+    const events = agentProgressAdapter(logFile).load()
+    const doneOrFailedCount = events.filter((e) => e.status === 'done' || e.status === 'failed').length
+    expect(doneOrFailedCount).toBe(jqEquivalentCount)
+  })
+})
+
+describe('journal/subagent-skeleton: 対応する既存gap checkが無いため、Adapter自体の正しさを既知件数fixtureで直接検証する', () => {
+  it('journalAdapterはagent-*.jsonl/.meta.jsonのペア件数を正しく読む(既知件数=1)', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-equiv-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-a1.jsonl'),
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(1)
+  })
+
+  it('subagentSkeletonAdapterはStart+Stopの2行を正しく読む(既知件数=2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skeleton-equiv-'))
+    const logFile = join(dir, 'subagent-skeleton.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'a1', agentType: 'workflow-subagent' }),
+        line({ timestamp: '2026-07-27T00:00:02Z', hookEvent: 'SubagentStop', agentId: 'a1', agentType: 'workflow-subagent', lastAssistantMessage: 'ok' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = subagentSkeletonAdapter(logFile).load()
+    expect(events).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/canonical-event-gap-check-equivalence.test.ts`
+Expected: PASS（Task 2-5で実装済みのAdapterに対する回帰テストのため）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add scripts/lib/canonical-event-gap-check-equivalence.test.ts
+git commit -m "test: canonical-event.tsの等価性テストを追加(issue #569)"
+```
+
+---
+
+### Task 10: verify-agent-progress-transcript.tsのリファクタ
+
+**Files:**
+- Modify: `scripts/lib/verify-agent-progress-transcript.ts`
+- Modify: `scripts/lib/verify-agent-progress-transcript.test.ts`
+
+**Interfaces:**
+- Consumes: `loadAllEvents`, `correlateEvents`, `CorrelatedExecution`, `CanonicalEvent`, `extractAgentType`, `KNOWN_AGENT_TYPES`（`./canonical-event`）
+- Produces: `compareStatus`, `compareDetail`, `LOW_OVERLAP_THRESHOLD`, `VerificationReportEntry`, `VerificationReport`, `buildReport(correlated: CorrelatedExecution[]): VerificationReport`（シグネチャ変更）
+
+- [ ] **Step 1: 新しい`buildReport`シグネチャに合わせてテストを書き換える**
+
+```ts
+// scripts/lib/verify-agent-progress-transcript.test.ts を全面的に書き換える
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { compareDetail, compareStatus, buildReport } from './verify-agent-progress-transcript'
+import { correlateEvents, type CanonicalEvent } from './canonical-event'
+
+describe('compareStatus', () => {
+  it('自己申告doneとtranscript passは一致とみなす', () => {
+    expect(compareStatus('done', 'pass')).toBe('match')
+  })
+
+  it('自己申告doneとtranscript blockedは一致とみなす（仕様確認待ち等の正常停止もあるため）', () => {
+    expect(compareStatus('done', 'blocked')).toBe('match')
+  })
+
+  it('自己申告doneなのにtranscriptがfailなら食い違いとみなす', () => {
+    expect(compareStatus('done', 'fail')).toBe('mismatch')
+  })
+
+  it('自己申告failedとtranscript failは一致とみなす', () => {
+    expect(compareStatus('failed', 'fail')).toBe('match')
+  })
+
+  it('自己申告failedなのにtranscriptがpassなら食い違いとみなす', () => {
+    expect(compareStatus('failed', 'pass')).toBe('mismatch')
+  })
+
+  it('transcript側にstatusが無ければunknownとする', () => {
+    expect(compareStatus('done', null)).toBe('unknown')
+  })
+})
+
+describe('compareDetail', () => {
+  it('内容が近い場合はmatchとする', () => {
+    expect(compareDetail('UI層調査完了。propsの型不整合を2件検出', 'UI層の調査が完了した。propsの型不整合を2件検出した')).toBe('match')
+  })
+
+  it('内容が無関係な場合はlow_overlapとする', () => {
+    expect(compareDetail('実装完了', '別の話題について全く違う内容を書いています')).toBe('low_overlap')
+  })
+
+  it('どちらかが空文字の場合はunknownとする', () => {
+    expect(compareDetail('', '実装完了')).toBe('unknown')
+    expect(compareDetail('実装完了', null)).toBe('unknown')
+  })
+})
+
+describe('buildReport', () => {
+  it('食い違いをmismatchesに、低一致をlowOverlapDetailsに分類する', () => {
+    const anchor1: CanonicalEvent = {
+      eventId: 'j1', agentId: 'a1', agentType: 'sweep-ui', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:10.000Z', status: 'fail',
+      detail: 'propsの型不整合を検出、未修正のまま終了', intent: null, scenario: null, source: 'journal',
+    }
+    const self1: CanonicalEvent = {
+      eventId: 's1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:12.000Z', status: 'done',
+      detail: 'UI層調査完了', intent: null, scenario: null, source: 'agent-progress',
+    }
+    const anchor2: CanonicalEvent = {
+      eventId: 'j2', agentId: 'a2', agentType: 'reviewer', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-15T04:00:10.000Z', status: 'pass',
+      detail: '無関係な全く別のセキュリティ観点の長い説明文をここに書く', intent: null, scenario: null, source: 'journal',
+    }
+    const self2: CanonicalEvent = {
+      eventId: 's2', agentId: null, agentType: 'reviewer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T04:00:12.000Z', status: 'done',
+      detail: '完了', intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const correlated = correlateEvents([anchor1, self1, anchor2, self2])
+    const report = buildReport(correlated)
+
+    expect(report.matchedCount).toBe(2)
+    expect(report.mismatches).toHaveLength(1)
+    expect(report.mismatches[0].selfEvent.agentType).toBe('sweep-ui')
+    expect(report.lowOverlapDetails.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('自己申告が0件なら空のレポートを返す', () => {
+    const report = buildReport(correlateEvents([]))
+    expect(report.totalSelfReports).toBe(0)
+    expect(report.matchedCount).toBe(0)
+    expect(report.mismatches).toHaveLength(0)
+  })
+
+  it('running/waiting/startingの中間状態はtotalSelfReportsに含めない', () => {
+    const self: CanonicalEvent = {
+      eventId: 's1', agentId: null, agentType: 'implementer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:12.000Z', status: 'running',
+      detail: '実行中', intent: null, scenario: null, source: 'agent-progress',
+    }
+    const report = buildReport(correlateEvents([self]))
+    expect(report.totalSelfReports).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `npx vitest run scripts/lib/verify-agent-progress-transcript.test.ts`
+Expected: FAIL（`buildReport`が旧シグネチャ`(selfReports, transcripts)`のまま）
+
+- [ ] **Step 3: `verify-agent-progress-transcript.ts`を全面的に書き換える**
+
+```ts
+// scripts/lib/verify-agent-progress-transcript.ts
+import { loadAllEvents, correlateEvents, type CanonicalEvent, type CorrelatedExecution } from './canonical-event'
+
+export type StatusComparison = 'match' | 'mismatch' | 'unknown'
+
+// WHY: 自己申告は進捗ライフサイクル語彙(done/failed)、transcriptは成果語彙(pass/fail/blocked)で
+//      語彙が異なる。「done」は成功系(pass/blocked)、「failed」は失敗(fail)に対応すると解釈する。
+//      blockedは仕様確認待ち等の正常な停止でも起こりうるため、doneとの不一致とはみなさない。
+export function compareStatus(selfStatus: string, anchorStatus: 'pass' | 'fail' | 'blocked' | null): StatusComparison {
+  if (anchorStatus === null) return 'unknown'
+  if (selfStatus === 'done') {
+    return anchorStatus === 'fail' ? 'mismatch' : 'match'
+  }
+  if (selfStatus === 'failed') {
+    return anchorStatus === 'pass' ? 'mismatch' : 'match'
+  }
+  return 'unknown'
+}
+
+export type DetailComparison = 'match' | 'low_overlap' | 'unknown'
+
+function charBigrams(text: string): Set<string> {
+  const normalized = text.replace(/\s+/g, '')
+  const bigrams = new Set<string>()
+  for (let i = 0; i < normalized.length - 1; i++) {
+    bigrams.add(normalized.slice(i, i + 2))
+  }
+  return bigrams
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let intersection = 0
+  for (const item of a) {
+    if (b.has(item)) intersection += 1
+  }
+  const union = a.size + b.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+// WHY: LLMを使わずに日本語の自由記述同士の関連度を見るため、文字bigramのJaccard類似度を使う
+//      （分かち書き不要・軽量）。閾値未満は「低一致=要目視確認」という弱いシグナルに留め、
+//      機械的な確定NG扱いにはしない（自己申告note・transcript detailは表現が違って当然のため）。
+export const LOW_OVERLAP_THRESHOLD = 0.08
+
+export function compareDetail(note: string, detail: string | null): DetailComparison {
+  if (!detail || detail.trim().length === 0 || !note || note.trim().length === 0) return 'unknown'
+  const similarity = jaccardSimilarity(charBigrams(note), charBigrams(detail))
+  return similarity < LOW_OVERLAP_THRESHOLD ? 'low_overlap' : 'match'
+}
+
+export interface VerificationReportEntry {
+  selfEvent: CanonicalEvent
+  anchorEvent: CanonicalEvent
+  statusComparison: StatusComparison
+  detailComparison: DetailComparison
+}
+
+export interface VerificationReport {
+  totalSelfReports: number
+  matchedCount: number
+  unmatchedSelf: CanonicalEvent[]
+  mismatches: VerificationReportEntry[]
+  lowOverlapDetails: VerificationReportEntry[]
+}
+
+// issue #569: 突合ロジック(agentId厳密一致 + agentType/時刻窓フォールバック)は
+// canonical-event.tsのcorrelateEvents()へ移設した。ここでは正規化済みの
+// CorrelatedExecution[]から、意味変換(status/detailの一致判定)とレポート整形のみを行う。
+export function buildReport(correlated: CorrelatedExecution[]): VerificationReport {
+  const entries: VerificationReportEntry[] = []
+  const unmatchedSelf: CanonicalEvent[] = []
+  let totalSelfReports = 0
+
+  for (const exec of correlated) {
+    const selfEvent = exec.events.find(
+      (e) => e.source === 'agent-progress' && (e.status === 'done' || e.status === 'failed'),
+    )
+    if (!selfEvent) continue
+    totalSelfReports += 1
+
+    const anchorEvent = exec.events.find((e) => e.source === 'journal' || e.source === 'subagent-skeleton')
+    if (!anchorEvent || anchorEvent.status === null) {
+      unmatchedSelf.push(selfEvent)
+      continue
+    }
+
+    entries.push({
+      selfEvent,
+      anchorEvent,
+      statusComparison: compareStatus(selfEvent.status ?? '', anchorEvent.status as 'pass' | 'fail' | 'blocked'),
+      detailComparison: compareDetail(selfEvent.detail ?? '', anchorEvent.detail),
+    })
+  }
+
+  return {
+    totalSelfReports,
+    matchedCount: entries.length,
+    unmatchedSelf,
+    mismatches: entries.filter((entry) => entry.statusComparison === 'mismatch'),
+    lowOverlapDetails: entries.filter((entry) => entry.detailComparison === 'low_overlap'),
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const getArg = (name: string, fallback: string) => {
+    const index = args.indexOf(name)
+    return index === -1 ? fallback : args[index + 1]
+  }
+
+  const agentProgressLogFile = getArg('--log-file', 'logs/agent-progress.jsonl')
+  const subagentSkeletonLogFile = getArg('--skeleton-log-file', 'logs/subagent-skeleton.jsonl')
+  const projectDir = getArg(
+    '--project-dir',
+    `${process.env.HOME ?? ''}/.claude/projects/-Users-masanori-medical-inventory-vkumai`,
+  )
+  const asJson = args.includes('--json')
+
+  const events = loadAllEvents({ agentProgressLogFile, subagentSkeletonLogFile, projectDir })
+  const correlated = correlateEvents(events)
+  const report = buildReport(correlated)
+
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log(
+      `自己申告(done/failed): ${report.totalSelfReports}件 / 突合成功: ${report.matchedCount}件 / 未対応(未突合): ${report.unmatchedSelf.length}件`,
+    )
+    if (report.mismatches.length > 0) {
+      console.log(`\n食い違い(status): ${report.mismatches.length}件`)
+      for (const entry of report.mismatches) {
+        console.log(
+          `  - agentType=${entry.selfEvent.agentType} feature=${entry.selfEvent.feature} 自己申告=${entry.selfEvent.status}(${entry.selfEvent.detail}) anchor=${entry.anchorEvent.status}(${entry.anchorEvent.detail ?? ''})`,
+        )
+      }
+    }
+    if (report.lowOverlapDetails.length > 0) {
+      console.log(`\ndetail低一致(要目視確認・弱いシグナル): ${report.lowOverlapDetails.length}件`)
+      for (const entry of report.lowOverlapDetails) {
+        console.log(
+          `  - agentType=${entry.selfEvent.agentType} feature=${entry.selfEvent.feature} note="${entry.selfEvent.detail}" detail="${entry.anchorEvent.detail ?? ''}"`,
+        )
+      }
+    }
+  }
+
+  if (report.mismatches.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `npx vitest run scripts/lib/verify-agent-progress-transcript.test.ts scripts/lib/canonical-event.test.ts scripts/lib/canonical-event-gap-check-equivalence.test.ts`
+Expected: 全てPASS
+
+- [ ] **Step 5: `npm test`全体を実行し、他への影響が無いことを確認する**
+
+Run: `npm test`
+Expected: 全体PASS（既存の他テストに影響が無いこと）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add scripts/lib/verify-agent-progress-transcript.ts scripts/lib/verify-agent-progress-transcript.test.ts
+git commit -m "refactor: verify-agent-progress-transcript.tsをcanonical-event.ts経由に統合(issue #569)"
+```
+
+---
+
+### Task 11: ドキュメント更新
+
+**Files:**
+- Modify: `docs/agents/observability-internals.md`
+- Modify: `docs/agents/common.md`
+
+- [ ] **Step 1: `docs/agents/observability-internals.md`に統合の説明を追記する**
+
+`## agent-progress記録の構造的限界・記録内容検証の詳細`セクションの末尾（`## サブエージェント骨格記録の機械強制（issue #423）`の直前）に以下を追記する:
+
+```markdown
+## canonical event moduleへの統合（issue #569）
+
+上記4つのログ（agent-progress/loop-observability/subagent-skeleton/journal）は`scripts/lib/canonical-event.ts`
+が読み取り専用Adapterとして正規化する。設計・突合アルゴリズム・実機検証結果（hookのagent_idと
+journal.jsonlのagentIdが同一空間であることを確認済み）は
+[`docs/superpowers/specs/2026-07-27-canonical-event-module-design.md`](../superpowers/specs/2026-07-27-canonical-event-module-design.md)参照。
+`verify-agent-progress-transcript.ts`は本モジュール経由の薄いラッパーに統合済み。既存gap check
+bashスクリプト（`check-loop-observability-gap.sh`等）・ログ書き込み側は無改修のまま。
+```
+
+- [ ] **Step 2: `docs/agents/common.md`の「重要ファイルへのパス」表に1行追加する**
+
+`scripts/verify-agent-progress-transcript.sh` の行の直後に追加:
+
+```markdown
+| `scripts/lib/canonical-event.ts` | hook/journal/agent-progress/loop-observabilityの4ログを正規化する読み取り専用Adapter層（issue #569） |
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add docs/agents/observability-internals.md docs/agents/common.md
+git commit -m "docs: canonical event module統合をobservability-internals.md/common.mdに反映(issue #569)"
+```
+
+---
+
+## Self-Review 結果
+
+- **spec coverage**: 仕様書の全セクション（アーキテクチャ／データ型／突合アルゴリズム／Adapter詳細／消費側移行／テスト計画／ファイル一覧）に対応するタスクが存在する（Task 1〜11）
+- **placeholder scan**: 全ステップに実コードを記載済み。TBD/TODOなし
+- **type consistency**: `CanonicalEvent`/`CorrelatedExecution`/`EventAdapter`の型・フィールド名はTask 1で定義したものをTask 2以降で一貫して使用している

--- a/docs/superpowers/specs/2026-07-27-canonical-event-module-design.md
+++ b/docs/superpowers/specs/2026-07-27-canonical-event-module-design.md
@@ -1,0 +1,184 @@
+# AIDD実行記録 canonical event module 設計
+
+**日付:** 2026-07-27
+**対象issue:** [#569](https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/issues/569)
+
+---
+
+## 背景・目的
+
+アーキテクチャレビュー(2026-07-26)で指摘された通り、同一AIDD実行の意味情報が以下4つのログに分散している。
+
+- `logs/agent-progress.jsonl` — 自己申告。starting/running/waiting/done/failedの状態遷移
+- `logs/loop-observability.jsonl` — 自己申告。1 attempt = 1行、pass/fail + intent/scenario/reason
+- `logs/subagent-skeleton.jsonl` — `SubagentStart`/`SubagentStop` hookによる機械記録。agent_id/agent_type/timestamp
+- `subagents/workflows/wf_*/journal.jsonl` + `agent-<id>.jsonl`/`.meta.json` — Workflow DSL自体が書く構造化result（`agent()`呼び出し時のみ存在）
+
+いずれも共通の実行IDを持たず、既存の`scripts/lib/verify-agent-progress-transcript.ts`はagentType一致＋時刻近接（30分許容）というヒューリスティックで突き合わせている。本設計はこの分散を解消する「canonical execution event module」を定義する。
+
+**非目的:** OTelは定量計測用の別Adapterとして現状維持（統合対象外）。ログの書き込み側（`log-agent-progress.sh`等の自己申告shellスクリプト）・既存gap check bashスクリプトは無改修。
+
+---
+
+## スコープ
+
+**対象:** `scripts/lib/canonical-event.ts`という読み取り専用Adapterモジュールの新設と、既存`verify-agent-progress-transcript.ts`のリファクタ
+**対象外:** ログ生成側（各`log-*.sh`）の変更、gap check bashスクリプト（`check-loop-observability-gap.sh`等）自体の変更、OTel統合
+
+---
+
+## アーキテクチャ
+
+新規モジュール`scripts/lib/canonical-event.ts`は、4つの既存ログそれぞれを正規化された`CanonicalEvent`に変換する**Adapter**と、それらを同一実行単位へ突合する`correlateEvents()`を提供する読み取り専用の層である。
+
+- 各ログの書き込み側は無改修
+- `verify-agent-progress-transcript.ts`は、正規化・突合ロジックを本モジュールへ委譲する薄いラッパーに変わる（レポート整形・CLI・終了コードのみ残す）
+- gap check群(`check-loop-observability-gap.sh`等)は変更しない。代わりに等価性テストで「新モジュールの件数カウントと既存bashロジックが同等であること」を保証する
+
+---
+
+## データ型
+
+```ts
+export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
+export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'
+
+export interface CanonicalEvent {
+  eventId: string           // `${source}:${agentType ?? 'unknown'}:${timestamp}:${lineIndex}`
+  agentId: string | null    // skeleton/journalのみ保持
+  agentType: string | null  // 優先順位は下記参照
+  feature: string | null    // 自己申告のみ保持
+  startTimestamp: string | null
+  endTimestamp: string | null
+  status: EventStatus | null
+  detail: string | null
+  intent: string | null
+  scenario: string | null   // loop-observabilityのみ
+  source: EventSource
+}
+
+export interface CorrelatedExecution {
+  agentId: string           // skeleton/journal由来のagentId、無ければ自己申告側の合成eventId
+  events: CanonicalEvent[]  // 4ソースの生CanonicalEventをそのまま保持、マージしない
+}
+
+export function correlateEvents(events: CanonicalEvent[]): CorrelatedExecution[]
+```
+
+### eventIdの一意性
+
+各`log-*.sh`は`date -u +"%Y-%m-%dT%H:%M:%SZ"`（秒精度、ミリ秒無し）でタイムスタンプを書くため、同一秒内に複数の状態遷移が起きるとタイムスタンプだけでは衝突しうる。ログ生成側（bash）は無改修という前提のもと、**ファイル内での出現順インデックス（`lineIndex`、0始まり）をeventIdに含める**ことで一意性を保証する。
+
+### agentTypeの優先順位
+
+`agent()`が`opts.agentType`を指定せずに呼ばれた場合、hookの`agent_type`・journalの`meta.json`の`agentType`は両方とも`"workflow-subagent"`という汎用値になる（下記「実機検証」参照）。したがって`agentType`は**自己申告側（agent-progress/loop-observability）が`extractAgentType`で復元した値を優先し、無ければskeleton/journal側の生値にフォールバック**する。Stage 1（agentId厳密一致）はagentTypeに依存しないため、この優先順位はStage 1のロジックに影響しない。
+
+### correlateEvents()の戻り値の設計判断
+
+突合結果は個々の`CanonicalEvent`を1つにマージせず、`CorrelatedExecution.events`配列として生データのまま保持する。マージ（どのソースのdetailを勝たせるか等）は消費側（`verify-agent-progress-transcript.ts`のレポート生成）の責務とする。理由: マージを`correlateEvents()`内に隠すと、暗黙の優先順位ルールがコードレビューで見えなくなる。生データを保持することで、後段が「どのソースの情報を根拠にレポートしたか」を追跡でき、デバッグ性が高い。
+
+---
+
+## 突合アルゴリズム（2段階アンカー方式）
+
+### Stage 1 — agentId厳密一致（skeleton ⇔ journal）
+
+`subagent-skeleton`は`SubagentStart`/`SubagentStop`の2行を同じ`agentId`で書くため、ペアリング処理は不要。`correlateEvents()`は同一`agentId`を持つイベントを厳密一致でグループ化するだけで、skeletonのStart行・Stop行・journal由来のイベントが自動的に1つの`CorrelatedExecution`にまとまる。
+
+**実機検証済み（2026-07-27）:** Workflowで1エージェントのみのプローブ実行を行い、journal.jsonlの`agentId`(`a86f06bf88161050f`)とhookが書いた`subagent-skeleton.jsonl`の`agent_id`が完全一致することを確認した。
+
+```
+journal.jsonl:            {"type":"result","agentId":"a86f06bf88161050f","result":"PROBE_OK"}
+subagent-skeleton.jsonl:  {"hookEvent":"SubagentStart","agentId":"a86f06bf88161050f",...}
+                           {"hookEvent":"SubagentStop","agentId":"a86f06bf88161050f",
+                            "agentTranscriptPath":".../wf_.../agent-a86f06bf88161050f.jsonl",...}
+```
+
+同時に、`opts.agentType`未指定時は`agent_type`/`meta.json`の`agentType`が両方とも`"workflow-subagent"`になることも確認した（`meta.json`実体: `{"agentType":"workflow-subagent","spawnDepth":1}`）。これが上記「agentTypeの優先順位」ルールの根拠である。
+
+### Stage 2 — agentTypeの時刻窓フォールバック（agent-progress / loop-observability）
+
+`agentId`を持たない自己申告2ソースは、既存`matchRecords`と同じ方式を踏襲する。
+
+- 対象: `agent-progress`は`status ∈ {done, failed}`の行のみ。`loop-observability`は全行（1 attempt = 1 event）。
+- 同一`agentType`を持つアンカー（Stage 1で確定した`CorrelatedExecution`）群の中から、`endTimestamp`が最も近い（かつ30分以内の）ものへ貪欲に割り当てる。30分許容値は既存踏襲（変更の実測根拠が無いため現状維持）。
+- 排他制御は「ソース×agentType」単位でスコープする。同じアンカーに`agent-progress`と`loop-observability`の両方が対応付くのは正常（別ソースなので競合しない）。同一ソース内で複数の自己申告行が同じアンカーを奪い合う場合は使用済みアンカーを除外する（既存`usedTranscriptIndexes`と同じ）。
+- アンカーに対応するものが見つからない自己申告行（hook導入以前の古いログ等）は、単独の`CorrelatedExecution`（`agentId`は自身の合成`eventId`）としてそのまま返す。既存の`unmatchedSelf`概念はここに吸収される。
+
+**中間状態（running/waiting/starting）の扱い:** `agentProgressAdapter`は`agent-progress.jsonl`の全行を`CanonicalEvent`として出力するが、Stage 2の突合対象は`done`/`failed`のみである。したがって`running`/`waiting`/`starting`の行は常に単独の`CorrelatedExecution`になる。これは新しい制約ではなく、既存`loadSelfReports`が最初からdone/failedのみを検証対象としてきたのを踏襲するだけの意図的な仕様である。
+
+**既知の限界（既存踏襲）:** 高並行実行下で同一`agentType`かつ同一時刻窓に3件以上重なる場合、誤対応の可能性は既存同様残る。これは`docs/agents/observability-internals.md`に既に明記済みの限界であり、今回の統合でも解消しない。
+
+---
+
+## Adapter詳細
+
+```ts
+export interface EventAdapter {
+  source: EventSource
+  load(): CanonicalEvent[]
+}
+```
+
+| Adapter | 入力 | agentId | agentType | timestamp | status/detail |
+|---|---|---|---|---|---|
+| `subagentSkeletonAdapter(logFile?)` | `logs/subagent-skeleton.jsonl` | hookの`agent_id`そのまま | hookの`agent_type`生値 | Start行→`startTimestamp`、Stop行→`endTimestamp` | status=null、detail=`lastAssistantMessage` |
+| `journalAdapter(projectDir?)` | 既存`loadTranscripts()`（`reconstruct-loop-observability.ts`のjournal優先ロジックを再利用、無改修） | journal/meta.jsonの`agentId` | `meta.json`の`agentType`生値 | endTimestampのみ（transcript解析由来） | journal優先→無ければtranscript解析 |
+| `agentProgressAdapter(logFile?)` | `logs/agent-progress.jsonl`全行（新規`loadAllAgentProgressRecords()`。既存`loadSelfReports`はdone/failedのみ抽出していたため別関数にする） | null | `extractAgentType(agent)`（`KNOWN_AGENT_TYPES`を`verify-agent-progress-transcript.ts`から本モジュールへ移設） | 単一timestampを`endTimestamp`に格納 | status=自己申告そのまま、detail=`note` |
+| `loopObservabilityAdapter(logFile?)` | `logs/loop-observability.jsonl`全行 | null | `extractAgentType(agent)` | `endTimestamp`のみ | status=`result`、detail=`reason`、intent/scenarioも保持 |
+
+`loadAllEvents(opts?)`が4 Adapterをまとめて呼び、`CanonicalEvent[]`を返す（`correlateEvents()`への入力）。`journalAdapter`のみ`~/.claude/projects/**`のファイルツリー走査を伴うため重い点は既存同様・無改修。
+
+---
+
+## 消費側の移行
+
+`verify-agent-progress-transcript.ts`は以下のパイプラインに書き換える。
+
+```
+loadAllEvents() → correlateEvents() → compareStatus/compareDetail（意味変換、verify側に残す）→ buildReport()
+```
+
+`matchRecords`/`extractAgentType`/`KNOWN_AGENT_TYPES`は`canonical-event.ts`へ移設する。CLIオプション・出力フォーマット・exit codeは無変更。
+
+---
+
+## テスト計画
+
+### 単体テスト
+
+- `canonical-event.test.ts` — 4 Adapterそれぞれの正規化・`correlateEvents()`のStage1/Stage2ロジック
+- `verify-agent-progress-transcript.test.ts` — 意味変換（`compareStatus`/`compareDetail`）・レポート整形のみに縮小
+
+### 等価性テスト
+
+既存gap checkとの対応関係は**ソースごとに性質が異なる**ため、一律の「等価性テスト」ではなく2種類に分けて設計する。
+
+| ソース | 既存bash比較対象 | 検証の性質 |
+|---|---|---|
+| `loop-observability` | `check-loop-observability-gap.sh`（`wc -l`、全行が対象） | **既存ロジックとの同等性検証**: Adapter出力件数 = 生ファイル`wc -l` |
+| `agent-progress` | `check-agent-progress-gap.sh`（`jq`で`status=="done" or "failed"`のみカウント） | ①fidelity検証: Adapter出力件数（全ステータス）= 生ファイル`wc -l`。②**既存ロジックとの同等性検証（本体）**: Adapter出力のうち`status∈{done,failed}`の件数 = 既存`jq`フィルタ件数 |
+| `journal` | 無し（`wf_*/`ディレクトリに分散しており対応する単一ファイルの既存gap checkが存在しない） | **Adapter自体の正しさを保証する単体テスト**: 既知件数を仕込んだfixture（`wf_*/journal.jsonl`+`agent-*.jsonl`+`.meta.json`一式）に対し、Adapter出力件数が既知件数と一致することを直接assertする |
+| `subagent-skeleton` | 無し | 同上（journalと同じ性質） |
+
+`journal`/`subagent-skeleton`について「同等性テスト」という呼称は使わない。対応する既存bashロジックが無いため、比較対象自体が存在しないからである。
+
+---
+
+## ファイル一覧・ロールアウト順
+
+1. `scripts/lib/canonical-event.ts`（新規）+ `canonical-event.test.ts`
+2. `scripts/lib/canonical-event-gap-check-equivalence.test.ts`（新規、上表の①②のみ対象）
+3. `scripts/lib/verify-agent-progress-transcript.ts`（リファクタ、CLI/出力互換）
+4. `scripts/lib/verify-agent-progress-transcript.test.ts`（テスト再配置）
+5. `docs/agents/observability-internals.md`に本統合の設計・実機検証結果を追記
+
+---
+
+## 決定事項サマリ
+
+1. アーキテクチャ: 読み取り専用アダプタ層`canonical-event.ts`を新設。書き込み側・gap check bashは無改修
+2. 型: `CanonicalEvent`（1件粒度、`eventId`は`source:agentType:timestamp:lineIndex`）+ `CorrelatedExecution`（グループ化、マージしない）
+3. 突合: Stage1（agentId厳密一致、実機検証済み）→ Stage2（agentType＋30分窓の貪欲割当、既存踏襲）
+4. Adapter: 4種、共通インターフェース、agentTypeは自己申告側の復元値を優先
+5. 等価性テスト: ソースごとに性質が異なる（既存ロジックとの同等性2つ＋Adapter自体の正しさ検証2つ）

--- a/scripts/lib/canonical-event-gap-check-equivalence.test.ts
+++ b/scripts/lib/canonical-event-gap-check-equivalence.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { agentProgressAdapter, journalAdapter, loopObservabilityAdapter, subagentSkeletonAdapter } from './canonical-event'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+describe('loop-observability: 既存check-loop-observability-gap.sh(wc -l)との等価性', () => {
+  it('Adapter出力件数が生ファイルの行数と一致する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'loop-obs-equiv-'))
+    const logFile = join(dir, 'loop-observability.jsonl')
+    const rawLines = [
+      line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }),
+      line({ timestamp: '2026-07-27T00:01:00Z', agent: 'reviewer', feature: 'f1', intent: 'i', scenario: 's', result: 'fail', reason: 'r' }),
+      line({ timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }),
+    ]
+    writeFileSync(logFile, rawLines.join('\n') + '\n', 'utf-8')
+
+    const events = loopObservabilityAdapter(logFile).load()
+    expect(events).toHaveLength(rawLines.length) // = check-loop-observability-gap.shの`wc -l`相当
+  })
+})
+
+describe('agent-progress: 既存check-agent-progress-gap.shとの等価性', () => {
+  const rawRecords = [
+    { timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'starting', note: 'n' },
+    { timestamp: '2026-07-27T00:01:00Z', agent: 'implementer', feature: 'f1', status: 'running', note: 'n' },
+    { timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n' },
+    { timestamp: '2026-07-27T00:03:00Z', agent: 'reviewer', feature: 'f1', status: 'failed', note: 'n' },
+  ]
+
+  it('①fidelity: Adapter出力件数(全ステータス)が生ファイルの行数と一致する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-equiv-fidelity-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, rawRecords.map(line).join('\n') + '\n', 'utf-8')
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events).toHaveLength(rawRecords.length)
+  })
+
+  it('②既存jqフィルタ(status=="done" or "failed")との等価性(gap check本体)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-equiv-jq-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, rawRecords.map(line).join('\n') + '\n', 'utf-8')
+
+    // check-agent-progress-gap.shの
+    // `jq '[.[] | select(.status == "done" or .status == "failed")] | length'`をJSで再現した基準値
+    const jqEquivalentCount = rawRecords.filter((r) => r.status === 'done' || r.status === 'failed').length
+    expect(jqEquivalentCount).toBe(2)
+
+    const events = agentProgressAdapter(logFile).load()
+    const doneOrFailedCount = events.filter((e) => e.status === 'done' || e.status === 'failed').length
+    expect(doneOrFailedCount).toBe(jqEquivalentCount)
+  })
+})
+
+describe('journal/subagent-skeleton: 対応する既存gap checkが無いため、Adapter自体の正しさを既知件数fixtureで直接検証する', () => {
+  it('journalAdapterはagent-*.jsonl/.meta.jsonのペア件数を正しく読む(既知件数=1)', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-equiv-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-a1.jsonl'),
+      line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(1)
+  })
+
+  it('subagentSkeletonAdapterはStart+Stopの2行を正しく読む(既知件数=2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skeleton-equiv-'))
+    const logFile = join(dir, 'subagent-skeleton.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'a1', agentType: 'workflow-subagent' }),
+        line({ timestamp: '2026-07-27T00:00:02Z', hookEvent: 'SubagentStop', agentId: 'a1', agentType: 'workflow-subagent', lastAssistantMessage: 'ok' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = subagentSkeletonAdapter(logFile).load()
+    expect(events).toHaveLength(2)
+  })
+})

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -230,4 +230,39 @@ describe('journalAdapter', () => {
     const events = journalAdapter(projectDir).load()
     expect(events).toHaveLength(2)
   })
+
+  it('journal.jsonlが無い場合はtranscriptのStructuredOutput結果(status/detail)にフォールバックする', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-adapter-fallback-test-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-a1.jsonl'),
+      [
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+        line({
+          type: 'assistant',
+          message: {
+            model: 'claude-sonnet-5',
+            content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status: 'pass', detail: 'transcript由来のdetail' } }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+          timestamp: '2026-07-27T00:00:01.000Z',
+        }),
+      ].join('\n'),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    // journal.jsonlを意図的に作成しない(フォールバック経路を通す)
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      agentId: 'a1',
+      agentType: 'implementer',
+      status: 'pass',
+      detail: 'transcript由来のdetail',
+      endTimestamp: '2026-07-27T00:00:01.000Z',
+      source: 'journal',
+    })
+  })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter } from './canonical-event'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter, journalAdapter } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -168,5 +168,66 @@ describe('loopObservabilityAdapter', () => {
       agentId: null,
       source: 'loop-observability',
     })
+  })
+})
+
+describe('journalAdapter', () => {
+  it('journal.jsonlの構造化resultがある場合はそちらのstatus/detailを優先する', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-adapter-test-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-a1.jsonl'),
+      [
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+        line({
+          type: 'assistant',
+          message: {
+            model: 'claude-sonnet-5',
+            content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status: 'fail', detail: 'transcript側(上書きされるはず)' } }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+          timestamp: '2026-07-27T00:00:01.000Z',
+        }),
+      ].join('\n'),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
+    writeFileSync(
+      join(wfDir, 'journal.jsonl'),
+      [
+        line({ type: 'started', key: 'v2:xxx', agentId: 'a1' }),
+        line({ type: 'result', key: 'v2:xxx', agentId: 'a1', result: { status: 'pass', detail: 'journal側のdetail' } }),
+      ].join('\n'),
+      'utf-8',
+    )
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      agentId: 'a1',
+      agentType: 'implementer',
+      status: 'pass',
+      detail: 'journal側のdetail',
+      endTimestamp: '2026-07-27T00:00:01.000Z',
+      source: 'journal',
+    })
+  })
+
+  it('複数のwf_*ディレクトリを横断して読む', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-adapter-multi-test-'))
+    for (const [wfName, agentId] of [['wf_1', 'a1'], ['wf_2', 'a2']] as const) {
+      const wfDir = join(projectDir, wfName)
+      mkdirSync(wfDir)
+      writeFileSync(
+        join(wfDir, `agent-${agentId}.jsonl`),
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:00.000Z' }),
+        'utf-8',
+      )
+      writeFileSync(join(wfDir, `agent-${agentId}.meta.json`), JSON.stringify({ agentType: 'reviewer' }), 'utf-8')
+    }
+
+    const events = journalAdapter(projectDir).load()
+    expect(events).toHaveLength(2)
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter, journalAdapter, loadAllEvents } from './canonical-event'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter, journalAdapter, loadAllEvents, correlateEvents } from './canonical-event'
+import type { CanonicalEvent } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -336,5 +337,30 @@ describe('journalAdapter', () => {
       endTimestamp: '2026-07-27T00:00:01.000Z',
       source: 'journal',
     })
+  })
+})
+
+describe('correlateEvents (Stage 1: agentId厳密一致)', () => {
+  it('同一agentIdを持つsubagent-skeletonとjournalのイベントを1つのCorrelatedExecutionにまとめる', () => {
+    const events: CanonicalEvent[] = [
+      { eventId: 'e1', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: '2026-07-27T00:00:00Z', endTimestamp: null, status: null, detail: null, intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e2', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02Z', status: null, detail: 'ok', intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e3', agentId: 'a1', agentType: 'implementer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02.000Z', status: 'pass', detail: 'journal detail', intent: null, scenario: null, source: 'journal' },
+    ]
+
+    const result = correlateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].agentId).toBe('a1')
+    expect(result[0].events).toHaveLength(3)
+  })
+
+  it('agentIdが異なれば別々のCorrelatedExecutionになる', () => {
+    const events: CanonicalEvent[] = [
+      { eventId: 'e1', agentId: 'a1', agentType: 'implementer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:00Z', status: 'pass', detail: null, intent: null, scenario: null, source: 'journal' },
+      { eventId: 'e2', agentId: 'a2', agentType: 'reviewer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:00Z', status: 'pass', detail: null, intent: null, scenario: null, source: 'journal' },
+    ]
+
+    const result = correlateEvents(events)
+    expect(result).toHaveLength(2)
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter, journalAdapter } from './canonical-event'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter, journalAdapter, loadAllEvents } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -168,6 +168,25 @@ describe('loopObservabilityAdapter', () => {
       agentId: null,
       source: 'loop-observability',
     })
+  })
+})
+
+describe('loadAllEvents', () => {
+  it('指定した4ソースのイベントをすべて結合する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'load-all-test-'))
+    const agentProgressLogFile = join(dir, 'agent-progress.jsonl')
+    const loopObservabilityLogFile = join(dir, 'loop-observability.jsonl')
+    writeFileSync(agentProgressLogFile, line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n' }) + '\n', 'utf-8')
+    writeFileSync(loopObservabilityLogFile, line({ timestamp: '2026-07-27T00:00:01Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }) + '\n', 'utf-8')
+
+    const events = loadAllEvents({ agentProgressLogFile, loopObservabilityLogFile })
+    expect(events).toHaveLength(2)
+    expect(events.map((e) => e.source).sort()).toEqual(['agent-progress', 'loop-observability'])
+  })
+
+  it('パスを指定しなかったソースは含めない', () => {
+    const events = loadAllEvents({})
+    expect(events).toEqual([])
   })
 })
 

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter } from './canonical-event'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter, loopObservabilityAdapter } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -134,5 +134,39 @@ describe('agentProgressAdapter', () => {
 
     const events = agentProgressAdapter(logFile).load()
     expect(events[0].agentType).toBe('reviewer')
+  })
+})
+
+describe('loopObservabilityAdapter', () => {
+  it('1行=1イベントとして正規化する(result->status, reason->detail)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'loop-obs-test-'))
+    const logFile = join(dir, 'loop-observability.jsonl')
+    writeFileSync(
+      logFile,
+      line({
+        timestamp: '2026-07-27T00:00:00Z',
+        agent: 'implementer',
+        feature: 'f1',
+        intent: 'テスト実装',
+        scenario: '正常系',
+        result: 'pass',
+        reason: '全テスト成功',
+      }) + '\n',
+      'utf-8',
+    )
+
+    const events = loopObservabilityAdapter(logFile).load()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      agentType: 'implementer',
+      feature: 'f1',
+      endTimestamp: '2026-07-27T00:00:00Z',
+      status: 'pass',
+      detail: '全テスト成功',
+      intent: 'テスト実装',
+      scenario: '正常系',
+      agentId: null,
+      source: 'loop-observability',
+    })
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -83,4 +83,25 @@ describe('subagentSkeletonAdapter', () => {
     const events = subagentSkeletonAdapter('/tmp/does-not-exist-xyz.jsonl').load()
     expect(events).toEqual([])
   })
+
+  it('必須フィールド欠落の行（例: agentId欠落）はスキップされる', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skeleton-test-invalid-'))
+    const logFile = join(dir, 'subagent-skeleton-invalid.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'valid-a1' }),
+        // agentIdが欠落した無効な行
+        line({ timestamp: '2026-07-27T00:00:01Z', hookEvent: 'SubagentStop' }),
+        line({ timestamp: '2026-07-27T00:00:02Z', hookEvent: 'SubagentStop', agentId: 'valid-a2' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = subagentSkeletonAdapter(logFile).load()
+    // 最初と3番目の行だけが有効で、2番目はスキップされる
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({ agentId: 'valid-a1' })
+    expect(events[1]).toMatchObject({ agentId: 'valid-a2' })
+  })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -363,6 +363,28 @@ describe('correlateEvents (Stage 1: agentId厳密一致)', () => {
     const result = correlateEvents(events)
     expect(result).toHaveLength(2)
   })
+
+  it('同一agentId内でskeletonの生agentType(例:workflow-subagent)とjournalのagentType(例:implementer)が食い違う場合、journal側の値をアンカー代表値として採用する', () => {
+    const events: CanonicalEvent[] = [
+      { eventId: 'e1', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: '2026-07-27T00:00:00Z', endTimestamp: null, status: null, detail: null, intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e2', agentId: 'a1', agentType: 'workflow-subagent', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02Z', status: null, detail: 'skeleton detail', intent: null, scenario: null, source: 'subagent-skeleton' },
+      { eventId: 'e3', agentId: 'a1', agentType: 'implementer', feature: null, startTimestamp: null, endTimestamp: '2026-07-27T00:00:02.000Z', status: 'pass', detail: 'journal detail', intent: null, scenario: null, source: 'journal' },
+    ]
+    // agentType='implementer'(journal由来)で時刻窓内の自己申告を追加し、Stage2でこのアンカーに
+    // マッチすることを見て、代表agentTypeがjournal側('implementer')であることを間接的に検証する。
+    // (仮にskeleton側の'workflow-subagent'が採用されていればagentType不一致でマッチしない)
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'implementer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:05.000Z', status: 'done', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([...events, self])
+    expect(result).toHaveLength(1)
+    expect(result[0].agentId).toBe('a1')
+    expect(result[0].events).toHaveLength(4)
+    expect(result[0].events.some((e) => e.eventId === 'self1')).toBe(true)
+  })
 })
 
 describe('correlateEvents (Stage 2: agentType+時刻窓フォールバック)', () => {
@@ -439,5 +461,56 @@ describe('correlateEvents (Stage 2: agentType+時刻窓フォールバック)', 
     expect(result.every((r) => r.events.length === 2)).toBe(true)
     const assignedAgentIds = result.map((r) => r.agentId).sort()
     expect(assignedAgentIds).toEqual(['a1', 'a2'])
+  })
+
+  it('agentTypeが異なるアンカーとは対応付けない(自己申告は未突合のまま単独になる)', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-db', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+    const selfExec = result.find((r) => r.agentId === 'self1')
+    expect(selfExec?.events).toHaveLength(1)
+    expect(selfExec?.events[0].eventId).toBe('self1')
+  })
+
+  it('既知agentTypeに復元できない(agentTypeがnullの)自己申告は突合対象にならず単独になる', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: null, feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+    const selfExec = result.find((r) => r.agentId === 'self1')
+    expect(selfExec?.events).toHaveLength(1)
+  })
+
+  it('journalを持たないskeleton-onlyのアンカーはStage2の割当候補から除外され、自己申告は他の正しいjournalアンカーにマッチするか未突合になる', () => {
+    // journalが存在しない(通常のAgent tool経由等の)skeleton-onlyのグループ。statusは常にnull。
+    const skeletonOnly: CanonicalEvent = {
+      eventId: 'skeleton1', agentId: 'a-skeleton-only', agentType: 'sweep-ui', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.000Z', status: null, detail: 'skeleton only',
+      intent: null, scenario: null, source: 'subagent-skeleton',
+    }
+    // skeletonOnlyの方がself(time=00:00:12)に近い(diff=1s) が journalを持たないため候補から除外され、
+    // 正しいjournalアンカー(diff=2s)にマッチするべき。
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'done', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, skeletonOnly, self])
+    expect(result).toHaveLength(2)
+    const anchorExec = result.find((r) => r.agentId === 'a1')
+    expect(anchorExec?.events).toHaveLength(2)
+    expect(anchorExec?.events.some((e) => e.eventId === 'self1')).toBe(true)
+    const skeletonOnlyExec = result.find((r) => r.agentId === 'a-skeleton-only')
+    expect(skeletonOnlyExec?.events).toHaveLength(1)
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -172,7 +172,60 @@ describe('loopObservabilityAdapter', () => {
 })
 
 describe('loadAllEvents', () => {
-  it('指定した4ソースのイベントをすべて結合する', () => {
+  it('指定した4ソース全てのイベントを結合する（全ソース同時指定）', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'load-all-test-all-sources-'))
+    const subagentSkeletonLogFile = join(dir, 'subagent-skeleton.jsonl')
+    const agentProgressLogFile = join(dir, 'agent-progress.jsonl')
+    const loopObservabilityLogFile = join(dir, 'loop-observability.jsonl')
+
+    // subagent-skeleton: Start/Stop各1行
+    writeFileSync(
+      subagentSkeletonLogFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'a1', agentType: 'workflow-subagent' }),
+        line({ timestamp: '2026-07-27T00:00:01Z', hookEvent: 'SubagentStop', agentId: 'a1', agentType: 'workflow-subagent' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    // agent-progress: 1行
+    writeFileSync(agentProgressLogFile, line({ timestamp: '2026-07-27T00:00:02Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n' }) + '\n', 'utf-8')
+
+    // loop-observability: 1行
+    writeFileSync(loopObservabilityLogFile, line({ timestamp: '2026-07-27T00:00:03Z', agent: 'implementer', feature: 'f1', intent: 'i', scenario: 's', result: 'pass', reason: 'r' }) + '\n', 'utf-8')
+
+    // journal: wf_*ディレクトリ配下にagent-*.jsonl+.meta.jsonのペア
+    const projectDir = mkdtempSync(join(tmpdir(), 'journal-all-test-'))
+    const wfDir = join(projectDir, 'wf_1')
+    mkdirSync(wfDir)
+    writeFileSync(
+      join(wfDir, 'agent-j1.jsonl'),
+      [
+        line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-27T00:00:04.000Z' }),
+        line({
+          type: 'assistant',
+          message: {
+            model: 'claude-sonnet-5',
+            content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status: 'pass', detail: 'ok' } }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+          timestamp: '2026-07-27T00:00:05.000Z',
+        }),
+      ].join('\n'),
+      'utf-8',
+    )
+    writeFileSync(join(wfDir, 'agent-j1.meta.json'), JSON.stringify({ agentType: 'reviewer' }), 'utf-8')
+
+    const events = loadAllEvents({ subagentSkeletonLogFile, agentProgressLogFile, loopObservabilityLogFile, projectDir })
+    expect(events.length).toBeGreaterThanOrEqual(4)
+    const sources = events.map((e) => e.source)
+    expect(sources).toContain('subagent-skeleton')
+    expect(sources).toContain('agent-progress')
+    expect(sources).toContain('loop-observability')
+    expect(sources).toContain('journal')
+  })
+
+  it('指定した2ソースのイベントをすべて結合する', () => {
     const dir = mkdtempSync(join(tmpdir(), 'load-all-test-'))
     const agentProgressLogFile = join(dir, 'agent-progress.jsonl')
     const loopObservabilityLogFile = join(dir, 'loop-observability.jsonl')

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter } from './canonical-event'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter, agentProgressAdapter } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -103,5 +103,36 @@ describe('subagentSkeletonAdapter', () => {
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ agentId: 'valid-a1' })
     expect(events[1]).toMatchObject({ agentId: 'valid-a2' })
+  })
+})
+
+describe('agentProgressAdapter', () => {
+  it('全ステータス(starting/running/waiting/done/failed)を落とさずに出力する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-test-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', agent: 'implementer', feature: 'f1', status: 'starting', note: 'n1' }),
+        line({ timestamp: '2026-07-27T00:01:00Z', agent: 'implementer', feature: 'f1', status: 'running', note: 'n2' }),
+        line({ timestamp: '2026-07-27T00:02:00Z', agent: 'implementer', feature: 'f1', status: 'done', note: 'n3' }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events).toHaveLength(3)
+    expect(events.map((e) => e.status)).toEqual(['starting', 'running', 'done'])
+    expect(events[0].agentType).toBe('implementer')
+    expect(events[2]).toMatchObject({ feature: 'f1', endTimestamp: '2026-07-27T00:02:00Z', detail: 'n3', agentId: null, source: 'agent-progress' })
+  })
+
+  it('役割サフィックス付きagent(reviewer-correctness)からagentTypeを復元する', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-progress-test-suffix-'))
+    const logFile = join(dir, 'agent-progress.jsonl')
+    writeFileSync(logFile, line({ timestamp: '2026-07-27T00:00:00Z', agent: 'reviewer-correctness', feature: 'f1', status: 'done', note: 'n' }) + '\n', 'utf-8')
+
+    const events = agentProgressAdapter(logFile).load()
+    expect(events[0].agentType).toBe('reviewer')
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES } from './canonical-event'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES, subagentSkeletonAdapter } from './canonical-event'
 
 describe('KNOWN_AGENT_TYPES', () => {
   it('12種類のagentTypeを含む', () => {
@@ -44,5 +47,40 @@ describe('buildEventId', () => {
     const a = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 0)
     const b = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 1)
     expect(a).not.toBe(b)
+  })
+})
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+describe('subagentSkeletonAdapter', () => {
+  it('Start行はstartTimestamp、Stop行はendTimestampに割り当てる', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skeleton-test-'))
+    const logFile = join(dir, 'subagent-skeleton.jsonl')
+    writeFileSync(
+      logFile,
+      [
+        line({ timestamp: '2026-07-27T00:00:00Z', hookEvent: 'SubagentStart', agentId: 'a1', agentType: 'workflow-subagent' }),
+        line({
+          timestamp: '2026-07-27T00:00:02Z',
+          hookEvent: 'SubagentStop',
+          agentId: 'a1',
+          agentType: 'workflow-subagent',
+          lastAssistantMessage: 'ok',
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    )
+
+    const events = subagentSkeletonAdapter(logFile).load()
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({ agentId: 'a1', startTimestamp: '2026-07-27T00:00:00Z', endTimestamp: null, source: 'subagent-skeleton' })
+    expect(events[1]).toMatchObject({ agentId: 'a1', startTimestamp: null, endTimestamp: '2026-07-27T00:00:02Z', detail: 'ok' })
+  })
+
+  it('ファイルが存在しない場合は空配列を返す', () => {
+    const events = subagentSkeletonAdapter('/tmp/does-not-exist-xyz.jsonl').load()
+    expect(events).toEqual([])
   })
 })

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -364,3 +364,80 @@ describe('correlateEvents (Stage 1: agentId厳密一致)', () => {
     expect(result).toHaveLength(2)
   })
 })
+
+describe('correlateEvents (Stage 2: agentType+時刻窓フォールバック)', () => {
+  const anchor: CanonicalEvent = {
+    eventId: 'anchor1', agentId: 'a1', agentType: 'sweep-ui', feature: null,
+    startTimestamp: null, endTimestamp: '2026-07-27T00:00:10.000Z', status: 'pass', detail: 'anchor detail',
+    intent: null, scenario: null, source: 'journal',
+  }
+
+  it('agentIdを持たないagent-progress(done)を同一agentType・時刻窓内のアンカーへ対応付ける', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'done', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(1)
+    expect(result[0].events).toHaveLength(2)
+  })
+
+  it('agent-progressのrunning/waiting/startingは常に単独になる(突合対象外)', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'running', detail: 'self detail',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+    const selfExec = result.find((r) => r.agentId === 'self1')
+    expect(selfExec?.events).toHaveLength(1)
+  })
+
+  it('許容誤差を超えるアンカーとは対応付けない', () => {
+    const self: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T02:00:00.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    const result = correlateEvents([anchor, self])
+    expect(result).toHaveLength(2)
+  })
+
+  it('同じアンカーにagent-progressとloop-observabilityの両方が対応付いても競合しない', () => {
+    const selfProgress: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.000Z', status: 'done', detail: 'd1',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+    const selfLoop: CanonicalEvent = {
+      eventId: 'self2', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:11.500Z', status: 'pass', detail: 'd2',
+      intent: 'i', scenario: 's', source: 'loop-observability',
+    }
+
+    const result = correlateEvents([anchor, selfProgress, selfLoop])
+    expect(result).toHaveLength(1)
+    expect(result[0].events).toHaveLength(3)
+  })
+
+  it('同一agentTypeが複数ある場合、それぞれ最も近いアンカーに1件ずつ割り当てる(使い回さない)', () => {
+    const anchor2: CanonicalEvent = { ...anchor, agentId: 'a2', endTimestamp: '2026-07-27T00:10:10.000Z' }
+    const self1: CanonicalEvent = {
+      eventId: 'self1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-27T00:00:12.000Z', status: 'done', detail: 'd',
+      intent: null, scenario: null, source: 'agent-progress',
+    }
+    const self2: CanonicalEvent = { ...self1, eventId: 'self2', endTimestamp: '2026-07-27T00:10:12.000Z' }
+
+    const result = correlateEvents([anchor, anchor2, self1, self2])
+    expect(result).toHaveLength(2)
+    expect(result.every((r) => r.events.length === 2)).toBe(true)
+    const assignedAgentIds = result.map((r) => r.agentId).sort()
+    expect(assignedAgentIds).toEqual(['a1', 'a2'])
+  })
+})

--- a/scripts/lib/canonical-event.test.ts
+++ b/scripts/lib/canonical-event.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildEventId, extractAgentType, KNOWN_AGENT_TYPES } from './canonical-event'
+
+describe('KNOWN_AGENT_TYPES', () => {
+  it('12種類のagentTypeを含む', () => {
+    expect(KNOWN_AGENT_TYPES).toHaveLength(12)
+    expect(KNOWN_AGENT_TYPES).toContain('sweep-ui')
+    expect(KNOWN_AGENT_TYPES).toContain('implementer')
+  })
+})
+
+describe('extractAgentType', () => {
+  it('agentType単体の完全一致を認識する', () => {
+    expect(extractAgentType('reviewer')).toBe('reviewer')
+  })
+
+  it('役割サフィックス付き(reviewer-correctness)からagentTypeを復元する', () => {
+    expect(extractAgentType('reviewer-correctness')).toBe('reviewer')
+  })
+
+  it('既知agentTypeに前方一致しない場合はnullを返す', () => {
+    expect(extractAgentType('unknown-agent')).toBeNull()
+  })
+
+  it('sweep-uiとsweep-dataのように前方一致が紛らわしい場合でも正しく判定する', () => {
+    expect(extractAgentType('sweep-data-something')).toBe('sweep-data')
+  })
+})
+
+describe('buildEventId', () => {
+  it('source:agentType:timestamp:lineIndexの形式で組み立てる', () => {
+    expect(buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 0)).toBe(
+      'agent-progress:implementer:2026-07-27T00:00:00Z:0',
+    )
+  })
+
+  it('agentTypeがnullの場合はunknownを使う', () => {
+    expect(buildEventId('subagent-skeleton', null, '2026-07-27T00:00:00Z', 3)).toBe(
+      'subagent-skeleton:unknown:2026-07-27T00:00:00Z:3',
+    )
+  })
+
+  it('同一秒・同一agentTypeでもlineIndexが異なれば衝突しない', () => {
+    const a = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 0)
+    const b = buildEventId('agent-progress', 'implementer', '2026-07-27T00:00:00Z', 1)
+    expect(a).not.toBe(b)
+  })
+})

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -174,3 +174,50 @@ export function agentProgressAdapter(logFile: string): EventAdapter {
     },
   }
 }
+
+interface LoopObservabilityLine {
+  timestamp: string
+  agent: string
+  feature: string
+  intent: string
+  scenario: string
+  result: string
+  reason: string
+}
+
+export function loadAllLoopObservabilityRecords(logFile: string): LoopObservabilityLine[] {
+  let content: string
+  try {
+    content = readFileSync(logFile, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((raw) => JSON.parse(raw) as LoopObservabilityLine)
+}
+
+export function loopObservabilityAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'loop-observability',
+    load(): CanonicalEvent[] {
+      return loadAllLoopObservabilityRecords(logFile).map((record, lineIndex) => {
+        const agentType = extractAgentType(record.agent)
+        return {
+          eventId: buildEventId('loop-observability', agentType, record.timestamp, lineIndex),
+          agentId: null,
+          agentType,
+          feature: record.feature,
+          startTimestamp: null,
+          endTimestamp: record.timestamp,
+          status: record.result as EventStatus,
+          detail: record.reason,
+          intent: record.intent,
+          scenario: record.scenario,
+          source: 'loop-observability',
+        }
+      })
+    },
+  }
+}

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -358,19 +358,31 @@ export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_
   }
 
   // アンカー(agentId確定済みグループ)のagentType/endTimestamp代表値を算出する。
+  // WHY: loadAllEventsはsubagent-skeletonをjournalより先に積むため、両方存在する場合に
+  //      単純な.findだとskeleton側(生のhookペイロード値、例:'workflow-subagent')を誤って拾って
+  //      しまう(buildReportで既に修正済みの「journal優先」バグと同種)。meta.json由来の正確な
+  //      agentType/endTimestampを持つjournalを優先し、無ければskeletonへフォールバックする。
+  //
+  // また、Stage 2のアンカー候補としては「journalを含むagentIdグループのみ」を対象にする。
+  // subagent-skeletonのみ(journal無し)のグループはstatusが常にnullで、buildReport側では
+  // 結局unmatchedSelf扱いになるため、Stage2でこれを「使用済み」にしてしまうと、本来別の
+  // journalアンカーにマッチできたはずの自己申告イベントを誤って奪ってしまう構造的リスクがある。
   interface AnchorInfo {
     agentId: string
     agentType: string | null
     endTimestamp: string | null
   }
-  const anchorInfos: AnchorInfo[] = [...executions.entries()].map(([agentId, exec]) => {
-    const withEndTs = exec.events.find((e) => e.endTimestamp !== null)
-    return {
-      agentId,
-      agentType: withEndTs?.agentType ?? exec.events[0]?.agentType ?? null,
-      endTimestamp: withEndTs?.endTimestamp ?? null,
-    }
-  })
+  const anchorInfos: AnchorInfo[] = [...executions.entries()]
+    .filter(([, exec]) => exec.events.some((e) => e.source === 'journal'))
+    .map(([agentId, exec]) => {
+      const journalEvent = exec.events.find((e) => e.source === 'journal')
+      const skeletonWithEndTs = exec.events.find((e) => e.endTimestamp !== null)
+      return {
+        agentId,
+        agentType: journalEvent?.agentType ?? skeletonWithEndTs?.agentType ?? exec.events[0]?.agentType ?? null,
+        endTimestamp: journalEvent?.endTimestamp ?? skeletonWithEndTs?.endTimestamp ?? null,
+      }
+    })
 
   // Stage 2: ソースごとに独立した排他プールで、agentType一致・時刻窓内の最近傍アンカーへ貪欲割当する。
   // 排他制御を「ソース×agentType」単位にスコープすることで、agent-progressとloop-observabilityの

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
 export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'
 
@@ -53,4 +55,62 @@ export function buildEventId(
   lineIndex: number,
 ): string {
   return `${source}:${agentType ?? 'unknown'}:${timestamp}:${lineIndex}`
+}
+
+export interface EventAdapter {
+  source: EventSource
+  load(): CanonicalEvent[]
+}
+
+interface SkeletonLine {
+  timestamp: string
+  hookEvent: string
+  agentId: string
+  agentType?: string
+  lastAssistantMessage?: string
+  intent?: string
+}
+
+function parseSkeletonLine(raw: string): SkeletonLine | null {
+  try {
+    return JSON.parse(raw) as SkeletonLine
+  } catch {
+    return null
+  }
+}
+
+export function subagentSkeletonAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'subagent-skeleton',
+    load(): CanonicalEvent[] {
+      let content: string
+      try {
+        content = readFileSync(logFile, 'utf-8')
+      } catch {
+        return []
+      }
+      const lines = content.split('\n').filter(Boolean)
+      const events: CanonicalEvent[] = []
+      lines.forEach((raw, lineIndex) => {
+        const parsed = parseSkeletonLine(raw)
+        if (!parsed) return
+        const isStart = parsed.hookEvent === 'SubagentStart'
+        const agentType = parsed.agentType ?? null
+        events.push({
+          eventId: buildEventId('subagent-skeleton', agentType, parsed.timestamp, lineIndex),
+          agentId: parsed.agentId,
+          agentType,
+          feature: null,
+          startTimestamp: isStart ? parsed.timestamp : null,
+          endTimestamp: isStart ? null : parsed.timestamp,
+          status: null,
+          detail: parsed.lastAssistantMessage ?? null,
+          intent: parsed.intent ?? null,
+          scenario: null,
+          source: 'subagent-skeleton',
+        })
+      })
+      return events
+    },
+  }
 }

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadJournalResults, pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability'
 
 export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
 export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'
@@ -218,6 +220,81 @@ export function loopObservabilityAdapter(logFile: string): EventAdapter {
           source: 'loop-observability',
         }
       })
+    },
+  }
+}
+
+// 既存verify-agent-progress-transcript.tsのfindWorkflowDirsと同一ロジック。
+// wf_*という名前のディレクトリを再帰的に探索する。
+function findWorkflowDirs(projectDir: string): string[] {
+  const results: string[] = []
+  function walk(dir: string) {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry)
+      let stat
+      try {
+        stat = statSync(fullPath)
+      } catch {
+        continue
+      }
+      if (!stat.isDirectory()) continue
+      if (entry.startsWith('wf_')) {
+        results.push(fullPath)
+        continue
+      }
+      walk(fullPath)
+    }
+  }
+  walk(projectDir)
+  return results
+}
+
+export function journalAdapter(projectDir: string): EventAdapter {
+  return {
+    source: 'journal',
+    load(): CanonicalEvent[] {
+      const events: CanonicalEvent[] = []
+      let lineIndex = 0
+      for (const wfDir of findWorkflowDirs(projectDir)) {
+        const filenames = readdirSync(wfDir)
+        const pairs = pairAgentFiles(filenames)
+        const journalResults = loadJournalResults(wfDir, filenames)
+        for (const { agentId, jsonlFile, metaFile } of pairs) {
+          let agentType = 'unknown'
+          try {
+            const meta = JSON.parse(readFileSync(join(wfDir, metaFile), 'utf-8')) as { agentType?: string }
+            agentType = meta.agentType ?? 'unknown'
+          } catch {
+            continue
+          }
+          const lines = readFileSync(join(wfDir, jsonlFile), 'utf-8').split('\n').filter(Boolean)
+          const summary = parseAgentTranscriptLines(lines)
+          const journalResult = journalResults.get(agentId)
+          const status = journalResult ? journalResult.status : summary.status
+          const detail = journalResult ? journalResult.detail : summary.detail
+
+          events.push({
+            eventId: buildEventId('journal', agentType, summary.endTimestamp ?? 'unknown', lineIndex++),
+            agentId,
+            agentType,
+            feature: null,
+            startTimestamp: summary.startTimestamp,
+            endTimestamp: summary.endTimestamp,
+            status,
+            detail,
+            intent: null,
+            scenario: null,
+            source: 'journal',
+          })
+        }
+      }
+      return events
     },
   }
 }

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -298,3 +298,19 @@ export function journalAdapter(projectDir: string): EventAdapter {
     },
   }
 }
+
+export interface LoadAllEventsOptions {
+  subagentSkeletonLogFile?: string
+  agentProgressLogFile?: string
+  loopObservabilityLogFile?: string
+  projectDir?: string
+}
+
+export function loadAllEvents(opts: LoadAllEventsOptions = {}): CanonicalEvent[] {
+  const events: CanonicalEvent[] = []
+  if (opts.subagentSkeletonLogFile) events.push(...subagentSkeletonAdapter(opts.subagentSkeletonLogFile).load())
+  if (opts.agentProgressLogFile) events.push(...agentProgressAdapter(opts.agentProgressLogFile).load())
+  if (opts.loopObservabilityLogFile) events.push(...loopObservabilityAdapter(opts.loopObservabilityLogFile).load())
+  if (opts.projectDir) events.push(...journalAdapter(opts.projectDir).load())
+  return events
+}

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -72,11 +72,26 @@ interface SkeletonLine {
 }
 
 function parseSkeletonLine(raw: string): SkeletonLine | null {
+  let parsed: unknown
   try {
-    return JSON.parse(raw) as SkeletonLine
+    parsed = JSON.parse(raw)
   } catch {
+    // JSONパースに失敗した行は無言でスキップする（ログファイルに混在する非JSON行を許容）
     return null
   }
+  // オブジェクトでない、またはnullの場合はスキップ
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const candidate = parsed as Record<string, unknown>
+  // 必須フィールド（timestamp, hookEvent, agentId）の型検証
+  // これらが欠落していたり型が異なる場合は、このレコードは無効なため無言でスキップ
+  if (
+    typeof candidate.timestamp !== 'string' ||
+    typeof candidate.hookEvent !== 'string' ||
+    typeof candidate.agentId !== 'string'
+  ) {
+    return null
+  }
+  return candidate as unknown as SkeletonLine
 }
 
 export function subagentSkeletonAdapter(logFile: string): EventAdapter {

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -129,3 +129,48 @@ export function subagentSkeletonAdapter(logFile: string): EventAdapter {
     },
   }
 }
+
+interface AgentProgressLine {
+  timestamp: string
+  agent: string
+  feature: string
+  status: string
+  note: string
+}
+
+export function loadAllAgentProgressRecords(logFile: string): AgentProgressLine[] {
+  let content: string
+  try {
+    content = readFileSync(logFile, 'utf-8')
+  } catch {
+    return []
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((raw) => JSON.parse(raw) as AgentProgressLine)
+}
+
+export function agentProgressAdapter(logFile: string): EventAdapter {
+  return {
+    source: 'agent-progress',
+    load(): CanonicalEvent[] {
+      return loadAllAgentProgressRecords(logFile).map((record, lineIndex) => {
+        const agentType = extractAgentType(record.agent)
+        return {
+          eventId: buildEventId('agent-progress', agentType, record.timestamp, lineIndex),
+          agentId: null,
+          agentType,
+          feature: record.feature,
+          startTimestamp: null,
+          endTimestamp: record.timestamp,
+          status: record.status as EventStatus,
+          detail: record.note,
+          intent: null,
+          scenario: null,
+          source: 'agent-progress',
+        }
+      })
+    },
+  }
+}

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -322,13 +322,28 @@ export interface CorrelatedExecution {
 
 const DEFAULT_TOLERANCE_MS = 30 * 60 * 1000
 
+function toEpochMs(timestamp: string): number | null {
+  const ms = Date.parse(timestamp)
+  return Number.isNaN(ms) ? null : ms
+}
+
+const TERMINAL_AGENT_PROGRESS_STATUSES = new Set(['done', 'failed'])
+
+// agent-progressの中間状態(starting/running/waiting)は突合対象にしない。
+// 既存loadSelfReports(verify-agent-progress-transcript.ts)がdone/failedのみを検証対象として
+// きたのを踏襲する意図的な仕様(docs/superpowers/specs/2026-07-27-canonical-event-module-design.md参照)。
+function isMatchTarget(event: CanonicalEvent): boolean {
+  if (event.source === 'agent-progress') return TERMINAL_AGENT_PROGRESS_STATUSES.has(event.status ?? '')
+  return true
+}
+
 export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_TOLERANCE_MS): CorrelatedExecution[] {
-  // Stage 1: agentIdを持つイベント(subagent-skeleton/journal)を厳密一致でグループ化する。
-  // 両者は同一agentId空間であることを実機検証済み(2026-07-27、docs/superpowers/specs/
-  // 2026-07-27-canonical-event-module-design.md参照)。
   const executions = new Map<string, CorrelatedExecution>()
   const selfReportEvents: CanonicalEvent[] = []
 
+  // Stage 1: agentIdを持つイベント(subagent-skeleton/journal)を厳密一致でグループ化する。
+  // 両者は同一agentId空間であることを実機検証済み(2026-07-27、docs/superpowers/specs/
+  // 2026-07-27-canonical-event-module-design.md参照)。
   for (const event of events) {
     if (event.agentId !== null) {
       const existing = executions.get(event.agentId)
@@ -342,8 +357,68 @@ export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_
     }
   }
 
-  // Stage 2は次のタスクで実装する。ここでは自己申告イベントを一旦すべて単独のCorrelatedExecutionにする。
+  // アンカー(agentId確定済みグループ)のagentType/endTimestamp代表値を算出する。
+  interface AnchorInfo {
+    agentId: string
+    agentType: string | null
+    endTimestamp: string | null
+  }
+  const anchorInfos: AnchorInfo[] = [...executions.entries()].map(([agentId, exec]) => {
+    const withEndTs = exec.events.find((e) => e.endTimestamp !== null)
+    return {
+      agentId,
+      agentType: withEndTs?.agentType ?? exec.events[0]?.agentType ?? null,
+      endTimestamp: withEndTs?.endTimestamp ?? null,
+    }
+  })
+
+  // Stage 2: ソースごとに独立した排他プールで、agentType一致・時刻窓内の最近傍アンカーへ貪欲割当する。
+  // 排他制御を「ソース×agentType」単位にスコープすることで、agent-progressとloop-observabilityの
+  // 両方が同じアンカーに対応付くこと自体は許容する(別ソースなので競合しない)。
+  const bySource = new Map<EventSource, CanonicalEvent[]>()
   for (const event of selfReportEvents) {
+    if (!isMatchTarget(event)) continue
+    const bucket = bySource.get(event.source) ?? []
+    bucket.push(event)
+    bySource.set(event.source, bucket)
+  }
+
+  const matchedEventIds = new Set<string>()
+
+  for (const candidates of bySource.values()) {
+    const usedAgentIds = new Set<string>()
+    const sorted = [...candidates].sort((a, b) => (a.endTimestamp ?? '').localeCompare(b.endTimestamp ?? ''))
+
+    for (const candidate of sorted) {
+      if (candidate.agentType === null || candidate.endTimestamp === null) continue
+      const candidateEpoch = toEpochMs(candidate.endTimestamp)
+      if (candidateEpoch === null) continue
+
+      let bestAgentId: string | null = null
+      let bestDiff = Infinity
+      for (const anchor of anchorInfos) {
+        if (usedAgentIds.has(anchor.agentId)) continue
+        if (anchor.agentType !== candidate.agentType || anchor.endTimestamp === null) continue
+        const anchorEpoch = toEpochMs(anchor.endTimestamp)
+        if (anchorEpoch === null) continue
+        const diff = Math.abs(anchorEpoch - candidateEpoch)
+        if (diff <= toleranceMs && diff < bestDiff) {
+          bestDiff = diff
+          bestAgentId = anchor.agentId
+        }
+      }
+
+      if (bestAgentId !== null) {
+        usedAgentIds.add(bestAgentId)
+        executions.get(bestAgentId)!.events.push(candidate)
+        matchedEventIds.add(candidate.eventId)
+      }
+    }
+  }
+
+  // 突合対象外(中間状態)、または対応するアンカーが見つからなかった自己申告は単独扱いにする。
+  for (const event of selfReportEvents) {
+    if (matchedEventIds.has(event.eventId)) continue
     executions.set(event.eventId, { agentId: event.eventId, events: [event] })
   }
 

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -314,3 +314,38 @@ export function loadAllEvents(opts: LoadAllEventsOptions = {}): CanonicalEvent[]
   if (opts.projectDir) events.push(...journalAdapter(opts.projectDir).load())
   return events
 }
+
+export interface CorrelatedExecution {
+  agentId: string
+  events: CanonicalEvent[]
+}
+
+const DEFAULT_TOLERANCE_MS = 30 * 60 * 1000
+
+export function correlateEvents(events: CanonicalEvent[], toleranceMs = DEFAULT_TOLERANCE_MS): CorrelatedExecution[] {
+  // Stage 1: agentIdを持つイベント(subagent-skeleton/journal)を厳密一致でグループ化する。
+  // 両者は同一agentId空間であることを実機検証済み(2026-07-27、docs/superpowers/specs/
+  // 2026-07-27-canonical-event-module-design.md参照)。
+  const executions = new Map<string, CorrelatedExecution>()
+  const selfReportEvents: CanonicalEvent[] = []
+
+  for (const event of events) {
+    if (event.agentId !== null) {
+      const existing = executions.get(event.agentId)
+      if (existing) {
+        existing.events.push(event)
+      } else {
+        executions.set(event.agentId, { agentId: event.agentId, events: [event] })
+      }
+    } else {
+      selfReportEvents.push(event)
+    }
+  }
+
+  // Stage 2は次のタスクで実装する。ここでは自己申告イベントを一旦すべて単独のCorrelatedExecutionにする。
+  for (const event of selfReportEvents) {
+    executions.set(event.eventId, { agentId: event.eventId, events: [event] })
+  }
+
+  return [...executions.values()]
+}

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -1,0 +1,56 @@
+export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
+export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'
+
+export interface CanonicalEvent {
+  eventId: string
+  agentId: string | null
+  agentType: string | null
+  feature: string | null
+  startTimestamp: string | null
+  endTimestamp: string | null
+  status: EventStatus | null
+  detail: string | null
+  intent: string | null
+  scenario: string | null
+  source: EventSource
+}
+
+// docs/agents/common.md「サブエージェント進捗の可視化（issue #18）」に列挙されている
+// 進捗記録対象agentType一覧。verify-agent-progress-transcript.tsから本モジュールへ移設（issue #569）。
+export const KNOWN_AGENT_TYPES = [
+  'sweep-db',
+  'sweep-ui',
+  'sweep-types',
+  'sweep-data',
+  'implementer',
+  'reviewer',
+  'integrator',
+  'judge-panel',
+  'proposer',
+  'adversarial-verify',
+  'completeness-critic',
+  'contract-writer',
+] as const
+
+// 自己申告jsonlの--agentは「reviewer-correctness」「implementer-groupA」のように
+// agentTypeへ役割サフィックスを付けた自由記述のため、既知agentType一覧との前方一致
+// （区切りは'-'または完全一致）で復元する。
+export function extractAgentType(selfAgentField: string): string | null {
+  const candidates = KNOWN_AGENT_TYPES.filter(
+    (type) => selfAgentField === type || selfAgentField.startsWith(`${type}-`),
+  )
+  if (candidates.length === 0) return null
+  return candidates.reduce((longest, current) => (current.length > longest.length ? current : longest))
+}
+
+// 各log-*.shは秒精度タイムスタンプ(date -u +"%Y-%m-%dT%H:%M:%SZ")しか書かないため、
+// 同一秒内の複数状態遷移がタイムスタンプだけでは衝突しうる。ログ生成側は無改修という前提のため、
+// ファイル内の出現順インデックス(lineIndex)をキーに含めて一意性を保証する。
+export function buildEventId(
+  source: EventSource,
+  agentType: string | null,
+  timestamp: string,
+  lineIndex: number,
+): string {
+  return `${source}:${agentType ?? 'unknown'}:${timestamp}:${lineIndex}`
+}

--- a/scripts/lib/reconstruct-loop-observability.ts
+++ b/scripts/lib/reconstruct-loop-observability.ts
@@ -293,7 +293,7 @@ const JOURNAL_FILENAME = 'journal.jsonl'
 // journal.jsonlはWorkflowツール経由の`agent()`呼び出しでのみ生成される（通常のAgent tool
 // 直接起動には存在しない）。存在しない場合は空のMapを返し、呼び出し側は自動的に
 // transcriptパース方式（従来どおりの`parseAgentTranscriptLines`の結果）にフォールバックする。
-// issue #493: verify-agent-progress-transcript.tsのloadTranscriptsからも同一ロジックを
+// issue #493: canonical-event.tsのjournalAdapterからも同一ロジックを
 // 再利用するためexportする（インライン複製を避ける。同一プロセスの通常importで足りる）。
 export function loadJournalResults(wfDirPath: string, filenames: string[]): Map<string, JournalStructuredResult> {
   if (!filenames.includes(JOURNAL_FILENAME)) return new Map()

--- a/scripts/lib/verify-agent-progress-transcript.test.ts
+++ b/scripts/lib/verify-agent-progress-transcript.test.ts
@@ -1,59 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import {
-  buildReport,
-  compareDetail,
-  compareStatus,
-  extractAgentType,
-  loadTranscripts,
-  matchRecords,
-  type SelfReportRecord,
-  type TranscriptRecord,
-} from './verify-agent-progress-transcript'
-
-function line(obj: unknown): string {
-  return JSON.stringify(obj)
-}
-
-function agentTranscriptLines(status: string, detail: string, timestamp: string): string {
-  return [
-    line({ type: 'user', message: { role: 'user', content: 'p' }, timestamp: '2026-07-11T03:00:00.000Z' }),
-    line({
-      type: 'assistant',
-      message: {
-        model: 'claude-sonnet-5',
-        content: [{ type: 'tool_use', name: 'StructuredOutput', input: { status, detail } }],
-        usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      timestamp,
-    }),
-  ].join('\n')
-}
-
-describe('extractAgentType', () => {
-  it('agentType単体の完全一致を認識する', () => {
-    expect(extractAgentType('reviewer')).toBe('reviewer')
-  })
-
-  it('役割サフィックス付き(reviewer-correctness)からagentTypeを復元する', () => {
-    expect(extractAgentType('reviewer-correctness')).toBe('reviewer')
-  })
-
-  it('implementer-groupAのようなグループ名サフィックスも復元する', () => {
-    expect(extractAgentType('implementer-groupA')).toBe('implementer')
-  })
-
-  it('既知agentTypeに前方一致しない場合はnullを返す', () => {
-    expect(extractAgentType('unknown-agent')).toBeNull()
-  })
-
-  it('sweep-uiとsweep-dataのように前方一致が紛らわしい場合でも正しく判定する', () => {
-    expect(extractAgentType('sweep-ui')).toBe('sweep-ui')
-    expect(extractAgentType('sweep-data-something')).toBe('sweep-data')
-  })
-})
+import { compareDetail, compareStatus, buildReport } from './verify-agent-progress-transcript'
+import { correlateEvents, type CanonicalEvent } from './canonical-event'
 
 describe('compareStatus', () => {
   it('自己申告doneとtranscript passは一致とみなす', () => {
@@ -83,9 +30,7 @@ describe('compareStatus', () => {
 
 describe('compareDetail', () => {
   it('内容が近い場合はmatchとする', () => {
-    expect(compareDetail('UI層調査完了。propsの型不整合を2件検出', 'UI層の調査が完了した。propsの型不整合を2件検出した')).toBe(
-      'match',
-    )
+    expect(compareDetail('UI層調査完了。propsの型不整合を2件検出', 'UI層の調査が完了した。propsの型不整合を2件検出した')).toBe('match')
   })
 
   it('内容が無関係な場合はlow_overlapとする', () => {
@@ -98,169 +43,52 @@ describe('compareDetail', () => {
   })
 })
 
-describe('matchRecords', () => {
-  const baseTranscript: TranscriptRecord = {
-    wfDir: '/tmp/wf_1',
-    agentId: 'a1',
-    agentType: 'sweep-ui',
-    endTimestamp: '2026-07-15T03:00:10.000Z',
-    status: 'pass',
-    detail: 'UI層調査完了',
-  }
-
-  const baseSelf: SelfReportRecord = {
-    timestamp: '2026-07-15T03:00:12.000Z',
-    agent: 'sweep-ui',
-    feature: 'news-feed',
-    status: 'done',
-    note: 'UI層調査完了',
-  }
-
-  it('同一agentTypeで最も時刻が近いtranscriptと対応付ける', () => {
-    const { matched, unmatchedSelf } = matchRecords([baseSelf], [baseTranscript])
-    expect(matched).toHaveLength(1)
-    expect(matched[0].transcript.agentId).toBe('a1')
-    expect(unmatchedSelf).toHaveLength(0)
-  })
-
-  it('許容誤差を超えるtranscriptとは対応付けない', () => {
-    const farTranscript = { ...baseTranscript, endTimestamp: '2026-07-15T05:00:00.000Z' }
-    const { matched, unmatchedSelf } = matchRecords([baseSelf], [farTranscript], 60_000)
-    expect(matched).toHaveLength(0)
-    expect(unmatchedSelf).toHaveLength(1)
-  })
-
-  it('agentTypeが異なるtranscriptとは対応付けない', () => {
-    const otherType = { ...baseTranscript, agentType: 'reviewer' }
-    const { matched, unmatchedSelf } = matchRecords([baseSelf], [otherType])
-    expect(matched).toHaveLength(0)
-    expect(unmatchedSelf).toHaveLength(1)
-  })
-
-  it('同一agentTypeが複数ある場合、それぞれ最も近いtranscriptに1件ずつ割り当てる（使い回さない）', () => {
-    const self2: SelfReportRecord = { ...baseSelf, timestamp: '2026-07-15T03:10:12.000Z' }
-    const transcript2: TranscriptRecord = { ...baseTranscript, agentId: 'a2', endTimestamp: '2026-07-15T03:10:10.000Z' }
-    const { matched } = matchRecords([baseSelf, self2], [baseTranscript, transcript2])
-    expect(matched).toHaveLength(2)
-    const assignedIds = matched.map((m) => m.transcript.agentId).sort()
-    expect(assignedIds).toEqual(['a1', 'a2'])
-  })
-
-  it('既知agentTypeに復元できないagent名は未突合とする', () => {
-    const weirdSelf = { ...baseSelf, agent: 'totally-unknown-agent' }
-    const { matched, unmatchedSelf } = matchRecords([weirdSelf], [baseTranscript])
-    expect(matched).toHaveLength(0)
-    expect(unmatchedSelf).toHaveLength(1)
-  })
-})
-
-describe('loadTranscripts', () => {
-  it('journal.jsonlに該当agentIdの構造化resultがある場合、TranscriptRecordのstatus/detailがjournal側の値になる', () => {
-    const projectDir = mkdtempSync(join(tmpdir(), 'load-transcripts-journal-test-'))
-    const wfDir = join(projectDir, 'wf_1')
-    mkdirSync(wfDir)
-    writeFileSync(
-      join(wfDir, 'agent-a1.jsonl'),
-      agentTranscriptLines('fail', 'transcript側のdetail(journal側で上書きされるはず)', '2026-07-11T03:00:01.000Z'),
-      'utf-8',
-    )
-    writeFileSync(join(wfDir, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
-    writeFileSync(
-      join(wfDir, 'journal.jsonl'),
-      [
-        line({ type: 'started', key: 'v2:xxx', agentId: 'a1' }),
-        line({ type: 'result', key: 'v2:xxx', agentId: 'a1', result: { status: 'pass', detail: 'journal側のdetail' } }),
-      ].join('\n'),
-      'utf-8',
-    )
-
-    const records = loadTranscripts(projectDir)
-    expect(records).toHaveLength(1)
-    expect(records[0].status).toBe('pass')
-    expect(records[0].detail).toBe('journal側のdetail')
-    // endTimestampはjournal.jsonlに存在しないためtranscript側の値のまま
-    expect(records[0].endTimestamp).toBe('2026-07-11T03:00:01.000Z')
-  })
-
-  it('journal.jsonlが存在しない場合、従来のtranscriptパース結果のままとする（回帰確認）', () => {
-    const projectDir = mkdtempSync(join(tmpdir(), 'load-transcripts-no-journal-test-'))
-    const wfDir = join(projectDir, 'wf_2')
-    mkdirSync(wfDir)
-    writeFileSync(
-      join(wfDir, 'agent-a2.jsonl'),
-      agentTranscriptLines('blocked', 'transcriptのみのdetail', '2026-07-11T03:00:01.000Z'),
-      'utf-8',
-    )
-    writeFileSync(join(wfDir, 'agent-a2.meta.json'), JSON.stringify({ agentType: 'reviewer' }), 'utf-8')
-
-    const records = loadTranscripts(projectDir)
-    expect(records).toHaveLength(1)
-    expect(records[0].status).toBe('blocked')
-    expect(records[0].detail).toBe('transcriptのみのdetail')
-  })
-
-  it('journal.jsonlはあるが該当agentIdの行が無い、またはresultがプレーン文字列の場合はtranscriptパース結果へフォールバックする', () => {
-    const projectDir = mkdtempSync(join(tmpdir(), 'load-transcripts-fallback-test-'))
-    const wfDir = join(projectDir, 'wf_3')
-    mkdirSync(wfDir)
-    writeFileSync(
-      join(wfDir, 'agent-a3.jsonl'),
-      agentTranscriptLines('pass', 'transcript側フォールバックのdetail', '2026-07-11T03:00:01.000Z'),
-      'utf-8',
-    )
-    writeFileSync(join(wfDir, 'agent-a3.meta.json'), JSON.stringify({ agentType: 'implementer' }), 'utf-8')
-    writeFileSync(
-      join(wfDir, 'journal.jsonl'),
-      [
-        line({ type: 'result', key: 'v2:yyy', agentId: 'a-other', result: { status: 'fail', detail: '別agent' } }),
-        line({ type: 'result', key: 'v2:zzz', agentId: 'a3', result: 'af57a6077ca388dede819b409c55a1216b5eb329' }),
-      ].join('\n'),
-      'utf-8',
-    )
-
-    const records = loadTranscripts(projectDir)
-    expect(records).toHaveLength(1)
-    expect(records[0].status).toBe('pass')
-    expect(records[0].detail).toBe('transcript側フォールバックのdetail')
-  })
-})
-
 describe('buildReport', () => {
   it('食い違いをmismatchesに、低一致をlowOverlapDetailsに分類する', () => {
-    const selfReports: SelfReportRecord[] = [
-      { timestamp: '2026-07-15T03:00:12.000Z', agent: 'sweep-ui', feature: 'f1', status: 'done', note: 'UI層調査完了' },
-      { timestamp: '2026-07-15T04:00:12.000Z', agent: 'reviewer-security', feature: 'f1', status: 'done', note: '完了' },
-    ]
-    const transcripts: TranscriptRecord[] = [
-      {
-        wfDir: '/tmp/wf_1',
-        agentId: 'a1',
-        agentType: 'sweep-ui',
-        endTimestamp: '2026-07-15T03:00:10.000Z',
-        status: 'fail',
-        detail: 'propsの型不整合を検出、未修正のまま終了',
-      },
-      {
-        wfDir: '/tmp/wf_2',
-        agentId: 'a2',
-        agentType: 'reviewer',
-        endTimestamp: '2026-07-15T04:00:10.000Z',
-        status: 'pass',
-        detail: '無関係な全く別のセキュリティ観点の長い説明文をここに書く',
-      },
-    ]
+    const anchor1: CanonicalEvent = {
+      eventId: 'j1', agentId: 'a1', agentType: 'sweep-ui', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:10.000Z', status: 'fail',
+      detail: 'propsの型不整合を検出、未修正のまま終了', intent: null, scenario: null, source: 'journal',
+    }
+    const self1: CanonicalEvent = {
+      eventId: 's1', agentId: null, agentType: 'sweep-ui', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:12.000Z', status: 'done',
+      detail: 'UI層調査完了', intent: null, scenario: null, source: 'agent-progress',
+    }
+    const anchor2: CanonicalEvent = {
+      eventId: 'j2', agentId: 'a2', agentType: 'reviewer', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-15T04:00:10.000Z', status: 'pass',
+      detail: '無関係な全く別のセキュリティ観点の長い説明文をここに書く', intent: null, scenario: null, source: 'journal',
+    }
+    const self2: CanonicalEvent = {
+      eventId: 's2', agentId: null, agentType: 'reviewer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T04:00:12.000Z', status: 'done',
+      detail: '完了', intent: null, scenario: null, source: 'agent-progress',
+    }
 
-    const report = buildReport(selfReports, transcripts)
+    const correlated = correlateEvents([anchor1, self1, anchor2, self2])
+    const report = buildReport(correlated)
+
     expect(report.matchedCount).toBe(2)
     expect(report.mismatches).toHaveLength(1)
-    expect(report.mismatches[0].self.agent).toBe('sweep-ui')
+    expect(report.mismatches[0].selfEvent.agentType).toBe('sweep-ui')
     expect(report.lowOverlapDetails.length).toBeGreaterThanOrEqual(1)
   })
 
   it('自己申告が0件なら空のレポートを返す', () => {
-    const report = buildReport([], [])
+    const report = buildReport(correlateEvents([]))
     expect(report.totalSelfReports).toBe(0)
     expect(report.matchedCount).toBe(0)
     expect(report.mismatches).toHaveLength(0)
+  })
+
+  it('running/waiting/startingの中間状態はtotalSelfReportsに含めない', () => {
+    const self: CanonicalEvent = {
+      eventId: 's1', agentId: null, agentType: 'implementer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T03:00:12.000Z', status: 'running',
+      detail: '実行中', intent: null, scenario: null, source: 'agent-progress',
+    }
+    const report = buildReport(correlateEvents([self]))
+    expect(report.totalSelfReports).toBe(0)
   })
 })

--- a/scripts/lib/verify-agent-progress-transcript.test.ts
+++ b/scripts/lib/verify-agent-progress-transcript.test.ts
@@ -82,6 +82,33 @@ describe('buildReport', () => {
     expect(report.mismatches).toHaveLength(0)
   })
 
+  it('同一execにsubagent-skeleton(status:null)とjournal(status有り)が両方ある場合はjournal側を優先してanchorに使う', () => {
+    const skeletonAnchor: CanonicalEvent = {
+      eventId: 'sk1', agentId: 'a3', agentType: 'implementer', feature: null,
+      startTimestamp: '2026-07-15T05:00:00.000Z', endTimestamp: null, status: null,
+      detail: null, intent: null, scenario: null, source: 'subagent-skeleton',
+    }
+    const journalAnchor: CanonicalEvent = {
+      eventId: 'j3', agentId: 'a3', agentType: 'implementer', feature: null,
+      startTimestamp: null, endTimestamp: '2026-07-15T05:00:10.000Z', status: 'pass',
+      detail: '実装完了', intent: null, scenario: null, source: 'journal',
+    }
+    const self3: CanonicalEvent = {
+      eventId: 's3', agentId: null, agentType: 'implementer', feature: 'f1',
+      startTimestamp: null, endTimestamp: '2026-07-15T05:00:12.000Z', status: 'done',
+      detail: '実装完了', intent: null, scenario: null, source: 'agent-progress',
+    }
+
+    // loadAllEventsの呼び出し順(subagentSkeletonAdapter→...→journalAdapter)を再現するため、
+    // subagent-skeletonをjournalより先の順序で渡す。
+    const correlated = correlateEvents([skeletonAnchor, journalAnchor, self3])
+    const report = buildReport(correlated)
+
+    expect(report.unmatchedSelf).toHaveLength(0)
+    expect(report.matchedCount).toBe(1)
+    expect(report.mismatches).toHaveLength(0)
+  })
+
   it('running/waiting/startingの中間状態はtotalSelfReportsに含めない', () => {
     const self: CanonicalEvent = {
       eventId: 's1', agentId: null, agentType: 'implementer', feature: 'f1',

--- a/scripts/lib/verify-agent-progress-transcript.ts
+++ b/scripts/lib/verify-agent-progress-transcript.ts
@@ -78,7 +78,13 @@ export function buildReport(correlated: CorrelatedExecution[]): VerificationRepo
     if (!selfEvent) continue
     totalSelfReports += 1
 
-    const anchorEvent = exec.events.find((e) => e.source === 'journal' || e.source === 'subagent-skeleton')
+    // WHY: journalはstatus/detailを持つがsubagent-skeletonはstatusが常にnull。
+    //      同一execにsubagent-skeletonがjournalより先に積まれている場合(loadAllEventsの
+    //      呼び出し順に依存)、単純な.findだとstatus=nullのsubagent-skeleton側を誤って
+    //      拾いunmatchedSelfへ落ちてしまう(検証すべき食い違いを見逃すfalse negative)ため、
+    //      journalを優先し無ければsubagent-skeletonへフォールバックする。
+    const anchorEvent =
+      exec.events.find((e) => e.source === 'journal') ?? exec.events.find((e) => e.source === 'subagent-skeleton')
     if (!anchorEvent || anchorEvent.status === null) {
       unmatchedSelf.push(selfEvent)
       continue

--- a/scripts/lib/verify-agent-progress-transcript.ts
+++ b/scripts/lib/verify-agent-progress-transcript.ts
@@ -1,129 +1,17 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
-import { loadJournalResults, pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability'
-
-// WHY: docs/agents/common.md「サブエージェント進捗の可視化（issue #18）」に列挙されている
-//      進捗記録対象agentType一覧。ここに無い名前（Find/Adversarial Verify等の一部）はそもそも
-//      進捗記録の対象外のため、突き合わせ対象からも自然に外れる。
-export const KNOWN_AGENT_TYPES = [
-  'sweep-db',
-  'sweep-ui',
-  'sweep-types',
-  'sweep-data',
-  'implementer',
-  'reviewer',
-  'integrator',
-  'judge-panel',
-  'proposer',
-  'adversarial-verify',
-  'completeness-critic',
-  'contract-writer',
-] as const
-
-export interface SelfReportRecord {
-  timestamp: string
-  agent: string
-  feature: string
-  status: string
-  note: string
-}
-
-export interface TranscriptRecord {
-  wfDir: string
-  agentId: string
-  agentType: string
-  endTimestamp: string | null
-  status: 'pass' | 'fail' | 'blocked' | null
-  detail: string | null
-}
-
-// WHY: 自己申告jsonlの--agentは「reviewer-correctness」「implementer-groupA」のように
-//      agentTypeへ役割サフィックスを付けた自由記述のため、transcript側のagentType（完全一致）と
-//      直接は一致しない。既知agentType一覧との前方一致（区切りは'-'または完全一致）で復元する。
-export function extractAgentType(selfAgentField: string): string | null {
-  const candidates = KNOWN_AGENT_TYPES.filter(
-    (type) => selfAgentField === type || selfAgentField.startsWith(`${type}-`),
-  )
-  if (candidates.length === 0) return null
-  return candidates.reduce((longest, current) => (current.length > longest.length ? current : longest))
-}
-
-function toEpochMs(timestamp: string): number | null {
-  const ms = Date.parse(timestamp)
-  return Number.isNaN(ms) ? null : ms
-}
-
-export interface MatchedPair {
-  self: SelfReportRecord
-  transcript: TranscriptRecord
-}
-
-export interface MatchOutcome {
-  matched: MatchedPair[]
-  unmatchedSelf: SelfReportRecord[]
-}
-
-// WHY: agent-progress.jsonlはagentId/workflow実行IDを保持しないため、transcriptとの対応は
-//      1:1のID突合ができない。同じagentType内で最も時刻が近いtranscriptに貪欲に割り当てる
-//      ベストエフォート方式（許容誤差外・使用済みtranscriptは対象外）。高並行実行下では
-//      誤対応の可能性が残ることをこの関数の利用側は認識すること。
-export function matchRecords(
-  selfReports: SelfReportRecord[],
-  transcripts: TranscriptRecord[],
-  toleranceMs = 30 * 60 * 1000,
-): MatchOutcome {
-  const usedTranscriptIndexes = new Set<number>()
-  const matched: MatchedPair[] = []
-  const unmatchedSelf: SelfReportRecord[] = []
-
-  const sortedSelf = [...selfReports].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
-
-  for (const self of sortedSelf) {
-    const agentType = extractAgentType(self.agent)
-    const selfEpoch = toEpochMs(self.timestamp)
-    if (!agentType || selfEpoch === null) {
-      unmatchedSelf.push(self)
-      continue
-    }
-
-    let bestIndex = -1
-    let bestDiff = Infinity
-    transcripts.forEach((transcript, index) => {
-      if (usedTranscriptIndexes.has(index)) return
-      if (transcript.agentType !== agentType) return
-      if (!transcript.endTimestamp) return
-      const transcriptEpoch = toEpochMs(transcript.endTimestamp)
-      if (transcriptEpoch === null) return
-      const diff = Math.abs(transcriptEpoch - selfEpoch)
-      if (diff <= toleranceMs && diff < bestDiff) {
-        bestDiff = diff
-        bestIndex = index
-      }
-    })
-
-    if (bestIndex === -1) {
-      unmatchedSelf.push(self)
-    } else {
-      usedTranscriptIndexes.add(bestIndex)
-      matched.push({ self, transcript: transcripts[bestIndex] })
-    }
-  }
-
-  return { matched, unmatchedSelf }
-}
+import { loadAllEvents, correlateEvents, type CanonicalEvent, type CorrelatedExecution } from './canonical-event'
 
 export type StatusComparison = 'match' | 'mismatch' | 'unknown'
 
 // WHY: 自己申告は進捗ライフサイクル語彙(done/failed)、transcriptは成果語彙(pass/fail/blocked)で
 //      語彙が異なる。「done」は成功系(pass/blocked)、「failed」は失敗(fail)に対応すると解釈する。
 //      blockedは仕様確認待ち等の正常な停止でも起こりうるため、doneとの不一致とはみなさない。
-export function compareStatus(selfStatus: string, transcriptStatus: 'pass' | 'fail' | 'blocked' | null): StatusComparison {
-  if (transcriptStatus === null) return 'unknown'
+export function compareStatus(selfStatus: string, anchorStatus: 'pass' | 'fail' | 'blocked' | null): StatusComparison {
+  if (anchorStatus === null) return 'unknown'
   if (selfStatus === 'done') {
-    return transcriptStatus === 'fail' ? 'mismatch' : 'match'
+    return anchorStatus === 'fail' ? 'mismatch' : 'match'
   }
   if (selfStatus === 'failed') {
-    return transcriptStatus === 'pass' ? 'mismatch' : 'match'
+    return anchorStatus === 'pass' ? 'mismatch' : 'match'
   }
   return 'unknown'
 }
@@ -161,8 +49,8 @@ export function compareDetail(note: string, detail: string | null): DetailCompar
 }
 
 export interface VerificationReportEntry {
-  self: SelfReportRecord
-  transcript: TranscriptRecord
+  selfEvent: CanonicalEvent
+  anchorEvent: CanonicalEvent
   statusComparison: StatusComparison
   detailComparison: DetailComparison
 }
@@ -170,110 +58,47 @@ export interface VerificationReportEntry {
 export interface VerificationReport {
   totalSelfReports: number
   matchedCount: number
-  unmatchedSelf: SelfReportRecord[]
+  unmatchedSelf: CanonicalEvent[]
   mismatches: VerificationReportEntry[]
   lowOverlapDetails: VerificationReportEntry[]
 }
 
-export function buildReport(
-  selfReports: SelfReportRecord[],
-  transcripts: TranscriptRecord[],
-  toleranceMs?: number,
-): VerificationReport {
-  const { matched, unmatchedSelf } = matchRecords(selfReports, transcripts, toleranceMs)
+// issue #569: 突合ロジック(agentId厳密一致 + agentType/時刻窓フォールバック)は
+// canonical-event.tsのcorrelateEvents()へ移設した。ここでは正規化済みの
+// CorrelatedExecution[]から、意味変換(status/detailの一致判定)とレポート整形のみを行う。
+export function buildReport(correlated: CorrelatedExecution[]): VerificationReport {
+  const entries: VerificationReportEntry[] = []
+  const unmatchedSelf: CanonicalEvent[] = []
+  let totalSelfReports = 0
 
-  const entries: VerificationReportEntry[] = matched.map(({ self, transcript }) => ({
-    self,
-    transcript,
-    statusComparison: compareStatus(self.status, transcript.status),
-    detailComparison: compareDetail(self.note, transcript.detail),
-  }))
+  for (const exec of correlated) {
+    const selfEvent = exec.events.find(
+      (e) => e.source === 'agent-progress' && (e.status === 'done' || e.status === 'failed'),
+    )
+    if (!selfEvent) continue
+    totalSelfReports += 1
+
+    const anchorEvent = exec.events.find((e) => e.source === 'journal' || e.source === 'subagent-skeleton')
+    if (!anchorEvent || anchorEvent.status === null) {
+      unmatchedSelf.push(selfEvent)
+      continue
+    }
+
+    entries.push({
+      selfEvent,
+      anchorEvent,
+      statusComparison: compareStatus(selfEvent.status ?? '', anchorEvent.status as 'pass' | 'fail' | 'blocked'),
+      detailComparison: compareDetail(selfEvent.detail ?? '', anchorEvent.detail),
+    })
+  }
 
   return {
-    totalSelfReports: selfReports.length,
-    matchedCount: matched.length,
+    totalSelfReports,
+    matchedCount: entries.length,
     unmatchedSelf,
     mismatches: entries.filter((entry) => entry.statusComparison === 'mismatch'),
     lowOverlapDetails: entries.filter((entry) => entry.detailComparison === 'low_overlap'),
   }
-}
-
-export function loadSelfReports(logFilePath: string): SelfReportRecord[] {
-  let content: string
-  try {
-    content = readFileSync(logFilePath, 'utf-8')
-  } catch {
-    return []
-  }
-  return content
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as SelfReportRecord)
-    .filter((record) => record.status === 'done' || record.status === 'failed')
-}
-
-function findWorkflowDirs(projectDir: string): string[] {
-  const results: string[] = []
-  function walk(dir: string) {
-    let entries: string[]
-    try {
-      entries = readdirSync(dir)
-    } catch {
-      return
-    }
-    for (const entry of entries) {
-      const fullPath = join(dir, entry)
-      let stat
-      try {
-        stat = statSync(fullPath)
-      } catch {
-        continue
-      }
-      if (!stat.isDirectory()) continue
-      if (entry.startsWith('wf_')) {
-        results.push(fullPath)
-        continue
-      }
-      walk(fullPath)
-    }
-  }
-  walk(projectDir)
-  return results
-}
-
-export function loadTranscripts(projectDir: string): TranscriptRecord[] {
-  const records: TranscriptRecord[] = []
-  for (const wfDir of findWorkflowDirs(projectDir)) {
-    const filenames = readdirSync(wfDir)
-    const pairs = pairAgentFiles(filenames)
-    // issue #493: journal.jsonlにその agentId の構造化result（status/detail）があれば、
-    // transcript最終メッセージのパース結果より優先して使う（endTimestampはjournal.jsonlに
-    // タイムスタンプが無いため引き続きtranscript側から取得し、matchRecordsの時刻近接突合
-    // ロジックには影響しない）。journal.jsonlが無い/該当agentIdが無い場合は従来どおり
-    // transcriptパース結果のままフォールバックする。
-    const journalResults = loadJournalResults(wfDir, filenames)
-    for (const { agentId, jsonlFile, metaFile } of pairs) {
-      let agentType = 'unknown'
-      try {
-        const meta = JSON.parse(readFileSync(join(wfDir, metaFile), 'utf-8')) as { agentType?: string }
-        agentType = meta.agentType ?? 'unknown'
-      } catch {
-        continue
-      }
-      const lines = readFileSync(join(wfDir, jsonlFile), 'utf-8').split('\n').filter(Boolean)
-      const summary = parseAgentTranscriptLines(lines)
-      const journalResult = journalResults.get(agentId)
-      records.push({
-        wfDir,
-        agentId,
-        agentType,
-        endTimestamp: summary.endTimestamp,
-        status: journalResult ? journalResult.status : summary.status,
-        detail: journalResult ? journalResult.detail : summary.detail,
-      })
-    }
-  }
-  return records
 }
 
 function main() {
@@ -283,28 +108,29 @@ function main() {
     return index === -1 ? fallback : args[index + 1]
   }
 
-  const logFilePath = getArg('--log-file', 'logs/agent-progress.jsonl')
+  const agentProgressLogFile = getArg('--log-file', 'logs/agent-progress.jsonl')
+  const subagentSkeletonLogFile = getArg('--skeleton-log-file', 'logs/subagent-skeleton.jsonl')
   const projectDir = getArg(
     '--project-dir',
-    join(process.env.HOME ?? '', '.claude/projects/-Users-masanori-medical-inventory-vkumai'),
+    `${process.env.HOME ?? ''}/.claude/projects/-Users-masanori-medical-inventory-vkumai`,
   )
   const asJson = args.includes('--json')
 
-  const selfReports = loadSelfReports(logFilePath)
-  const transcripts = loadTranscripts(projectDir)
-  const report = buildReport(selfReports, transcripts)
+  const events = loadAllEvents({ agentProgressLogFile, subagentSkeletonLogFile, projectDir })
+  const correlated = correlateEvents(events)
+  const report = buildReport(correlated)
 
   if (asJson) {
     console.log(JSON.stringify(report, null, 2))
   } else {
     console.log(
-      `自己申告(done/failed): ${report.totalSelfReports}件 / transcriptと突き合わせ成功: ${report.matchedCount}件 / 未対応(未突合): ${report.unmatchedSelf.length}件`,
+      `自己申告(done/failed): ${report.totalSelfReports}件 / 突合成功: ${report.matchedCount}件 / 未対応(未突合): ${report.unmatchedSelf.length}件`,
     )
     if (report.mismatches.length > 0) {
       console.log(`\n食い違い(status): ${report.mismatches.length}件`)
       for (const entry of report.mismatches) {
         console.log(
-          `  - agent=${entry.self.agent} feature=${entry.self.feature} 自己申告=${entry.self.status}(${entry.self.note}) transcript=${entry.transcript.status}(${entry.transcript.detail ?? ''})`,
+          `  - agentType=${entry.selfEvent.agentType} feature=${entry.selfEvent.feature} 自己申告=${entry.selfEvent.status}(${entry.selfEvent.detail}) anchor=${entry.anchorEvent.status}(${entry.anchorEvent.detail ?? ''})`,
         )
       }
     }
@@ -312,7 +138,7 @@ function main() {
       console.log(`\ndetail低一致(要目視確認・弱いシグナル): ${report.lowOverlapDetails.length}件`)
       for (const entry of report.lowOverlapDetails) {
         console.log(
-          `  - agent=${entry.self.agent} feature=${entry.self.feature} note="${entry.self.note}" detail="${entry.transcript.detail ?? ''}"`,
+          `  - agentType=${entry.selfEvent.agentType} feature=${entry.selfEvent.feature} note="${entry.selfEvent.detail}" detail="${entry.anchorEvent.detail ?? ''}"`,
         )
       }
     }


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: issue #569。同一AIDD実行の意味情報が`agent-progress.jsonl`/`loop-observability.jsonl`/`subagent-skeleton.jsonl`/`journal.jsonl`(Workflow)の4ログに分散し、workflow ID不足を時刻近接ヒューリスティックで再構成する必要があった構造を解消する。
- 変更した範囲:
  - 新規 `scripts/lib/canonical-event.ts`: 4ログを`CanonicalEvent`型へ正規化する読み取り専用Adapter層(subagentSkeletonAdapter/agentProgressAdapter/loopObservabilityAdapter/journalAdapter) + `loadAllEvents()` + 2段階アンカー突合`correlateEvents()`(Stage1: agentId厳密一致、実機検証済み / Stage2: agentType+30分窓の貪欲割当)
  - `scripts/lib/verify-agent-progress-transcript.ts`: 上記モジュール経由の薄いラッパーへリファクタ(重複していた`matchRecords`/`extractAgentType`/`loadTranscripts`等は削除・移設)
  - `docs/agents/observability-internals.md` / `docs/agents/common.md`: 統合内容の追記
  - 設計仕様書 `docs/superpowers/specs/2026-07-27-canonical-event-module-design.md` / 実装計画 `docs/superpowers/plans/2026-07-27-canonical-event-module.md`
- 触っていない範囲:
  - 各`log-*.sh`(自己申告ログの書き込み側)は無改修
  - 既存gap check bashスクリプト(`check-loop-observability-gap.sh`/`check-agent-progress-gap.sh`)は無改修。代わりに新規`canonical-event-gap-check-equivalence.test.ts`で等価性を担保
  - `scripts/lib/reconstruct-loop-observability.ts`の実体は無改修(1コメントのみ、削除済みシンボル参照の追従修正)

## 検証済み
- 実行したコマンド: `npm test`(vitest run) 172ファイル/1306テスト全PASS、`npx tsc --noEmit` エラー0件
- 確認した画面: 該当なし(バックエンドのログ処理基盤のみ、UI変更なし)
- 確認したDB/RLS: 該当なし(supabase/migrations・src/lib/supabase・middleware.tsへの変更なし。TRI/RISK機械判定の対象外)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 該当なし(facility/tenant/RLS等のドメインに触れていないため対象外)
- 追加で実機検証: Workflowで1エージェントのみのプローブ実行を行い、hookが書く`subagent-skeleton.jsonl`の`agent_id`とWorkflowの`journal.jsonl`の`agentId`が完全一致することを確認(Stage1突合の前提の実証)。最終レビューでは実際の本番`logs/`データに対し旧実装(リファクタ前)と新実装で`verify-agent-progress-transcript`の出力(`totalSelfReports=100 / matched=26 / unmatched=74 / mismatches=15 / lowOverlap=19`)が完全一致することを確認済み(挙動保存を裏付け)

## 既知の未対応
- 今回あえて対応しなかったこと:
  - `scripts/verify-agent-progress-transcript.sh`は新しい`--skeleton-log-file`引数の透過や`resolve_log_dir`(issue #546)経由のパス解決に未対応
  - `agentProgressAdapter`/`loopObservabilityAdapter`の`JSON.parse`は行単位の耐性がなく、不正な行があると`load()`全体が例外を投げる(`subagentSkeletonAdapter`は行単位でスキップする非対称な設計)
  - `EventStatus`へのキャスト(`record.status as EventStatus`等)は値域チェックを伴わない型アサーション
- 理由: いずれも現状の実データでは実害が確認されておらず、YAGNIの観点でスコープ外とした(最終全体レビューでMinor/deferred判定済み)
- 次に触るなら見る場所: `scripts/lib/canonical-event.ts`のAdapter群(`agentProgressAdapter`/`loopObservabilityAdapter`)と`scripts/verify-agent-progress-transcript.sh`

## 後任AIへの注意
- この実装で壊してはいけない前提:
  - `subagentSkeletonAdapter`が書くhookの`agent_id`と、Workflow `journal.jsonl`の`agentId`は同一空間(実機検証済み、`docs/superpowers/specs/2026-07-27-canonical-event-module-design.md`参照)。この前提が崩れるとStage1の突合が全滅する
  - `correlateEvents`のStage2アンカー候補は「`journal`イベントを含むagentIdグループのみ」に絞り込み済み(`subagent-skeleton`のみのアンカーは`status`が常に`null`のため除外)。この絞り込みを外すと最終レビューで指摘された「skeleton-onlyアンカーが正しいjournalアンカーを横取りする」バグが再発する
  - `anchorInfos`のagentType/endTimestamp算出は`journal`イベント優先(`buildReport`と同じ優先順位)。`loadAllEvents`の呼び出し順(skeleton→journal)に依存した実装ではないことを確認してから変更すること
- 似ているが別物の用語:
  - `agent-progress`の`status`(starting/running/waiting/done/failed、自己申告のライフサイクル語彙) と `journal`/`subagent-skeleton`側の`status`(pass/fail/blocked、成果語彙)は別語彙。`compareStatus`(`verify-agent-progress-transcript.ts`)がこの変換を担う
  - `CorrelatedExecution.agentId`は、skeleton/journal由来の実際のagentIdの場合と、単独実行(自己申告のみ)の場合の合成`eventId`の場合がある(型は`string`だが意味が異なる)
- 勝手にリファクタしない場所:
  - `scripts/lib/reconstruct-loop-observability.ts`(`pairAgentFiles`/`loadJournalResults`/`parseAgentTranscriptLines`)は無改修の前提でTask 5(journalAdapter)が依存している。変更する場合はcanonical-event.ts側への影響を必ず確認すること