### PR TITLE
ci: typecheck/lint/testを並列3ジョブで実行するCI workflowを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run typecheck
+        run: npm run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run lint
+        run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run unit tests
+        run: npm run test


### PR DESCRIPTION
## 作業サマリ
Required Status Checksへ接続する土台として、既存のnpm scripts (`typecheck`/`lint`/`test`) をPR上で並列3ジョブ実行するCI workflow (`.github/workflows/ci.yml`) を追加した。既存の`e2e.yml`はe2e/integrationテストのみを担っており、typecheck/lint/unit testを回すCIが無かったギャップを埋める。

- `typecheck` ジョブ: `npm run typecheck` (`tsc --noEmit`)
- `lint` ジョブ: `npm run lint` (`eslint`)
- `test` ジョブ: `npm run test` (`vitest run`)

## 検証済み
- ローカルで `npm run typecheck` / `npm run lint` / `npm run test` を個別実行し、いずれも成功することを確認（`lint`はこのPRと無関係な既存warning 2件のみ、exit code 0）
- `.github/workflows/ci.yml` のYAML構文をPythonの`yaml.safe_load`でパース確認済み
- 本PRのCI実行結果（Actions）は別途確認が必要

## 残作業（別途確認が必要）
本PRマージ後、GitHub Settings → Branches → main のRequired status checksへ `typecheck` / `lint` / `test` の3ジョブ名を登録する必要がある（リポジトリ設定変更のため、別途ユーザー確認の上で実施予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)