### PR TITLE
fix: 発注系RPC 4関数のsearch_pathを空にして完全修飾する

### DIFF
--- a/docs/agents/decisions/db-rls.md
+++ b/docs/agents/decisions/db-rls.md
@@ -116,6 +116,30 @@ CI（本番相当RLS）で初めて失敗するまで気づかれなかった。
 （products/categories/distributor_products等）のCUD操作に触れる場合は、着手前にこのセクションと
 該当migrationの `-- WHY:` コメントを必ず確認すること。**
 
+## なぜ発注系RPC 4関数のみsearch_path=''+完全修飾にし、他のSECURITY DEFINER関数は据え置いたか
+
+**結論: `create_case_order_atomic`/`create_loan_order_atomic`/`create_consumable_order_atomic`/`resolve_jan_unit_price`の4関数を`SET search_path = ''`＋全参照`public.`完全修飾に変更した（`20260804000001_harden_order_rpc_search_path.sql`）。`is_facility_member`・`get_distributor_product_price_history`等、他の既存`SECURITY DEFINER`関数は`SET search_path = public`のまま据え置いている。**
+
+`SET search_path = public`のままだと、`SECURITY DEFINER`関数は理論上、呼び出し元セッションが
+`public`より前に別スキーマを検索パスに追加していた場合の名前解決に依存する余地が残る
+（search_path hijacking）。`search_path = ''`＋全オブジェクトの完全修飾にすれば、名前解決が
+実行時のセッション設定と無関係に固定される。
+
+今回はSupabase機能のハンズオン学習として発注系4関数のみをスコープにした。したがって
+**このリポジトリの`SECURITY DEFINER`関数は`search_path=public`（旧方式）と`search_path=''`
+＋完全修飾（新方式）が混在した過渡状態にある。** 新規に`SECURITY DEFINER`関数を書く場合は
+新方式（`search_path=''`＋完全修飾）を採用し、他の既存関数（`is_facility_member`・
+`get_distributor_product_price_history`等）を横展開で新方式に揃えるかどうかは、範囲が
+広がるため別途判断すること。
+
+検証は、変更対象4関数の中に拡張機能（`extensions`スキーマ）由来の関数呼び出しがないこと
+（`gen_random_uuid()`は各テーブルの`id`列`DEFAULT`としてDDL側でのみ使用されており、
+CREATE TABLE時に関数OIDへ解決済みのため`search_path`変更の影響を受けない）を確認したうえで、
+ローカルSupabaseへ実際に`db push`し、実DB統合テスト（`order-repositories.integration.test.ts`
+ほかRLS/IDOR統合テスト計6ファイル・22件）が全て通ることまで確認した。静的なSQLテキスト検証
+（`__tests__/harden_order_rpc_search_path.test.ts`）だけでは、スキーマ修飾漏れによる実行時
+エラーは検知できないため、実DBでの検証を省略しないこと。
+
 ## なぜスキーマドリフト検知（issue #305）にEdge Functionを使わずpg_cron + GitHub Actionsポーリングを採用したか
 
 **結論: リアルタイムEdge Function通知案は未確認依存が多く不採用。pg_cronでDB内部に記録し、通知はGitHub Actionsの日次ポーリングに委譲する構成にした。**

--- a/supabase/__tests__/integration/order-rpc-search-path-idor.integration.test.ts
+++ b/supabase/__tests__/integration/order-rpc-search-path-idor.integration.test.ts
@@ -1,0 +1,147 @@
+// supabase/__tests__/integration/order-rpc-search-path-idor.integration.test.ts
+// WHY: 20260804000001_harden_order_rpc_search_path.sqlはsearch_path=''化と
+//      public.完全修飾のみを変更し、is_facility_memberによる認可チェック自体は
+//      変更していない。ただしorder-repositories.integration.test.tsは自施設内での
+//      成功パスしか検証しておらず、他施設IDでの拒否は未検証だった。
+//      RLS/facility境界に触れる変更のため、他テナントのfacility_idを渡した場合に
+//      forbiddenで拒否されることをこのテストで固定する。
+
+import { randomUUID } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+
+const TEST_USER_PASSWORD = 'order-rpc-idor-test-0000'
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[order-rpc-search-path-idor] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+describe('発注作成RPC 4関数 search_path=\'\'化後のIDOR拒否確認', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+
+  let ownFacilityId: string
+  let otherFacilityId: string
+  let userId: string
+  let userClient: SupabaseClient
+  let consumableIdInOtherFacility: string
+
+  beforeAll(async () => {
+    const { data: ownFacility, error: ownFacilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-自施設-${runId}` })
+      .select('id')
+      .single()
+    if (ownFacilityError || !ownFacility) {
+      throw new Error(`自施設作成失敗: ${ownFacilityError?.message}`)
+    }
+    ownFacilityId = ownFacility.id as string
+
+    const { data: otherFacility, error: otherFacilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-他施設-${runId}` })
+      .select('id')
+      .single()
+    if (otherFacilityError || !otherFacility) {
+      throw new Error(`他施設作成失敗: ${otherFacilityError?.message}`)
+    }
+    otherFacilityId = otherFacility.id as string
+
+    const email = `order-rpc-idor-test-${runId}@example.test`
+    const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+      email,
+      password: TEST_USER_PASSWORD,
+      email_confirm: true,
+    })
+    if (userError || !userData.user) {
+      throw new Error(`ユーザー作成失敗: ${userError?.message}`)
+    }
+    userId = userData.user.id
+
+    // 自施設のみ所属させ、他施設には所属させない
+    const { error: linkError } = await serviceClient
+      .from('user_facilities')
+      .insert({ user_id: userId, facility_id: ownFacilityId, role: 'staff' })
+    if (linkError) {
+      throw new Error(`user_facilities作成失敗: ${linkError.message}`)
+    }
+
+    const { data: consumable, error: consumableError } = await serviceClient
+      .from('consumables')
+      .insert({ facility_id: otherFacilityId, name: `他施設消耗品-${runId}`, purpose: 'テスト用途' })
+      .select('id')
+      .single()
+    if (consumableError || !consumable) {
+      throw new Error(`consumables作成失敗: ${consumableError?.message}`)
+    }
+    consumableIdInOtherFacility = consumable.id as string
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    userClient = createClient(supabaseUrl, anonKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+    const { error: signInError } = await userClient.auth.signInWithPassword({
+      email,
+      password: TEST_USER_PASSWORD,
+    })
+    if (signInError) {
+      throw new Error(`サインイン失敗: ${signInError.message}`)
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    await serviceClient.auth.admin.deleteUser(userId)
+    await serviceClient.from('facilities').delete().eq('id', ownFacilityId)
+    await serviceClient.from('facilities').delete().eq('id', otherFacilityId)
+  })
+
+  it('create_case_order_atomic: 他施設のfacility_idを渡すとforbiddenで拒否される', async () => {
+    const { error } = await userClient.rpc('create_case_order_atomic', {
+      p_facility_id: otherFacilityId,
+      p_case_datetime: new Date().toISOString(),
+      p_procedure_name: 'IDORテスト術式',
+      p_patient_id: 'PT-IDOR',
+      p_patient_initials: 'X.X.',
+      p_gender: 'other',
+      p_doctor_name: 'IDORテスト医師',
+      p_items: [],
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+
+  it('create_loan_order_atomic: 他施設のfacility_idを渡すとforbiddenで拒否される', async () => {
+    const { error } = await userClient.rpc('create_loan_order_atomic', {
+      p_facility_id: otherFacilityId,
+      p_procedure_name: 'IDORテスト術式',
+      p_maker: 'IDORテストメーカー',
+      p_items: [],
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+
+  it('create_consumable_order_atomic: 他施設のfacility_idを渡すとforbiddenで拒否される', async () => {
+    const { error } = await userClient.rpc('create_consumable_order_atomic', {
+      p_facility_id: otherFacilityId,
+      p_items: [{ consumable_id: consumableIdInOtherFacility, quantity: 1 }],
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+})

--- a/supabase/migrations/20260804000001_harden_order_rpc_search_path.sql
+++ b/supabase/migrations/20260804000001_harden_order_rpc_search_path.sql
@@ -1,0 +1,165 @@
+-- supabase/migrations/20260804000001_harden_order_rpc_search_path.sql
+-- ハンズオン: search_path hijacking対策として、発注系RPC 4関数の
+-- SET search_path = public を SET search_path = '' に変更し、
+-- 参照するテーブル・%ROWTYPE・他関数呼び出しをすべて public. で完全修飾する。
+-- WHY: SECURITY DEFINER関数はsearch_path=publicのままだと、呼び出し元が
+--      public以外のスキーマに同名オブジェクトを仕込んでいた場合に解決順序が
+--      影響を受ける余地が残る。search_path=''にして全参照を完全修飾すれば、
+--      名前解決が常に固定され、乗っ取りの余地がなくなる。
+-- WHY(既存migrationは追記・修正禁止): 20260715000002で定義済みの4関数を
+--      CREATE OR REPLACE FUNCTIONで再定義する。列・ロジックは変更しない。
+
+CREATE OR REPLACE FUNCTION resolve_jan_unit_price(
+  p_jan TEXT,
+  p_facility_id UUID
+)
+RETURNS NUMERIC
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+  SELECT MIN(hp.purchase_price)
+  FROM public.products p
+  JOIN public.distributor_products dp ON dp.product_id = p.id
+  JOIN public.hospital_prices hp
+    ON hp.distributor_product_id = dp.id
+   AND hp.facility_id = p_facility_id
+  WHERE p.jan = p_jan
+$$;
+
+-- 症例発注
+CREATE OR REPLACE FUNCTION create_case_order_atomic(
+  p_facility_id UUID,
+  p_case_datetime TIMESTAMPTZ,
+  p_procedure_name TEXT,
+  p_patient_id TEXT,
+  p_patient_initials TEXT,
+  p_gender TEXT,
+  p_doctor_name TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.case_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.case_orders (
+    facility_id, case_datetime, procedure_name,
+    patient_id, patient_initials, gender, doctor_name
+  ) VALUES (
+    p_facility_id, p_case_datetime, p_procedure_name,
+    p_patient_id, p_patient_initials, p_gender, p_doctor_name
+  )
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.case_order_items i
+  WHERE i.case_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+-- 短貸発注
+CREATE OR REPLACE FUNCTION create_loan_order_atomic(
+  p_facility_id UUID,
+  p_procedure_name TEXT,
+  p_maker TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.loan_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.loan_orders (facility_id, procedure_name, maker)
+  VALUES (p_facility_id, p_procedure_name, p_maker)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.loan_order_items (loan_order_id, jan, name, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'name',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.loan_order_items i
+  WHERE i.loan_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+-- 消耗品発注
+CREATE OR REPLACE FUNCTION create_consumable_order_atomic(
+  p_facility_id UUID,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.consumable_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_member(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.consumable_orders (facility_id)
+  VALUES (p_facility_id)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)
+  SELECT
+    v_order.id,
+    (elem->>'consumable_id')::UUID,
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    (
+      SELECT public.resolve_jan_unit_price(c.jan, p_facility_id)
+      FROM public.consumables c
+      WHERE c.id = (elem->>'consumable_id')::UUID
+    )
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.consumable_order_items i
+  WHERE i.consumable_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;

--- a/supabase/migrations/__tests__/harden_order_rpc_search_path.test.ts
+++ b/supabase/migrations/__tests__/harden_order_rpc_search_path.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無い実行環境でも回帰を検知できるよう、生成したSQL
+//      マイグレーションの中身を静的に検証する。実DB上の動作確認は別途
+//      ローカルSupabaseへのdb push + RPC呼び出しで行う（このテストの対象外）。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_harden_order_rpc_search_path.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_harden_order_rpc_search_path.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('既存migrationを追記せず、CREATE OR REPLACE FUNCTIONで4つのRPC/ヘルパーを再定義する', () => {
+    expect(n).toContain('create or replace function resolve_jan_unit_price(')
+    expect(n).toContain('create or replace function create_case_order_atomic(')
+    expect(n).toContain('create or replace function create_loan_order_atomic(')
+    expect(n).toContain('create or replace function create_consumable_order_atomic(')
+  })
+
+  it('4関数すべてがsearch_pathを空文字に固定している（search_path hijacking対策）', () => {
+    const occurrences = n.match(/set search_path = ''/g) ?? []
+    expect(occurrences.length).toBe(4)
+    // 旧来の SET search_path = public は残っていないこと
+    expect(n).not.toContain('set search_path = public')
+  })
+
+  it('is_facility_memberチェックを維持している（施設境界チェックの退行防止）', () => {
+    const occurrences = n.match(/if not public\.is_facility_member\(p_facility_id\) then/g) ?? []
+    expect(occurrences.length).toBe(3)
+  })
+
+  it('resolve_jan_unit_price内の全テーブル参照がpublic.で完全修飾されている', () => {
+    expect(n).toContain('from public.products p')
+    expect(n).toContain('join public.distributor_products dp on dp.product_id = p.id')
+    expect(n).toContain('join public.hospital_prices hp')
+  })
+
+  it('%ROWTYPE宣言がpublic.で完全修飾されている', () => {
+    expect(n).toContain('v_order public.case_orders%rowtype')
+    expect(n).toContain('v_order public.loan_orders%rowtype')
+    expect(n).toContain('v_order public.consumable_orders%rowtype')
+  })
+
+  it('INSERT/SELECT先のテーブルがpublic.で完全修飾されている', () => {
+    expect(n).toContain('insert into public.case_orders (')
+    expect(n).toContain('insert into public.case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)')
+    expect(n).toContain('from public.case_order_items i')
+    expect(n).toContain('insert into public.loan_orders (facility_id, procedure_name, maker)')
+    expect(n).toContain('insert into public.loan_order_items (loan_order_id, jan, name, quantity, unit_price)')
+    expect(n).toContain('from public.loan_order_items i')
+    expect(n).toContain('insert into public.consumable_orders (facility_id)')
+    expect(n).toContain(
+      'insert into public.consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)'
+    )
+    expect(n).toContain('from public.consumable_order_items i')
+    expect(n).toContain('from public.consumables c')
+  })
+
+  it('resolve_jan_unit_price呼び出しがpublic.で完全修飾されている', () => {
+    const occurrences = n.match(/public\.resolve_jan_unit_price\(/g) ?? []
+    expect(occurrences.length).toBe(3)
+  })
+
+  it('単価解決に失敗してもRAISE EXCEPTIONせずNULLのまま挿入する(best-effort、例外はforbiddenメッセージのみ)', () => {
+    const raiseCount = (n.match(/raise exception/g) ?? []).length
+    expect(raiseCount).toBe(3)
+    expect(n).toContain("raise exception 'forbidden: not a member of this facility'")
+    expect(n).not.toMatch(/raise exception.{0,120}unit_price/i)
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: SECURITY DEFINER関数`resolve_jan_unit_price`/`create_case_order_atomic`/`create_loan_order_atomic`/`create_consumable_order_atomic`の`SET search_path = public`を`SET search_path = ''`に変更し、名前解決がセッションのsearch_path設定から独立するよう固定する（search_path hijacking対策のハンズオン学習）。
- 変更した範囲: 上記4関数のみ。テーブル参照・`%ROWTYPE`・関数呼び出し(`is_facility_member`/`resolve_jan_unit_price`)を`public.`で完全修飾。認可ロジック（`is_facility_member`によるforbiddenチェック）自体は変更していない。
- 触っていない範囲: `is_facility_member`・`get_distributor_product_price_history`など他の`SECURITY DEFINER`関数は`search_path=public`のまま据え置き。このリポジトリの`SECURITY DEFINER`関数群は新方式(`search_path=''`)と旧方式が混在した過渡状態になった（背景は`docs/agents/decisions/db-rls.md`参照）。

## 検証済み
- 実行したコマンド: `npx vitest run`（全体1320件）/ `npm run lint` / `supabase db push --local` / `npx vitest run --config vitest.integration.config.ts`（全7ファイル25件）。`npm run ai:check`相当の個別コマンドで代替、専用スクリプトは未実行。
- 確認した画面: なし（DB層のみの変更、UI変更なし）
- 確認したDB/RLS: ローカルSupabaseへ実際にmigrationを適用し、4関数を実際に呼び出す統合テスト（`order-repositories.integration.test.ts`）と、既存のRLS/IDOR統合テスト5ファイルが全て通過することを確認。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 確認した。既存テストは自施設内の成功パスのみだったため、新規`order-rpc-search-path-idor.integration.test.ts`を追加し、他施設の`facility_id`を渡した場合に3関数すべてが`forbidden`エラーで拒否されることを実DBで検証した。

## 既知の未対応
- 今回あえて対応しなかったこと: 他の`SECURITY DEFINER`関数（`is_facility_member`等）への同パターンの横展開。
- 理由: 今回はSupabase機能のハンズオン学習として発注系4関数にスコープを限定したため。
- 次に触るなら見る場所: `docs/agents/decisions/db-rls.md`「なぜ発注系RPC 4関数のみsearch_path=''+完全修飾にし、他のSECURITY DEFINER関数は据え置いたか」に、新規関数を書く際の方式選択と横展開の判断材料を記録済み。

## 後任AIへの注意
- この実装で壊してはいけない前提: 4関数内のテーブル参照・関数呼び出しは`public.`で完全修飾されていること。将来この4関数を`CREATE OR REPLACE FUNCTION`で再定義する際、スキーマ修飾を外して`search_path=''`のままにすると、実行時エラー（該当オブジェクトが見つからない）になる。
- 似ているが別物の用語: `search_path=public`（旧方式・他のSECURITY DEFINER関数がまだ使用中）と`search_path=''`+完全修飾（新方式・この4関数のみ）を混同しないこと。
- 勝手にリファクタしない場所: 他の`SECURITY DEFINER`関数への横展開は、範囲が広がる別判断のため今回のPRスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)