### PR TITLE
feat: ヘッダーにログアウトボタンを追加

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -34,3 +34,15 @@ test('未認証でアクセスすると /login にリダイレクトされる', 
   await expect(page).toHaveURL(/\/login/)
   await context.close()
 })
+
+test('認証済みでヘッダーのログアウトボタンをクリックすると /login に遷移し、再アクセスで未認証扱いになる', async ({ page }) => {
+  await page.goto('/facilities')
+  await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'ログアウト' }).click()
+  await expect(page).toHaveURL(/\/login/)
+
+  // ログアウト後は保護ページへ再アクセスすると未認証としてリダイレクトされる
+  await page.goto('/facilities')
+  await expect(page).toHaveURL(/\/login/)
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Ubuntu, Oswald } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
+import { createServerSupabase } from "@/lib/supabase/server";
+import { LogoutButton } from "@/components/LogoutButton";
 
 const ubuntu = Ubuntu({
   variable: "--font-ubuntu",
@@ -30,11 +32,14 @@ const navLinks = [
   { href: '/other', label: 'その他' },
 ]
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const supabase = await createServerSupabase();
+  const { data: { user } } = await supabase.auth.getUser();
+
   return (
     <html
       lang="ja"
@@ -61,6 +66,12 @@ export default function RootLayout({
                 {label}
               </Link>
             ))}
+            {user && (
+              <>
+                <div className="h-6 w-px bg-white/20 mx-2" />
+                <LogoutButton />
+              </>
+            )}
           </nav>
         </header>
         <main className="flex-1">{children}</main>

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'
+
+export function LogoutButton() {
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  async function handleLogout() {
+    setLoading(true)
+    const supabase = createSupabaseBrowserClient()
+    await supabase.auth.signOut()
+    router.push('/login')
+    router.refresh()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleLogout}
+      disabled={loading}
+      className="px-4 py-4 text-sm font-medium text-white/70 hover:text-white transition-colors duration-150 disabled:opacity-50"
+      style={{ fontFamily: 'var(--font-ubuntu), sans-serif' }}
+    >
+      {loading ? 'ログアウト中...' : 'ログアウト'}
+    </button>
+  )
+}

--- a/src/components/__tests__/LogoutButton.test.tsx
+++ b/src/components/__tests__/LogoutButton.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LogoutButton } from '../LogoutButton'
+
+const mockSignOut = vi.fn()
+vi.mock('@/lib/supabase/client', () => ({
+  createSupabaseBrowserClient: vi.fn(() => ({
+    auth: {
+      signOut: mockSignOut,
+    },
+  })),
+}))
+
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  })),
+}))
+
+describe('LogoutButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSignOut.mockResolvedValue({ error: null })
+  })
+
+  it('「ログアウト」ボタンが表示される', () => {
+    render(<LogoutButton />)
+    expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument()
+  })
+
+  it('クリックするとsignOutが呼ばれ、/loginへ遷移する', async () => {
+    const user = userEvent.setup()
+    render(<LogoutButton />)
+
+    await user.click(screen.getByRole('button', { name: 'ログアウト' }))
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledTimes(1)
+    })
+    expect(mockPush).toHaveBeenCalledWith('/login')
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('signOut処理中はボタンが「ログアウト中...」表示になり無効化される', async () => {
+    let resolveSignOut: (value: { error: null }) => void = () => {}
+    mockSignOut.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignOut = resolve
+      })
+    )
+    const user = userEvent.setup()
+    render(<LogoutButton />)
+
+    await user.click(screen.getByRole('button', { name: 'ログアウト' }))
+
+    const button = screen.getByRole('button', { name: 'ログアウト中...' })
+    expect(button).toBeDisabled()
+
+    resolveSignOut({ error: null })
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/login')
+    })
+  })
+})


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: `signOut()`を呼ぶUIがリポジトリ内に一切存在せず、ログインユーザーが手動でCookieを消す以外にログアウトする手段がなかった（GitHub/Supabase学習マップの棚卸し中に発見した実装漏れ）。ヘッダーにログアウトボタンを追加する。
- 変更した範囲: `src/components/LogoutButton.tsx`（新規クライアントコンポーネント）、`src/app/layout.tsx`（サーバー側で`auth.getUser()`し、ログイン中のみボタンを表示するよう変更、`RootLayout`を非同期化）。認可ロジック・RLS・DBスキーマは一切変更していない。
- 触っていない範囲: ログイン方式（Email OTP）自体、admin判定ロジック（`resolveIsAdmin`）、middleware.tsの認証ガードには手を入れていない。

## 検証済み
- 実行したコマンド: `npm run typecheck` / `npm run lint` / `npm test`（全1323件通過）。`npm run test:e2e`は追加した回帰テスト込みでこのローカルサンドボックス環境では実行不可だった（下記「既知の未対応」参照）。`npm run ai:check`相当を個別コマンドで代替。
- 確認した画面: `/login`ページをブラウザで目視確認（未認証時はログアウトボタンが表示されないことを確認）。認証済み状態でのボタン表示・クリック動作はコンポーネント単体テスト（`LogoutButton.test.tsx`、3件）でモックベースに検証。
- 確認したDB/RLS: 対象外（DBスキーマ変更なし）。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（facility/RLS境界には触れていない、UIの表示制御のみ）。

## 既知の未対応
- 今回あえて対応しなかったこと: 追加した`e2e/smoke.spec.ts`のログアウトE2Eテスト（マジックリンクで認証済みstorageStateを生成し、ログアウトボタンのクリック→`/login`遷移→再アクセスで未認証扱いになることを検証）を、このローカルサンドボックス環境では実行できなかった。
- 理由: `npm run e2e:auth`実行時、Playwrightが起動するChromiumが`http://127.0.0.1:54321`（ローカルSupabase）へ`net::ERR_CONNECTION_REFUSED`で到達できなかった。同じホストへの`curl`はBashツールから200 OKで到達できており、Chromiumプロセス起動経路特有のネットワーク制約とみられる（`dangerouslySkipSandbox`相当を試しても再現）。CIの`e2e.yml`は同じPlaywright+ローカルSupabaseの組み合わせで過去のPRで動作実績があるため、CIでの実行結果を正としてこの後確認する。
- 次に触るなら見る場所: CI（`e2e`ジョブ）のこのPRでの結果を必ず確認すること。CIで失敗した場合はテストロジックではなく環境差異を先に疑う。

## 後任AIへの注意
- この実装で壊してはいけない前提: `LogoutButton`は`user`がnullでない（サーバー側で認証確認済み）ときのみ`layout.tsx`からレンダリングされる前提。未認証ページ（`/login`）にはこのボタンを出さないこと。
- 似ているが別物の用語: このPRの「ログアウト」はSupabase Authのセッション破棄のみで、admin権限判定（`resolveIsAdmin`）やfacility所属（`user_facilities`）には一切影響しない。
- 勝手にリファクタしない場所: `layout.tsx`を非同期化した点。他のServer Componentから同期的にpropsを渡す実装を追加する場合、この非同期化を前提にすること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)