### PR TITLE
ci: 全ワークフローにpermissions最小化とconcurrencyキャンセルを追加

### DIFF
--- a/.github/workflows/agent-baseline-check.yml
+++ b/.github/workflows/agent-baseline-check.yml
@@ -12,6 +12,13 @@ on:
       - '.claude/agents/**'
       - '.claude/workflows/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-baseline-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/eval-runs-freshness-check.yml
+++ b/.github/workflows/eval-runs-freshness-check.yml
@@ -12,6 +12,13 @@ on:
     paths:
       - '.claude/workflows/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-runs-freshness-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -25,6 +25,12 @@ on:
     - cron: '0 0 * * *' # UTC 0:00。DB側の日次チェック(UTC 23:00)より後に実行する
   workflow_dispatch:
 
+# WHY: issue作成/クローズを行う途中でキャンセルされると中途半端な状態になりうるため、
+# 古い実行を殺すのではなく新しい実行を待たせる（cancel-in-progress: false）。
+concurrency:
+  group: schema-drift-check
+  cancel-in-progress: false
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub Actionsのサプライチェーン保護学習（permissions最小化・concurrency）を、実際の5ワークフローに適用する。
- 変更した範囲: `.github/workflows/`配下の5ファイル全て。`ci.yml`/`e2e.yml`/`eval-runs-freshness-check.yml`/`agent-baseline-check.yml`に`permissions: contents: read`（workflow単位）と`concurrency`（同一ref上の古い実行を`cancel-in-progress: true`でキャンセル）を追加。`schema-drift-check.yml`は既にjob単位で`issues: write`のみに絞られていたためpermissionsは変更せず、`concurrency`のみ追加（issue作成/クローズ途中のキャンセル事故を避けるため`cancel-in-progress: false`）。
- 触っていない範囲: 各ワークフローのジョブ本体（実行コマンド・トリガー条件・Secrets参照）は一切変更していない。

## 検証済み
- 実行したコマンド: `python3 -c "yaml.safe_load(...)"`で5ファイル全てのYAML構文チェック（OK）。`npm test`（全1323件通過）/`npm run lint`（無関係な既存警告2件のみ）。`npm run typecheck`は本変更に無関係（.yml以外変更なし）のため未実行。
- 確認した画面: 対象外（GitHub Actions設定のみ、UI変更なし）。
- 確認したDB/RLS: 対象外。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLSドメインに触れていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: `Composite Actions`/`Reusable Workflows`化（`ci.yml`の3ジョブが`checkout`→`setup-node`→`npm install`をほぼ同一コードで重複している）は別issue/別PRとして扱う。今回はpermissions/concurrencyのみに絞った。
- 理由: 変更は小さく1つずつ確認する方針のため。
- 次に触るなら見る場所: 次のステップは`Dependabot`設定の追加を予定（学習ロードマップの③）。

## 後任AIへの注意
- この実装で壊してはいけない前提: `permissions:`ブロックを追加したワークフローに、今後PRコメント投稿・チェック結果の書き込み・パッケージpublish等の書き込み系ステップを追加する場合、対応するscope（例: `pull-requests: write`）をjob単位で明示的に追加しないと権限不足で失敗する（`contents: read`のみでは不足）。
- 似ているが別物の用語: `schema-drift-check.yml`の`cancel-in-progress: false`は他4ファイルの`true`と意図的に異なる（issue作成の冪等性を壊さないため）。一括で揃えて`true`にしないこと。
- 勝手にリファクタしない場所: `ci.yml`の3ジョブ重複コードは意図的に今回のスコープ外にした。触るなら別PRで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)