### PR TITLE
ci: Dependabotでnpm依存とGitHub Actionsのバージョンを自動追従させる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# WHY: npm依存関係とGitHub Actions（actions/checkout等）のバージョンを
+# 自動追従させる。非公開リポジトリでもDependency Graphは無料で有効なため、
+# Dependabot自体はプラン制約なく利用できる（Secret Scanning/CodeQLとは異なる）。
+# open PR数を絞るためweeklyかつ上限を小さめに設定する（単独開発でレビュー容量が限られるため）。
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub学習ロードマップの「Dependabot」を実際に導入する。npm依存とGitHub Actionsのバージョンが古いまま放置されるのを防ぐ。
- 変更した範囲: `.github/dependabot.yml`の新規追加のみ。`npm`（directory: `/`）と`github-actions`（directory: `/`）の2エコシステムをweekly監視、`open-pull-requests-limit: 5`。
- 触っていない範囲: 既存の5ワークフローファイル・パッケージ本体のバージョンには一切手を入れていない。

## 検証済み
- 実行したコマンド: `python3 -c "yaml.safe_load(...)"`でdependabot.ymlの構文チェック（OK）。`npm run lint`（無関係な既存警告2件のみ）。設定ファイル追加のみのためtypecheck/test/test:e2eは対象外（変更なし）。
- 確認した画面: 対象外。
- 確認したDB/RLS: 対象外。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLSドメインに触れていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: Dependabotが実際にPRを作成する挙動そのものはこのPRでは検証していない（スケジュール実行のため、マージ後の初回実行を待つ必要がある）。
- 理由: マージ前に検証する手段がない（GitHub側の機能でありローカル実行不可）。
- 次に触るなら見る場所: マージ後、`dependencies`/`github-actions`ラベルが自動生成されたPRが実際に立つか、次回このリポジトリを触るタイミングで確認する。open-pull-requests-limitに達して古い更新が積み残っていないかも合わせて見る。

## 後任AIへの注意
- この実装で壊してはいけない前提: 特になし（設定ファイル追加のみ、既存コード・CIには影響しない）。
- 似ているが別物の用語: 「Dependabot」（依存関係の自動更新PR、このPRの内容）と「Dependency Review」（PRで追加された脆弱な依存をブロックする別機能、非公開リポジトリではAdvanced Security要の可能性がありこのPRのスコープ外）を混同しないこと。
- 勝手にリファクタしない場所: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)