### PR TITLE
ci: typecheck/lint/testの重複をReusable Workflowに切り出す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,40 +13,16 @@ concurrency:
 
 jobs:
   typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm install
-      - name: Run typecheck
-        run: npm run typecheck
+    uses: ./.github/workflows/node-check.yml
+    with:
+      run-script: typecheck
 
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm install
-      - name: Run lint
-        run: npm run lint
+    uses: ./.github/workflows/node-check.yml
+    with:
+      run-script: lint
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm install
-      - name: Run unit tests
-        run: npm run test
+    uses: ./.github/workflows/node-check.yml
+    with:
+      run-script: test

--- a/.github/workflows/node-check.yml
+++ b/.github/workflows/node-check.yml
@@ -1,0 +1,33 @@
+# WHY: ci.ymlのtypecheck/lint/testの3ジョブがcheckout→setup-node→npm installを
+# ほぼ同一コードで重複させていた。Reusable Workflow(workflow_call)に切り出し、
+# 呼び出し側は実行するnpm scriptだけを渡す形にする。
+# GitHub学習ロードマップの「Reusable Workflows」のハンズオン。
+
+name: Node Check (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      run-script:
+        description: "実行するnpm run scriptの名前(package.jsonのscripts)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run npm run ${{ inputs.run-script }}
+        env:
+          RUN_SCRIPT: ${{ inputs.run-script }}
+        run: npm run "$RUN_SCRIPT"


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub学習ロードマップの「Reusable Workflows」を実際に導入する。`ci.yml`の3ジョブ（typecheck/lint/test）が`checkout`→`setup-node`→`npm install`をほぼ同一コードで重複させていたのを解消する。
- 変更した範囲: 新規`.github/workflows/node-check.yml`（`workflow_call`トリガー、`run-script`inputでnpm scriptを受け取る）。`ci.yml`の3ジョブを`uses: ./.github/workflows/node-check.yml`呼び出しに置き換え。各ジョブの実行内容（typecheck/lint/test）自体は変更していない。
- 触っていない範囲: `e2e.yml`・`eval-runs-freshness-check.yml`・`agent-baseline-check.yml`・`schema-drift-check.yml`は対象外（今回は`ci.yml`のみ）。

## 検証済み
- 実行したコマンド: `python3 -c "yaml.safe_load(...)"`で`ci.yml`/`node-check.yml`の構文チェック（OK）。`npm run lint`（無関係な既存警告2件のみ）。このPR自体のCI実行が「Reusable Workflow呼び出しが実際に動くか」の実地検証を兼ねる（マージ前にCIグリーンを確認する）。
- 確認した画面: 対象外。
- 確認したDB/RLS: 対象外。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLSドメインに触れていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: 学習ロードマップの「2リポジトリから同じReusable Workflowを利用」というノルマは、このリポジトリ単体では達成できない（別リポジトリが必要）。今回は同一リポジトリ内3ジョブでの重複解消にとどめた。
- 理由: 別リポジトリを用意するかどうかはスコープ外の判断が必要なため。
- 次に触るなら見る場所: 他リポジトリで同じ`node-check.yml`パターンを試す場合、`uses: huuriekaiseki-sketch/medical-inventory-vkumai/.github/workflows/node-check.yml@main`のように完全参照形式にする必要がある（同一リポジトリ内は`./`で参照できるが、他リポジトリからは不可）。

## 後任AIへの注意
- この実装で壊してはいけない前提: `node-check.yml`は`run-script`inputで受け取った値をそのまま`npm run "$RUN_SCRIPT"`として実行する。呼び出し元は`ci.yml`内の固定リテラル（typecheck/lint/test）のみで、外部入力（PR本文やissueタイトル等)を渡さないこと。
- 似ているが別物の用語: 「Reusable Workflow」（`workflow_call`、ジョブ単位で呼び出す、このPRの内容）と「Composite Action」（ステップ単位で再利用する別の仕組み）を混同しないこと。今回はジョブ全体が同じ形だったためReusable Workflowを選んだ。
- 勝手にリファクタしない場所: `e2e.yml`は`ci.yml`と似た`checkout`→`setup-node`の並びを含むが、後続ステップ（Playwright/Supabase起動）が大きく異なるため、今回意図的に共通化対象から外した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)