### PR TITLE
ci: vX.Y.Zタグpushで変更履歴付きGitHub Releaseを自動作成する

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+# WHY: GitHub Releaseの自動生成ノート(--generate-notes)がPRラベルでカテゴリ分けする際の
+# 分類定義。Dependabot作成PRには"dependencies"ラベルが自動で付くため、それを専用セクションに
+# まとめ、それ以外は「その他の変更」に落とす。
+
+changelog:
+  categories:
+    - title: 依存関係の更新
+      labels:
+        - "dependencies"
+    - title: その他の変更
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# WHY: GitHub学習ロードマップの「Release、Tag、Changelog」のハンズオン。
+# vX.Y.Zタグがpushされたら、そのタグ位置でGitHub Releaseを作成し、
+# 前回リリースからのマージ済みPRを元に変更履歴を自動生成する
+# (--generate-notes、カテゴリ分類は.github/release.ymlに従う)。
+# タグを打つタイミング・バージョニング方針自体はこのワークフローの範囲外
+# （いつ・どのバージョンでリリースするかは人間が判断してtagをpushする）。
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release create "$TAG_NAME" --generate-notes


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub学習ロードマップの「Release、Tag、Changelog」を実際に導入する。タグからの変更履歴自動生成を体験する。
- 変更した範囲: 新規`.github/workflows/release.yml`（`v*.*.*`タグpushをトリガーに`gh release create --generate-notes`を実行）。新規`.github/release.yml`（Dependabotの`dependencies`ラベルを別カテゴリにまとめる分類設定）。
- 触っていない範囲: バージョニング方針そのもの（いつ・どのバージョン番号でタグを打つか）は決めていない。実際にタグをpushして動作確認するかは別途判断が必要（このPRでは自動化の土台のみ用意）。

## 検証済み
- 実行したコマンド: `python3 -c "yaml.safe_load(...)"`で`release.yml`（workflow）と`.github/release.yml`（分類設定）の構文チェック（OK）。`npm run lint`（無関係な既存警告2件のみ）。
- 確認した画面: 対象外。
- 確認したDB/RLS: 対象外。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLSドメインに触れていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: 実際にタグをpushしてワークフローが動くかの実地検証。このワークフローは`push: tags: v*.*.*`のみをトリガーとするため、PRのCI実行では検証できない。
- 理由: タグを打つ＝バージョン番号を確定させる行為であり、このPRの範囲を超えた判断（ユーザーが決めるべきバージョニング方針）が必要なため。
- 次に触るなら見る場所: マージ後、実際に最初のタグ（例: `v0.1.0`）をpushして動作確認する。その際`gh release create`が権限不足（`contents: write`）で失敗しないか、`.github/release.yml`のカテゴリ分類が意図通り効くかを確認すること。

## 後任AIへの注意
- この実装で壊してはいけない前提: このワークフローは`v*.*.*`形式のタグにのみ反応する。それ以外の命名規則のタグ（例: リリース以外の目的のタグ）を運用する場合は誤発火に注意。
- 似ているが別物の用語: 「Changelog」はこのPRでは独立したCHANGELOGファイルではなく、GitHub Releaseページ上の自動生成ノートとして実現している。別途`CHANGELOG.md`ファイルを求められた場合はこの実装では満たさない。
- 勝手にリファクタしない場所: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)