### PR TITLE
docs: Issue Formsでバグ報告/機能要望を構造化する

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: バグ報告
+description: 動作しない・想定と違う挙動を報告する
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が起きているか簡潔に
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 番号付きで手順を書いてください
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の挙動
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: 重大度
+      options:
+        - critical(データ破損・認可バイパス等)
+        - high(主要機能が使えない)
+        - medium(一部機能に支障)
+        - low(軽微・見た目のみ)
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 補足(ログ・スクリーンショット・環境など)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+# WHY: pending_issues.jsonl経由のStop hook自動issue化(docs/agents/common.md参照)は
+# GitHub APIで直接issueを作成するため、テンプレート選択UIを経由しない。
+# blank_issues_enabled: trueのままにして、テンプレートに当てはまらないissueの
+# 手動作成経路も残す。
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: 機能要望
+description: 新機能・改善の提案
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい課題
+      description: 今何に困っているか、なぜこれが必要か
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する解決策
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 検討した代替案
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 補足
+    validations:
+      required: false


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub学習ロードマップの「Issue Forms」を実際に導入する。issue作成時に必要な情報（再現手順・期待/実際の挙動・重大度など）を構造化して漏れを防ぐ。
- 変更した範囲: 新規`.github/ISSUE_TEMPLATE/bug_report.yml`（`bug`ラベル）、`feature_request.yml`（`enhancement`ラベル）、`config.yml`（`blank_issues_enabled: true`）。既存issueのラベル運用（`gh issue list`で確認した`bug`/`enhancement`/`documentation`の実態）に合わせた。
- 触っていない範囲: 既存issueの内容・ラベル定義自体は変更していない。`docs/agents/common.md`の「GitHub issue自動作成（Stop hookとの連携）」で使われている`gh issue create`経由のAPI直接作成（テンプレートUIを経由しない）には影響しない。

## 検証済み
- 実行したコマンド: `python3 -c "yaml.safe_load(...)"`で3ファイルの構文チェック（OK）。`npm run lint`（無関係な既存警告2件のみ）。
- 確認した画面: 対象外（GitHubのissue作成UIはローカルで再現できないため未確認。マージ後にGitHub上の「New issue」ボタンから実際にテンプレートが選択できるか確認が必要）。
- 確認したDB/RLS: 対象外。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLSドメインに触れていない）。

## 既知の未対応
- 今回あえて対応しなかったこと: マージ後、実際にGitHub UIで「New issue」を開いてテンプレートが選択肢に表示されるかの実地確認。
- 理由: ローカル環境からGitHubのissue作成UIをレンダリング確認する手段がないため。
- 次に触るなら見る場所: マージ後に一度「New issue」ボタンを押してテンプレート選択画面を確認すること。

## 後任AIへの注意
- この実装で壊してはいけない前提: `config.yml`の`blank_issues_enabled: true`を`false`に変更すると、`docs/agents/common.md`のpending_issues.jsonl経由の自動issue化（Stop hookが`gh issue create`をAPI経由で実行）自体は引き続き動く（API呼び出しはUIのブランクissue許可設定と無関係）が、人間が手動でテンプレートに合わないissueを作る手段が塞がれる。安易に`false`にしないこと。
- 似ているが別物の用語: 「Issue Forms」（`.yml`形式の構造化テンプレート、このPRの内容）と旧来の「Issue Templates」（`.md`形式、フリーテキスト）を混同しないこと。
- 勝手にリファクタしない場所: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)