### PR TITLE
feat: ログイン画面にGoogle OAuthログインを追加する

### DIFF
--- a/src/app/login/__tests__/page.test.tsx
+++ b/src/app/login/__tests__/page.test.tsx
@@ -5,10 +5,12 @@ import LoginPage from '../page'
 
 // createSupabaseBrowserClient をモック
 const mockSignInWithOtp = vi.fn()
+const mockSignInWithOAuth = vi.fn()
 vi.mock('@/lib/supabase/client', () => ({
   createSupabaseBrowserClient: vi.fn(() => ({
     auth: {
       signInWithOtp: mockSignInWithOtp,
+      signInWithOAuth: mockSignInWithOAuth,
     },
   })),
 }))
@@ -54,6 +56,40 @@ describe('LoginPage', () => {
     it('初期状態でエラーメッセージは表示されない', () => {
       render(<LoginPage />)
       expect(screen.queryByText('メールの送信に失敗しました。メールアドレスを確認してください。')).not.toBeInTheDocument()
+    })
+
+    it('「Googleでログイン」ボタンが表示される', () => {
+      render(<LoginPage />)
+      expect(screen.getByRole('button', { name: 'Googleでログイン' })).toBeInTheDocument()
+    })
+  })
+
+  describe('Googleログイン', () => {
+    it('クリックするとsignInWithOAuthがprovider: googleで呼ばれる', async () => {
+      mockSignInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      render(<LoginPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'Googleでログイン' }))
+
+      await waitFor(() => {
+        expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+          provider: 'google',
+          options: {
+            redirectTo: 'http://localhost:3000/auth/callback',
+          },
+        })
+      })
+    })
+
+    it('失敗時にエラーメッセージが表示される', async () => {
+      mockSignInWithOAuth.mockResolvedValueOnce({ error: new Error('oauth error') })
+
+      render(<LoginPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'Googleでログイン' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Googleログインに失敗しました。もう一度お試しください。')).toBeInTheDocument()
+      })
     })
   })
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -49,6 +49,22 @@ function LoginForm() {
     setSent(true)
   }
 
+  async function handleGoogleLogin() {
+    setError(null)
+    const supabase = createSupabaseBrowserClient()
+    const { error: signInError } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? ''}/auth/callback`,
+      },
+    })
+
+    if (signInError) {
+      setError('Googleログインに失敗しました。もう一度お試しください。')
+    }
+    // 成功時はSupabaseがGoogleの認証画面へリダイレクトするため、ここでの遷移処理は不要
+  }
+
   if (sent) {
     return (
       <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: '#EDEADE' }}>
@@ -100,6 +116,20 @@ function LoginForm() {
             {loading ? '送信中...' : 'ログインリンクを送信'}
           </button>
         </form>
+
+        <div className="flex items-center gap-3 my-4">
+          <div className="flex-1 h-px bg-gray-200" />
+          <span className="text-xs text-gray-400">または</span>
+          <div className="flex-1 h-px bg-gray-200" />
+        </div>
+
+        <button
+          type="button"
+          onClick={handleGoogleLogin}
+          className="w-full py-2 px-4 rounded border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+        >
+          Googleでログイン
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: Supabase学習ロードマップの「OAuthログイン」を実際に導入する。既存のEmail OTPログインに加えてGoogleログインの選択肢を追加する。
- 変更した範囲: `src/app/login/page.tsx`に`handleGoogleLogin`（`supabase.auth.signInWithOAuth({ provider: 'google', ... })`）とGoogleログインボタンを追加。リダイレクト先は既存の`/auth/callback`ルート（`src/app/auth/callback/route.ts`、PKCEコード交換用）をそのまま再利用し、新規作成していない。
- 触っていない範囲: Email OTPログインのフロー・middleware.tsの認証ガード・RLS/facility境界には一切触れていない。OAuthでログインしたユーザーも既存のEmail OTPユーザーと全く同じセッション・RLSポリシー・`is_facility_member`チェックを通る。

## 検証済み
- 実行したコマンド: `npm run typecheck` / `npm run lint` / `npm test`（全1326件通過、Googleログインの単体テスト3件追加）。
- 確認した画面: `/login`をブラウザで目視確認し、「Googleでログイン」ボタンの表示・クリック時の遷移を確認した。
- **重要な注意**: このブラウザ確認の際、`npm run dev`が`.env.local`（本番Supabase接続情報）をデフォルトで読み込む仕様のため、意図せず本番Supabaseプロジェクト（`dddwaoooqzrtlbtcnwso.supabase.co`）の`/auth/v1/authorize`エンドポイントへ実際にリクエストが飛んだ。結果は`Unsupported provider: provider is not enabled`という400エラーのみで、状態変更を伴う副作用は無いことを確認済み（GoogleプロバイダーがSupabase側で無効なため即座に拒否されただけ）。念のためユーザーに報告済み。
- 確認したDB/RLS: 対象外（DBスキーマ変更なし）。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外。OAuthは認証方法の追加のみで、認可ロジック（RLS/`is_facility_member`）は一切変更していない。OAuthでログインしたユーザーも既存のOTPユーザーと同じ認可パスを通るため、追加の他テナント検証は不要と判断した。

## 既知の未対応
- 今回あえて対応しなかったこと: 実際にGoogleでログインできるようにするための設定（Google Cloud ConsoleでのOAuthクライアント作成、Supabase Dashboard（本番プロジェクト）でのGoogleプロバイダー有効化とClient ID/Secret登録、ローカル`supabase/config.toml`への`[auth.external.google]`追加）。
- 理由: これらは実際の認証情報（Client ID/Secret）を扱う作業であり、Claude Codeの権限では代行できない。ユーザー自身がGoogle Cloud ConsoleとSupabase Dashboardで設定する必要がある。
- 次に触るなら見る場所: 上記設定が完了するまで、このPRの機能は本番環境で実際には動作しない（ボタンを押すと`provider is not enabled`エラーになる）。設定完了後、`supabase/config.toml`にローカル開発用の設定を追加するかどうかも別途判断が必要。

## 後任AIへの注意
- この実装で壊してはいけない前提: `/auth/callback`ルート（`route.ts`）は既存のPKCEコード交換ロジックをそのまま使っている。Email OTPのhashベースフロー（`login/page.tsx`の`useEffect`内の`access_token`処理）とは別経路であり、混同して片方を消さないこと。
- 似ているが別物の用語: Email OTPの`emailRedirectTo`とOAuthの`redirectTo`はオプション名が違う（Supabase SDKの仕様）。どちらも`/auth/callback`を指すが、内部の処理経路（hash vs code exchange）は異なる。
- 勝手にリファクタしない場所: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)