### PR TITLE
feat: TOTPによる二段階認証(MFA)を追加する

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -19,14 +19,19 @@ beforeEach(() => {
 })
 
 // resolveIsAdmin は get_admin_status RPC を呼ぶため、rpc モックを用意する
+// MFAガード用にmfa.getAuthenticatorAssuranceLevelもデフォルトでaal1/aal1(MFA未要求)を返す
 function makeSupabaseClientWithAdminRpc(
   user: { id: string; email: string } | null,
   userIsAdmin: boolean,
-  dbHasAdmin: boolean
+  dbHasAdmin: boolean,
+  aal: { currentLevel: string; nextLevel: string } = { currentLevel: 'aal1', nextLevel: 'aal1' }
 ) {
   return {
     auth: {
       getUser: vi.fn().mockResolvedValueOnce({ data: { user } }),
+      mfa: {
+        getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue({ data: aal, error: null }),
+      },
     },
     rpc: vi.fn().mockResolvedValue({
       data: [{ user_is_admin: userIsAdmin, db_has_admin: dbHasAdmin }],
@@ -103,6 +108,12 @@ describe('middleware', () => {
             .mockResolvedValueOnce({
               data: { user: { id: 'user-123', email: 'user@example.com' } },
             }),
+          mfa: {
+            getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue({
+              data: { currentLevel: 'aal1', nextLevel: 'aal1' },
+              error: null,
+            }),
+          },
         },
       } as unknown as ReturnType<typeof createServerClient>)
 
@@ -323,6 +334,89 @@ describe('middleware', () => {
     })
   })
 
+  describe('MFAガード', () => {
+    it('aal1→aal2が必要なユーザーが保護パスにアクセス→ /mfa-challenge にリダイレクト', async () => {
+      const { createServerClient } = await import('@supabase/ssr')
+      vi.mocked(createServerClient).mockReturnValueOnce(
+        makeSupabaseClientWithAdminRpc(
+          { id: 'mfa-user', email: 'mfa@example.com' },
+          false,
+          false,
+          { currentLevel: 'aal1', nextLevel: 'aal2' }
+        ) as unknown as ReturnType<typeof createServerClient>
+      )
+
+      const request = new NextRequest(
+        new URL('http://localhost:3000/facilities')
+      )
+
+      const response = await middleware(request)
+
+      expect(response?.status).toBe(307)
+      expect(response?.headers.get('location')).toContain('/mfa-challenge')
+    })
+
+    it('aal1→aal2が必要なユーザーが /mfa-challenge 自体にアクセス→ そのまま通す', async () => {
+      const { createServerClient } = await import('@supabase/ssr')
+      vi.mocked(createServerClient).mockReturnValueOnce(
+        makeSupabaseClientWithAdminRpc(
+          { id: 'mfa-user', email: 'mfa@example.com' },
+          false,
+          false,
+          { currentLevel: 'aal1', nextLevel: 'aal2' }
+        ) as unknown as ReturnType<typeof createServerClient>
+      )
+
+      const request = new NextRequest(
+        new URL('http://localhost:3000/mfa-challenge')
+      )
+
+      const response = await middleware(request)
+
+      expect(response?.status).not.toBe(307)
+    })
+
+    it('MFA未設定(aal1→aal1)のユーザーは保護パスへ通常通りアクセスできる', async () => {
+      const { createServerClient } = await import('@supabase/ssr')
+      vi.mocked(createServerClient).mockReturnValueOnce(
+        makeSupabaseClientWithAdminRpc(
+          { id: 'no-mfa-user', email: 'nomfa@example.com' },
+          false,
+          false,
+          { currentLevel: 'aal1', nextLevel: 'aal1' }
+        ) as unknown as ReturnType<typeof createServerClient>
+      )
+
+      const request = new NextRequest(
+        new URL('http://localhost:3000/facilities')
+      )
+
+      const response = await middleware(request)
+
+      expect(response?.status).not.toBe(307)
+    })
+
+    it('既にaal2のユーザーは保護パスへ通常通りアクセスできる', async () => {
+      const { createServerClient } = await import('@supabase/ssr')
+      vi.mocked(createServerClient).mockReturnValueOnce(
+        makeSupabaseClientWithAdminRpc(
+          { id: 'aal2-user', email: 'aal2@example.com' },
+          false,
+          false,
+          { currentLevel: 'aal2', nextLevel: 'aal2' }
+        ) as unknown as ReturnType<typeof createServerClient>
+      )
+
+      const request = new NextRequest(
+        new URL('http://localhost:3000/facilities')
+      )
+
+      const response = await middleware(request)
+
+      expect(response?.status).not.toBe(307)
+    })
+  })
+
   describe('パスマッチング（admin パス）', () => {
     it('名前空間の誤マッチを避ける（/adminfoo は admin パスではない）', async () => {
       // /admin のみ、または /admin/ 配下が正しい admin パス
@@ -333,6 +427,12 @@ describe('middleware', () => {
           getUser: vi.fn().mockResolvedValueOnce({
             data: { user: { id: 'admin-1', email: 'admin@example.com' } },
           }),
+          mfa: {
+            getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue({
+              data: { currentLevel: 'aal1', nextLevel: 'aal1' },
+              error: null,
+            }),
+          },
         },
       } as unknown as ReturnType<typeof createServerClient>)
 

--- a/src/app/account/mfa/__tests__/page.test.tsx
+++ b/src/app/account/mfa/__tests__/page.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MfaSettingsPage from '../page'
+
+const mockListFactors = vi.fn()
+const mockEnroll = vi.fn()
+const mockChallenge = vi.fn()
+const mockVerify = vi.fn()
+const mockUnenroll = vi.fn()
+
+vi.mock('@/lib/supabase/client', () => ({
+  createSupabaseBrowserClient: vi.fn(() => ({
+    auth: {
+      mfa: {
+        listFactors: mockListFactors,
+        enroll: mockEnroll,
+        challenge: mockChallenge,
+        verify: mockVerify,
+        unenroll: mockUnenroll,
+      },
+    },
+  })),
+}))
+
+describe('MfaSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('MFA未登録の場合、有効化ボタンが表示される', async () => {
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+  })
+
+  it('検証済みfactorがある場合、有効状態と解除ボタンが表示される', async () => {
+    mockListFactors.mockResolvedValueOnce({
+      data: { totp: [{ id: 'factor-1', status: 'verified' }] },
+      error: null,
+    })
+
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('✓ 二段階認証は有効です。')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '二段階認証を解除する' })).toBeInTheDocument()
+  })
+
+  it('有効化ボタンをクリックするとenrollが呼ばれQRコードが表示される', async () => {
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockEnroll.mockResolvedValueOnce({
+      data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
+      error: null,
+    })
+
+    const user = userEvent.setup()
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: '二段階認証を有効化する' }))
+
+    await waitFor(() => {
+      expect(screen.getByAltText('MFA QRコード')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/SECRET123/)).toBeInTheDocument()
+  })
+
+  it('確認コードを入力してverifyが成功すると有効状態に切り替わる', async () => {
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockEnroll.mockResolvedValueOnce({
+      data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
+      error: null,
+    })
+    mockChallenge.mockResolvedValueOnce({ data: { id: 'challenge-1' }, error: null })
+    mockVerify.mockResolvedValueOnce({ error: null })
+
+    const user = userEvent.setup()
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: '二段階認証を有効化する' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('確認コード')).toBeInTheDocument()
+    })
+    await user.type(screen.getByLabelText('確認コード'), '123456')
+    await user.click(screen.getByRole('button', { name: '確認して有効化' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('✓ 二段階認証は有効です。')).toBeInTheDocument()
+    })
+    expect(mockVerify).toHaveBeenCalledWith({
+      factorId: 'new-factor',
+      challengeId: 'challenge-1',
+      code: '123456',
+    })
+  })
+
+  it('確認コードが誤っている場合エラーメッセージが表示される', async () => {
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockEnroll.mockResolvedValueOnce({
+      data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
+      error: null,
+    })
+    mockChallenge.mockResolvedValueOnce({ data: { id: 'challenge-1' }, error: null })
+    mockVerify.mockResolvedValueOnce({ error: new Error('invalid code') })
+
+    const user = userEvent.setup()
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: '二段階認証を有効化する' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('確認コード')).toBeInTheDocument()
+    })
+    await user.type(screen.getByLabelText('確認コード'), '000000')
+    await user.click(screen.getByRole('button', { name: '確認して有効化' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('コードが正しくありません。もう一度お試しください。')).toBeInTheDocument()
+    })
+  })
+
+  it('解除ボタンをクリックするとunenrollが呼ばれ未登録状態に戻る', async () => {
+    mockListFactors.mockResolvedValueOnce({
+      data: { totp: [{ id: 'factor-1', status: 'verified' }] },
+      error: null,
+    })
+    mockUnenroll.mockResolvedValueOnce({ error: null })
+
+    const user = userEvent.setup()
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を解除する' })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: '二段階認証を解除する' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+    expect(mockUnenroll).toHaveBeenCalledWith({ factorId: 'factor-1' })
+  })
+})

--- a/src/app/account/mfa/page.tsx
+++ b/src/app/account/mfa/page.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useEffect, useState, FormEvent } from 'react'
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'
+
+type EnrollState =
+  | { status: 'loading' }
+  | { status: 'verified'; factorId: string }
+  | { status: 'not-enrolled' }
+  | {
+      status: 'enrolling'
+      factorId: string
+      qrCode: string
+      secret: string
+    }
+
+export default function MfaSettingsPage() {
+  const [state, setState] = useState<EnrollState>({ status: 'loading' })
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const supabase = createSupabaseBrowserClient()
+    supabase.auth.mfa.listFactors().then(({ data, error: listError }) => {
+      if (cancelled) return
+      if (listError) {
+        setError('MFA設定の取得に失敗しました。')
+        setState({ status: 'not-enrolled' })
+        return
+      }
+      const verified = data.totp.find(f => f.status === 'verified')
+      setState(verified ? { status: 'verified', factorId: verified.id } : { status: 'not-enrolled' })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function handleEnroll() {
+    setError(null)
+    const supabase = createSupabaseBrowserClient()
+    const { data, error: enrollError } = await supabase.auth.mfa.enroll({ factorType: 'totp' })
+    if (enrollError || !data) {
+      setError('MFAの登録開始に失敗しました。')
+      return
+    }
+    setState({
+      status: 'enrolling',
+      factorId: data.id,
+      qrCode: data.totp.qr_code,
+      secret: data.totp.secret,
+    })
+  }
+
+  async function handleVerify(e: FormEvent) {
+    e.preventDefault()
+    if (state.status !== 'enrolling') return
+    setSubmitting(true)
+    setError(null)
+
+    const supabase = createSupabaseBrowserClient()
+    const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
+      factorId: state.factorId,
+    })
+    if (challengeError || !challengeData) {
+      setSubmitting(false)
+      setError('確認コードの検証に失敗しました。')
+      return
+    }
+
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId: state.factorId,
+      challengeId: challengeData.id,
+      code,
+    })
+
+    setSubmitting(false)
+    if (verifyError) {
+      setError('コードが正しくありません。もう一度お試しください。')
+      return
+    }
+    setCode('')
+    setState({ status: 'verified', factorId: state.factorId })
+  }
+
+  async function handleUnenroll() {
+    if (state.status !== 'verified') return
+    setSubmitting(true)
+    setError(null)
+
+    const supabase = createSupabaseBrowserClient()
+    const { error: unenrollError } = await supabase.auth.mfa.unenroll({ factorId: state.factorId })
+
+    setSubmitting(false)
+    if (unenrollError) {
+      setError('MFAの解除に失敗しました。')
+      return
+    }
+    setState({ status: 'not-enrolled' })
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-10">
+      <div className="mb-8 border-b pb-4" style={{ borderColor: '#072C2C33' }}>
+        <p className="text-xs font-semibold uppercase tracking-widest mb-1" style={{ color: '#FF5F03', fontFamily: 'var(--font-oswald), sans-serif' }}>
+          Account Settings
+        </p>
+        <h1 className="text-3xl font-bold" style={{ color: '#072C2C', fontFamily: 'var(--font-oswald), sans-serif', letterSpacing: '0.04em' }}>
+          二段階認証(MFA)
+        </h1>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded bg-white shadow-sm p-6" style={{ border: '1px solid #E5E7EB' }}>
+        {state.status === 'loading' && <p className="text-sm text-gray-500">読み込み中...</p>}
+
+        {state.status === 'not-enrolled' && (
+          <>
+            <p className="text-sm text-gray-600 mb-4">
+              二段階認証は現在無効です。認証アプリ(Google Authenticator等)を使って有効化できます。
+            </p>
+            <button
+              type="button"
+              onClick={handleEnroll}
+              className="py-2 px-4 rounded text-white text-sm font-medium"
+              style={{ backgroundColor: '#072C2C' }}
+            >
+              二段階認証を有効化する
+            </button>
+          </>
+        )}
+
+        {state.status === 'enrolling' && (
+          <form onSubmit={handleVerify} className="space-y-4">
+            <p className="text-sm text-gray-600">
+              認証アプリでQRコードを読み取り、表示された6桁のコードを入力してください。
+            </p>
+            {/* eslint-disable-next-line @next/next/no-img-element -- Supabaseが実行時に返すSVG data URIで、next/imageの最適化対象にできないため */}
+            <img src={state.qrCode} alt="MFA QRコード" className="w-40 h-40" />
+            <p className="text-xs text-gray-400 break-all">シークレットキー: {state.secret}</p>
+            <div>
+              <label htmlFor="mfa-code" className="block text-sm font-medium text-gray-700 mb-1">
+                確認コード
+              </label>
+              <input
+                id="mfa-code"
+                type="text"
+                inputMode="numeric"
+                required
+                value={code}
+                onChange={e => setCode(e.target.value)}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-600"
+                placeholder="123456"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="py-2 px-4 rounded text-white text-sm font-medium disabled:opacity-50"
+              style={{ backgroundColor: '#072C2C' }}
+            >
+              {submitting ? '検証中...' : '確認して有効化'}
+            </button>
+          </form>
+        )}
+
+        {state.status === 'verified' && (
+          <>
+            <p className="text-sm text-green-700 mb-4">✓ 二段階認証は有効です。</p>
+            <button
+              type="button"
+              onClick={handleUnenroll}
+              disabled={submitting}
+              className="py-2 px-4 rounded border border-red-300 text-red-700 text-sm font-medium disabled:opacity-50"
+            >
+              {submitting ? '解除中...' : '二段階認証を解除する'}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/mfa-challenge/__tests__/page.test.tsx
+++ b/src/app/mfa-challenge/__tests__/page.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MfaChallengePage from '../page'
+
+const mockGetAAL = vi.fn()
+const mockListFactors = vi.fn()
+const mockChallenge = vi.fn()
+const mockVerify = vi.fn()
+
+vi.mock('@/lib/supabase/client', () => ({
+  createSupabaseBrowserClient: vi.fn(() => ({
+    auth: {
+      mfa: {
+        getAuthenticatorAssuranceLevel: mockGetAAL,
+        listFactors: mockListFactors,
+        challenge: mockChallenge,
+        verify: mockVerify,
+      },
+    },
+  })),
+}))
+
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  })),
+}))
+
+describe('MfaChallengePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('既にaal2の場合はトップへリダイレクトする', async () => {
+    mockGetAAL.mockResolvedValueOnce({
+      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+      error: null,
+    })
+
+    render(<MfaChallengePage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('aal1→aal2が必要な場合、確認コード入力フォームが表示される', async () => {
+    mockGetAAL.mockResolvedValueOnce({
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      error: null,
+    })
+    mockListFactors.mockResolvedValueOnce({
+      data: { totp: [{ id: 'factor-1', status: 'verified' }] },
+      error: null,
+    })
+
+    render(<MfaChallengePage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('認証アプリの確認コード')).toBeInTheDocument()
+    })
+  })
+
+  it('コードを送信するとchallenge→verifyが呼ばれ成功時にトップへ遷移する', async () => {
+    mockGetAAL.mockResolvedValueOnce({
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      error: null,
+    })
+    mockListFactors.mockResolvedValueOnce({
+      data: { totp: [{ id: 'factor-1', status: 'verified' }] },
+      error: null,
+    })
+    mockChallenge.mockResolvedValueOnce({ data: { id: 'challenge-1' }, error: null })
+    mockVerify.mockResolvedValueOnce({ error: null })
+
+    const user = userEvent.setup()
+    render(<MfaChallengePage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('認証アプリの確認コード')).toBeInTheDocument()
+    })
+    await user.type(screen.getByLabelText('認証アプリの確認コード'), '123456')
+    await user.click(screen.getByRole('button', { name: '確認する' }))
+
+    await waitFor(() => {
+      expect(mockVerify).toHaveBeenCalledWith({
+        factorId: 'factor-1',
+        challengeId: 'challenge-1',
+        code: '123456',
+      })
+    })
+    expect(mockPush).toHaveBeenCalledWith('/')
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('コードが誤っている場合エラーメッセージが表示される', async () => {
+    mockGetAAL.mockResolvedValueOnce({
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      error: null,
+    })
+    mockListFactors.mockResolvedValueOnce({
+      data: { totp: [{ id: 'factor-1', status: 'verified' }] },
+      error: null,
+    })
+    mockChallenge.mockResolvedValueOnce({ data: { id: 'challenge-1' }, error: null })
+    mockVerify.mockResolvedValueOnce({ error: new Error('invalid code') })
+
+    const user = userEvent.setup()
+    render(<MfaChallengePage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('認証アプリの確認コード')).toBeInTheDocument()
+    })
+    await user.type(screen.getByLabelText('認証アプリの確認コード'), '000000')
+    await user.click(screen.getByRole('button', { name: '確認する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('コードが正しくありません。もう一度お試しください。')).toBeInTheDocument()
+    })
+    expect(mockPush).not.toHaveBeenCalledWith('/')
+  })
+})

--- a/src/app/mfa-challenge/page.tsx
+++ b/src/app/mfa-challenge/page.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useState, FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { createSupabaseBrowserClient } from '@/lib/supabase/client'
+
+export default function MfaChallengePage() {
+  const router = useRouter()
+  const [factorId, setFactorId] = useState<string | null>(null)
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function init() {
+      const supabase = createSupabaseBrowserClient()
+
+      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+      if (cancelled) return
+      if (aal && aal.currentLevel === aal.nextLevel) {
+        // 既にaal2達成済み(このページに来る必要がない)ならトップへ戻す
+        router.push('/')
+        return
+      }
+
+      const { data, error: listError } = await supabase.auth.mfa.listFactors()
+      if (cancelled) return
+      if (listError) {
+        setError('MFA情報の取得に失敗しました。')
+        setLoading(false)
+        return
+      }
+      const verified = data.totp.find(f => f.status === 'verified')
+      if (!verified) {
+        setError('有効な二段階認証が見つかりませんでした。')
+        setLoading(false)
+        return
+      }
+      setFactorId(verified.id)
+      setLoading(false)
+    }
+
+    init()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- マウント時に1回だけ実行する初期化処理
+  }, [])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!factorId) return
+    setSubmitting(true)
+    setError(null)
+
+    const supabase = createSupabaseBrowserClient()
+    const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
+      factorId,
+    })
+    if (challengeError || !challengeData) {
+      setSubmitting(false)
+      setError('確認コードの送信に失敗しました。')
+      return
+    }
+
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData.id,
+      code,
+    })
+
+    setSubmitting(false)
+    if (verifyError) {
+      setError('コードが正しくありません。もう一度お試しください。')
+      return
+    }
+
+    router.push('/')
+    router.refresh()
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: '#EDEADE' }}>
+      <div className="bg-white rounded-lg shadow p-8 max-w-md w-full">
+        <h1 className="text-2xl font-bold mb-6 text-center" style={{ color: '#072C2C' }}>
+          二段階認証
+        </h1>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading && <p className="text-sm text-gray-500 text-center">読み込み中...</p>}
+
+        {!loading && factorId && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="mfa-challenge-code" className="block text-sm font-medium text-gray-700 mb-1">
+                認証アプリの確認コード
+              </label>
+              <input
+                id="mfa-challenge-code"
+                type="text"
+                inputMode="numeric"
+                required
+                value={code}
+                onChange={e => setCode(e.target.value)}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-600"
+                placeholder="123456"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full py-2 px-4 rounded text-white text-sm font-medium transition-colors disabled:opacity-50"
+              style={{ backgroundColor: '#072C2C' }}
+            >
+              {submitting ? '検証中...' : '確認する'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/other/page.tsx
+++ b/src/app/other/page.tsx
@@ -25,6 +25,18 @@ export default function OtherPage() {
             カテゴリ管理
           </Link>
         </div>
+        <div className="px-6 py-4">
+          <p className="text-xs font-semibold uppercase tracking-widest mb-3" style={{ color: '#6B7280', fontFamily: 'var(--font-oswald), sans-serif' }}>
+            アカウント設定
+          </p>
+          <Link
+            href="/account/mfa"
+            className="inline-flex items-center gap-2 text-sm font-medium hover:underline"
+            style={{ color: '#072C2C' }}
+          >
+            二段階認証(MFA)
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,11 @@ import { resolveIsAdmin } from '@/lib/admin-status'
 
 const PUBLIC_PATHS = ['/login', '/auth/callback']
 
+// WHY: MFA(TOTP)を有効化したユーザーがaal1(パスワード/メールリンクのみ)の
+// セッションのまま保護ページへアクセスするのを防ぐ。nextLevelがaal2で
+// currentLevelと異なる間は/mfa-challenge以外へのアクセスを許さない。
+const MFA_CHALLENGE_PATH = '/mfa-challenge'
+
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request })
 
@@ -42,6 +47,14 @@ export async function middleware(request: NextRequest) {
   // 未認証ガード
   if (!user && !PUBLIC_PATHS.some(p => pathname.startsWith(p))) {
     return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  // MFAガード（aal1のまま保護ページへ進ませない）
+  if (user && pathname !== MFA_CHALLENGE_PATH) {
+    const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+    if (aal && aal.nextLevel === 'aal2' && aal.currentLevel !== aal.nextLevel) {
+      return NextResponse.redirect(new URL(MFA_CHALLENGE_PATH, request.url))
+    }
   }
 
   // admin ガード（middleware + 各 route で二重チェック）

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,3 +7,10 @@ project_id = "medical-inventory-vkumai"
 # localhostでアクセスするテストに認証が引き継がれない）
 site_url = "http://localhost:3000"
 additional_redirect_urls = ["http://localhost:3000", "http://localhost:3000/**"]
+
+# CLIデフォルトはTOTP MFAのenroll/verifyが無効。ローカルでMFA機能を検証できるよう有効化する。
+# 本番(Supabase Dashboard)側は別途手動でMFA(TOTP)を有効化する必要がある(このファイルの設定は
+# ローカル開発専用で本番には反映されない)。
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: Supabase学習ロードマップの「MFA」を実際に導入する。ユーザーが任意でTOTP認証アプリによる二段階認証を有効化できるようにする。
- 変更した範囲:
  - `src/app/account/mfa/page.tsx`（新規）: enroll→QRコード表示→確認コード検証→有効化、および解除(unenroll)のUI
  - `src/app/mfa-challenge/page.tsx`（新規）: ログイン後、aal1→aal2昇格が必要なユーザー向けの確認コード入力ページ
  - `src/middleware.ts`: 認証済みユーザーのAAL(Authenticator Assurance Level)をチェックし、aal2昇格が必要なら`/mfa-challenge`以外へのアクセスをリダイレクトする一段を追加
  - `src/app/other/page.tsx`: 「その他」ページに`/account/mfa`へのリンクを追加
  - `supabase/config.toml`: ローカルSupabaseはTOTP enroll/verifyがCLIデフォルトで無効なため、`[auth.mfa.totp]`で明示的に有効化
- 触っていない範囲: `is_facility_member`・`is_admin`等の既存認可ロジック、RLS、facility境界チェックには一切触れていない。MFAは認証強度(AAL)の追加レイヤーであり、認可(誰が何にアクセスできるか)とは別軸。

## 検証済み
- 実行したコマンド: `npm run typecheck` / `npm run lint` / `npm test`（全1340件通過、middlewareの新規テスト4件・MFAページのテスト10件を含む）。
- 確認した画面: ローカルSupabase（`supabase stop`→config.toml変更→`supabase start`で反映）に対して実際にブラウザで一通り検証した。
  1. Email OTPで新規ユーザーとしてログイン（Mailpit経由）
  2. `/account/mfa`でenrollしQRコード・シークレットキーを取得
  3. シークレットキーからPythonでRFC6238準拠のTOTPコードを計算し、実際に入力して有効化成功
  4. ログアウト→同じユーザーで再ログイン→middlewareが`/mfa-challenge`へ正しくリダイレクトすることを確認
  5. `/mfa-challenge`で再度TOTPコードを計算・入力し、verify成功→トップページへ遷移
  6. 保護ページ(`/facilities`)へ正常にアクセスできることを確認（aal2昇格後）
- 確認したDB/RLS: DBスキーマ変更なし。RLSポリシーへの影響なし。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外。MFAは認証強度の追加であり、facility境界のチェック(`is_facility_member`)は今回変更していないため、既存の他テナント拒否の挙動に影響しない。

## 既知の未対応
- 今回あえて対応しなかったこと:
  1. 本番Supabase Dashboard側でのTOTP MFA有効化設定。`supabase/config.toml`の変更はローカル開発専用で、本番環境には反映されない。
  2. MFAの強制（現状は任意でユーザーが自分で有効化する方式。特定ロール(admin等)への強制はスコープ外）
  3. リカバリーコード(backup codes)の発行・表示。認証アプリを紛失した場合の復旧手段は未実装
- 理由: 1は本番Supabase Dashboardの操作権限がClaude Codeには無いため。2・3は今回のハンズオンのスコープを絞るため意図的に対応しなかった。
- 次に触るなら見る場所: 本番で実際にMFAを使いたい場合は、まずSupabase Dashboard（本番プロジェクト）でMFA(TOTP)を有効化する必要がある。リカバリーコード未実装のため、認証アプリを紛失したユーザーのサポート手順（service_roleでの強制unenroll等）を運用ドキュメント化する必要がある。

## 後任AIへの注意
- この実装で壊してはいけない前提: `middleware.ts`のMFAガードは`pathname !== MFA_CHALLENGE_PATH`の場合のみ発火する。`/mfa-challenge`自体をこのチェック対象に含めると、MFA未完了ユーザーが永遠にリダイレクトループする。
- 似ているが別物の用語: 「AAL(Authenticator Assurance Level)」は認証の強度（aal1=単要素、aal2=二要素）を表す概念で、`is_admin`/`role`などの認可(RBAC)とは全く別軸。両者を混同した実装をしないこと。
- 勝手にリファクタしない場所: `middleware.test.ts`の`makeSupabaseClientWithAdminRpc`ヘルパーに`aal`引数を追加し、デフォルトを`{currentLevel:'aal1', nextLevel:'aal1'}`（MFA未要求）にした。既存の全admin guardテストがこのデフォルトに依存しているため、デフォルト値を変更すると既存テストが軒並み壊れる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)