### PR TITLE
feat: RBACにviewerロールを追加する(書き込み全般不可)

### DIFF
--- a/src/app/api/admin/user-facilities/__tests__/route.test.ts
+++ b/src/app/api/admin/user-facilities/__tests__/route.test.ts
@@ -68,6 +68,22 @@ describe('POST /api/admin/user-facilities', () => {
     )
   })
 
+  it('role=viewer で upsert して 200 を返す', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert })
+    mockUpsert.mockResolvedValue({ error: null })
+
+    const req = new NextRequest('http://localhost/api/admin/user-facilities', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'u1', facilityId: 'f1', role: 'viewer' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { user_id: 'u1', facility_id: 'f1', role: 'viewer' },
+      { onConflict: 'user_id,facility_id' }
+    )
+  })
+
   it('既存レコードの role を staff から admin に更新できる', async () => {
     mockFrom.mockReturnValue({ upsert: mockUpsert })
     mockUpsert.mockResolvedValue({ error: null })

--- a/src/app/api/admin/user-facilities/route.ts
+++ b/src/app/api/admin/user-facilities/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
   const user = await requireAdmin()
   if (!user) return apiError('権限がありません', 403)
 
-  let userId: string | undefined, facilityId: string | undefined, role: 'staff' | 'admin' | undefined
+  let userId: string | undefined, facilityId: string | undefined, role: 'staff' | 'admin' | 'viewer' | undefined
   try {
     const body = await request.json()
     userId = body.userId
@@ -17,8 +17,8 @@ export async function POST(request: NextRequest) {
     return apiError('リクエストが不正です', 400)
   }
   if (!userId || !facilityId) return apiError('userId と facilityId は必須です', 400)
-  if (role !== undefined && role !== 'staff' && role !== 'admin') {
-    return apiError("role は 'staff' か 'admin' のみ指定できます", 400)
+  if (role !== undefined && role !== 'staff' && role !== 'admin' && role !== 'viewer') {
+    return apiError("role は 'staff'・'admin'・'viewer' のいずれかのみ指定できます", 400)
   }
 
   const admin = createAdminSupabase()

--- a/supabase/__tests__/integration/rbac-viewer-role.integration.test.ts
+++ b/supabase/__tests__/integration/rbac-viewer-role.integration.test.ts
@@ -1,0 +1,162 @@
+// supabase/__tests__/integration/rbac-viewer-role.integration.test.ts
+// WHY: 20260805000001_add_viewer_role.sqlはuser_facilities.roleに'viewer'を追加し、
+//      「書き込み全般不可・閲覧のみ」という認可境界を新設した。RLSポリシー分割と
+//      発注系RPCの認可チェック変更(is_facility_member→is_facility_writer)を
+//      実DBで検証する。既存のRLS/IDOR統合テストはテナント境界(他施設)のみを
+//      検証しており、同一施設内のrole差分(staff/admin vs viewer)は未カバーだった。
+
+import { randomUUID } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+
+const TEST_USER_PASSWORD = 'rbac-viewer-role-test-0000'
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[rbac-viewer-role] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+async function createSignedInClient(
+  serviceClient: SupabaseClient,
+  facilityId: string,
+  role: 'staff' | 'admin' | 'viewer',
+  runId: string
+): Promise<SupabaseClient> {
+  const email = `rbac-viewer-role-${role}-${runId}@example.test`
+  const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+    email,
+    password: TEST_USER_PASSWORD,
+    email_confirm: true,
+  })
+  if (userError || !userData.user) {
+    throw new Error(`ユーザー作成失敗(${role}): ${userError?.message}`)
+  }
+
+  const { error: linkError } = await serviceClient
+    .from('user_facilities')
+    .insert({ user_id: userData.user.id, facility_id: facilityId, role })
+  if (linkError) {
+    throw new Error(`user_facilities作成失敗(${role}): ${linkError.message}`)
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  const client = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+  if (signInError) {
+    throw new Error(`サインイン失敗(${role}): ${signInError.message}`)
+  }
+  return client
+}
+
+describe('viewerロールは書き込み不可・閲覧のみ(issue: RBAC拡張)', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+
+  let facilityId: string
+  let viewerClient: SupabaseClient
+  let staffClient: SupabaseClient
+  let viewerUserId: string
+  let staffUserId: string
+
+  beforeAll(async () => {
+    const { data: facility, error: facilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-RBAC-${runId}` })
+      .select('id')
+      .single()
+    if (facilityError || !facility) {
+      throw new Error(`施設作成失敗: ${facilityError?.message}`)
+    }
+    facilityId = facility.id as string
+
+    viewerClient = await createSignedInClient(serviceClient, facilityId, 'viewer', runId)
+    staffClient = await createSignedInClient(serviceClient, facilityId, 'staff', runId)
+
+    const { data: viewerUser } = await serviceClient.auth.admin.listUsers()
+    viewerUserId = viewerUser.users.find((u) => u.email?.startsWith('rbac-viewer-role-viewer'))!.id
+    staffUserId = viewerUser.users.find((u) => u.email?.startsWith('rbac-viewer-role-staff'))!.id
+  }, 60_000)
+
+  afterAll(async () => {
+    await serviceClient.auth.admin.deleteUser(viewerUserId)
+    await serviceClient.auth.admin.deleteUser(staffUserId)
+    await serviceClient.from('facilities').delete().eq('id', facilityId)
+  })
+
+  it('viewerはSELECTできる(consumables)', async () => {
+    const { error } = await viewerClient.from('consumables').select('id').eq('facility_id', facilityId)
+    expect(error).toBeNull()
+  })
+
+  it('viewerはconsumablesへのINSERTがRLSで拒否される', async () => {
+    const { error } = await viewerClient
+      .from('consumables')
+      .insert({ facility_id: facilityId, name: 'viewer-insert-test', purpose: 'テスト' })
+    expect(error).not.toBeNull()
+  })
+
+  it('viewerはcreate_case_order_atomic RPCがforbiddenで拒否される', async () => {
+    const { error } = await viewerClient.rpc('create_case_order_atomic', {
+      p_facility_id: facilityId,
+      p_case_datetime: new Date().toISOString(),
+      p_procedure_name: 'viewerテスト術式',
+      p_patient_id: 'PT-VIEWER',
+      p_patient_initials: 'V.V.',
+      p_gender: 'other',
+      p_doctor_name: 'viewerテスト医師',
+      p_items: [],
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+
+  it('viewerはcreate_loan_order_atomic RPCがforbiddenで拒否される', async () => {
+    const { error } = await viewerClient.rpc('create_loan_order_atomic', {
+      p_facility_id: facilityId,
+      p_procedure_name: 'viewerテスト術式',
+      p_maker: 'viewerテストメーカー',
+      p_items: [],
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+
+  it('viewerはcreate_consumable_order_atomic RPCがforbiddenで拒否される', async () => {
+    const { error } = await viewerClient.rpc('create_consumable_order_atomic', {
+      p_facility_id: facilityId,
+      p_items: [],
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('forbidden')
+  })
+
+  it('staffは同じ施設でconsumablesへのINSERTが成功する(回帰確認)', async () => {
+    const { error } = await staffClient
+      .from('consumables')
+      .insert({ facility_id: facilityId, name: 'staff-insert-test', purpose: 'テスト' })
+    expect(error).toBeNull()
+  })
+
+  it('staffは同じ施設でcreate_loan_order_atomic RPCが成功する(回帰確認)', async () => {
+    const { error } = await staffClient.rpc('create_loan_order_atomic', {
+      p_facility_id: facilityId,
+      p_procedure_name: 'staffテスト術式',
+      p_maker: 'staffテストメーカー',
+      p_items: [],
+    })
+    expect(error).toBeNull()
+  })
+})

--- a/supabase/migrations/20260805000001_add_viewer_role.sql
+++ b/supabase/migrations/20260805000001_add_viewer_role.sql
@@ -1,0 +1,362 @@
+-- supabase/migrations/20260805000001_add_viewer_role.sql
+-- WHY: RBAC拡張のハンズオン。user_facilities.roleに'viewer'を追加し、
+--      「書き込み全般不可・閲覧のみ」というシンプルな定義で運用する
+--      （施設ごとの細かい操作単位での権限分けはしない）。
+--      is_admin()はrole='admin'の等価比較のみで判定しているため、
+--      viewer追加によるis_admin()自体のロジック変更は不要。
+
+-- =========================================================================
+-- 1. role CHECK制約にviewerを追加
+-- =========================================================================
+ALTER TABLE user_facilities DROP CONSTRAINT user_facilities_role_check;
+ALTER TABLE user_facilities
+  ADD CONSTRAINT user_facilities_role_check
+  CHECK (role IN ('staff', 'admin', 'viewer'));
+
+-- =========================================================================
+-- 2. is_facility_writer() ヘルパー関数
+--    is_facility_member()と同じ施設所属チェックに加え、role='viewer'では
+--    falseを返す。is_admin()は別途ORで組み合わせて使う(既存のfacility_
+--    member_or_adminパターンと同じ構成)。
+-- =========================================================================
+CREATE OR REPLACE FUNCTION is_facility_writer(p_facility_id UUID)
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM user_facilities
+    WHERE user_id = auth.uid() AND facility_id = p_facility_id AND role IN ('staff', 'admin')
+  );
+$$;
+
+-- =========================================================================
+-- 3. RLS: FOR ALLだった書き込み系ポリシーをSELECT(member)とALL(writer)に分割
+--    SELECTポリシーとALLポリシーは permissive(OR結合) のため、
+--    SELECT時は member_or_admin(=旧来通り) OR writer_or_admin の合成となり
+--    実質member_or_adminのまま。INSERT/UPDATE/DELETEはALLポリシーのみが
+--    マッチするため writer_or_admin に限定される。
+-- =========================================================================
+DROP POLICY IF EXISTS "facility_member_or_admin" ON consumable_orders;
+CREATE POLICY "facility_member_or_admin" ON consumable_orders
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON consumable_orders
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON case_orders;
+CREATE POLICY "facility_member_or_admin" ON case_orders
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON case_orders
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON loan_orders;
+CREATE POLICY "facility_member_or_admin" ON loan_orders
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON loan_orders
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON loan_returns;
+CREATE POLICY "facility_member_or_admin" ON loan_returns
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON loan_returns
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON hospital_prices;
+CREATE POLICY "facility_member_or_admin" ON hospital_prices
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON hospital_prices
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON consumables;
+CREATE POLICY "facility_member_or_admin" ON consumables
+  FOR SELECT TO authenticated
+  USING (is_facility_member(facility_id) OR is_admin());
+CREATE POLICY "facility_writer_or_admin" ON consumables
+  FOR ALL TO authenticated
+  USING (is_facility_writer(facility_id) OR is_admin())
+  WITH CHECK (is_facility_writer(facility_id) OR is_admin());
+
+-- facilities（UPDATEのみwriter化。SELECT/INSERTは既存のまま）
+DROP POLICY IF EXISTS "facility_member_or_admin_update" ON facilities;
+CREATE POLICY "facility_writer_or_admin_update" ON facilities
+  FOR UPDATE TO authenticated
+  USING (is_facility_writer(id) OR is_admin())
+  WITH CHECK (is_facility_writer(id) OR is_admin());
+
+-- items テーブル（親order経由。同じSELECT/ALL分割パターン）
+DROP POLICY IF EXISTS "facility_member_or_admin" ON case_order_items;
+CREATE POLICY "facility_member_or_admin" ON case_order_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM case_orders o
+    WHERE o.id = case_order_items.case_order_id
+      AND (is_facility_member(o.facility_id) OR is_admin())
+  ));
+CREATE POLICY "facility_writer_or_admin" ON case_order_items
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM case_orders o
+    WHERE o.id = case_order_items.case_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM case_orders o
+    WHERE o.id = case_order_items.case_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ));
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON consumable_order_items;
+CREATE POLICY "facility_member_or_admin" ON consumable_order_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM consumable_orders o
+    WHERE o.id = consumable_order_items.consumable_order_id
+      AND (is_facility_member(o.facility_id) OR is_admin())
+  ));
+CREATE POLICY "facility_writer_or_admin" ON consumable_order_items
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM consumable_orders o
+    WHERE o.id = consumable_order_items.consumable_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM consumable_orders o
+    WHERE o.id = consumable_order_items.consumable_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ));
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON loan_order_items;
+CREATE POLICY "facility_member_or_admin" ON loan_order_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM loan_orders o
+    WHERE o.id = loan_order_items.loan_order_id
+      AND (is_facility_member(o.facility_id) OR is_admin())
+  ));
+CREATE POLICY "facility_writer_or_admin" ON loan_order_items
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM loan_orders o
+    WHERE o.id = loan_order_items.loan_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM loan_orders o
+    WHERE o.id = loan_order_items.loan_order_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ));
+
+DROP POLICY IF EXISTS "facility_member_or_admin" ON loan_return_items;
+CREATE POLICY "facility_member_or_admin" ON loan_return_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM loan_returns o
+    WHERE o.id = loan_return_items.loan_return_id
+      AND (is_facility_member(o.facility_id) OR is_admin())
+  ));
+CREATE POLICY "facility_writer_or_admin" ON loan_return_items
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM loan_returns o
+    WHERE o.id = loan_return_items.loan_return_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM loan_returns o
+    WHERE o.id = loan_return_items.loan_return_id
+      AND (is_facility_writer(o.facility_id) OR is_admin())
+  ));
+
+-- =========================================================================
+-- 4. 発注/返却系RPCの認可チェックをis_facility_memberからis_facility_writer
+--    へ変更する。既存migrationは追記・修正禁止のため、CREATE OR REPLACE
+--    FUNCTIONで再定義する(列・ロジックは変更しない、認可チェックのみ変更)。
+--    resolve_jan_unit_priceは読み取り専用ヘルパーのため対象外。
+-- =========================================================================
+CREATE OR REPLACE FUNCTION create_case_order_atomic(
+  p_facility_id UUID,
+  p_case_datetime TIMESTAMPTZ,
+  p_procedure_name TEXT,
+  p_patient_id TEXT,
+  p_patient_initials TEXT,
+  p_gender TEXT,
+  p_doctor_name TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.case_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.case_orders (
+    facility_id, case_datetime, procedure_name,
+    patient_id, patient_initials, gender, doctor_name
+  ) VALUES (
+    p_facility_id, p_case_datetime, p_procedure_name,
+    p_patient_id, p_patient_initials, p_gender, p_doctor_name
+  )
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.case_order_items i
+  WHERE i.case_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_loan_order_atomic(
+  p_facility_id UUID,
+  p_procedure_name TEXT,
+  p_maker TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.loan_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.loan_orders (facility_id, procedure_name, maker)
+  VALUES (p_facility_id, p_procedure_name, p_maker)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.loan_order_items (loan_order_id, jan, name, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'name',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.loan_order_items i
+  WHERE i.loan_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_consumable_order_atomic(
+  p_facility_id UUID,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.consumable_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO public.consumable_orders (facility_id)
+  VALUES (p_facility_id)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)
+  SELECT
+    v_order.id,
+    (elem->>'consumable_id')::UUID,
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    (
+      SELECT public.resolve_jan_unit_price(c.jan, p_facility_id)
+      FROM public.consumables c
+      WHERE c.id = (elem->>'consumable_id')::UUID
+    )
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.consumable_order_items i
+  WHERE i.consumable_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_loan_return_atomic(
+  p_header JSONB,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_facility_id UUID := (p_header->>'facility_id')::UUID;
+  v_loan_order_id UUID := NULLIF(p_header->>'loan_order_id', '')::UUID;
+  v_return loan_returns%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT is_facility_writer(v_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+
+  INSERT INTO loan_returns (facility_id, return_datetime, loan_order_id)
+  VALUES (v_facility_id, (p_header->>'return_datetime')::TIMESTAMPTZ, v_loan_order_id)
+  RETURNING * INTO v_return;
+
+  INSERT INTO loan_return_items (loan_return_id, jan, lot, ubd, quantity)
+  SELECT
+    v_return.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM loan_return_items i
+  WHERE i.loan_return_id = v_return.id;
+
+  RETURN to_jsonb(v_return) || jsonb_build_object('items', v_items);
+END;
+$$;

--- a/supabase/migrations/__tests__/add_viewer_role.test.ts
+++ b/supabase/migrations/__tests__/add_viewer_role.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無い実行環境でも回帰を検知できるよう、生成したSQL
+//      マイグレーションの中身を静的に検証する。実DB上の動作確認は別途
+//      統合テスト(rbac-viewer-role.integration.test.ts)で行う。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_viewer_role.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_viewer_role.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('user_facilities.roleのCHECK制約にviewerを追加する', () => {
+    expect(n).toContain('alter table user_facilities drop constraint user_facilities_role_check')
+    expect(n).toContain("check (role in ('staff', 'admin', 'viewer'))")
+  })
+
+  it('is_facility_writer()ヘルパー関数を定義する(role staff/adminのみtrue)', () => {
+    expect(n).toContain('create or replace function is_facility_writer(p_facility_id uuid)')
+    expect(n).toContain("and role in ('staff', 'admin')")
+  })
+
+  it('書き込み系RLSポリシーをSELECT(member_or_admin)とALL(writer_or_admin)に分割する', () => {
+    const tables = [
+      'consumable_orders',
+      'case_orders',
+      'loan_orders',
+      'loan_returns',
+      'hospital_prices',
+      'consumables',
+    ]
+    for (const t of tables) {
+      expect(n).toContain(`drop policy if exists "facility_member_or_admin" on ${t}`)
+      expect(n).toContain(`create policy "facility_member_or_admin" on ${t} for select to authenticated using (is_facility_member(facility_id) or is_admin())`)
+      expect(n).toContain(`create policy "facility_writer_or_admin" on ${t} for all to authenticated using (is_facility_writer(facility_id) or is_admin()) with check (is_facility_writer(facility_id) or is_admin())`)
+    }
+  })
+
+  it('facilitiesのUPDATEポリシーをwriter基準に変更する', () => {
+    expect(n).toContain('drop policy if exists "facility_member_or_admin_update" on facilities')
+    expect(n).toContain('create policy "facility_writer_or_admin_update" on facilities for update to authenticated using (is_facility_writer(id) or is_admin()) with check (is_facility_writer(id) or is_admin())')
+  })
+
+  it('itemsテーブル(親order経由)もSELECT/ALLに分割する', () => {
+    const itemTables = [
+      { table: 'case_order_items', parent: 'case_orders', fk: 'case_order_id' },
+      { table: 'consumable_order_items', parent: 'consumable_orders', fk: 'consumable_order_id' },
+      { table: 'loan_order_items', parent: 'loan_orders', fk: 'loan_order_id' },
+      { table: 'loan_return_items', parent: 'loan_returns', fk: 'loan_return_id' },
+    ]
+    for (const { table, fk } of itemTables) {
+      expect(n).toContain(`create policy "facility_writer_or_admin" on ${table}`)
+      expect(n).toContain(`where o.id = ${table}.${fk}`)
+    }
+  })
+
+  it('発注/返却系4RPCがis_facility_writerで認可チェックする(is_facility_memberは残さない)', () => {
+    const occurrences = n.match(/if not (public\.)?is_facility_writer\(/g) ?? []
+    expect(occurrences.length).toBe(4)
+    expect(n).not.toMatch(/if not (public\.)?is_facility_member\(/)
+  })
+
+  it('resolve_jan_unit_priceは書き込みチェック対象外(再定義しない)', () => {
+    expect(n).not.toContain('create or replace function resolve_jan_unit_price(')
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: Supabase学習ロードマップの「RBAC拡張」を実際に導入する。`user_facilities.role`に`viewer`を追加し、「閲覧のみ・書き込み全般不可」という認可境界を新設する。
- 変更した範囲:
  - `supabase/migrations/20260805000001_add_viewer_role.sql`: `user_facilities.role`のCHECK制約に`viewer`追加、`is_facility_writer()`ヘルパー関数新設、書き込み系RLSポリシー（6テーブル+items4テーブル+facilitiesのUPDATE）をSELECT/ALLの2ポリシーに分割、発注/返却系4RPC（`create_case_order_atomic`/`create_loan_order_atomic`/`create_consumable_order_atomic`/`create_loan_return_atomic`）の認可チェックを`is_facility_member`→`is_facility_writer`に変更
  - `src/app/api/admin/user-facilities/route.ts`: role受け入れ値に`viewer`を追加
- 触っていない範囲: `owner`ロールは追加していない（対応する専用機能＝組織設定・ユーザー招待UIが無いため今回は見送り、事前にユーザーと合意済み）。「発注はOKだが在庫更新はNG」のような操作単位の細分化もしていない（viewerは書き込み全般不可というシンプルな定義、事前合意済み）。`is_admin()`のロジック自体は変更していない（role='admin'の等価比較のみで、viewer追加の影響を受けない）。

## 検証済み
- 実行したコマンド: `npm run typecheck` / `npm run lint` / `npm test`（全1350件通過）。`supabase db push --local`でマイグレーション適用。`npx vitest run --config vitest.integration.config.ts`（全8ファイル32件、新規RBAC統合テスト7件を含む）。
- 確認した画面: 対象外（DB層・APIルートのみの変更、UI変更なし）。
- 確認したDB/RLS: ローカルSupabaseで実際にviewer/staffユーザーを作成し、以下を実DBで確認した。
  1. viewerは`consumables`をSELECTできる
  2. viewerは`consumables`への直接INSERTがRLSで拒否される
  3. viewerは発注系3RPC（case/loan/consumable）が`forbidden`で拒否される
  4. staff（回帰確認）は同じ施設で`consumables`への書き込み・`create_loan_order_atomic`が引き続き成功する
- 他テナントのIDでアクセスし、弾かれることを確認したか: 既存のテナント境界（他施設）チェックは今回変更していないため対象外。代わりに「同一施設内でのrole差分（viewer vs staff）」という新しい認可軸を実DBで検証した（上記参照）。

## 既知の未対応
- 今回あえて対応しなかったこと:
  1. `owner`ロールの追加
  2. viewerロールを実際にUIから割り当てる管理画面（既存の`/api/admin/user-facilities`はAPIのみでUIは無い。役割変更UI自体がこのリポジトリに元々存在しない）
  3. `price_histories`テーブルはSELECT専用ポリシーのみで元々書き込みRLSが無いため対象外とした
- 理由: 1・2はスコープを絞る事前合意（ユーザーとの相談）に基づく。3は既存仕様のまま。
- 次に触るなら見る場所: `owner`ロールを将来追加する場合は、対応する組織設定・ユーザー招待機能を先に設計する必要がある。role割り当てUIが必要になった場合は`/api/admin/user-facilities`を叩く管理画面を別途作る。

## 後任AIへの注意
- この実装で壊してはいけない前提: RLSの「SELECT(member_or_admin) + ALL(writer_or_admin)」という2ポリシー構成は、permissiveポリシーのOR結合に依存している。SELECT用ポリシーを消すとwriterでない一般memberがSELECTできなくなり、ALL用ポリシーをFOR SELECTに変えると書き込みが誰にもできなくなる。両方揃って初めて意図通りに動く。
- 似ているが別物の用語: `is_facility_member`（施設所属のみ、role問わず）と`is_facility_writer`（施設所属かつrole IN staff/admin）を混同しないこと。新しいRLSポリシーやRPCを書く際、読み取り専用なら前者、書き込みを伴うなら後者を使う。
- 勝手にリファクタしない場所: 発注系4RPCの`search_path`設定は`create_case_order_atomic`等3つは`''`（完全修飾、PR #584由来）、`create_loan_return_atomic`は`public`のまま（未着手）と意図的に混在している。今回はauthorizationチェックの変更のみに絞り、search_path統一は別スコープとして触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)