### PR TITLE
feat: Custom Access Token HookでJWTにuser_roleクレームを埋め込む

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ e2e/.auth/*.json
 
 # AIDD Run Manifest（フロー実行ごとに生成される一時状態。スキーマはdocs/agents/run-manifest.md参照）
 /.aidd/
+
+# Supabase Studio SQL EditorがローカルDB調査時に自動保存するスニペット（デバッグ用・ローカル専用）
+/supabase/snippets/

--- a/supabase/__tests__/integration/custom-access-token-hook.integration.test.ts
+++ b/supabase/__tests__/integration/custom-access-token-hook.integration.test.ts
@@ -1,0 +1,125 @@
+// supabase/__tests__/integration/custom-access-token-hook.integration.test.ts
+// WHY: 20260805000002_add_custom_access_token_hook.sqlで追加したCustom Access
+//      Token Hookが、実際にSupabase Authのトークン発行時に呼ばれ、user_facilities
+//      のroleを集約した`user_role`クレームがJWTに正しく埋め込まれることを実DBで
+//      検証する。hook関数はSECURITY DEFINERを使わずsupabase_auth_adminへの
+//      明示的GRANTのみで動くため、権限設定が正しいかもここで実質的に確認する
+//      (GRANT漏れがあればトークン発行自体が失敗するかclaimが欠落する)。
+
+import { randomUUID } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+
+const TEST_USER_PASSWORD = 'custom-access-token-hook-test-0000'
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[custom-access-token-hook] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+function decodeJwtClaims(accessToken: string): Record<string, unknown> {
+  const payload = accessToken.split('.')[1]
+  const json = Buffer.from(payload, 'base64url').toString('utf-8')
+  return JSON.parse(json)
+}
+
+async function signUpAndAssignRole(
+  serviceClient: SupabaseClient,
+  facilityId: string,
+  role: 'staff' | 'admin' | 'viewer' | null,
+  runId: string
+): Promise<SupabaseClient> {
+  const roleLabel = role ?? 'none'
+  const email = `custom-claim-${roleLabel}-${runId}@example.test`
+  const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+    email,
+    password: TEST_USER_PASSWORD,
+    email_confirm: true,
+  })
+  if (userError || !userData.user) {
+    throw new Error(`ユーザー作成失敗(${roleLabel}): ${userError?.message}`)
+  }
+
+  if (role !== null) {
+    const { error: linkError } = await serviceClient
+      .from('user_facilities')
+      .insert({ user_id: userData.user.id, facility_id: facilityId, role })
+    if (linkError) {
+      throw new Error(`user_facilities作成失敗(${roleLabel}): ${linkError.message}`)
+    }
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  const client = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+  if (signInError) {
+    throw new Error(`サインイン失敗(${roleLabel}): ${signInError.message}`)
+  }
+  return client
+}
+
+describe('custom_access_token_hook: JWTにuser_roleクレームが埋め込まれる', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+
+  let facilityId: string
+  const createdUserIds: string[] = []
+
+  beforeAll(async () => {
+    const { data: facility, error: facilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-JWTクレーム-${runId}` })
+      .select('id')
+      .single()
+    if (facilityError || !facility) {
+      throw new Error(`施設作成失敗: ${facilityError?.message}`)
+    }
+    facilityId = facility.id as string
+  }, 60_000)
+
+  afterAll(async () => {
+    for (const id of createdUserIds) {
+      await serviceClient.auth.admin.deleteUser(id)
+    }
+    await serviceClient.from('facilities').delete().eq('id', facilityId)
+  })
+
+  it.each([
+    ['admin', 'admin'],
+    ['staff', 'staff'],
+    ['viewer', 'viewer'],
+  ] as const)('role=%sのユーザーはJWTのuser_roleクレームが%sになる', async (role, expected) => {
+    const client = await signUpAndAssignRole(serviceClient, facilityId, role, runId)
+    const { data: userResult } = await client.auth.getUser()
+    createdUserIds.push(userResult.user!.id)
+
+    const { data: sessionData } = await client.auth.getSession()
+    const claims = decodeJwtClaims(sessionData.session!.access_token)
+
+    expect(claims.user_role).toBe(expected)
+  })
+
+  it('どの施設にも所属しないユーザーはuser_roleクレームがnullになる', async () => {
+    const client = await signUpAndAssignRole(serviceClient, facilityId, null, runId)
+    const { data: userResult } = await client.auth.getUser()
+    createdUserIds.push(userResult.user!.id)
+
+    const { data: sessionData } = await client.auth.getSession()
+    const claims = decodeJwtClaims(sessionData.session!.access_token)
+
+    expect(claims.user_role).toBeNull()
+  })
+})

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -14,3 +14,10 @@ additional_redirect_urls = ["http://localhost:3000", "http://localhost:3000/**"]
 [auth.mfa.totp]
 enroll_enabled = true
 verify_enabled = true
+
+# custom_access_token_hook(20260805000002マイグレーション)をローカルで有効化する。
+# 本番(Supabase Dashboard > Authentication > Hooks)側は別途手動設定が必要
+# (このファイルの設定はローカル開発専用で本番には反映されない)。
+[auth.hook.custom_access_token]
+enabled = true
+uri = "pg-functions://postgres/public/custom_access_token_hook"

--- a/supabase/migrations/20260805000002_add_custom_access_token_hook.sql
+++ b/supabase/migrations/20260805000002_add_custom_access_token_hook.sql
@@ -1,0 +1,65 @@
+-- supabase/migrations/20260805000002_add_custom_access_token_hook.sql
+-- WHY: Supabase学習ロードマップの「JWT Custom Claims / Custom Access Token Hook」の
+--      ハンズオン。user_facilitiesのroleを集約した`user_role`クレームをJWTへ
+--      埋め込む。これにより、クライアント側でセッションのJWTをデコードするだけで
+--      「グローバルにどのroleを持っているか」が分かるようになり、都度RPCへ
+--      問い合わせなくて済む場面を作れる。
+--
+-- WHY(既存middleware.tsのadmin判定には反映しない): admin判定は現状
+--      resolveIsAdmin()(DB role + ADMIN_EMAILSフォールバックの二重登録防止ロジック)
+--      に依存しており、このフォールバックとDB roleの乖離自体が別issue(#567
+--      「管理者判定のtruthをDB roleへ統一する」)として追跡中。このhookの追加を
+--      理由にmiddleware側の実装を差し替えると、#567の論点を素通りして
+--      セキュリティ境界を変えることになるため、今回はhookとclaimの追加のみに
+--      とどめ、実際の認可判定の切り替えは行わない。
+--
+-- WHY(SECURITY DEFINERが必要な理由・実機検証で判明): user_facilitiesのRLSポリシー
+--      "self_read"はTO authenticatedのみが対象で、supabase_auth_adminにはSELECT権限
+--      をGRANTしてもRLSが対象ロール外として全行を隠してしまう(supabase_auth_admin
+--      はrolbypassrls=false)。SECURITY DEFINERなしで実装し実際にログインさせたところ
+--      GoTrueから"output claims do not conform to the expected schema: (root):
+--      Invalid type. Expected: object, given: null"という500エラーになることを確認した。
+--      SECURITY DEFINERにして関数所有者(postgres、テーブルオーナーのためRLSをバイパス)
+--      として実行させることで解消する。呼び出し可能なロールをsupabase_auth_adminのみに
+--      REVOKE/GRANTで厳格に絞っているため、SECURITY DEFINERによる権限昇格の範囲は
+--      「auth hookとしてのみ・claims生成目的のみ」に限定される
+--      (docs/agents/known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの
+--      認可バイパス」に該当する誤用ではない。任意の認証ユーザーからは実行不可)。
+--
+-- WHY(coalesce(to_jsonb(v_role), 'null'::jsonb)が必要な理由・実機検証で判明):
+--      to_jsonb(NULL::text)はJSON null('null'::jsonb)ではなくSQL NULLを返す。
+--      jsonb_setはSTRICT関数のため、new_value引数にSQL NULLを渡すと関数全体がNULLを
+--      返し、eventがまるごとNULLになる(施設未所属でv_roleがNULLになるケースで発生、
+--      実機で発見。COALESCEでJSON null literalに変換してから渡す)。
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := (event->>'user_id')::UUID;
+  v_role TEXT;
+BEGIN
+  SELECT
+    CASE
+      WHEN bool_or(role = 'admin') THEN 'admin'
+      WHEN bool_or(role = 'staff') THEN 'staff'
+      WHEN bool_or(role = 'viewer') THEN 'viewer'
+      ELSE NULL
+    END
+  INTO v_role
+  FROM public.user_facilities
+  WHERE user_id = v_user_id;
+
+  event := jsonb_set(event, '{claims,user_role}', COALESCE(to_jsonb(v_role), 'null'::jsonb));
+
+  RETURN event;
+END;
+$$;
+
+GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook TO supabase_auth_admin;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook FROM authenticated, anon, PUBLIC;

--- a/supabase/migrations/__tests__/add_custom_access_token_hook.test.ts
+++ b/supabase/migrations/__tests__/add_custom_access_token_hook.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無い実行環境でも回帰を検知できるよう、生成したSQL
+//      マイグレーションの中身を静的に検証する。実DB上の動作確認は別途
+//      統合テスト(custom-access-token-hook.integration.test.ts)で行う。
+//      このテストは特にSECURITY DEFINERとCOALESCEの2点を固定する
+//      (実機検証で判明した回帰しやすいポイント。docs/agents参照)。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_custom_access_token_hook.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_custom_access_token_hook.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('custom_access_token_hook関数を定義する', () => {
+    expect(n).toContain('create or replace function public.custom_access_token_hook(event jsonb)')
+  })
+
+  it('SECURITY DEFINERである(supabase_auth_adminはuser_facilitiesのRLS対象外のため必須)', () => {
+    expect(n).toContain('security definer')
+  })
+
+  it('to_jsonb(v_role)をCOALESCEでJSON null化してからjsonb_setに渡す(STRICT関数のNULL伝播対策)', () => {
+    expect(n).toContain("coalesce(to_jsonb(v_role), 'null'::jsonb)")
+  })
+
+  it('role集約ロジックがadmin > staff > viewerの優先順位で判定する', () => {
+    expect(n).toContain("when bool_or(role = 'admin') then 'admin'")
+    expect(n).toContain("when bool_or(role = 'staff') then 'staff'")
+    expect(n).toContain("when bool_or(role = 'viewer') then 'viewer'")
+  })
+
+  it('supabase_auth_adminにのみEXECUTE権限を付与し、authenticated/anon/PUBLICからは剥奪する', () => {
+    expect(n).toContain('grant execute on function public.custom_access_token_hook to supabase_auth_admin')
+    expect(n).toContain('revoke execute on function public.custom_access_token_hook from authenticated, anon, public')
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: Supabase学習ロードマップの最終項目「JWT Custom Claims / Custom Access Token Hook」を実際に導入する。`user_facilities`のroleを集約した`user_role`クレームをJWTへ埋め込む。
- 変更した範囲: 新規`supabase/migrations/20260805000002_add_custom_access_token_hook.sql`（`custom_access_token_hook`関数、`supabase_auth_admin`への限定GRANT）。`supabase/config.toml`にローカル用hook登録（`[auth.hook.custom_access_token]`）。
- 触っていない範囲: `middleware.ts`の既存admin判定（`resolveIsAdmin`、ADMIN_EMAILSフォールバック）には一切反映していない。このフォールバックとDB roleの乖離は別issue #567として追跡中の論点であり、今回のhook追加を理由に素通りで認可ロジックを差し替えることはしなかった（事前にユーザーへ説明済み）。

## 検証済み
- 実行したコマンド: `npm run typecheck` / `npm run lint` / `npm test`（全1357件通過）。`supabase db reset --local`で全マイグレーションを最初から適用。`npx vitest run --config vitest.integration.config.ts`（全9ファイル36件、新規JWTクレーム統合テスト4件を含む）。
- 確認した画面: 対象外（DB層のみの変更、UI変更なし）。
- 確認したDB/RLS: ローカルSupabaseで実際にadmin/staff/viewer/施設未所属の4パターンのユーザーを作成し、`/auth/v1/token`でサインインしてJWTをデコードし、`user_role`クレームが正しい値（`"admin"`/`"staff"`/`"viewer"`/`null`）になることを確認した。
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外。このhookは認証トークンへのクレーム埋め込みのみで、認可ロジック（RLS/`is_facility_member`）は変更していない。

## 実機検証で発見した2つの非自明なバグ（重要）
1. **SECURITY DEFINERが必須**: `user_facilities`のRLSポリシー`self_read`は`TO authenticated`のみが対象で、hookの実行ロール`supabase_auth_admin`は`rolbypassrls=false`のため、`SELECT`権限をGRANTしてもRLSに全行を隠される。`SECURITY DEFINER`なしで実装し実際にログインさせたところ、GoTrueが`"output claims do not conform to the expected schema: (root): Invalid type. Expected: object, given: null"`という500エラーを返すことを確認した。呼び出し可能ロールを`supabase_auth_admin`のみに`REVOKE`/`GRANT`で厳格に絞っているため、この用途での`SECURITY DEFINER`は許容範囲と判断した。
2. **`to_jsonb(NULL::text)`は SQL NULL を返す**（JSON null `'null'::jsonb`ではない）。`jsonb_set`はSTRICT関数のため、`new_value`引数にSQL NULLを渡すと関数全体がNULLを返し、施設未所属ユーザーのログインが失敗していた。`COALESCE(to_jsonb(v_role), 'null'::jsonb)`で修正した。

いずれも静的レビューでは発見できず、ローカルSupabaseで実際にログインを試行して初めて判明した。

## 既知の未対応
- 今回あえて対応しなかったこと: 本番Supabase Dashboard（Authentication > Hooks）側でのCustom Access Token Hook有効化。`supabase/config.toml`の設定はローカル開発専用で本番には反映されない。middleware.tsのadmin判定をこのJWTクレームに置き換えること（issue #567が解決してから検討すべき別スコープ）。
- 理由: 前者はDashboard操作権限がClaude Codeには無いため。後者はセキュリティ境界に関わる別判断のため意図的にスコープ外にした。
- 次に触るなら見る場所: issue #567が解決し、admin判定のtruthをDB roleへ統一する方針が決まった場合、このJWTクレーム（`user_role`）をmiddleware.tsでのRPC往復削減に活用できる可能性がある。ただしその際も「JWTクレームは発行時点のスナップショットであり、ロール変更が即座に反映されない（リフレッシュまでタイムラグがある）」という特性を踏まえた設計が必要。

## 後任AIへの注意
- この実装で壊してはいけない前提: `custom_access_token_hook`は`supabase_auth_admin`のみが呼び出せる（`authenticated`/`anon`/`PUBLIC`からは`REVOKE`済み）。誤って一般ユーザーに`EXECUTE`権限を戻さないこと（`user_facilities`の全ユーザー分のroleを誰でも問い合わせ可能になってしまう）。
- 似ているが別物の用語: `to_jsonb(NULL)`（SQL NULLを返す）と`'null'::jsonb`（JSON null literal）は別物。この関数以外で同様のNULL処理を書く場合も同じ罠に注意すること。
- 勝手にリファクタしない場所: `middleware.ts`のadmin判定ロジック。このPRのJWTクレームを使って書き換えたくなるかもしれないが、issue #567（ADMIN_EMAILSフォールバックとDB roleの乖離）が未解決のまま置き換えると、既存の認可境界を意図せず変える可能性がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)