### PR TITLE
fix: create_loan_return_atomicのsearch_pathを空文字に硬化する

### DIFF
--- a/supabase/migrations/20260805000001_add_viewer_role.sql
+++ b/supabase/migrations/20260805000001_add_viewer_role.sql
@@ -327,23 +327,23 @@ CREATE OR REPLACE FUNCTION create_loan_return_atomic(
 RETURNS JSONB
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public
+SET search_path = ''
 AS $$
 DECLARE
   v_facility_id UUID := (p_header->>'facility_id')::UUID;
   v_loan_order_id UUID := NULLIF(p_header->>'loan_order_id', '')::UUID;
-  v_return loan_returns%ROWTYPE;
+  v_return public.loan_returns%ROWTYPE;
   v_items JSONB;
 BEGIN
-  IF NOT is_facility_writer(v_facility_id) THEN
+  IF NOT public.is_facility_writer(v_facility_id) THEN
     RAISE EXCEPTION 'forbidden: not a member of this facility';
   END IF;
 
-  INSERT INTO loan_returns (facility_id, return_datetime, loan_order_id)
+  INSERT INTO public.loan_returns (facility_id, return_datetime, loan_order_id)
   VALUES (v_facility_id, (p_header->>'return_datetime')::TIMESTAMPTZ, v_loan_order_id)
   RETURNING * INTO v_return;
 
-  INSERT INTO loan_return_items (loan_return_id, jan, lot, ubd, quantity)
+  INSERT INTO public.loan_return_items (loan_return_id, jan, lot, ubd, quantity)
   SELECT
     v_return.id,
     elem->>'jan',
@@ -354,7 +354,7 @@ BEGIN
 
   SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
   INTO v_items
-  FROM loan_return_items i
+  FROM public.loan_return_items i
   WHERE i.loan_return_id = v_return.id;
 
   RETURN to_jsonb(v_return) || jsonb_build_object('items', v_items);

--- a/supabase/migrations/__tests__/add_viewer_role.test.ts
+++ b/supabase/migrations/__tests__/add_viewer_role.test.ts
@@ -87,6 +87,20 @@ describe('*_add_viewer_role.sql', () => {
     expect(n).not.toContain('create or replace function resolve_jan_unit_price(')
   })
 
+  it('create_loan_return_atomicがsearch_pathを空文字に固定し、テーブル参照をpublic.で完全修飾する(search_path hijacking対策)', () => {
+    const startIdx = n.indexOf('create or replace function create_loan_return_atomic(')
+    expect(startIdx).toBeGreaterThanOrEqual(0)
+    const fnBody = n.slice(startIdx)
+
+    expect(fnBody).toContain('set search_path = \'\'')
+    expect(fnBody).not.toContain('set search_path = public')
+    expect(fnBody).toContain('v_return public.loan_returns%rowtype')
+    expect(fnBody).toContain('if not public.is_facility_writer(v_facility_id) then')
+    expect(fnBody).toContain('insert into public.loan_returns (facility_id, return_datetime, loan_order_id)')
+    expect(fnBody).toContain('insert into public.loan_return_items (loan_return_id, jan, lot, ubd, quantity)')
+    expect(fnBody).toContain('from public.loan_return_items i')
+  })
+
   it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
     expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
   })


### PR DESCRIPTION
## 作業サマリ
issue #611 で指摘された、`create_loan_return_atomic` RPC関数のsearch_path硬化漏れを修正した。

他の3つの発注RPC(create_case_order_atomic, create_loan_order_atomic, create_consumable_order_atomic)は#20260804000001_harden_order_rpc_search_path.sqlで `SET search_path = ''` + `public.` 完全修飾に硬化済みだったが、`create_loan_return_atomic` のみ#601のviewer対応(20260805000001_add_viewer_role.sql)で再定義された際に `SET search_path = public` のまま取り残されていた(search_path hijacking対策の抜け穴)。

変更内容:
- `SET search_path = public` → `SET search_path = ''`
- 関数内のテーブル参照(`loan_returns%ROWTYPE`, `is_facility_writer(...)`, `INSERT INTO loan_returns`, `INSERT INTO loan_return_items`, `FROM loan_return_items`)を `public.` で完全修飾
- 認可チェック(`is_facility_writer`呼び出し)のロジック自体は変更なし

## 検証済み
- `npx vitest run supabase/migrations/__tests__/add_viewer_role.test.ts` — 新規追加した検証ケース含め10件全てパス
- `npx vitest run supabase/migrations/__tests__/harden_order_rpc_search_path.test.ts supabase/migrations/__tests__/add_loan_order_id_to_loan_return_atomic_rpc.test.ts` — 既存の関連テスト15件、回帰なし
- `npm run lint` — 今回の変更に起因するエラー・警告なし(既存の無関係な警告2件のみ)

Closes #611