### PR TITLE
fix: MFA未確認factorの残留と管理画面のviewerロール誤表示を修正する

### DIFF
--- a/src/app/account/mfa/__tests__/page.test.tsx
+++ b/src/app/account/mfa/__tests__/page.test.tsx
@@ -53,7 +53,8 @@ describe('MfaSettingsPage', () => {
   })
 
   it('有効化ボタンをクリックするとenrollが呼ばれQRコードが表示される', async () => {
-    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null }) // 初期表示用
+    mockListFactors.mockResolvedValueOnce({ data: { all: [] }, error: null }) // enroll前のunverified掃除用
     mockEnroll.mockResolvedValueOnce({
       data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
       error: null,
@@ -74,7 +75,8 @@ describe('MfaSettingsPage', () => {
   })
 
   it('確認コードを入力してverifyが成功すると有効状態に切り替わる', async () => {
-    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null }) // 初期表示用
+    mockListFactors.mockResolvedValueOnce({ data: { all: [] }, error: null }) // enroll前のunverified掃除用
     mockEnroll.mockResolvedValueOnce({
       data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
       error: null,
@@ -107,7 +109,8 @@ describe('MfaSettingsPage', () => {
   })
 
   it('確認コードが誤っている場合エラーメッセージが表示される', async () => {
-    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null })
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null }) // 初期表示用
+    mockListFactors.mockResolvedValueOnce({ data: { all: [] }, error: null }) // enroll前のunverified掃除用
     mockEnroll.mockResolvedValueOnce({
       data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
       error: null,
@@ -132,6 +135,33 @@ describe('MfaSettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('コードが正しくありません。もう一度お試しください。')).toBeInTheDocument()
     })
+  })
+
+  it('登録途中離脱でunverified factorが残っている場合、再度有効化ボタンを押すとunenrollで掃除してからenrollする', async () => {
+    mockListFactors.mockResolvedValueOnce({ data: { totp: [] }, error: null }) // 初期表示用
+    mockListFactors.mockResolvedValueOnce({
+      data: { all: [{ id: 'orphan-factor', factor_type: 'totp', status: 'unverified' }] },
+      error: null,
+    }) // enroll前のunverified掃除用
+    mockUnenroll.mockResolvedValueOnce({ error: null })
+    mockEnroll.mockResolvedValueOnce({
+      data: { id: 'new-factor', totp: { qr_code: 'data:image/svg+xml;base64,xxx', secret: 'SECRET123' } },
+      error: null,
+    })
+
+    const user = userEvent.setup()
+    render(<MfaSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '二段階認証を有効化する' })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: '二段階認証を有効化する' }))
+
+    await waitFor(() => {
+      expect(screen.getByAltText('MFA QRコード')).toBeInTheDocument()
+    })
+    expect(mockUnenroll).toHaveBeenCalledWith({ factorId: 'orphan-factor' })
+    expect(mockEnroll).toHaveBeenCalled()
   })
 
   it('解除ボタンをクリックするとunenrollが呼ばれ未登録状態に戻る', async () => {

--- a/src/app/account/mfa/page.tsx
+++ b/src/app/account/mfa/page.tsx
@@ -41,6 +41,22 @@ export default function MfaSettingsPage() {
   async function handleEnroll() {
     setError(null)
     const supabase = createSupabaseBrowserClient()
+
+    // WHY: enroll()は未確認(unverified)factorが残っていても新規factorを作れてしまい、
+    // 登録を途中離脱するたびにunverified factorが積み上がる。再度有効化を試みる前に
+    // 既存のunverified factorを掃除してから新規enrollする。
+    const { data: existingFactors, error: listError } = await supabase.auth.mfa.listFactors()
+    if (listError) {
+      setError('MFA設定の取得に失敗しました。')
+      return
+    }
+    // WHY: data.totpは型上verifiedのfactorのみ(SDKの型定義上の制約)。unverifiedを含む
+    // 全factorはdata.allから取得する必要がある。
+    const unverified = existingFactors.all.filter(f => f.factor_type === 'totp' && f.status === 'unverified')
+    for (const factor of unverified) {
+      await supabase.auth.mfa.unenroll({ factorId: factor.id })
+    }
+
     const { data, error: enrollError } = await supabase.auth.mfa.enroll({ factorType: 'totp' })
     if (enrollError || !data) {
       setError('MFAの登録開始に失敗しました。')

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -72,7 +72,7 @@ export default function AdminUsersPage() {
     }
   }
 
-  const handleChangeRole = async (userId: string, facilityId: string, role: 'admin' | 'staff') => {
+  const handleChangeRole = async (userId: string, facilityId: string, role: 'admin' | 'staff' | 'viewer') => {
     try {
       const res = await fetch('/api/admin/user-facilities', {
         method: 'POST',

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -24,10 +24,10 @@ export async function GET() {
   if (facilityError) return apiError(toClientErrorMessage(facilityError, 'ユーザー一覧の取得に失敗しました'))
 
   // Group by user_id in memory
-  const facilityMap = new Map<string, { id: string; role: 'admin' | 'staff' }[]>()
+  const facilityMap = new Map<string, { id: string; role: 'admin' | 'staff' | 'viewer' }[]>()
   for (const row of (facilityRows ?? [])) {
     const list = facilityMap.get(row.user_id) ?? []
-    list.push({ id: row.facility_id, role: asEnum(row.role, ['admin', 'staff'] as const, 'staff') })
+    list.push({ id: row.facility_id, role: asEnum(row.role, ['admin', 'staff', 'viewer'] as const, 'staff') })
     facilityMap.set(row.user_id, list)
   }
 

--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -8,7 +8,7 @@ type Props = {
   facilities: Facility[]
   onToggleFacility: (userId: string, facilityId: string, add: boolean) => void
   onDeleteUser: (userId: string, email: string) => void
-  onChangeRole: (userId: string, facilityId: string, role: 'admin' | 'staff') => void
+  onChangeRole: (userId: string, facilityId: string, role: 'admin' | 'staff' | 'viewer') => void
 }
 
 export function UserTable({ users, facilities, onToggleFacility, onDeleteUser, onChangeRole }: Props) {
@@ -77,12 +77,13 @@ export function UserTable({ users, facilities, onToggleFacility, onDeleteUser, o
                               aria-label={`${f.name}のrole`}
                               value={assigned.role}
                               onChange={(e) =>
-                                onChangeRole(user.id, f.id, e.target.value as 'admin' | 'staff')
+                                onChangeRole(user.id, f.id, e.target.value as 'admin' | 'staff' | 'viewer')
                               }
                               className="text-xs border rounded px-1"
                             >
                               <option value="staff">staff</option>
                               <option value="admin">admin</option>
+                              <option value="viewer">viewer</option>
                             </select>
                           )}
                         </div>

--- a/src/components/admin/__tests__/UserTable.test.tsx
+++ b/src/components/admin/__tests__/UserTable.test.tsx
@@ -124,4 +124,32 @@ describe('UserTable', () => {
     fireEvent.change(select, { target: { value: 'admin' } })
     expect(onChangeRole).toHaveBeenCalledWith('u1', 'f1', 'admin')
   })
+
+  it('viewerロールが正しく選択表示され、viewerへの変更もonChangeRoleに伝わる', () => {
+    const viewerUsers: AdminUser[] = [
+      {
+        id: 'u2',
+        email: 'viewer@test.com',
+        lastSignInAt: null,
+        facilities: [{ id: 'f1', role: 'viewer' }],
+      },
+    ]
+    const onChangeRole = vi.fn()
+    render(
+      <UserTable
+        users={viewerUsers}
+        facilities={facilities}
+        onToggleFacility={vi.fn()}
+        onDeleteUser={vi.fn()}
+        onChangeRole={onChangeRole}
+      />
+    )
+    fireEvent.click(screen.getByText('▼ 展開して設定'))
+    const select = screen.getByLabelText('中央病院のrole') as HTMLSelectElement
+    // viewerロールのユーザーがstaffとして誤表示されない(issue #609)
+    expect(select.value).toBe('viewer')
+
+    fireEvent.change(select, { target: { value: 'viewer' } })
+    expect(onChangeRole).toHaveBeenCalledWith('u2', 'f1', 'viewer')
+  })
 })

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -2,7 +2,7 @@ export type AdminUser = {
   id: string
   email: string
   lastSignInAt: string | null
-  facilities: { id: string; role: 'admin' | 'staff' }[]
+  facilities: { id: string; role: 'admin' | 'staff' | 'viewer' }[]
 }
 
 // facility.ts の Facility はフルフィールド（createdAt/updatedAt含む）を持つため、


### PR DESCRIPTION
## 作業サマリ
issue #609 で指摘された、認証・RBAC設計評価(#599-#602)由来の小粒な指摘2件を修正した。

1. MFA登録フローのunverified factor残留: src/app/account/mfa/page.tsx の handleEnroll は、登録を途中離脱して再度有効化ボタンを押すたびに新規factorを作り続けてしまい、unverifiedなfactorが積み上がる問題があった。enroll前に listFactors() で既存のunverified TOTPファクターを検出し、unenroll で掃除してから新規enrollするよう変更した。
   - 実装時にSDKの型上の落とし穴を発見: listFactors() が返す data.totp は型定義上verifiedのfactorのみに固定されており、unverifiedなfactorを含まない。そのため data.all から factor_type と status を絞り込んで検出するよう実装した。

2. 管理画面でviewerロールがstaffと誤表示される: #601 でviewerロールを追加した後も src/app/api/admin/users/route.ts の asEnum が admin と staff のみを許可リストに含めており、viewerを未知の値としてデフォルトの staff にフォールバックしていた。型定義(src/types/admin.ts)・API・UserTable.tsx のroleセレクトボックス(選択肢にviewerを追加)・admin/users/page.tsx の handleChangeRole 型を一貫して viewer を含む3値に拡張した。
   - user-facilities API(src/app/api/admin/user-facilities/route.ts)は既にviewerを受け付ける実装だったため変更不要。

## 検証済み
- npx vitest run src/app/account/mfa/__tests__/page.test.tsx — unverified factor掃除の新規テスト含め7件全てパス
- npx vitest run src/components/admin/__tests__/UserTable.test.tsx src/app/admin/users/__tests__/page.test.tsx — viewerロール表示・変更の新規テスト含め全てパス
- npx tsc --noEmit -p tsconfig.json — 型エラーなし(SDKの型定義の落とし穴を修正時に検出・対応済み)
- npm test — 全1359件パス(179ファイル)、既存機能への回帰なし
- npm run lint — 今回の変更に起因するエラー・警告なし(既存の無関係な警告2件のみ)

Closes #609