### PR TITLE
feat: 発注・返却RPCにaal2(MFA完了)要求を追加する

### DIFF
--- a/supabase/__tests__/integration/require-aal2-for-order-rpcs.integration.test.ts
+++ b/supabase/__tests__/integration/require-aal2-for-order-rpcs.integration.test.ts
@@ -1,0 +1,188 @@
+// supabase/__tests__/integration/require-aal2-for-order-rpcs.integration.test.ts
+// WHY: issue #612。発注RPCにaal2要求を追加した(20260806000001_require_aal2_for_order_rpcs.sql)。
+//      「MFA未登録ユーザーは影響を受けない」だけでなく、本来の目的である「MFA登録済み
+//      だがaal1のセッションは拒否され、aal2まで昇格したセッションは成功する」を、
+//      実際のTOTP enroll→challenge→verifyフローで検証する。
+//      TOTPコードはRFC 6238に基づきNode組み込みcryptoのみで生成し、新規npm依存
+//      (otpauth等)を追加しない。
+
+import { randomUUID, createHmac } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+
+const TEST_USER_PASSWORD = 'require-aal2-order-rpcs-test-0000'
+
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  const clean = input.toUpperCase().replace(/=+$/, '')
+  let bits = ''
+  for (const char of clean) {
+    const val = alphabet.indexOf(char)
+    if (val === -1) throw new Error(`invalid base32 character: ${char}`)
+    bits += val.toString(2).padStart(5, '0')
+  }
+  const bytes: number[] = []
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2))
+  }
+  return Buffer.from(bytes)
+}
+
+// RFC 6238 (TOTP) / RFC 4226 (HOTP) 準拠。30秒ステップ・6桁・SHA1。
+function generateTotp(secretBase32: string): string {
+  const key = base32Decode(secretBase32)
+  const counter = Math.floor(Date.now() / 1000 / 30)
+  const counterBuffer = Buffer.alloc(8)
+  counterBuffer.writeBigUInt64BE(BigInt(counter))
+  const hmac = createHmac('sha1', key).update(counterBuffer).digest()
+  const offset = hmac[hmac.length - 1] & 0xf
+  const binCode =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff)
+  return (binCode % 1_000_000).toString().padStart(6, '0')
+}
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[require-aal2-for-order-rpcs] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+function createAnonClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+describe('発注RPCはMFA登録済みユーザーのaal2昇格を要求する(issue #612)', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+  const email = `require-aal2-${runId}@example.test`
+
+  let facilityId: string
+  let userId: string
+  let factorId: string
+  let secret: string
+
+  beforeAll(async () => {
+    const { data: facility, error: facilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-AAL2-${runId}` })
+      .select('id')
+      .single()
+    if (facilityError || !facility) throw new Error(`施設作成失敗: ${facilityError?.message}`)
+    facilityId = facility.id as string
+
+    const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+      email,
+      password: TEST_USER_PASSWORD,
+      email_confirm: true,
+    })
+    if (userError || !userData.user) throw new Error(`ユーザー作成失敗: ${userError?.message}`)
+    userId = userData.user.id
+
+    const { error: linkError } = await serviceClient
+      .from('user_facilities')
+      .insert({ user_id: userId, facility_id: facilityId, role: 'staff' })
+    if (linkError) throw new Error(`user_facilities作成失敗: ${linkError.message}`)
+  }, 60_000)
+
+  afterAll(async () => {
+    await serviceClient.auth.admin.deleteUser(userId)
+    await serviceClient.from('facilities').delete().eq('id', facilityId)
+  })
+
+  it('MFA未登録・aal1のセッションでは発注RPCが成功する(既存ユーザーへの回帰なし)', async () => {
+    const client = createAnonClient()
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    expect(signInError).toBeNull()
+
+    const { error } = await client.rpc('create_loan_order_atomic', {
+      p_facility_id: facilityId,
+      p_procedure_name: 'aal2テスト術式(MFA未登録)',
+      p_maker: 'テストメーカー',
+      p_items: [],
+    })
+    expect(error).toBeNull()
+  })
+
+  it('TOTP factorをenroll・verifyできる(以降のテストの前提)', async () => {
+    const client = createAnonClient()
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    expect(signInError).toBeNull()
+
+    const { data: enrollData, error: enrollError } = await client.auth.mfa.enroll({ factorType: 'totp' })
+    expect(enrollError).toBeNull()
+    expect(enrollData).not.toBeNull()
+    factorId = enrollData!.id
+    secret = enrollData!.totp.secret
+
+    const { data: challengeData, error: challengeError } = await client.auth.mfa.challenge({ factorId })
+    expect(challengeError).toBeNull()
+
+    const { error: verifyError } = await client.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData!.id,
+      code: generateTotp(secret),
+    })
+    expect(verifyError).toBeNull()
+  }, 30_000)
+
+  it('MFA登録済みだがaal1のセッションでは発注RPCがforbidden(aal2 required)で拒否される', async () => {
+    // パスワードのみの再サインインは、factorが検証済みでも新規セッションはaal1から始まる
+    // (src/middleware.tsのnextLevel判定と同じ挙動)
+    const client = createAnonClient()
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    expect(signInError).toBeNull()
+
+    const { data: aal } = await client.auth.mfa.getAuthenticatorAssuranceLevel()
+    expect(aal?.currentLevel).toBe('aal1')
+    expect(aal?.nextLevel).toBe('aal2')
+
+    const { error } = await client.rpc('create_loan_order_atomic', {
+      p_facility_id: facilityId,
+      p_procedure_name: 'aal2テスト術式(aal1で拒否)',
+      p_maker: 'テストメーカー',
+      p_items: [],
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('aal2')
+  })
+
+  it('MFA登録済みでaal2まで昇格したセッションでは発注RPCが成功する', async () => {
+    const client = createAnonClient()
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    expect(signInError).toBeNull()
+
+    const { data: challengeData, error: challengeError } = await client.auth.mfa.challenge({ factorId })
+    expect(challengeError).toBeNull()
+
+    const { error: verifyError } = await client.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData!.id,
+      code: generateTotp(secret),
+    })
+    expect(verifyError).toBeNull()
+
+    const { error } = await client.rpc('create_loan_order_atomic', {
+      p_facility_id: facilityId,
+      p_procedure_name: 'aal2テスト術式(aal2で成功)',
+      p_maker: 'テストメーカー',
+      p_items: [],
+    })
+    expect(error).toBeNull()
+  })
+})

--- a/supabase/migrations/20260806000001_require_aal2_for_order_rpcs.sql
+++ b/supabase/migrations/20260806000001_require_aal2_for_order_rpcs.sql
@@ -1,0 +1,224 @@
+-- supabase/migrations/20260806000001_require_aal2_for_order_rpcs.sql
+-- WHY: #600でTOTP MFAを追加したが、aal2への昇格強制はsrc/middleware.tsのみで
+--      行っており、RLS/RPC側はAALを一切見ていなかった(issue #612)。
+--      SupabaseのanonキーとプロジェクトURLはブラウザに公開されており、ログイン
+--      済みユーザーは自分のアクセストークンを使ってNext.jsアプリを経由せず直接
+--      SupabaseのREST/RPCエンドポイントを呼び出せる。つまりmiddlewareは正規ルートの
+--      UX誘導であり、DB層(RLS/RPC)こそが唯一の実効的なセキュリティ境界となる。
+--      発注・返却は在庫変動と金額を伴う操作のため、aal1のまま(MFA未完了)で
+--      直接叩かれても実行できないようDB側で独立に強制する。
+--      対象は発注・返却の4RPCのみ(閲覧系・軽微な更新系は対象外。将来の要否は
+--      都度個別に判断する)。
+
+-- WHY: MFAは#600でオプトイン機能として実装されている(有効化ボタンを押した
+--      ユーザーのみ登録)。auth.jwt()->>'aal'を無条件でaal2要求にすると、
+--      MFAを一度も有効化していないユーザーは検証済みfactorが存在せず永久に
+--      aal2へ到達できないため、全員が発注できなくなってしまう。
+--      src/middleware.tsのnextLevel判定(検証済みfactorがある場合のみaal2昇格を
+--      要求する)と同じロジックをDB側でも再現し、「MFA登録済みユーザーが
+--      aal1のまま」の場合のみ拒否する。auth.mfa_factorsはauthenticatedロールに
+--      直接SELECT権限が無いためSECURITY DEFINERで読む。
+CREATE OR REPLACE FUNCTION has_aal2()
+RETURNS BOOLEAN LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_mfa_enrolled BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM auth.mfa_factors
+    WHERE user_id = auth.uid() AND factor_type = 'totp' AND status = 'verified'
+  ) INTO v_mfa_enrolled;
+
+  IF NOT v_mfa_enrolled THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN COALESCE(auth.jwt() ->> 'aal', '') = 'aal2';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_case_order_atomic(
+  p_facility_id UUID,
+  p_case_datetime TIMESTAMPTZ,
+  p_procedure_name TEXT,
+  p_patient_id TEXT,
+  p_patient_initials TEXT,
+  p_gender TEXT,
+  p_doctor_name TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.case_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+  IF NOT public.has_aal2() THEN
+    RAISE EXCEPTION 'forbidden: aal2 required';
+  END IF;
+
+  INSERT INTO public.case_orders (
+    facility_id, case_datetime, procedure_name,
+    patient_id, patient_initials, gender, doctor_name
+  ) VALUES (
+    p_facility_id, p_case_datetime, p_procedure_name,
+    p_patient_id, p_patient_initials, p_gender, p_doctor_name
+  )
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.case_order_items (case_order_id, jan, lot, ubd, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.case_order_items i
+  WHERE i.case_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_loan_order_atomic(
+  p_facility_id UUID,
+  p_procedure_name TEXT,
+  p_maker TEXT,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.loan_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+  IF NOT public.has_aal2() THEN
+    RAISE EXCEPTION 'forbidden: aal2 required';
+  END IF;
+
+  INSERT INTO public.loan_orders (facility_id, procedure_name, maker)
+  VALUES (p_facility_id, p_procedure_name, p_maker)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.loan_order_items (loan_order_id, jan, name, quantity, unit_price)
+  SELECT
+    v_order.id,
+    elem->>'jan',
+    elem->>'name',
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    public.resolve_jan_unit_price(elem->>'jan', p_facility_id)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.loan_order_items i
+  WHERE i.loan_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_consumable_order_atomic(
+  p_facility_id UUID,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_order public.consumable_orders%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(p_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+  IF NOT public.has_aal2() THEN
+    RAISE EXCEPTION 'forbidden: aal2 required';
+  END IF;
+
+  INSERT INTO public.consumable_orders (facility_id)
+  VALUES (p_facility_id)
+  RETURNING * INTO v_order;
+
+  INSERT INTO public.consumable_order_items (consumable_order_id, consumable_id, quantity, unit_price)
+  SELECT
+    v_order.id,
+    (elem->>'consumable_id')::UUID,
+    COALESCE((elem->>'quantity')::INTEGER, 1),
+    (
+      SELECT public.resolve_jan_unit_price(c.jan, p_facility_id)
+      FROM public.consumables c
+      WHERE c.id = (elem->>'consumable_id')::UUID
+    )
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.consumable_order_items i
+  WHERE i.consumable_order_id = v_order.id;
+
+  RETURN to_jsonb(v_order) || jsonb_build_object('items', v_items);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_loan_return_atomic(
+  p_header JSONB,
+  p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_facility_id UUID := (p_header->>'facility_id')::UUID;
+  v_loan_order_id UUID := NULLIF(p_header->>'loan_order_id', '')::UUID;
+  v_return public.loan_returns%ROWTYPE;
+  v_items JSONB;
+BEGIN
+  IF NOT public.is_facility_writer(v_facility_id) THEN
+    RAISE EXCEPTION 'forbidden: not a member of this facility';
+  END IF;
+  IF NOT public.has_aal2() THEN
+    RAISE EXCEPTION 'forbidden: aal2 required';
+  END IF;
+
+  INSERT INTO public.loan_returns (facility_id, return_datetime, loan_order_id)
+  VALUES (v_facility_id, (p_header->>'return_datetime')::TIMESTAMPTZ, v_loan_order_id)
+  RETURNING * INTO v_return;
+
+  INSERT INTO public.loan_return_items (loan_return_id, jan, lot, ubd, quantity)
+  SELECT
+    v_return.id,
+    elem->>'jan',
+    elem->>'lot',
+    elem->>'ubd',
+    COALESCE((elem->>'quantity')::INTEGER, 1)
+  FROM jsonb_array_elements(COALESCE(p_items, '[]'::JSONB)) AS elem;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(i) ORDER BY i.created_at), '[]'::JSONB)
+  INTO v_items
+  FROM public.loan_return_items i
+  WHERE i.loan_return_id = v_return.id;
+
+  RETURN to_jsonb(v_return) || jsonb_build_object('items', v_items);
+END;
+$$;

--- a/supabase/migrations/__tests__/require_aal2_for_order_rpcs.test.ts
+++ b/supabase/migrations/__tests__/require_aal2_for_order_rpcs.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無い実行環境でも回帰を検知できるよう、生成したSQL
+//      マイグレーションの中身を静的に検証する。実DB上の動作確認は別途
+//      ローカルSupabaseへのdb push + RPC呼び出しで行う（このテストの対象外）。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_require_aal2_for_order_rpcs.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_require_aal2_for_order_rpcs.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('has_aal2()ヘルパー関数を定義する(MFA未登録ユーザーはaal1のまま許可し、登録済みユーザーのみaal2を要求する)', () => {
+    expect(n).toContain('create or replace function has_aal2()')
+    expect(n).toContain('security definer')
+    // MFA未登録(検証済みtotp factorが存在しない)なら常にtrueを返す
+    expect(n).toContain('from auth.mfa_factors')
+    expect(n).toContain("where user_id = auth.uid() and factor_type = 'totp' and status = 'verified'")
+    expect(n).toContain('if not v_mfa_enrolled then')
+    expect(n).toContain('return true')
+    // MFA登録済みの場合のみ実際のaalクレームを検証する
+    expect(n).toContain("return coalesce(auth.jwt() ->> 'aal', '') = 'aal2'")
+  })
+
+  it('既存migrationを追記せず、CREATE OR REPLACE FUNCTIONで発注/返却4RPCを再定義する', () => {
+    expect(n).toContain('create or replace function create_case_order_atomic(')
+    expect(n).toContain('create or replace function create_loan_order_atomic(')
+    expect(n).toContain('create or replace function create_consumable_order_atomic(')
+    expect(n).toContain('create or replace function create_loan_return_atomic(')
+  })
+
+  it('発注/返却4RPCすべてがhas_aal2()チェックを追加している', () => {
+    const occurrences = n.match(/if not public\.has_aal2\(\) then/g) ?? []
+    expect(occurrences.length).toBe(4)
+  })
+
+  it('is_facility_writerチェックを維持している(施設境界チェックの退行防止)', () => {
+    const occurrences = n.match(/if not public\.is_facility_writer\(/g) ?? []
+    expect(occurrences.length).toBe(4)
+  })
+
+  it('aal2チェックはfacility_writerチェックの後に来る(施設非所属者にもaal2要求メッセージを誤って先出ししない)', () => {
+    const caseOrderIdx = n.indexOf('create or replace function create_case_order_atomic(')
+    const body = n.slice(caseOrderIdx)
+    const writerIdx = body.indexOf('if not public.is_facility_writer(')
+    const aalIdx = body.indexOf('if not public.has_aal2() then')
+    expect(writerIdx).toBeGreaterThanOrEqual(0)
+    expect(aalIdx).toBeGreaterThan(writerIdx)
+  })
+
+  it('search_pathはすべて空文字で完全修飾を維持している(search_path hijacking対策の退行防止)', () => {
+    const occurrences = n.match(/set search_path = ''/g) ?? []
+    // has_aal2 + 発注/返却4RPC = 5関数
+    expect(occurrences.length).toBe(5)
+    expect(n).not.toContain('set search_path = public')
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
issue #612 で判断した方針(発注・在庫変動を伴う書き込みRPCのみ対象、middlewareのaal2強制をDB層でも独立に担保する)に基づき実装した。

背景: #600でTOTP MFAを追加したが、aal2への昇格強制はsrc/middleware.tsのみで行っておりRLS/RPC側はAALを一切見ていなかった。SupabaseのanonキーとプロジェクトURLはブラウザに公開されており、ログイン済みユーザーは自分のアクセストークンを使ってNext.jsアプリを経由せず直接SupabaseのRPCエンドポイントを呼び出せる。つまりmiddlewareは正規ルートのUX誘導であり、DB層(RLS/RPC)こそが唯一の実効的なセキュリティ境界となる。

変更内容:
- has_aal2()ヘルパー関数を追加。MFA未登録(検証済みTOTP factorが存在しない)ユーザーには常にtrueを返し、MFA登録済みユーザーのみ実際のauth.jwt()のaalクレームを検証する。これはsrc/middleware.tsのnextLevel判定(検証済みfactorがある場合のみaal2昇格を要求する)と同じロジックで、MFAをまだ有効化していないユーザーの発注を誤ってブロックしないための設計。
- 発注・在庫変動を伴う4RPC(create_case_order_atomic / create_loan_order_atomic / create_consumable_order_atomic / create_loan_return_atomic)にhas_aal2()チェックを追加。既存のis_facility_writerチェックは維持。
- 閲覧系・軽微な更新系は対象外(全RPC一律にすると将来の軽微な操作にまでaal2要求が波及しUXを不必要に壊すリスクがあるため)。
- エラーメッセージは既存のforbiddenパターンを踏襲(RLS/RPCは最終防衛ラインのため、親切な誘導文言は追加しない。誘導は既にmiddleware側の正規ルートで行われている)。

## 検証済み
- `npx vitest run supabase/migrations/__tests__/require_aal2_for_order_rpcs.test.ts` — SQL構造の静的テスト8件パス
- `supabase db push --local` — ローカルPostgresへの適用成功(構文エラーなし)
- 実際のTOTP enroll→challenge→verifyフローを実行する統合テスト(`supabase/__tests__/integration/require-aal2-for-order-rpcs.integration.test.ts`)で以下の3パターンを実測:
  - MFA未登録・aal1のセッションでは発注RPCが成功する(既存ユーザーへの回帰なし)
  - MFA登録済みだがaal1のセッションでは発注RPCがforbidden(aal2 required)で拒否される
  - MFA登録済みでaal2まで昇格したセッションでは発注RPCが成功する
  - TOTPコード生成はRFC 6238に基づきNode組み込みcryptoのみで実装し、新規npm依存(otpauth等)は追加していない(package.json/package-lock.jsonの差分なしを確認済み)
- `npm run test:integration` — 既存の統合テスト10ファイル40件、回帰なし
- `npm test` — 全1368件パス(180ファイル)
- `npm run lint` / `npx tsc --noEmit` — エラーなし(既存の無関係な警告2件のみ)

Closes #612