### PR TITLE
feat: viewerロールのUIゲーティングを実装する

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/app/api/facilities/[id]/my-role/__tests__/route.test.ts
+++ b/src/app/api/facilities/[id]/my-role/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '../route'
+
+const mockGetUser = vi.fn()
+const mockResolveIsAdmin = vi.fn()
+const mockGetUserFacilityRole = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/admin-status', () => ({
+  resolveIsAdmin: (...args: unknown[]) => mockResolveIsAdmin(...args),
+}))
+
+vi.mock('@/lib/user-facilities/repository', () => ({
+  getUserFacilityRole: (...args: unknown[]) => mockGetUserFacilityRole(...args),
+}))
+
+const context = { params: Promise.resolve({ id: 'f1' }) }
+const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
+const authenticated = () => mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'u1@test.com' } }, error: null })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResolveIsAdmin.mockResolvedValue(false)
+})
+
+describe('GET /api/facilities/[id]/my-role', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const res = await GET(new Request('http://localhost') as never, context)
+    expect(res.status).toBe(401)
+    expect(mockGetUserFacilityRole).not.toHaveBeenCalled()
+  })
+
+  it('adminの場合はuser_facilitiesを問い合わせずadminを返す(施設に行がなくても全施設を操作できるため)', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(true)
+    const res = await GET(new Request('http://localhost') as never, context)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ role: 'admin' })
+    expect(mockGetUserFacilityRole).not.toHaveBeenCalled()
+  })
+
+  it('staffの場合はstaffを返す', async () => {
+    authenticated()
+    mockGetUserFacilityRole.mockResolvedValue('staff')
+    const res = await GET(new Request('http://localhost') as never, context)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ role: 'staff' })
+  })
+
+  it('viewerの場合はviewerを返す(issue #608)', async () => {
+    authenticated()
+    mockGetUserFacilityRole.mockResolvedValue('viewer')
+    const res = await GET(new Request('http://localhost') as never, context)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ role: 'viewer' })
+  })
+
+  it('未所属の場合はnullを返す', async () => {
+    authenticated()
+    mockGetUserFacilityRole.mockResolvedValue(null)
+    const res = await GET(new Request('http://localhost') as never, context)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ role: null })
+  })
+})

--- a/src/app/api/facilities/[id]/my-role/route.ts
+++ b/src/app/api/facilities/[id]/my-role/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/supabase/require-auth'
+import { resolveIsAdmin } from '@/lib/admin-status'
+import { getUserFacilityRole } from '@/lib/user-facilities/repository'
+import { apiError, toClientErrorMessage } from '@/lib/api-error'
+import type { RouteContext } from '@/types/route'
+
+// WHY: viewerロールのUIゲーティング(issue #608)用。自分が指定施設で
+//      admin/staff/viewerのどれか、あるいは未所属(null)かを返す。
+//      adminはuser_facilitiesに行が無くても全施設を操作できるため、
+//      resolveIsAdminを先に見て早期にadmin扱いする。
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { id } = await context.params
+  const db = await createServerSupabase()
+  let user
+  try {
+    user = await requireAuth(db)
+  } catch {
+    return apiError('認証が必要です', 401)
+  }
+
+  try {
+    const isAdmin = await resolveIsAdmin(db, user)
+    if (isAdmin) {
+      return NextResponse.json({ role: 'admin' })
+    }
+    const role = await getUserFacilityRole(db, user.id, id)
+    return NextResponse.json({ role })
+  } catch (error) {
+    return apiError(toClientErrorMessage(error, 'ロールの取得に失敗しました'))
+  }
+}

--- a/src/app/api/facilities/__tests__/route.test.ts
+++ b/src/app/api/facilities/__tests__/route.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { POST } from '../route'
+import { GET, POST } from '../route'
 
 const mockGetUser = vi.fn()
 const mockResolveIsAdmin = vi.fn()
+const mockListFacilities = vi.fn()
 const mockCreateFacility = vi.fn()
+const mockListUserFacilities = vi.fn()
 
 vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: async () => ({
@@ -16,8 +18,12 @@ vi.mock('@/lib/admin-status', () => ({
 }))
 
 vi.mock('@/lib/facilities/repository', () => ({
-  listFacilities: vi.fn(),
+  listFacilities: (...args: unknown[]) => mockListFacilities(...args),
   createFacility: (...args: unknown[]) => mockCreateFacility(...args),
+}))
+
+vi.mock('@/lib/user-facilities/repository', () => ({
+  listUserFacilities: (...args: unknown[]) => mockListUserFacilities(...args),
 }))
 
 const unauthenticated = () => mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no user' } })
@@ -27,6 +33,31 @@ const validInput = { name: '施設A' }
 beforeEach(() => {
   vi.clearAllMocks()
   mockResolveIsAdmin.mockResolvedValue(true)
+  mockListFacilities.mockResolvedValue([])
+  mockListUserFacilities.mockResolvedValue([])
+})
+
+describe('GET /api/facilities', () => {
+  it('未認証の場合は401を返す', async () => {
+    unauthenticated()
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('施設一覧とfacilityId別roleを返す(issue #608)', async () => {
+    authenticated()
+    mockResolveIsAdmin.mockResolvedValue(false)
+    mockListFacilities.mockResolvedValue([{ id: 'f1', name: '施設A' }, { id: 'f2', name: '施設B' }])
+    mockListUserFacilities.mockResolvedValue([
+      { facilityId: 'f1', facilityName: '施設A', role: 'viewer' },
+      { facilityId: 'f2', facilityName: '施設B', role: 'staff' },
+    ])
+    const res = await GET()
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.isAdmin).toBe(false)
+    expect(body.roleByFacilityId).toEqual({ f1: 'viewer', f2: 'staff' })
+  })
 })
 
 describe('POST /api/facilities', () => {

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -3,6 +3,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { resolveIsAdmin } from '@/lib/admin-status'
 import { listFacilities, createFacility } from '@/lib/facilities/repository'
+import { listUserFacilities } from '@/lib/user-facilities/repository'
 import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import type { FacilityInput } from '@/types/facility'
 
@@ -16,7 +17,13 @@ export async function GET() {
     // require-facility-access.ts の resolveIsAdmin と同じ判定にすることで、
     // UIが「全施設」を選べるのにAPIがfacilityId必須で弾く、という不整合を防ぐ（issue #40）
     const isAdmin = await resolveIsAdmin(db, user)
-    return NextResponse.json({ facilities, isAdmin })
+    // WHY: viewerロールのUIゲーティング(issue #608)用。施設選択が単一のURLパラメータに
+    // 縛られないフォーム(hospital-prices/new等)で、施設ごとに書き込み可否を判定するために
+    // 一覧取得と同時にroleも返す。adminはuser_facilitiesに行が無くても書き込めるため、
+    // このmapはmembershipがある場合のみ意味を持つ(クライアント側はisAdminを優先して見る)。
+    const memberships = await listUserFacilities(db, user.id)
+    const roleByFacilityId = Object.fromEntries(memberships.map((m) => [m.facilityId, m.role]))
+    return NextResponse.json({ facilities, isAdmin, roleByFacilityId })
   } catch (error) {
     return apiError(toClientErrorMessage(error, '施設の取得に失敗しました'))
   }

--- a/src/app/facilities/[id]/page.tsx
+++ b/src/app/facilities/[id]/page.tsx
@@ -5,10 +5,13 @@ import Link from 'next/link'
 import type { Facility } from '@/types/facility'
 import { OrderButtons } from '@/components/orders/OrderButtons'
 
+type FacilityRole = 'admin' | 'staff' | 'viewer'
+
 export default function FacilityDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const [facility, setFacility] = useState<Facility | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [role, setRole] = useState<FacilityRole | null | undefined>(undefined)
 
   useEffect(() => {
     let cancelled = false
@@ -16,6 +19,15 @@ export default function FacilityDetailPage({ params }: { params: Promise<{ id: s
       .then((r) => { if (!r.ok) throw new Error(); return r.json() })
       .then((d) => { if (!cancelled) setFacility(d.facility) })
       .catch(() => { if (!cancelled) setError('施設の取得に失敗しました') })
+    return () => { cancelled = true }
+  }, [id])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/facilities/${id}/my-role`)
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
+      .then((d) => { if (!cancelled) setRole(d.role) })
+      .catch(() => { if (!cancelled) setRole(null) })
     return () => { cancelled = true }
   }, [id])
 
@@ -58,7 +70,7 @@ export default function FacilityDetailPage({ params }: { params: Promise<{ id: s
         </h1>
       </div>
 
-      <OrderButtons facilityId={id} />
+      <OrderButtons facilityId={id} role={role} />
 
       <div className="rounded bg-white shadow-sm overflow-hidden" style={{ border: '1px solid #E5E7EB' }}>
         <table className="min-w-full">

--- a/src/app/hospital-prices/[id]/edit/page.tsx
+++ b/src/app/hospital-prices/[id]/edit/page.tsx
@@ -15,6 +15,9 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
   const [facilities, setFacilities] = useState<Facility[]>([])
   const [distributorProducts, setDistributorProducts] = useState<DistributorProduct[]>([])
   const [error, setError] = useState<string | null>(null)
+  // WHY: viewerロールのUIゲーティング(issue #608)。undefinedは判定中(プレースホルダ)、
+  // falseならフォームの代わりに閲覧専用メッセージを出す。
+  const [canWrite, setCanWrite] = useState<boolean | undefined>(undefined)
 
   useEffect(() => {
     let cancelled = false
@@ -31,6 +34,11 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
       setPrice(priceData.price)
       setFacilities(facilitiesData.facilities)
       setDistributorProducts(dpData.items)
+
+      const isAdmin = Boolean(facilitiesData.isAdmin)
+      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, 'admin' | 'staff' | 'viewer'>
+      const role = roleByFacilityId[priceData.price.facilityId as string]
+      setCanWrite(isAdmin || role === 'admin' || role === 'staff')
     }).catch(() => {
       if (!cancelled) setError('データの取得に失敗しました')
     })
@@ -76,10 +84,23 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
     )
   }
 
-  if (!price) {
+  if (!price || canWrite === undefined) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
         <p className="text-gray-500">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (!canWrite) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <Link href="/hospital-prices" className="mb-4 inline-block text-sm text-blue-600 hover:text-blue-800">
+          &larr; 一覧に戻る
+        </Link>
+        <p className="rounded-md bg-gray-100 px-4 py-3 text-sm text-gray-600">
+          閲覧のみの権限のため、この価格情報を編集できません。
+        </p>
       </div>
     )
   }

--- a/src/app/hospital-prices/__tests__/page.test.tsx
+++ b/src/app/hospital-prices/__tests__/page.test.tsx
@@ -69,12 +69,16 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 function mockFetch({
   facilities: fac,
   pricesByFacility,
+  isAdmin = true,
+  roleByFacilityId = {},
 }: {
   facilities: typeof facilities
   pricesByFacility: Record<string, unknown[]>
+  isAdmin?: boolean
+  roleByFacilityId?: Record<string, 'admin' | 'staff' | 'viewer'>
 }) {
   return vi.fn((url: string) => {
-    if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: fac }))
+    if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: fac, isAdmin, roleByFacilityId }))
     if (url === '/api/distributor-products') return Promise.resolve(jsonResponse({ items: distributorProducts }))
     const match = url.match(/^\/api\/hospital-prices\?facilityId=(.+)$/)
     if (match) {
@@ -220,10 +224,43 @@ describe('HospitalPricesPage', () => {
     expect(select.children.length).toBe(0)
   })
 
+  it('選択中施設でviewerの場合、新規登録ボタンと編集/削除ボタンが表示されない(issue #608)', async () => {
+    const fetchMock = mockFetch({
+      facilities: [facilities[0]],
+      pricesByFacility: { f1: prices },
+      isAdmin: false,
+      roleByFacilityId: { f1: 'viewer' },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<HospitalPricesPage />)
+
+    await screen.findByText('テスト商品A')
+    expect(screen.queryByRole('button', { name: '+ 新規価格を登録' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '編集' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '削除' })).not.toBeInTheDocument()
+  })
+
+  it('選択中施設でstaffの場合、新規登録ボタンと編集/削除ボタンが表示される', async () => {
+    const fetchMock = mockFetch({
+      facilities: [facilities[0]],
+      pricesByFacility: { f1: prices },
+      isAdmin: false,
+      roleByFacilityId: { f1: 'staff' },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<HospitalPricesPage />)
+
+    await screen.findByText('テスト商品A')
+    expect(screen.getByRole('button', { name: '+ 新規価格を登録' })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: '編集' }).length).toBeGreaterThan(0)
+  })
+
   it('削除でfetchが例外を投げた場合もエラーバナーを表示する', async () => {
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (init?.method === 'DELETE') return Promise.reject(new Error('network error'))
-      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [facilities[0]] }))
+      if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [facilities[0]], isAdmin: true, roleByFacilityId: {} }))
       if (url === '/api/distributor-products') return Promise.resolve(jsonResponse({ items: distributorProducts }))
       const match = url.match(/^\/api\/hospital-prices\?facilityId=(.+)$/)
       if (match) return Promise.resolve(jsonResponse({ prices }))

--- a/src/app/hospital-prices/new/page.tsx
+++ b/src/app/hospital-prices/new/page.tsx
@@ -21,7 +21,19 @@ export default function NewHospitalPricePage() {
       fetch('/api/distributor-products').then((r) => { if (!r.ok) throw new Error(); return r.json() }),
     ]).then(([facilitiesData, dpData]) => {
       if (cancelled) return
-      setFacilities(facilitiesData.facilities)
+      // WHY: viewerロールのUIゲーティング(issue #608)。施設選択はこのフォーム内で
+      // 行われるため、あらかじめviewerの施設を選択肢から除外する(選んだ後にRLSで
+      // 拒否されるより、そもそも選べない方が分かりやすい)。実際の書き込み拒否は
+      // 引き続きRLS/RPCが最終防衛として担保する。
+      const isAdmin = Boolean(facilitiesData.isAdmin)
+      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, 'admin' | 'staff' | 'viewer'>
+      const writableFacilities = isAdmin
+        ? facilitiesData.facilities
+        : (facilitiesData.facilities as Facility[]).filter((f) => {
+            const role = roleByFacilityId[f.id]
+            return role === 'admin' || role === 'staff'
+          })
+      setFacilities(writableFacilities)
       setDistributorProducts(dpData.items)
     }).catch(() => {
       if (!cancelled) setError('データの取得に失敗しました')

--- a/src/app/hospital-prices/page.tsx
+++ b/src/app/hospital-prices/page.tsx
@@ -18,6 +18,8 @@ function HospitalPricesPageInner() {
   const [selectedFacilityId, setSelectedFacilityId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [roleByFacilityId, setRoleByFacilityId] = useState<Record<string, 'admin' | 'staff' | 'viewer'>>({})
 
   // 初回ロード用: facilities・distributorProducts を取得し、選択施設IDを決定する
   useEffect(() => {
@@ -37,6 +39,8 @@ function HospitalPricesPageInner() {
 
         setFacilities(loadedFacilities)
         setDistributorProducts(dpData.items)
+        setIsAdmin(Boolean(facilitiesData.isAdmin))
+        setRoleByFacilityId(facilitiesData.roleByFacilityId ?? {})
 
         const isValidUrlFacility =
           urlFacilityId !== null && loadedFacilities.some((f) => f.id === urlFacilityId)
@@ -124,16 +128,26 @@ function HospitalPricesPageInner() {
     [prices, facilityNameById, productNameById]
   )
 
+  // WHY: viewerロールのUIゲーティング(issue #608)。選択中施設でのroleがadmin/staffの
+  // 場合のみ書き込み操作(新規登録・編集・削除)のUIを出す。実際の拒否はRLSが最終的に
+  // 担保するため、ここでは「表示するかどうか」の判定のみ。
+  const canWrite =
+    isAdmin ||
+    (selectedFacilityId !== null &&
+      (roleByFacilityId[selectedFacilityId] === 'admin' || roleByFacilityId[selectedFacilityId] === 'staff'))
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">施設別価格管理</h1>
-        <button
-          onClick={() => router.push('/hospital-prices/new')}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          + 新規価格を登録
-        </button>
+        {canWrite && (
+          <button
+            onClick={() => router.push('/hospital-prices/new')}
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            + 新規価格を登録
+          </button>
+        )}
       </div>
 
       <div className="mb-4">
@@ -161,6 +175,7 @@ function HospitalPricesPageInner() {
           prices={resolvedPrices}
           onEdit={(id) => router.push(`/hospital-prices/${id}/edit`)}
           onDelete={handleDelete}
+          canWrite={canWrite}
         />
       </div>
     </div>

--- a/src/components/hospitalPrices/HospitalPriceList.tsx
+++ b/src/components/hospitalPrices/HospitalPriceList.tsx
@@ -6,6 +6,10 @@ type HospitalPriceListProps = {
   prices: (HospitalPrice & { facilityName: string; productName: string })[]
   onEdit: (id: string) => void
   onDelete: (id: string) => void
+  // WHY: viewerロールのUIゲーティング(issue #608)。falseの場合、編集/削除操作列を
+  // 出さない(実際の書き込み拒否はRLSが最終的に担保するが、viewerには操作不能な
+  // ボタンをそもそも見せない)。
+  canWrite: boolean
 }
 
 function formatRate(rate: number | null): string {
@@ -13,7 +17,7 @@ function formatRate(rate: number | null): string {
   return `${(rate * 100).toFixed(1)}%`
 }
 
-export function HospitalPriceList({ prices, onEdit, onDelete }: HospitalPriceListProps) {
+export function HospitalPriceList({ prices, onEdit, onDelete, canWrite }: HospitalPriceListProps) {
   if (prices.length === 0) {
     return (
       <p className="text-center text-gray-500 py-8">
@@ -34,7 +38,7 @@ export function HospitalPriceList({ prices, onEdit, onDelete }: HospitalPriceLis
             <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">粗利（円）</th>
             <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">仕入れ掛け率</th>
             <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">納入掛け率</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">操作</th>
+            {canWrite && <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">操作</th>}
           </tr>
         </thead>
         <tbody className="bg-white divide-y divide-gray-200">
@@ -47,20 +51,22 @@ export function HospitalPriceList({ prices, onEdit, onDelete }: HospitalPriceLis
               <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900">{price.grossProfit.toLocaleString()}</td>
               <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900">{formatRate(price.purchaseRate)}</td>
               <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900">{formatRate(price.deliveryRate)}</td>
-              <td className="px-6 py-4 whitespace-nowrap text-sm space-x-2">
-                <button
-                  onClick={() => onEdit(price.id)}
-                  className="text-indigo-600 hover:text-indigo-900 font-medium"
-                >
-                  編集
-                </button>
-                <button
-                  onClick={() => onDelete(price.id)}
-                  className="text-red-600 hover:text-red-900 font-medium"
-                >
-                  削除
-                </button>
-              </td>
+              {canWrite && (
+                <td className="px-6 py-4 whitespace-nowrap text-sm space-x-2">
+                  <button
+                    onClick={() => onEdit(price.id)}
+                    className="text-indigo-600 hover:text-indigo-900 font-medium"
+                  >
+                    編集
+                  </button>
+                  <button
+                    onClick={() => onDelete(price.id)}
+                    className="text-red-600 hover:text-red-900 font-medium"
+                  >
+                    削除
+                  </button>
+                </td>
+              )}
             </tr>
           ))}
         </tbody>

--- a/src/components/hospitalPrices/__tests__/HospitalPriceList.test.tsx
+++ b/src/components/hospitalPrices/__tests__/HospitalPriceList.test.tsx
@@ -37,7 +37,7 @@ const prices: (HospitalPrice & { facilityName: string; productName: string })[] 
 
 describe('HospitalPriceList', () => {
   it('価格一覧が表示される（施設名・商品名・仕切値・納品価格）', () => {
-    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={true} />)
     expect(screen.getByText('中央病院')).toBeInTheDocument()
     expect(screen.getByText('カテーテルA')).toBeInTheDocument()
     expect(screen.getByText('1,000')).toBeInTheDocument()
@@ -49,39 +49,48 @@ describe('HospitalPriceList', () => {
   })
 
   it('粗利がDBの値（grossProfit）で表示される', () => {
-    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={true} />)
     expect(screen.getByText('500')).toBeInTheDocument()
     expect(screen.getByText('5,000')).toBeInTheDocument()
   })
 
   it('掛け率が数値のとき % 表示される（小数点1桁）', () => {
-    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={true} />)
     expect(screen.getAllByText('80.0%')).toHaveLength(1)
     expect(screen.getAllByText('96.0%')).toHaveLength(1)
   })
 
   it('掛け率が null のとき「—」が表示される', () => {
-    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={true} />)
     const dashes = screen.getAllByText('—')
     expect(dashes).toHaveLength(2)
   })
 
   it('空のとき「価格情報が登録されていません」が表示される', () => {
-    render(<HospitalPriceList prices={[]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={[]} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={true} />)
     expect(screen.getByText('価格情報が登録されていません')).toBeInTheDocument()
   })
 
   it('編集ボタンクリックで onEdit が呼ばれる', async () => {
     const onEdit = vi.fn()
-    render(<HospitalPriceList prices={prices} onEdit={onEdit} onDelete={vi.fn()} />)
+    render(<HospitalPriceList prices={prices} onEdit={onEdit} onDelete={vi.fn()} canWrite={true} />)
     await userEvent.click(screen.getAllByText('編集')[0])
     expect(onEdit).toHaveBeenCalledWith('1')
   })
 
   it('削除ボタンクリックで onDelete が呼ばれる', async () => {
     const onDelete = vi.fn()
-    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={onDelete} />)
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={onDelete} canWrite={true} />)
     await userEvent.click(screen.getAllByText('削除')[0])
     expect(onDelete).toHaveBeenCalledWith('1')
+  })
+
+  it('canWrite=falseの場合、編集/削除ボタンも操作列ヘッダーも表示されない(issue #608)', () => {
+    render(<HospitalPriceList prices={prices} onEdit={vi.fn()} onDelete={vi.fn()} canWrite={false} />)
+    expect(screen.queryByText('編集')).not.toBeInTheDocument()
+    expect(screen.queryByText('削除')).not.toBeInTheDocument()
+    expect(screen.queryByText('操作')).not.toBeInTheDocument()
+    // 価格情報自体は引き続き閲覧できる
+    expect(screen.getByText('中央病院')).toBeInTheDocument()
   })
 })

--- a/src/components/orders/OrderButtons.tsx
+++ b/src/components/orders/OrderButtons.tsx
@@ -2,13 +2,34 @@
 
 import Link from 'next/link'
 
+type FacilityRole = 'admin' | 'staff' | 'viewer'
+
 type Props = {
   facilityId: string
+  // WHY: undefinedは取得中(プレースホルダ表示でレイアウトシフトを防ぐ)。
+  //      viewer/nullは書き込み不可のためボタンを出さない(issue #608)。
+  role: FacilityRole | null | undefined
 }
 
-export function OrderButtons({ facilityId }: Props) {
+export function OrderButtons({ facilityId, role }: Props) {
   const base = `/facilities/${facilityId}`
   const btnBase = 'px-4 py-2 text-sm font-semibold rounded text-white transition-opacity hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed inline-block'
+
+  if (role === undefined) {
+    return <div className="mb-8 h-[42px]" aria-hidden="true" />
+  }
+
+  const canWrite = role === 'admin' || role === 'staff'
+  if (!canWrite) {
+    return (
+      <div
+        className="mb-8 rounded px-4 py-3 text-sm"
+        style={{ backgroundColor: '#F3F4F6', color: '#6B7280', border: '1px solid #E5E7EB' }}
+      >
+        閲覧のみの権限のため、発注・返却はできません。
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-wrap gap-3 mb-8">

--- a/src/components/orders/__tests__/OrderButtons.test.tsx
+++ b/src/components/orders/__tests__/OrderButtons.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react'
 import { OrderButtons } from '../OrderButtons'
 
 describe('OrderButtons', () => {
-  it('4つのリンクと1つのdisabledボタンが表示される', () => {
-    render(<OrderButtons facilityId="f-1" />)
+  it('staffの場合、4つのリンクと1つのdisabledボタンが表示される', () => {
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('link', { name: '症例発注' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '消耗品発注' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '短貸発注' })).toBeInTheDocument()
@@ -12,28 +12,53 @@ describe('OrderButtons', () => {
     expect(screen.getByRole('button', { name: '長貸し処理' })).toBeInTheDocument()
   })
 
+  it('adminの場合も同様にボタンが表示される', () => {
+    render(<OrderButtons facilityId="f-1" role="admin" />)
+    expect(screen.getByRole('link', { name: '症例発注' })).toBeInTheDocument()
+  })
+
   it('症例発注リンクは正しいhrefを持つ', () => {
-    render(<OrderButtons facilityId="f-1" />)
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('link', { name: '症例発注' })).toHaveAttribute('href', '/facilities/f-1/case-orders')
   })
 
   it('消耗品発注リンクは正しいhrefを持つ', () => {
-    render(<OrderButtons facilityId="f-1" />)
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('link', { name: '消耗品発注' })).toHaveAttribute('href', '/facilities/f-1/consumable-orders')
   })
 
   it('短貸発注リンクは正しいhrefを持つ', () => {
-    render(<OrderButtons facilityId="f-1" />)
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('link', { name: '短貸発注' })).toHaveAttribute('href', '/facilities/f-1/loan-orders')
   })
 
   it('短貸返却リンクは正しいhrefを持つ', () => {
-    render(<OrderButtons facilityId="f-1" />)
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('link', { name: '短貸返却' })).toHaveAttribute('href', '/facilities/f-1/loan-returns')
   })
 
   it('長貸し処理ボタンはdisabledである', () => {
-    render(<OrderButtons facilityId="f-1" />)
+    render(<OrderButtons facilityId="f-1" role="staff" />)
     expect(screen.getByRole('button', { name: '長貸し処理' })).toBeDisabled()
+  })
+
+  it('viewerの場合、発注リンクは表示されず案内メッセージが表示される(issue #608)', () => {
+    render(<OrderButtons facilityId="f-1" role="viewer" />)
+    expect(screen.queryByRole('link', { name: '症例発注' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '消耗品発注' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '短貸発注' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '短貸返却' })).not.toBeInTheDocument()
+    expect(screen.getByText('閲覧のみの権限のため、発注・返却はできません。')).toBeInTheDocument()
+  })
+
+  it('未所属(null)の場合も発注リンクを表示しない', () => {
+    render(<OrderButtons facilityId="f-1" role={null} />)
+    expect(screen.queryByRole('link', { name: '症例発注' })).not.toBeInTheDocument()
+  })
+
+  it('role取得中(undefined)はプレースホルダのみでリンクも案内メッセージも表示しない', () => {
+    render(<OrderButtons facilityId="f-1" role={undefined} />)
+    expect(screen.queryByRole('link', { name: '症例発注' })).not.toBeInTheDocument()
+    expect(screen.queryByText('閲覧のみの権限のため、発注・返却はできません。')).not.toBeInTheDocument()
   })
 })

--- a/src/lib/user-facilities/__tests__/repository.test.ts
+++ b/src/lib/user-facilities/__tests__/repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { listUserFacilities } from '@/lib/user-facilities/repository'
+import { listUserFacilities, getUserFacilityRole } from '@/lib/user-facilities/repository'
 
 describe('listUserFacilities', () => {
   it('所属施設が複数件（adminロール混在）の場合、facilityId/facilityName/roleを返す', async () => {
@@ -22,6 +22,20 @@ describe('listUserFacilities', () => {
       { facilityId: 'f-1', facilityName: '病院A', role: 'admin' },
       { facilityId: 'f-2', facilityName: '病院B', role: 'staff' },
     ])
+  })
+
+  it('viewerロールのユーザーはstaffに丸められずviewerのまま返す(issue #608)', async () => {
+    const rows = [{ facility_id: 'f-5', role: 'viewer', facilities: { name: '病院E' } }]
+    const db = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ data: rows, error: null }),
+        })),
+      })),
+    } as unknown as SupabaseClient
+
+    const result = await listUserFacilities(db, 'u-5')
+    expect(result).toEqual([{ facilityId: 'f-5', facilityName: '病院E', role: 'viewer' }])
   })
 
   it('所属施設が0件の場合、空配列を返す', async () => {
@@ -61,5 +75,39 @@ describe('listUserFacilities', () => {
     } as unknown as SupabaseClient
 
     await expect(listUserFacilities(db, 'u-4')).rejects.toThrow('DB error')
+  })
+})
+
+describe('getUserFacilityRole', () => {
+  function buildDb(result: { data: unknown; error: unknown }) {
+    const maybeSingle = vi.fn().mockResolvedValue(result)
+    const eq2 = vi.fn(() => ({ maybeSingle }))
+    const eq1 = vi.fn(() => ({ eq: eq2 }))
+    const select = vi.fn(() => ({ eq: eq1 }))
+    const from = vi.fn(() => ({ select }))
+    return { from } as unknown as SupabaseClient
+  }
+
+  it('所属している場合はroleを返す', async () => {
+    const db = buildDb({ data: { role: 'viewer' }, error: null })
+    const role = await getUserFacilityRole(db, 'u-1', 'f-1')
+    expect(role).toBe('viewer')
+  })
+
+  it('不正なrole値が来てもstaffにフォールバックする', async () => {
+    const db = buildDb({ data: { role: 'unknown' }, error: null })
+    const role = await getUserFacilityRole(db, 'u-1', 'f-1')
+    expect(role).toBe('staff')
+  })
+
+  it('未所属の場合はnullを返す', async () => {
+    const db = buildDb({ data: null, error: null })
+    const role = await getUserFacilityRole(db, 'u-1', 'f-1')
+    expect(role).toBeNull()
+  })
+
+  it('エラー時は例外を投げる', async () => {
+    const db = buildDb({ data: null, error: { message: 'DB error' } })
+    await expect(getUserFacilityRole(db, 'u-1', 'f-1')).rejects.toThrow('DB error')
   })
 })

--- a/src/lib/user-facilities/repository.ts
+++ b/src/lib/user-facilities/repository.ts
@@ -16,7 +16,7 @@ export function mapUserFacilityMembership(row: UserFacilityRow): UserFacilityMem
   return {
     facilityId: asString(row.facility_id),
     facilityName: asString(row.facilities?.name),
-    role: asEnum(row.role, ['admin', 'staff'] as const, 'staff'),
+    role: asEnum(row.role, ['admin', 'staff', 'viewer'] as const, 'staff'),
   }
 }
 
@@ -34,4 +34,25 @@ export async function listUserFacilities(
     .eq('user_id', userId)
   if (error) throw new Error(error.message)
   return ((data ?? []) as unknown as UserFacilityRow[]).map(mapUserFacilityMembership)
+}
+
+/**
+ * 指定施設におけるユーザー自身のroleを取得する（UIゲーティング用）。
+ * user_facilities の RLS（self_read）により auth.uid() の行のみ取得可能。
+ * 未所属の場合は null（呼び出し元はis_admin判定と合わせて扱うこと）。
+ */
+export async function getUserFacilityRole(
+  db: SupabaseClient,
+  userId: string,
+  facilityId: string
+): Promise<'admin' | 'staff' | 'viewer' | null> {
+  const { data, error } = await db
+    .from('user_facilities')
+    .select('role')
+    .eq('user_id', userId)
+    .eq('facility_id', facilityId)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  if (!data) return null
+  return asEnum(data.role, ['admin', 'staff', 'viewer'] as const, 'staff')
 }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -7,7 +7,7 @@ import type { PriceHistory } from './priceHistory'
 export type UserFacilityMembership = {
   facilityId: string
   facilityName: string
-  role: 'admin' | 'staff'
+  role: 'admin' | 'staff' | 'viewer'
 }
 
 /**


### PR DESCRIPTION
## 作業サマリ
issue #608 で指摘された、viewerロール(#601)のUIゲーティング未実装を修正した。書き込みはRLS/RPCで最終的に拒否されるが、UI層でのゲーティングが無く「操作できそうに見えて失敗する」UXになっていた。

変更内容:
- GET /api/facilities/[id]/my-role を新設。指定施設における自分のrole(admin/staff/viewer/null)を返す。adminはuser_facilitiesに行が無くても全施設操作可能なため、resolveIsAdminを優先判定する。
- GET /api/facilities に roleByFacilityId を追加。施設選択が単一のURLパラメータに縛られないフォーム(hospital-prices/new等)で、施設ごとの書き込み可否を判定するために一覧取得と同時にroleも返す。
- OrderButtons: roleがviewer/null(未所属)の場合、発注・返却ボタンの代わりに案内メッセージを表示。facilities/[id]/page.tsxからmy-roleを取得して渡す。
- hospital-prices一覧: 選択中施設でwriter権限が無い場合、「+ 新規価格を登録」ボタンと各行の編集/削除操作列を非表示にする(HospitalPriceListにcanWrite propを追加)。
- hospital-prices/new: 施設選択肢をwriter権限のある施設のみに絞る。
- hospital-prices/[id]/edit: 対象価格のfacilityIdでwriter権限が無い場合、フォームの代わりに案内メッセージを表示するページレベルガードを追加(URL直打ちでのアクセスも防ぐ)。
- 副産物として発見したバグ修正: src/lib/user-facilities/repository.ts の asEnumがviewerロールを許可リストに含んでおらず、ダッシュボード等でviewerユーザーがstaffとして誤表示される問題があった(#609で修正したapi/admin/users/route.tsと同種のバグの見落とし箇所)。
- .claude/launch.json を新設。プロジェクトのUI変更検証ルールに従い実際にブラウザで動作確認するため、devサーバー起動設定を追加した(既存になかった)。

## 検証済み
- npm test 全1387件パス(181ファイル)、新規/既存テスト込み
- npm run lint / npx tsc --noEmit エラーなし(既存の無関係な警告2件のみ)
- ローカルSupabase + 実ブラウザでviewer/staff両ロールのテストユーザーを作成し、facilities/[id]・hospital-prices一覧・hospital-prices/[id]/editの3画面で実際にログインして目視確認:
  - viewer: 発注ボタン非表示+案内メッセージ表示、hospital-prices新規登録ボタン非表示、編集操作列非表示、編集ページへの直URLアクセスもページレベルガードで拒否されることを確認
  - staff: 全ボタン・操作列が正常に表示されることを確認

Closes #608