### PR TITLE
refactor: FacilityRole型と許可リストをsrc/types/role.tsに一元化する

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { UserTable } from '@/components/admin/UserTable'
 import { InviteModal } from '@/components/admin/InviteModal'
 import type { AdminUser, Facility } from '@/types/admin'
+import type { FacilityRole } from '@/types/role'
 
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<AdminUser[]>([])
@@ -72,7 +73,7 @@ export default function AdminUsersPage() {
     }
   }
 
-  const handleChangeRole = async (userId: string, facilityId: string, role: 'admin' | 'staff' | 'viewer') => {
+  const handleChangeRole = async (userId: string, facilityId: string, role: FacilityRole) => {
     try {
       const res = await fetch('/api/admin/user-facilities', {
         method: 'POST',

--- a/src/app/api/admin/user-facilities/route.ts
+++ b/src/app/api/admin/user-facilities/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createAdminSupabase } from '@/lib/supabase/server'
 import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { requireAdmin } from '@/lib/admin-auth'
+import { FACILITY_ROLES, type FacilityRole } from '@/types/role'
 
 export async function POST(request: NextRequest) {
   const user = await requireAdmin()
   if (!user) return apiError('権限がありません', 403)
 
-  let userId: string | undefined, facilityId: string | undefined, role: 'staff' | 'admin' | 'viewer' | undefined
+  let userId: string | undefined, facilityId: string | undefined, role: FacilityRole | undefined
   try {
     const body = await request.json()
     userId = body.userId
@@ -17,8 +18,8 @@ export async function POST(request: NextRequest) {
     return apiError('リクエストが不正です', 400)
   }
   if (!userId || !facilityId) return apiError('userId と facilityId は必須です', 400)
-  if (role !== undefined && role !== 'staff' && role !== 'admin' && role !== 'viewer') {
-    return apiError("role は 'staff'・'admin'・'viewer' のいずれかのみ指定できます", 400)
+  if (role !== undefined && !FACILITY_ROLES.includes(role)) {
+    return apiError(`role は ${FACILITY_ROLES.map((r) => `'${r}'`).join('・')} のいずれかのみ指定できます`, 400)
   }
 
   const admin = createAdminSupabase()

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -4,6 +4,7 @@ import { apiError, toClientErrorMessage } from '@/lib/api-error'
 import { requireAdmin } from '@/lib/admin-auth'
 import { asEnum } from '@/lib/mapping'
 import type { AdminUser } from '@/types/admin'
+import { FACILITY_ROLES, type FacilityRole } from '@/types/role'
 
 export async function GET() {
   const user = await requireAdmin()
@@ -24,10 +25,10 @@ export async function GET() {
   if (facilityError) return apiError(toClientErrorMessage(facilityError, 'ユーザー一覧の取得に失敗しました'))
 
   // Group by user_id in memory
-  const facilityMap = new Map<string, { id: string; role: 'admin' | 'staff' | 'viewer' }[]>()
+  const facilityMap = new Map<string, { id: string; role: FacilityRole }[]>()
   for (const row of (facilityRows ?? [])) {
     const list = facilityMap.get(row.user_id) ?? []
-    list.push({ id: row.facility_id, role: asEnum(row.role, ['admin', 'staff', 'viewer'] as const, 'staff') })
+    list.push({ id: row.facility_id, role: asEnum(row.role, FACILITY_ROLES, 'staff') })
     facilityMap.set(row.user_id, list)
   }
 

--- a/src/app/facilities/[id]/page.tsx
+++ b/src/app/facilities/[id]/page.tsx
@@ -3,9 +3,8 @@
 import { use, useEffect, useState } from 'react'
 import Link from 'next/link'
 import type { Facility } from '@/types/facility'
+import type { FacilityRole } from '@/types/role'
 import { OrderButtons } from '@/components/orders/OrderButtons'
-
-type FacilityRole = 'admin' | 'staff' | 'viewer'
 
 export default function FacilityDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)

--- a/src/app/hospital-prices/[id]/edit/page.tsx
+++ b/src/app/hospital-prices/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import type { HospitalPrice, HospitalPriceInput } from '@/types/hospitalPrice'
 import type { Facility } from '@/types/facility'
 import type { DistributorProduct } from '@/types/distributorProduct'
+import type { FacilityRole } from '@/types/role'
 import { HospitalPriceForm } from '@/components/hospitalPrices/HospitalPriceForm'
 
 export default function EditHospitalPricePage({ params }: { params: Promise<{ id: string }> }) {
@@ -36,7 +37,7 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
       setDistributorProducts(dpData.items)
 
       const isAdmin = Boolean(facilitiesData.isAdmin)
-      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, 'admin' | 'staff' | 'viewer'>
+      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, FacilityRole>
       const role = roleByFacilityId[priceData.price.facilityId as string]
       setCanWrite(isAdmin || role === 'admin' || role === 'staff')
     }).catch(() => {

--- a/src/app/hospital-prices/new/page.tsx
+++ b/src/app/hospital-prices/new/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import type { HospitalPriceInput } from '@/types/hospitalPrice'
 import type { Facility } from '@/types/facility'
 import type { DistributorProduct } from '@/types/distributorProduct'
+import type { FacilityRole } from '@/types/role'
 import { HospitalPriceForm } from '@/components/hospitalPrices/HospitalPriceForm'
 
 export default function NewHospitalPricePage() {
@@ -26,7 +27,7 @@ export default function NewHospitalPricePage() {
       // 拒否されるより、そもそも選べない方が分かりやすい)。実際の書き込み拒否は
       // 引き続きRLS/RPCが最終防衛として担保する。
       const isAdmin = Boolean(facilitiesData.isAdmin)
-      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, 'admin' | 'staff' | 'viewer'>
+      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, FacilityRole>
       const writableFacilities = isAdmin
         ? facilitiesData.facilities
         : (facilitiesData.facilities as Facility[]).filter((f) => {

--- a/src/app/hospital-prices/page.tsx
+++ b/src/app/hospital-prices/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { HospitalPrice } from '@/types/hospitalPrice'
 import type { Facility } from '@/types/facility'
 import type { DistributorProduct } from '@/types/distributorProduct'
+import type { FacilityRole } from '@/types/role'
 import { HospitalPriceList } from '@/components/hospitalPrices/HospitalPriceList'
 
 function HospitalPricesPageInner() {
@@ -19,7 +20,7 @@ function HospitalPricesPageInner() {
   const [error, setError] = useState<string | null>(null)
   const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
   const [isAdmin, setIsAdmin] = useState(false)
-  const [roleByFacilityId, setRoleByFacilityId] = useState<Record<string, 'admin' | 'staff' | 'viewer'>>({})
+  const [roleByFacilityId, setRoleByFacilityId] = useState<Record<string, FacilityRole>>({})
 
   // 初回ロード用: facilities・distributorProducts を取得し、選択施設IDを決定する
   useEffect(() => {

--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -2,13 +2,14 @@
 
 import React, { useState } from 'react'
 import type { AdminUser, Facility } from '@/types/admin'
+import { FACILITY_ROLES, type FacilityRole } from '@/types/role'
 
 type Props = {
   users: AdminUser[]
   facilities: Facility[]
   onToggleFacility: (userId: string, facilityId: string, add: boolean) => void
   onDeleteUser: (userId: string, email: string) => void
-  onChangeRole: (userId: string, facilityId: string, role: 'admin' | 'staff' | 'viewer') => void
+  onChangeRole: (userId: string, facilityId: string, role: FacilityRole) => void
 }
 
 export function UserTable({ users, facilities, onToggleFacility, onDeleteUser, onChangeRole }: Props) {
@@ -77,13 +78,15 @@ export function UserTable({ users, facilities, onToggleFacility, onDeleteUser, o
                               aria-label={`${f.name}のrole`}
                               value={assigned.role}
                               onChange={(e) =>
-                                onChangeRole(user.id, f.id, e.target.value as 'admin' | 'staff' | 'viewer')
+                                onChangeRole(user.id, f.id, e.target.value as FacilityRole)
                               }
                               className="text-xs border rounded px-1"
                             >
-                              <option value="staff">staff</option>
-                              <option value="admin">admin</option>
-                              <option value="viewer">viewer</option>
+                              {FACILITY_ROLES.map((r) => (
+                                <option key={r} value={r}>
+                                  {r}
+                                </option>
+                              ))}
                             </select>
                           )}
                         </div>

--- a/src/components/orders/OrderButtons.tsx
+++ b/src/components/orders/OrderButtons.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-
-type FacilityRole = 'admin' | 'staff' | 'viewer'
+import type { FacilityRole } from '@/types/role'
 
 type Props = {
   facilityId: string

--- a/src/lib/user-facilities/repository.ts
+++ b/src/lib/user-facilities/repository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { asString, asEnum } from '@/lib/mapping'
 import type { UserFacilityMembership } from '@/types/dashboard'
+import { FACILITY_ROLES, type FacilityRole } from '@/types/role'
 
 interface UserFacilityRow {
   facility_id?: unknown
@@ -16,7 +17,7 @@ export function mapUserFacilityMembership(row: UserFacilityRow): UserFacilityMem
   return {
     facilityId: asString(row.facility_id),
     facilityName: asString(row.facilities?.name),
-    role: asEnum(row.role, ['admin', 'staff', 'viewer'] as const, 'staff'),
+    role: asEnum(row.role, FACILITY_ROLES, 'staff'),
   }
 }
 
@@ -45,7 +46,7 @@ export async function getUserFacilityRole(
   db: SupabaseClient,
   userId: string,
   facilityId: string
-): Promise<'admin' | 'staff' | 'viewer' | null> {
+): Promise<FacilityRole | null> {
   const { data, error } = await db
     .from('user_facilities')
     .select('role')
@@ -54,5 +55,5 @@ export async function getUserFacilityRole(
     .maybeSingle()
   if (error) throw new Error(error.message)
   if (!data) return null
-  return asEnum(data.role, ['admin', 'staff', 'viewer'] as const, 'staff')
+  return asEnum(data.role, FACILITY_ROLES, 'staff')
 }

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,8 +1,10 @@
+import type { FacilityRole } from './role'
+
 export type AdminUser = {
   id: string
   email: string
   lastSignInAt: string | null
-  facilities: { id: string; role: 'admin' | 'staff' | 'viewer' }[]
+  facilities: { id: string; role: FacilityRole }[]
 }
 
 // facility.ts の Facility はフルフィールド（createdAt/updatedAt含む）を持つため、

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,4 +1,5 @@
 import type { PriceHistory } from './priceHistory'
+import type { FacilityRole } from './role'
 
 /**
  * ユーザーが所属する施設情報（role付き）
@@ -7,7 +8,7 @@ import type { PriceHistory } from './priceHistory'
 export type UserFacilityMembership = {
   facilityId: string
   facilityName: string
-  role: 'admin' | 'staff' | 'viewer'
+  role: FacilityRole
 }
 
 /**

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -1,0 +1,7 @@
+// WHY: 施設ロールのリテラル型・許可リストが複数箇所に重複コピーされ、#601でviewerロールを
+// 追加した際にasEnumの許可リスト更新漏れによる誤表示バグが2回(別セッションで)発生した
+// (issue #609, #608実装時)。ここに一元化し、新しいロールを追加する際はこのファイルの
+// 変更だけで済むようにする(残りの参照箇所は型エラーとして機械的に列挙される)。
+export const FACILITY_ROLES = ['admin', 'staff', 'viewer'] as const
+
+export type FacilityRole = (typeof FACILITY_ROLES)[number]


### PR DESCRIPTION
## 作業サマリ
issue #620 で指摘した、ロールのリテラル型・許可リストの重複を解消した。純粋なリファクタリングで、振る舞いの変更はない(UserTableのselect選択肢の表示順序のみ変化)。

背景: ロールのリテラル型(admin/staff/viewer)と許可リスト配列が9箇所以上に重複コピーされており、#601でviewerロールを追加した際にasEnum許可リストの更新漏れが2回(別セッションで、#609と#608実装時)発生した。

変更内容:
- `src/types/role.ts` を新設し、`FACILITY_ROLES` 定数と `FacilityRole` 型を一元定義
- 以下の重複箇所を全てこの参照に置き換え:
  - `src/types/admin.ts` / `src/types/dashboard.ts`(型定義)
  - `src/lib/user-facilities/repository.ts`(asEnum許可リスト2箇所)
  - `src/app/api/admin/users/route.ts`(asEnum許可リスト)
  - `src/app/api/admin/user-facilities/route.ts`(手書きバリデーションを `FACILITY_ROLES.includes` に変更、エラーメッセージも動的生成に)
  - `src/components/admin/UserTable.tsx`(props型・selectの選択肢を `FACILITY_ROLES.map` で生成)
  - `src/app/admin/users/page.tsx`(handleChangeRole型)
  - `src/app/facilities/[id]/page.tsx` / `src/components/orders/OrderButtons.tsx`(ローカル定義していたFacilityRole型を削除)
  - `src/app/hospital-prices/` 配下3ファイル(roleByFacilityIdのRecord型)

これにより次にロールを追加する際は role.ts の1行変更で、UIのselect選択肢等の残り箇所は型エラーとして機械的に列挙されるようになる。DB側(migrationのCHECK制約・custom_access_token_hookのCASE文)はTS定数と自動同期できないため対象外(既存のDB側テストが引き続き整合を担保)。

## 検証済み
- `npx tsc --noEmit` エラーなし
- `npm test` 全1387件パス(181ファイル)、振る舞いの変更なし
- `npm run lint` エラーなし(既存の無関係な警告2件のみ)

Closes #620