### PR TITLE
refactor: 施設ロール取得をuseFacilityRoleフックに集約する

### DIFF
--- a/src/app/facilities/[id]/page.tsx
+++ b/src/app/facilities/[id]/page.tsx
@@ -3,14 +3,14 @@
 import { use, useEffect, useState } from 'react'
 import Link from 'next/link'
 import type { Facility } from '@/types/facility'
-import type { FacilityRole } from '@/types/role'
+import { useFacilityRole } from '@/hooks/useFacilityRole'
 import { OrderButtons } from '@/components/orders/OrderButtons'
 
 export default function FacilityDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const [facility, setFacility] = useState<Facility | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [role, setRole] = useState<FacilityRole | null | undefined>(undefined)
+  const { role } = useFacilityRole(id)
 
   useEffect(() => {
     let cancelled = false
@@ -18,15 +18,6 @@ export default function FacilityDetailPage({ params }: { params: Promise<{ id: s
       .then((r) => { if (!r.ok) throw new Error(); return r.json() })
       .then((d) => { if (!cancelled) setFacility(d.facility) })
       .catch(() => { if (!cancelled) setError('施設の取得に失敗しました') })
-    return () => { cancelled = true }
-  }, [id])
-
-  useEffect(() => {
-    let cancelled = false
-    fetch(`/api/facilities/${id}/my-role`)
-      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
-      .then((d) => { if (!cancelled) setRole(d.role) })
-      .catch(() => { if (!cancelled) setRole(null) })
     return () => { cancelled = true }
   }, [id])
 

--- a/src/app/hospital-prices/[id]/edit/page.tsx
+++ b/src/app/hospital-prices/[id]/edit/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import type { HospitalPrice, HospitalPriceInput } from '@/types/hospitalPrice'
 import type { Facility } from '@/types/facility'
 import type { DistributorProduct } from '@/types/distributorProduct'
-import type { FacilityRole } from '@/types/role'
+import { useFacilityRole } from '@/hooks/useFacilityRole'
 import { HospitalPriceForm } from '@/components/hospitalPrices/HospitalPriceForm'
 
 export default function EditHospitalPricePage({ params }: { params: Promise<{ id: string }> }) {
@@ -16,9 +16,11 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
   const [facilities, setFacilities] = useState<Facility[]>([])
   const [distributorProducts, setDistributorProducts] = useState<DistributorProduct[]>([])
   const [error, setError] = useState<string | null>(null)
-  // WHY: viewerロールのUIゲーティング(issue #608)。undefinedは判定中(プレースホルダ)、
-  // falseならフォームの代わりに閲覧専用メッセージを出す。
-  const [canWrite, setCanWrite] = useState<boolean | undefined>(undefined)
+  // WHY: viewerロールのUIゲーティング(issue #608)。price読み込み前はfacilityIdが
+  // 不明なためフックにnullを渡す(role=nullで待機)。price読み込み後、対象価格の
+  // facilityIdでのroleに切り替わる。isLoadingは「price未読み込み」または
+  // 「roleフック取得中」のどちらでもtrueになる。
+  const { canWrite, isLoading: roleLoading } = useFacilityRole(price?.facilityId ?? null)
 
   useEffect(() => {
     let cancelled = false
@@ -35,11 +37,6 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
       setPrice(priceData.price)
       setFacilities(facilitiesData.facilities)
       setDistributorProducts(dpData.items)
-
-      const isAdmin = Boolean(facilitiesData.isAdmin)
-      const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, FacilityRole>
-      const role = roleByFacilityId[priceData.price.facilityId as string]
-      setCanWrite(isAdmin || role === 'admin' || role === 'staff')
     }).catch(() => {
       if (!cancelled) setError('データの取得に失敗しました')
     })
@@ -85,7 +82,7 @@ export default function EditHospitalPricePage({ params }: { params: Promise<{ id
     )
   }
 
-  if (!price || canWrite === undefined) {
+  if (!price || roleLoading) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-8">
         <p className="text-gray-500">読み込み中...</p>

--- a/src/app/hospital-prices/__tests__/page.test.tsx
+++ b/src/app/hospital-prices/__tests__/page.test.tsx
@@ -80,6 +80,11 @@ function mockFetch({
   return vi.fn((url: string) => {
     if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: fac, isAdmin, roleByFacilityId }))
     if (url === '/api/distributor-products') return Promise.resolve(jsonResponse({ items: distributorProducts }))
+    const myRoleMatch = url.match(/^\/api\/facilities\/(.+)\/my-role$/)
+    if (myRoleMatch) {
+      const facilityId = decodeURIComponent(myRoleMatch[1])
+      return Promise.resolve(jsonResponse({ role: isAdmin ? 'admin' : (roleByFacilityId[facilityId] ?? null) }))
+    }
     const match = url.match(/^\/api\/hospital-prices\?facilityId=(.+)$/)
     if (match) {
       const facilityId = decodeURIComponent(match[1])
@@ -262,6 +267,7 @@ describe('HospitalPricesPage', () => {
       if (init?.method === 'DELETE') return Promise.reject(new Error('network error'))
       if (url === '/api/facilities') return Promise.resolve(jsonResponse({ facilities: [facilities[0]], isAdmin: true, roleByFacilityId: {} }))
       if (url === '/api/distributor-products') return Promise.resolve(jsonResponse({ items: distributorProducts }))
+      if (url.match(/^\/api\/facilities\/(.+)\/my-role$/)) return Promise.resolve(jsonResponse({ role: 'admin' }))
       const match = url.match(/^\/api\/hospital-prices\?facilityId=(.+)$/)
       if (match) return Promise.resolve(jsonResponse({ prices }))
       return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, { status: 500 }))

--- a/src/app/hospital-prices/new/page.tsx
+++ b/src/app/hospital-prices/new/page.tsx
@@ -26,6 +26,10 @@ export default function NewHospitalPricePage() {
       // 行われるため、あらかじめviewerの施設を選択肢から除外する(選んだ後にRLSで
       // 拒否されるより、そもそも選べない方が分かりやすい)。実際の書き込み拒否は
       // 引き続きRLS/RPCが最終防衛として担保する。
+      // このページはuseFacilityRoleフック(issue #618、1施設のroleのみ扱う)を
+      // 使わず、GET /api/facilitiesのroleByFacilityIdをそのまま使う。複数施設の
+      // 選択肢を同時にフィルタする必要があり、施設数だけmy-roleを個別リクエストする
+      // のは非効率なため意図的に分離している。
       const isAdmin = Boolean(facilitiesData.isAdmin)
       const roleByFacilityId = (facilitiesData.roleByFacilityId ?? {}) as Record<string, FacilityRole>
       const writableFacilities = isAdmin

--- a/src/app/hospital-prices/page.tsx
+++ b/src/app/hospital-prices/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { HospitalPrice } from '@/types/hospitalPrice'
 import type { Facility } from '@/types/facility'
 import type { DistributorProduct } from '@/types/distributorProduct'
-import type { FacilityRole } from '@/types/role'
+import { useFacilityRole } from '@/hooks/useFacilityRole'
 import { HospitalPriceList } from '@/components/hospitalPrices/HospitalPriceList'
 
 function HospitalPricesPageInner() {
@@ -19,8 +19,10 @@ function HospitalPricesPageInner() {
   const [selectedFacilityId, setSelectedFacilityId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [refreshKey, refresh] = useReducer((x: number) => x + 1, 0)
-  const [isAdmin, setIsAdmin] = useState(false)
-  const [roleByFacilityId, setRoleByFacilityId] = useState<Record<string, FacilityRole>>({})
+  // WHY: viewerロールのUIゲーティング(issue #608/#618)。選択中施設でのroleが
+  // admin/staffの場合のみ書き込み操作(新規登録・編集・削除)のUIを出す。実際の拒否は
+  // RLSが最終的に担保するため、ここでは「表示するかどうか」の判定のみ。
+  const { canWrite } = useFacilityRole(selectedFacilityId)
 
   // 初回ロード用: facilities・distributorProducts を取得し、選択施設IDを決定する
   useEffect(() => {
@@ -40,8 +42,6 @@ function HospitalPricesPageInner() {
 
         setFacilities(loadedFacilities)
         setDistributorProducts(dpData.items)
-        setIsAdmin(Boolean(facilitiesData.isAdmin))
-        setRoleByFacilityId(facilitiesData.roleByFacilityId ?? {})
 
         const isValidUrlFacility =
           urlFacilityId !== null && loadedFacilities.some((f) => f.id === urlFacilityId)
@@ -128,14 +128,6 @@ function HospitalPricesPageInner() {
       })),
     [prices, facilityNameById, productNameById]
   )
-
-  // WHY: viewerロールのUIゲーティング(issue #608)。選択中施設でのroleがadmin/staffの
-  // 場合のみ書き込み操作(新規登録・編集・削除)のUIを出す。実際の拒否はRLSが最終的に
-  // 担保するため、ここでは「表示するかどうか」の判定のみ。
-  const canWrite =
-    isAdmin ||
-    (selectedFacilityId !== null &&
-      (roleByFacilityId[selectedFacilityId] === 'admin' || roleByFacilityId[selectedFacilityId] === 'staff'))
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">

--- a/src/hooks/__tests__/useFacilityRole.test.ts
+++ b/src/hooks/__tests__/useFacilityRole.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useFacilityRole } from '../useFacilityRole'
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return {
+    ok: init.status === undefined || init.status < 400,
+    status: init.status ?? 200,
+    json: async () => body,
+  } as Response
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useFacilityRole', () => {
+  it('取得中はrole=undefined, isLoading=true, canWrite=falseを返す', async () => {
+    let resolveFetch: (v: Response) => void = () => {}
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => { resolveFetch = resolve })))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    expect(result.current.role).toBeUndefined()
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.canWrite).toBe(false)
+
+    resolveFetch(jsonResponse({ role: 'staff' }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+
+  it('facilityIdがnull/undefinedの場合、fetchせずrole=nullを返す', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useFacilityRole(null))
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.role).toBeNull()
+    expect(result.current.canWrite).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('adminの場合、canWrite=trueを返す', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse({ role: 'admin' }))))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    await waitFor(() => expect(result.current.role).toBe('admin'))
+    expect(result.current.canWrite).toBe(true)
+  })
+
+  it('staffの場合、canWrite=trueを返す', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse({ role: 'staff' }))))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    await waitFor(() => expect(result.current.role).toBe('staff'))
+    expect(result.current.canWrite).toBe(true)
+  })
+
+  it('viewerの場合、canWrite=falseを返す(issue #608/#618)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse({ role: 'viewer' }))))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    await waitFor(() => expect(result.current.role).toBe('viewer'))
+    expect(result.current.canWrite).toBe(false)
+  })
+
+  it('未所属(role: null)の場合、canWrite=falseを返す', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse({ role: null }))))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.role).toBeNull()
+    expect(result.current.canWrite).toBe(false)
+  })
+
+  it('fetch失敗時はrole=nullにフォールバックする(安全側)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse({ error: 'ng' }, { status: 500 }))))
+
+    const { result } = renderHook(() => useFacilityRole('f-1'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.role).toBeNull()
+    expect(result.current.canWrite).toBe(false)
+  })
+
+  it('facilityIdが変わると再取得する', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/facilities/f-1/my-role') return Promise.resolve(jsonResponse({ role: 'viewer' }))
+      if (url === '/api/facilities/f-2/my-role') return Promise.resolve(jsonResponse({ role: 'admin' }))
+      return Promise.resolve(jsonResponse({ error: 'unexpected' }, { status: 500 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(({ facilityId }) => useFacilityRole(facilityId), {
+      initialProps: { facilityId: 'f-1' },
+    })
+    await waitFor(() => expect(result.current.role).toBe('viewer'))
+
+    rerender({ facilityId: 'f-2' })
+    await waitFor(() => expect(result.current.role).toBe('admin'))
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/facilities/f-1/my-role')
+    expect(fetchMock).toHaveBeenCalledWith('/api/facilities/f-2/my-role')
+  })
+})

--- a/src/hooks/useFacilityRole.ts
+++ b/src/hooks/useFacilityRole.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { FacilityRole } from '@/types/role'
+
+export type UseFacilityRoleResult = {
+  // WHY: undefinedは取得中(プレースホルダ表示用)、nullは未所属(admin以外書き込み不可)。
+  role: FacilityRole | null | undefined
+  canWrite: boolean
+  isLoading: boolean
+}
+
+// WHY: 施設ごとのUIゲーティング(issue #608)を各ページが個別に配線すると、新しい
+// 書き込みページを作る際に配線を忘れて「viewerに操作できそうなボタンが見える」が
+// 再発しうる(issue #618)。GET /api/facilities/[id]/my-role の呼び出し・
+// 取得中/未所属/エラーのハンドリング・canWrite判定を1箇所にまとめる。
+//
+// 対象は「1つのfacilityIdに対する自分のroleが分かれば良い」ページ(施設詳細ページ、
+// 対象施設が確定した後の編集ページ等)。hospital-prices/newのように施設選択自体が
+// フォーム内で行われ、複数施設の書き込み可否を同時に知る必要があるページは対象外
+// (GET /api/facilities の roleByFacilityId をそのまま使う。この場合my-roleへの
+// 個別リクエストをfacility数だけ発行するのは非効率なため意図的に分離している)。
+//
+// SWR等のキャッシュライブラリは導入せず、素のfetch+useStateで実装している
+// (このリポジトリの既存ページも同パターンで新規依存を増やす理由が無いため)。
+type FetchedState = { facilityId: string; role: FacilityRole | null }
+
+export function useFacilityRole(facilityId: string | null | undefined): UseFacilityRoleResult {
+  const [state, setState] = useState<FetchedState | null>(null)
+
+  useEffect(() => {
+    if (!facilityId) return
+    let cancelled = false
+    fetch(`/api/facilities/${facilityId}/my-role`)
+      .then((r) => {
+        if (!r.ok) throw new Error()
+        return r.json()
+      })
+      .then((d) => {
+        if (!cancelled) setState({ facilityId, role: d.role })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ facilityId, role: null })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [facilityId])
+
+  if (!facilityId) {
+    return { role: null, canWrite: false, isLoading: false }
+  }
+
+  // WHY: facilityIdが切り替わった直後、stateはまだ前のfacilityId分のまま(effect内
+  // でのsetStateは非同期コールバック内でのみ行い、切り替わり検知のための同期的な
+  // リセットは行わない)。ここでレンダー時にstate.facilityIdと現在のfacilityIdを
+  // 突き合わせ、一致しない間は「取得中」として扱う。
+  const isStale = state === null || state.facilityId !== facilityId
+  const role = isStale ? undefined : state.role
+
+  return {
+    role,
+    canWrite: role === 'admin' || role === 'staff',
+    isLoading: isStale,
+  }
+}


### PR DESCRIPTION
## 作業サマリ
issue #618 で指摘した、UIゲーティング配線が各ページ個別実装で「配線漏れの検知手段がない」構造を解消した。

背景: #608のviewerロールUIゲーティングは各ページが個別にfetch+useStateで施設ロールを配線する方式だったため、新しい書き込みページを作る際に配線を忘れると「viewerに操作できそうなボタンが見える」が再発しうる構造だった。

変更内容:
- `src/hooks/useFacilityRole.ts` を新設。`GET /api/facilities/[id]/my-role` の呼び出し・取得中/未所属/エラーのハンドリング・canWrite判定を1箇所にまとめた。
- 以下の「1つのfacilityIdに対する自分のroleが分かれば良い」ページをこのフックに置き換え:
  - `src/app/facilities/[id]/page.tsx`(施設詳細)
  - `src/app/hospital-prices/page.tsx`(一覧。選択中施設のcanWriteをbulk roleByFacilityIdからの導出ではなくフックに置換)
  - `src/app/hospital-prices/[id]/edit/page.tsx`(編集。price読み込み後に判明するfacilityIdでフックを呼ぶ形に変更)
- `hospital-prices/new/page.tsx` は意図的に対象外とした。施設選択自体がフォーム内で行われ、複数施設の書き込み可否を同時にフィルタする必要があるため、単一facilityId用のこのフックとは要求が異なる(施設数だけmy-roleを個別リクエストするのは非効率)。理由をコメントで明記した。
- フック実装は `react-hooks/set-state-in-effect` ルール(effect本体での同期的なsetState呼び出しを避ける)に対応するため、facilityId切替時の「取得中」判定を、取得済みstateのfacilityIdと現在のfacilityIdをレンダー時に突き合わせる方式にしている(setStateは非同期コールバック内でのみ呼ぶ)。

## 検証済み
- `src/hooks/__tests__/useFacilityRole.test.ts` を新規追加(取得中/admin/staff/viewer/未所属/エラー時フォールバック/facilityId切替時の再取得、計8件)
- `npm test` 全1395件パス(182ファイル)、既存テストの回帰なし(hospital-prices一覧のcanWrite関連テストはmy-roleエンドポイントのモックを追加して対応)
- `npm run lint` / `npx tsc --noEmit` エラーなし
- ローカルSupabase + 実ブラウザでviewer/staffの既存テストユーザーを使い、facilities/[id]・hospital-prices一覧・hospital-prices/[id]/editの3画面でリファクタ後も従来通りの表示(viewer: ゲーティングメッセージ、staff: 全ボタン表示)を維持していることを目視確認

Closes #618