### PR TITLE
fix: facility_writer_or_admin RLSポリシーにaal2要件を追加する

### DIFF
--- a/docs/agents/decisions/db-rls.md
+++ b/docs/agents/decisions/db-rls.md
@@ -205,3 +205,37 @@ Phase 3の実装時（db-impl・api実装担当がそれぞれ別々にSPECを�
 を直接参照するようになった場合、この判断は無効になる。認可判断でJWTクレームを参照するコードを
 追加する際は、必ずこのセクションを読み直し、`user_role`クレームの施設非依存な集約方式（bool_or）が
 その用途に耐えるか再検証すること。
+
+## なぜaal2要求（issue #612）をRPC内チェックだけでなくRLSポリシー自体にも追加したか（issue #623）
+
+**結論: `facility_writer_or_admin`ポリシーが付与されている全テーブル（発注/返却4テーブル・items系4テーブル・`hospital_prices`・`consumables`）のRLSポリシー自体に`has_aal2()`を追加した（`20260806000002_require_aal2_in_facility_writer_rls.sql`）。`facilities`（UPDATE、施設名変更のみ）は対象外とした。**
+
+`20260806000001`（issue #612）で`create_case_order_atomic`等4つのRPC関数の**内部**に`has_aal2()`
+チェックを追加したが、これらのテーブル自体のRLSポリシーは`is_facility_writer(facility_id) OR
+is_admin()`のみで、aal2判定を一切含んでいなかった。Next.jsアプリは常にRPC経由で発注するため
+気づかないが、PostgRESTの`POST /rest/v1/case_orders`のようにRPCを経由せずテーブルへ直接INSERT
+すれば、aal1のセッションのままでも発注データを書き込める。issue #612が「middlewareを迂回して
+直接Supabase APIを叩く経路をDB層で塞ぐ」ことを目的としていたにもかかわらず、発注テーブル自体の
+RLSではこの経路が塞がっていなかった（RPC内チェックのみでは、RPCを経由しない直接書き込みを
+防げない）。
+
+対象範囲は、issue #619（hospital_prices・consumablesがaal2要求の対象外という指摘）の議論を
+本issueで吸収し、以下のように確定した:
+- 発注/返却4テーブル・items系4テーブル: #612の防御を完成させるために必須（バグ修正）
+- `hospital_prices`・`consumables`: 価格改定は金額に直結し、かつ発注同様に低頻度の操作と判断し
+  対象に含めた。`consumables`テーブルは在庫数列を持たず`name`/`jan`/`purpose`のみのカタログで
+  あり、頻繁な編集を想定した運用ではないことを`supabase/migrations/20260624000000_add_orders.sql`
+  のスキーマ定義で確認済み。
+- `facilities`（UPDATE）: 対象外。金額・在庫の移動を伴わない純粋な管理操作であり、issue #612の
+  「金額・在庫に影響する書き込み操作に限定する」という線引きに該当しないため。
+
+RPC内の既存`has_aal2()`チェックは冗長になるが削除しなかった。RLSとRPC両方でのチェックは
+defense-in-depthとして、このリポジトリの既存パターン（`is_facility_writer`もRLSとRPC両方で
+チェックしている）と一致するため。
+
+検証は、静的SQLテキスト検証に加え、実際のTOTP enroll→challenge→verifyフローを実行する統合テスト
+（`supabase/__tests__/integration/require-aal2-in-facility-writer-rls.integration.test.ts`）で
+「MFA登録済み・aal1のセッションでは`case_orders`・`hospital_prices`への直接INSERT（RPC非経由）が
+拒否される」「aal2まで昇格すると成功する」「`facilities`の更新はaal1のままでも成功する（対象外の
+回帰確認）」を実測した。RPC経由の防御だけを見て「実装済み」と判断せず、RLSポリシー自体が同じ
+チェックを持つかを都度確認すること。

--- a/supabase/__tests__/integration/require-aal2-in-facility-writer-rls.integration.test.ts
+++ b/supabase/__tests__/integration/require-aal2-in-facility-writer-rls.integration.test.ts
@@ -1,0 +1,230 @@
+// supabase/__tests__/integration/require-aal2-in-facility-writer-rls.integration.test.ts
+// WHY: issue #623。20260806000001でcreate_case_order_atomic等4RPCの内部にhas_aal2()
+//      チェックを追加したが、テーブル自体のRLSポリシー(facility_writer_or_admin)は
+//      aal2判定を含んでいなかったため、RPCを経由しない直接テーブル書き込み
+//      (PostgRESTの.from().insert()等)ではaal1のままでも書き込めてしまっていた。
+//      20260806000002でRLSポリシー自体にhas_aal2()を追加した修正が、実際にRPCを
+//      経由しない直接書き込みを拒否することを実測する(#612実装時と同じ理由で、
+//      コードレビューだけでは実行時の抜け穴を検知できないため実DBで検証する)。
+//
+//      あわせて、facilities(施設名更新)は意図的にaal2要求の対象外としたため、
+//      MFA登録済み・aal1のままでも更新できることも回帰確認する。
+
+import { randomUUID, createHmac } from 'crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { assertTestSupabaseEnv } from '../../../e2e/env-guard'
+
+const TEST_USER_PASSWORD = 'require-aal2-facility-writer-rls-test-0000'
+
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  const clean = input.toUpperCase().replace(/=+$/, '')
+  let bits = ''
+  for (const char of clean) {
+    const val = alphabet.indexOf(char)
+    if (val === -1) throw new Error(`invalid base32 character: ${char}`)
+    bits += val.toString(2).padStart(5, '0')
+  }
+  const bytes: number[] = []
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2))
+  }
+  return Buffer.from(bytes)
+}
+
+// RFC 6238 (TOTP) / RFC 4226 (HOTP) 準拠。30秒ステップ・6桁・SHA1。
+function generateTotp(secretBase32: string): string {
+  const key = base32Decode(secretBase32)
+  const counter = Math.floor(Date.now() / 1000 / 30)
+  const counterBuffer = Buffer.alloc(8)
+  counterBuffer.writeBigUInt64BE(BigInt(counter))
+  const hmac = createHmac('sha1', key).update(counterBuffer).digest()
+  const offset = hmac[hmac.length - 1] & 0xf
+  const binCode =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff)
+  return (binCode % 1_000_000).toString().padStart(6, '0')
+}
+
+function createServiceRoleClient(): SupabaseClient {
+  assertTestSupabaseEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      '[require-aal2-in-facility-writer-rls] NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。'
+    )
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+function createAnonClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+describe('facility_writer_or_adminポリシーはRPCを経由しない直接書き込みにもaal2を要求する(issue #623)', () => {
+  const runId = randomUUID()
+  const serviceClient = createServiceRoleClient()
+  const email = `require-aal2-rls-${runId}@example.test`
+
+  let facilityId: string
+  let userId: string
+  let factorId: string
+  let secret: string
+
+  beforeAll(async () => {
+    const { data: facility, error: facilityError } = await serviceClient
+      .from('facilities')
+      .insert({ name: `テスト施設-AAL2RLS-${runId}` })
+      .select('id')
+      .single()
+    if (facilityError || !facility) throw new Error(`施設作成失敗: ${facilityError?.message}`)
+    facilityId = facility.id as string
+
+    const { data: userData, error: userError } = await serviceClient.auth.admin.createUser({
+      email,
+      password: TEST_USER_PASSWORD,
+      email_confirm: true,
+    })
+    if (userError || !userData.user) throw new Error(`ユーザー作成失敗: ${userError?.message}`)
+    userId = userData.user.id
+
+    const { error: linkError } = await serviceClient
+      .from('user_facilities')
+      .insert({ user_id: userId, facility_id: facilityId, role: 'staff' })
+    if (linkError) throw new Error(`user_facilities作成失敗: ${linkError.message}`)
+
+    // 以降のテストで使うTOTP factorをここで一度だけ登録する
+    const client = createAnonClient()
+    const { error: signInError } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    if (signInError) throw new Error(`サインイン失敗: ${signInError.message}`)
+
+    const { data: enrollData, error: enrollError } = await client.auth.mfa.enroll({ factorType: 'totp' })
+    if (enrollError || !enrollData) throw new Error(`MFA enroll失敗: ${enrollError?.message}`)
+    factorId = enrollData.id
+    secret = enrollData.totp.secret
+
+    const { data: challengeData, error: challengeError } = await client.auth.mfa.challenge({ factorId })
+    if (challengeError || !challengeData) throw new Error(`MFA challenge失敗: ${challengeError?.message}`)
+
+    const { error: verifyError } = await client.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData.id,
+      code: generateTotp(secret),
+    })
+    if (verifyError) throw new Error(`MFA verify失敗: ${verifyError.message}`)
+  }, 60_000)
+
+  afterAll(async () => {
+    await serviceClient.auth.admin.deleteUser(userId)
+    await serviceClient.from('facilities').delete().eq('id', facilityId)
+  })
+
+  async function signInAtAal1(): Promise<SupabaseClient> {
+    // パスワードのみの再サインインは、factorが検証済みでも新規セッションはaal1から始まる
+    const client = createAnonClient()
+    const { error } = await client.auth.signInWithPassword({ email, password: TEST_USER_PASSWORD })
+    if (error) throw new Error(`サインイン失敗: ${error.message}`)
+    return client
+  }
+
+  async function stepUpToAal2(client: SupabaseClient): Promise<void> {
+    const { data: challengeData, error: challengeError } = await client.auth.mfa.challenge({ factorId })
+    if (challengeError || !challengeData) throw new Error(`MFA challenge失敗: ${challengeError?.message}`)
+    const { error: verifyError } = await client.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData.id,
+      code: generateTotp(secret),
+    })
+    if (verifyError) throw new Error(`MFA verify失敗: ${verifyError.message}`)
+  }
+
+  it('MFA登録済みだがaal1のセッションでは、case_ordersへの直接INSERT(RPC非経由)がRLSで拒否される', async () => {
+    const client = await signInAtAal1()
+
+    const { error } = await client.from('case_orders').insert({
+      facility_id: facilityId,
+      case_datetime: new Date().toISOString(),
+      procedure_name: 'RLS直接書き込みテスト(aal1)',
+      patient_id: 'PT-RLS-1',
+      patient_initials: 'R.L.',
+      gender: 'other',
+      doctor_name: 'RLSテスト医師',
+    })
+
+    expect(error).not.toBeNull()
+  })
+
+  it('aal2まで昇格したセッションでは、case_ordersへの直接INSERT(RPC非経由)が成功する', async () => {
+    const client = await signInAtAal1()
+    await stepUpToAal2(client)
+
+    const { error } = await client.from('case_orders').insert({
+      facility_id: facilityId,
+      case_datetime: new Date().toISOString(),
+      procedure_name: 'RLS直接書き込みテスト(aal2)',
+      patient_id: 'PT-RLS-2',
+      patient_initials: 'R.L.',
+      gender: 'other',
+      doctor_name: 'RLSテスト医師',
+    })
+
+    expect(error).toBeNull()
+  })
+
+  it('MFA登録済みだがaal1のセッションでは、hospital_pricesへの直接INSERTもRLSで拒否される(issue #619の判断: 価格改定も対象)', async () => {
+    const { data: product } = await serviceClient
+      .from('products')
+      .insert({ jan: `888${runId}`, ref: `REF-RLS-${runId}`, name: 'RLSテスト製品' })
+      .select('id')
+      .single()
+    const { data: category } = await serviceClient
+      .from('categories')
+      .insert({ name: `RLSテストカテゴリ-${runId}` })
+      .select('id')
+      .single()
+    const { data: dp } = await serviceClient
+      .from('distributor_products')
+      .insert({
+        product_id: product!.id,
+        category_id: category!.id,
+        maker: 'テストメーカー',
+        supplier: 'テスト仕入先',
+        name: 'RLSテスト商品',
+        reimbursement_price: 1000,
+        quantity: 1,
+      })
+      .select('id')
+      .single()
+
+    const client = await signInAtAal1()
+    const { error } = await client.from('hospital_prices').insert({
+      facility_id: facilityId,
+      distributor_product_id: dp!.id,
+      purchase_price: 500,
+      delivery_price: 700,
+    })
+
+    expect(error).not.toBeNull()
+  })
+
+  it('facilitiesの更新(施設名変更)は意図的に対象外のため、aal1のままでも成功する(issue #623の除外判断の回帰確認)', async () => {
+    const client = await signInAtAal1()
+
+    const { error } = await client
+      .from('facilities')
+      .update({ name: `RLSテスト施設-更新済み-${runId}` })
+      .eq('id', facilityId)
+
+    expect(error).toBeNull()
+  })
+})

--- a/supabase/migrations/20260806000002_require_aal2_in_facility_writer_rls.sql
+++ b/supabase/migrations/20260806000002_require_aal2_in_facility_writer_rls.sql
@@ -1,0 +1,141 @@
+-- supabase/migrations/20260806000002_require_aal2_in_facility_writer_rls.sql
+-- WHY: issue #623。20260806000001でcreate_case_order_atomic等4RPCの内部にhas_aal2()
+--      チェックを追加したが、これらのテーブル自体のRLSポリシー(facility_writer_or_admin)
+--      はis_facility_writer(facility_id) OR is_admin()のみで、aal2判定を一切含んで
+--      いなかった。Next.jsアプリは常にRPC経由で発注するため気づかないが、PostgRESTの
+--      POST /rest/v1/case_orders のようにRPCを経由せずテーブルへ直接INSERTすれば、
+--      aal1のセッションのままでも発注データを書き込める。20260806000001が「middlewareを
+--      迂回して直接Supabase APIを叩く経路をDB層で塞ぐ」ことを目的としていたにもかかわらず、
+--      発注テーブル自体のRLSではこの経路が塞がっていなかった(RPC内チェックのみでは、
+--      RPCを経由しない直接書き込みを防げない)。
+--
+-- WHY(対象範囲・facilitiesを除外する理由): facility_writer_or_admin系ポリシーが付与
+--      されている全テーブル(発注/返却4テーブル+items4テーブル+hospital_prices+
+--      consumables)にhas_aal2()を追加する。facilities(UPDATE、施設名変更のみ)は
+--      対象外とした。金額・在庫の移動を伴わない純粋な管理操作であり、issue #612の
+--      「金額・在庫に影響する書き込み操作に限定する」という線引きに該当しないため。
+--      hospital_prices・consumablesは#612時点では対象外だったが、issue #619の
+--      検討で「価格改定は金額に直結し、かつ発注同様に低頻度の操作」と判断し、
+--      本migrationで対象に含めた(consumablesテーブルは在庫数を持たずname/jan/purpose
+--      のみのカタログであるため、頻繁な編集を想定した運用ではない)。
+--
+-- WHY(RPC内の既存has_aal2()チェックを削除しない理由): RLSとRPC両方でのチェックは
+--      冗長になるが、defense-in-depthとしてこのリポジトリの既存パターン(is_facility_writer
+--      もRLSとRPC両方でチェックしている)と一致するため、RPC側のチェックは残す。
+
+-- =========================================================================
+-- 発注/返却系4テーブル
+-- =========================================================================
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON consumable_orders;
+CREATE POLICY "facility_writer_or_admin" ON consumable_orders
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON case_orders;
+CREATE POLICY "facility_writer_or_admin" ON case_orders
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON loan_orders;
+CREATE POLICY "facility_writer_or_admin" ON loan_orders
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON loan_returns;
+CREATE POLICY "facility_writer_or_admin" ON loan_returns
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+-- =========================================================================
+-- 価格・カタログ2テーブル(issue #619で対象に含めると判断)
+-- =========================================================================
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON hospital_prices;
+CREATE POLICY "facility_writer_or_admin" ON hospital_prices
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON consumables;
+CREATE POLICY "facility_writer_or_admin" ON consumables
+  FOR ALL TO authenticated
+  USING ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2())
+  WITH CHECK ((is_facility_writer(facility_id) OR is_admin()) AND has_aal2());
+
+-- =========================================================================
+-- items系4テーブル(親order経由でfacility_idを引くEXISTSパターン)
+-- =========================================================================
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON case_order_items;
+CREATE POLICY "facility_writer_or_admin" ON case_order_items
+  FOR ALL TO authenticated
+  USING (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM case_orders o
+      WHERE o.id = case_order_items.case_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  )
+  WITH CHECK (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM case_orders o
+      WHERE o.id = case_order_items.case_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  );
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON consumable_order_items;
+CREATE POLICY "facility_writer_or_admin" ON consumable_order_items
+  FOR ALL TO authenticated
+  USING (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM consumable_orders o
+      WHERE o.id = consumable_order_items.consumable_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  )
+  WITH CHECK (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM consumable_orders o
+      WHERE o.id = consumable_order_items.consumable_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  );
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON loan_order_items;
+CREATE POLICY "facility_writer_or_admin" ON loan_order_items
+  FOR ALL TO authenticated
+  USING (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM loan_orders o
+      WHERE o.id = loan_order_items.loan_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  )
+  WITH CHECK (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM loan_orders o
+      WHERE o.id = loan_order_items.loan_order_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  );
+
+DROP POLICY IF EXISTS "facility_writer_or_admin" ON loan_return_items;
+CREATE POLICY "facility_writer_or_admin" ON loan_return_items
+  FOR ALL TO authenticated
+  USING (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM loan_returns o
+      WHERE o.id = loan_return_items.loan_return_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  )
+  WITH CHECK (
+    has_aal2() AND EXISTS (
+      SELECT 1 FROM loan_returns o
+      WHERE o.id = loan_return_items.loan_return_id
+        AND (is_facility_writer(o.facility_id) OR is_admin())
+    )
+  );

--- a/supabase/migrations/__tests__/require_aal2_in_facility_writer_rls.test.ts
+++ b/supabase/migrations/__tests__/require_aal2_in_facility_writer_rls.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無い実行環境でも回帰を検知できるよう、生成したSQL
+//      マイグレーションの中身を静的に検証する。実DB上の動作確認は別途
+//      ローカルSupabaseへのdb push + RLSからの直接書き込みで行う（このテストの対象外）。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_require_aal2_in_facility_writer_rls.sql'))
+    .sort()
+    .at(-1)
+}
+
+const DIRECT_TABLES = [
+  'consumable_orders',
+  'case_orders',
+  'loan_orders',
+  'loan_returns',
+  'hospital_prices',
+  'consumables',
+]
+const ITEMS_TABLES = [
+  'case_order_items',
+  'consumable_order_items',
+  'loan_order_items',
+  'loan_return_items',
+]
+
+describe('*_require_aal2_in_facility_writer_rls.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('発注/返却4テーブル+価格/カタログ2テーブルのfacility_writer_or_adminポリシーを再定義する', () => {
+    for (const t of DIRECT_TABLES) {
+      expect(n).toContain(`drop policy if exists "facility_writer_or_admin" on ${t}`)
+      expect(n).toContain(
+        `create policy "facility_writer_or_admin" on ${t} for all to authenticated using ((is_facility_writer(facility_id) or is_admin()) and has_aal2()) with check ((is_facility_writer(facility_id) or is_admin()) and has_aal2())`
+      )
+    }
+  })
+
+  it('items系4テーブルのfacility_writer_or_adminポリシーにhas_aal2()を追加する', () => {
+    for (const t of ITEMS_TABLES) {
+      expect(n).toContain(`drop policy if exists "facility_writer_or_admin" on ${t}`)
+      const occurrences = n.match(
+        new RegExp(`create policy "facility_writer_or_admin" on ${t} for all to authenticated using \\( has_aal2\\(\\) and exists`, 'g')
+      ) ?? []
+      expect(occurrences.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('has_aal2()の出現回数は10テーブル×(using+with check)=20回', () => {
+    const occurrences = n.match(/has_aal2\(\)/g) ?? []
+    expect(occurrences.length).toBe(20)
+  })
+
+  it('facilitiesのfacility_writer_or_admin_updateポリシーは対象外のまま(意図的に除外)', () => {
+    expect(n).not.toContain('facility_writer_or_admin_update')
+  })
+
+  it('is_facility_writerチェックを維持している(施設境界チェックの退行防止)', () => {
+    const occurrences = n.match(/is_facility_writer\(/g) ?? []
+    // 10テーブル × (using句 + with check句) = 20箇所
+    expect(occurrences.length).toBe(20)
+  })
+
+  it('publicスキーマのテーブル追加/削除を伴わないため refresh_schema_baseline_snapshot を呼び出さない', () => {
+    expect(n).not.toMatch(/select\s+refresh_schema_baseline_snapshot\(/)
+  })
+})


### PR DESCRIPTION
## 作業サマリ
issue #623(#612の防御を完成させる修正)を実装した。

背景: #612で `create_case_order_atomic` 等4RPCの内部に `has_aal2()` チェックを追加したが、これらのテーブル自体のRLSポリシー(`facility_writer_or_admin`)は `is_facility_writer(facility_id) OR is_admin()` のみで、aal2判定を一切含んでいなかった。Next.jsアプリは常にRPC経由で発注するため気づかないが、PostgRESTの `POST /rest/v1/case_orders` のようにRPCを経由せずテーブルへ直接INSERTすれば、aal1のセッションのままでも発注データを書き込める。#612が「middlewareを迂回して直接Supabase APIを叩く経路をDB層で塞ぐ」ことを目的としていたにもかかわらず、発注テーブル自体のRLSではこの経路が塞がっていなかった。

変更内容:
- `facility_writer_or_admin` ポリシーが付与されている以下のテーブルのRLSポリシーに `has_aal2()` を追加:
  - 発注/返却4テーブル: `case_orders` / `consumable_orders` / `loan_orders` / `loan_returns`
  - items系4テーブル: `case_order_items` / `consumable_order_items` / `loan_order_items` / `loan_return_items`
  - `hospital_prices` / `consumables`(issue #619の議論を本issueで吸収し、価格改定・カタログ編集も対象に含めると判断)
- `facilities`(UPDATE、施設名変更のみ)は意図的に対象外とした。金額・在庫の移動を伴わない純粋な管理操作のため。
- RPC内の既存 `has_aal2()` チェックは冗長だが、defense-in-depthとして残した(`is_facility_writer` もRLS/RPC両方でチェックする既存パターンと一致)。
- 判断根拠を `docs/agents/decisions/db-rls.md` に記録した。

## 検証済み
- 静的SQLテスト7件パス
- `supabase db push --local` でローカルPostgresへの適用成功
- 実際のTOTP enroll→challenge→verifyフローを実行する統合テスト(`supabase/__tests__/integration/require-aal2-in-facility-writer-rls.integration.test.ts`)で以下を実測:
  - MFA登録済み・aal1のセッションでは `case_orders`・`hospital_prices` への直接INSERT(RPC非経由)がRLSで拒否される(**修正前は素通りしていた抜け穴が閉じたことの実測**)
  - aal2まで昇格すると成功する
  - `facilities` の更新は意図的に対象外のためaal1のままでも成功する(除外判断の回帰確認)
- 既存の統合テスト全11ファイル44件、回帰なし
- `npm test` 全1402件パス(183ファイル)
- `npm run lint` / `npx tsc --noEmit` エラーなし

Closes #623