### PR TITLE
feat: Workflowにトークン量のデフォルト上限サーキットブレーカーを追加する

### DIFF
--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -73,10 +73,27 @@ const MIN_BUDGET_FOR_SWEEP_ROUND = 400_000
 function isBudgetExhausted(minRemainingForRound) {
   return Boolean(budget?.total && budget.remaining() < minRemainingForRound)
 }
+
+// 単発タスクの総量サーキットブレーカー（2026-08-06 mentor評価）。正本・単体テストは
+// .claude/workflows/lib/budget-guard.js。Workflow DSLはrequire不可のためインライン複製し、
+// 同期は budget-guard-sync.test.js が検証する。budget.total（明示予算）が未設定のときのみ
+// DEFAULT_TOKEN_CAPを代替上限として適用し、原因を問わず量で止める。
+// 上限値はこのworkflow固有の仮置き値: router-risk.js誤判定インシデント（346万トークン、
+// issue #500）を確実に止められ、かつ正常収束時（maxRounds=3のSweep+後続フェーズ）の
+// 想定消費を大きく上回る値として2_000_000を選んだ。実測の裏付けは薄く、運用しながら
+// 再調整する前提（MIN_BUDGET_FOR_SWEEP_ROUNDと同じ位置づけ）。
+const DEFAULT_TOKEN_CAP = 2_000_000
+function isDefaultCapExceeded(budget, defaultCap) {
+  if (!budget || typeof budget.spent !== 'function') return false
+  if (budget.total) return false
+  return budget.spent() >= defaultCap
+}
+
 function shouldContinueSweepLoop(dryRounds, round, maxRounds, minRemainingForRound) {
   if (dryRounds >= 2) return false
   if (round > maxRounds) return false
   if (isBudgetExhausted(minRemainingForRound)) return false
+  if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) return false
   return true
 }
 
@@ -173,10 +190,13 @@ const sweepSummary = [
 // ケースも同様に一律「ラウンド上限到達」と誤報しないよう区別を追加）
 const sweepConverged = dryRounds >= 2
 const sweepBudgetExhausted = !sweepConverged && isBudgetExhausted(MIN_BUDGET_FOR_SWEEP_ROUND)
+const sweepTokenCapExceeded = !sweepConverged && !sweepBudgetExhausted && isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)
 if (sweepConverged) {
   log(`Sweep完了（収束）: ${round - 1}ラウンド`)
 } else if (sweepBudgetExhausted) {
   log(`Sweep未完了: budget残高不足のため打ち切り（残り${budget.remaining()}トークン < 閾値${MIN_BUDGET_FOR_SWEEP_ROUND}）。未解決の指摘が残っている可能性があります`)
+} else if (sweepTokenCapExceeded) {
+  log(`Sweep未完了: サーキットブレーカー発動のため打ち切り（累計${budget.spent()}トークン >= デフォルト上限${DEFAULT_TOKEN_CAP}）。未解決の指摘が残っている可能性があります`)
 } else {
   log(`Sweep未完了: ラウンド上限(${maxRounds})に到達したため打ち切り。未解決の指摘が残っている可能性があります`)
 }
@@ -211,6 +231,23 @@ if (draftSpec?.status !== 'pass') {
     draftSpec,
     blocked: true,
     blockedAt: 'Draft Spec',
+  }
+}
+
+// サーキットブレーカー: Find以降（Find 5体 → Adversarial Verify(opus×指摘数) → Judge Panel →
+// Synthesize）へ進む前にフェーズ境界で累計量を確認する。Sweepループ内のガードだけでは、
+// ループ外の後続フェーズが上限超過後もフルに走ってしまう
+if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) {
+  log(`サーキットブレーカー: 累計${budget.spent()}トークンがデフォルト上限${DEFAULT_TOKEN_CAP}を超過したため中断（Find以降へは進みません）`)
+  return {
+    sweepFindings: allFindings,
+    sweepConverged,
+    sweepBudgetExhausted,
+    sweepBlockedAxes: lastRoundBlockedAxes,
+    draftSpec,
+    blocked: true,
+    blockedAt: 'Token Cap (before Find)',
+    tokenCapExceeded: true,
   }
 }
 
@@ -267,6 +304,24 @@ const dedupedFindings = allFindResults.filter(f => {
   return true
 })
 log(`Find完了: ${allFindResults.length}件 → dedup後 ${dedupedFindings.length}件`)
+
+// サーキットブレーカー: Adversarial Verifyは指摘件数に比例してopusエージェントが起動する
+// 最も単価の高いフェーズのため、直前に累計量を再確認する（以降のJudge Panel/Synthesizeは
+// 台数上限が固定のためガードは置かない）
+if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) {
+  log(`サーキットブレーカー: 累計${budget.spent()}トークンがデフォルト上限${DEFAULT_TOKEN_CAP}を超過したため中断（Adversarial Verify以降へは進みません）`)
+  return {
+    sweepFindings: allFindings,
+    sweepConverged,
+    sweepBudgetExhausted,
+    sweepBlockedAxes: lastRoundBlockedAxes,
+    draftSpec,
+    dedupedFindings,
+    blocked: true,
+    blockedAt: 'Token Cap (before Adversarial Verify)',
+    tokenCapExceeded: true,
+  }
+}
 
 // ─── Phase 5: Adversarial Verify ─────────────────────────────────────
 phase('Adversarial Verify')

--- a/.claude/workflows/aidd-phase2.js
+++ b/.claude/workflows/aidd-phase2.js
@@ -91,6 +91,34 @@ function shouldBlock(results) {
   return !results.every(r => r?.status === 'pass' || isMinorOnlyFailure(r))
 }
 
+// 単発タスクの総量サーキットブレーカー（2026-08-06 mentor評価）。正本・単体テストは
+// .claude/workflows/lib/budget-guard.js。Workflow DSLはrequire不可のためインライン複製し、
+// 同期は budget-guard-sync.test.js が検証する。budget.total（明示予算）が未設定のときのみ
+// DEFAULT_TOKEN_CAPを代替上限として適用し、原因を問わず量で止める。
+// 上限値はこのworkflow固有の仮置き値: phase2は実装5体+統合+レビュー4体×最大4ラウンド+
+// 差し戻しimplementerを起動するためdeep-taskより高めの2_500_000を選んだ。実測の裏付けは
+// 薄く、運用しながら再調整する前提（deep-task側DEFAULT_TOKEN_CAPと同じ位置づけ）。
+const DEFAULT_TOKEN_CAP = 2_500_000
+function isDefaultCapExceeded(budget, defaultCap) {
+  if (!budget || typeof budget.spent !== 'function') return false
+  if (budget.total) return false
+  return budget.spent() >= defaultCap
+}
+
+// フェーズ境界でのサーキットブレーカー判定と、blocked相当の共通return生成。
+// 既存の品質ゲート（shouldBlock）と同じ「止めて人間に引き渡す」流儀に合わせる
+function tokenCapReturn(blockedAt, partialResults) {
+  log(`サーキットブレーカー: 累計${budget.spent()}トークンがデフォルト上限${DEFAULT_TOKEN_CAP}を超過したため中断（${blockedAt}へは進みません）`)
+  return {
+    done: false,
+    ...partialResults,
+    blocked: true,
+    blockedAt: `Token Cap (before ${blockedAt})`,
+    tokenCapExceeded: true,
+    stats: { phase: 'phase2', done: false, blocked: true, blockedAt: `Token Cap (before ${blockedAt})`, expectedLoopObservabilityRecords: loggableAgentCount, expectedAgentProgressRecords: progressLoggableAgentCount },
+  }
+}
+
 // ログ記録漏れ検知（.claude/workflows/lib/loop-observability-expectation.js の
 // isLoggableAgentType と同一ロジック。Workflow DSLはrequire不可のためインライン複製）。
 // reviewer/implementer/judge-panelのみ scripts/log-loop-observability.sh 呼び出し指示を
@@ -267,6 +295,9 @@ if (manifestCheck?.status !== 'pass') {
 // ─── Phase A: Contract Write + DB（並列）─────────────────────────────
 // contract-writer: src/types/ の型定義を確定（implementerの「契約」）
 // db-impl: supabase/migrations/ を実装（SPEC.mdから直接、contract-writerと並行）
+if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) {
+  return tokenCapReturn('Contract + DB', { specCheck, manifestCheck })
+}
 phase('Contract + DB')
 
 const [contractResult, dbResult] = await parallel([
@@ -314,6 +345,10 @@ if (shouldBlock([contractResult, dbResult])) {
   }
 }
 logMinorOnlyPassThrough('Contract + DB', [contractResult, dbResult])
+
+if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) {
+  return tokenCapReturn('Implement', { manifestCheck, contractResult, dbResult })
+}
 
 // ─── Phase B: data / api / ui（並列）─────────────────────────────────
 // 3グループは contract-writer の出力（src/types/）を契約として参照する
@@ -565,6 +600,21 @@ let reviewRetryAgentCount = 0
 const retryHistory = []
 
 while (true) {
+  // サーキットブレーカー: Review差し戻しループはこのworkflow内で唯一の反復構造のため、
+  // ラウンドごとに累計量を確認する（MAX_REVIEW_RETRIESの回数上限とは独立した量ベースの保険）
+  if (isDefaultCapExceeded(budget, DEFAULT_TOKEN_CAP)) {
+    return tokenCapReturn('Review', {
+      manifestCheck,
+      contractResult,
+      dbResult,
+      dataResult,
+      apiResult,
+      uiResult,
+      coverageCheck,
+      groupImplResult,
+      integration: integrationResult,
+    })
+  }
   reviewAttempt++
   log(`Reviewラウンド ${reviewAttempt}/${MAX_REVIEW_RETRIES + 1} 開始`)
 

--- a/.claude/workflows/lib/__tests__/budget-guard-sync.test.js
+++ b/.claude/workflows/lib/__tests__/budget-guard-sync.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const LIB_FILE = path.resolve(__dirname, '../budget-guard.js')
+const WORKFLOW_FILES = [
+  path.resolve(__dirname, '../../aidd-1-1-deep-task.js'),
+  path.resolve(__dirname, '../../aidd-phase2.js'),
+]
+
+// aidd-1-1-deep-task.js / aidd-phase2.js（Workflow DSL、require不可）内にインライン複製された
+// サーキットブレーカー判定（isDefaultCapExceeded）が、lib/budget-guard.js の正本と
+// 一字一句ドリフトしていないかを検証する（router-risk-sync.test.js と同型のガード）。
+// DEFAULT_TOKEN_CAPの値はworkflowごとに意図的に異なる（deep-task: 2M / phase2: 2.5M）ため
+// 同期対象にしない。既存のisBudgetExhaustedはdeep-task側がbudgetをクロージャで参照する
+// 適応版のため宣言単位の同期対象外（budget-guard.js冒頭コメント参照）。
+//
+// 注意: extractDeclarationは宣言後の最初の `{` を本体開始とみなすため、同期対象の関数は
+// パラメータに分割代入 `({ ... })` を使ってはならない（引数部分だけが抽出され、本体の
+// ドリフトを検知できない偽陰性になる。本テスト導入時のfault injectionで実測済み）。
+describe('isDefaultCapExceededのインライン複製同期', () => {
+  const libDecl = extractDeclaration(readFileSync(LIB_FILE, 'utf-8'), 'isDefaultCapExceeded')
+
+  for (const file of WORKFLOW_FILES) {
+    it(`${path.basename(file)} のisDefaultCapExceededがlib/budget-guard.jsと一致する`, () => {
+      const workflowDecl = extractDeclaration(readFileSync(file, 'utf-8'), 'isDefaultCapExceeded')
+      expect(workflowDecl).toBe(libDecl)
+    })
+  }
+})

--- a/.claude/workflows/lib/__tests__/budget-guard.test.js
+++ b/.claude/workflows/lib/__tests__/budget-guard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isBudgetExhausted, shouldContinueLoop } from '../budget-guard.js'
+import { isBudgetExhausted, isDefaultCapExceeded, shouldContinueLoop } from '../budget-guard.js'
 
 const MIN_REMAINING = 400_000
 
@@ -25,6 +25,38 @@ describe('isBudgetExhausted', () => {
   it('remaining()がちょうど閾値と同値ならfalse(境界は消費側に倒す)', () => {
     const budget = { total: 1_000_000, remaining: () => MIN_REMAINING }
     expect(isBudgetExhausted({ budget, minRemainingForRound: MIN_REMAINING })).toBe(false)
+  })
+})
+
+describe('isDefaultCapExceeded', () => {
+  const CAP = 2_000_000
+
+  it('budgetそのものが渡されない(undefined)場合はfalse（判定不能時はfail-openで既存動作維持）', () => {
+    expect(isDefaultCapExceeded(undefined, CAP)).toBe(false)
+  })
+
+  it('budget.spentが関数でない場合はfalse（Workflowツール外での誤用ガード）', () => {
+    expect(isDefaultCapExceeded({ total: null }, CAP)).toBe(false)
+  })
+
+  it('budget.totalが設定されている場合はfalse（明示予算はWorkflowツール本体がハード強制する）', () => {
+    const budget = { total: 500_000, spent: () => 10_000_000 }
+    expect(isDefaultCapExceeded(budget, CAP)).toBe(false)
+  })
+
+  it('total未設定でspent()がdefaultCap未満ならfalse', () => {
+    const budget = { total: null, spent: () => CAP - 1 }
+    expect(isDefaultCapExceeded(budget, CAP)).toBe(false)
+  })
+
+  it('total未設定でspent()がちょうどdefaultCapと同値ならtrue（境界は停止側に倒す）', () => {
+    const budget = { total: null, spent: () => CAP }
+    expect(isDefaultCapExceeded(budget, CAP)).toBe(true)
+  })
+
+  it('total未設定でspent()がdefaultCap超過ならtrue', () => {
+    const budget = { total: null, spent: () => CAP + 1 }
+    expect(isDefaultCapExceeded(budget, CAP)).toBe(true)
   })
 })
 

--- a/.claude/workflows/lib/budget-guard.js
+++ b/.claude/workflows/lib/budget-guard.js
@@ -13,6 +13,24 @@ export function isBudgetExhausted({ budget, minRemainingForRound }) {
   return Boolean(budget?.total && budget.remaining() < minRemainingForRound)
 }
 
+// 単発タスクの総量サーキットブレーカー（2026-08-06 mentor評価）。issue #500の再発防止
+// （キーワード誤判定という原因別の対策）とは独立に、「別の原因で暴走しても量で止める」
+// 保険として機能する。budget.total（ユーザーの「+500k」等の明示予算）が設定されている場合は
+// Workflowツール本体がハード強制する（超過時にagent()がthrowする）ため、このガードは
+// total未設定時のみdefaultCapを代替上限として適用する。budget.spent()はメインループと
+// 全workflowを合算したターン累計出力トークンであり、このworkflow単体の消費量ではない点に注意。
+// aidd-1-1-deep-task.js / aidd-phase2.js（Workflow DSL、require不可）にインライン複製している。
+// 同期は budget-guard-sync.test.js が検証する。このファイルは単体テスト用の正本。
+// 引数を既存関数のようなオブジェクト分割代入にしていないのは意図的:
+// extract-declaration.js は宣言後の最初の `{` を関数本体とみなすため、パラメータに
+// 分割代入 `({ ... })` があると引数部分だけを抽出してしまい、本体のドリフトを検知できない
+// （budget-guard-sync.test.js 導入時のfault injectionで実測した偽陰性）。
+export function isDefaultCapExceeded(budget, defaultCap) {
+  if (!budget || typeof budget.spent !== 'function') return false
+  if (budget.total) return false
+  return budget.spent() >= defaultCap
+}
+
 // Sweepループ(while)の継続条件。dryRounds/maxRoundsの既存条件に加え、budgetガードをORではなくAND連結する
 // （budgetが尽きていなくてもdry収束・ラウンド上限到達なら従来通り停止する）。
 export function shouldContinueLoop({ dryRounds, round, maxRounds, budget, minRemainingForRound }) {

--- a/docs/agents/decisions/aidd-pipeline.md
+++ b/docs/agents/decisions/aidd-pipeline.md
@@ -556,3 +556,42 @@ CI上のcheck名は`CI / test`・`CI / lint`）。新規CI jobの追加は不要
 mentorスキルの判断軸（閾値を先に決めてからゲートを作る）に従うが、今回は既存のci.yml/
 node-check.ymlが既にtest/lintを実行していたため、新規job作成ではなく既存jobへの閾値明記と
 lint scriptの`--max-warnings=0`追加のみをまとめて行った。
+
+## なぜトークン量のデフォルト上限（原因非依存のサーキットブレーカー）をWorkflow内に追加したか（2026-08-06 mentor評価）
+
+**結論: `budget.total`（ユーザーの「+500k」等の明示予算）が未設定でも、累計出力トークンがworkflow固有のデフォルト上限を超えたらフェーズ境界・ループ先頭で中断する量ベースの保険を`aidd-1-1-deep-task.js`と`aidd-phase2.js`に追加した。**
+
+`router-risk.js`の346万トークン消費インシデントは、issue #500で根本原因（changedFiles空時の
+キーワード誤判定によるルート誤選択）を修正済みだが、これは原因別の個別対策であり、
+「別の原因で暴走した場合に量で止める」汎用の上限はコード上どこにも存在しなかった
+（2026-08-06のmentor評価指摘）。既存機構の棚卸し結果:
+
+- Workflowツール本体の`budget.total`ハード強制（超過で`agent()`がthrow）は、ユーザーが
+  「+500k」等を明示したときだけ発動するopt-in
+- `budget-guard.js`（issue #442）は`aidd-1-1-deep-task.js`のSweepループ限定で、かつ
+  `budget.total`未設定なら素通りする後方互換設計
+- `/goal`のターン数上限はWorkflow外のセッション自走向けで、設定有無を機械検知できない
+  自己申告（`undetectable-rules-inventory.md`記載）
+
+つまり欠けていたのは「指示が無いときのデフォルト上限」のみ。`budget.spent()`は
+`budget.total`未設定でも呼べるため、正本`lib/budget-guard.js`の`isDefaultCapExceeded`
+（`total`設定時はWorkflowツール本体に委ねてfalse、未設定時のみ`spent() >= defaultCap`で判定）を
+両workflowへインライン複製し（同期は`budget-guard-sync.test.js`）、以下の位置で判定する:
+
+- `aidd-1-1-deep-task.js`（上限2,000,000トークン）: Sweepループ継続条件・Find前・
+  Adversarial Verify前（指摘件数比例でopusが起動する最高単価フェーズ）
+- `aidd-phase2.js`（上限2,500,000トークン）: Contract+DB前・Implement前・Review差し戻し
+  ループの各ラウンド先頭
+
+上限値はいずれも仮置き（346万インシデントを確実に止められ、正常収束時の想定消費を大きく
+上回る値）で、実測の裏付けは薄く運用しながら再調整する前提（`MIN_BUDGET_FOR_SWEEP_ROUND`と
+同じ位置づけ）。`budget.spent()`はメインループと全workflowを合算したターン累計のため、
+このworkflow単体の消費量より大きく出る（=安全側に倒れる）点に注意。
+
+**既知の限界（意図的にスコープ外）:** Workflow外、つまりメインセッションが手動でターンを
+重ねる暴走は引き続き`/goal`頼みで自己申告のまま。hookからトークン量を機械測定する手段が
+現状無く、statusline可視化（issue #446）止まりが現実的なため、今回は対象にしていない。
+
+**How to apply:** 新しいWorkflowスクリプトに反復構造（ループ・リトライ）や台数可変の
+フェーズを追加する際は、`isDefaultCapExceeded`をインライン複製し（`budget-guard-sync.test.js`の
+`WORKFLOW_FILES`にも追加）、workflow固有の`DEFAULT_TOKEN_CAP`を根拠コメント付きで定める。


### PR DESCRIPTION
## 作業サマリ
8/6のmentor評価が指摘した「原因を問わず量で止める汎用サーキットブレーカーの不在」への対応（層1: Workflow内）。

既存機構の棚卸しの結果、Workflowツールの`budget.total`ハード強制はopt-in（「+500k」明示時のみ）、`budget-guard.js`（issue #442）はSweepループ限定かつtotal未設定なら素通り、と確認。欠けていたのは「指示が無いときのデフォルト上限」のみだったため、以下を追加:

- **正本** `lib/budget-guard.js`: `isDefaultCapExceeded(budget, defaultCap)` — total設定時はWorkflowツール本体に委ねてfalse、未設定時のみ`spent() >= defaultCap`
- **aidd-1-1-deep-task.js**（上限2,000,000）: Sweepループ継続条件・Find前・Adversarial Verify前（指摘数比例でopusが起動する最高単価フェーズ）で判定。打ち切り理由のlogにトークンcap枯渇の区分を追加
- **aidd-phase2.js**（上限2,500,000）: Contract+DB前・Implement前・Review差し戻しループ各ラウンド先頭で判定。既存の品質ゲートと同じblocked形式（`blockedAt: 'Token Cap (before X)'`・`tokenCapExceeded: true`）で返す
- 上限値は仮置き（346万トークンインシデントを確実に止め、正常収束時の想定消費を大きく上回る値）。運用しながら再調整する前提を根拠コメント・docsに明記
- `docs/agents/decisions/aidd-pipeline.md`に設計判断エントリ追加。**Workflow外（メインセッション自走）の暴走は/goal頼みのままで、意図的にスコープ外**

### 副次的な発見
同期テスト（`budget-guard-sync.test.js`）導入時のfault injectionで、`extractDeclaration`が**分割代入パラメータ`({ ... })`の`{`を関数本体と誤認し、本体ドリフトを見逃す偽陰性**を実測。同期対象関数は位置引数とする制約をコメントに明記して回避した（`extractDeclaration`自体の修正は別タスク候補）。

## 検証済み
- fault injection: phase2側インライン複製の`>=`を`>`に改変 → 同期テストが本体差分つきでredになることを実測（分割代入シグネチャ時代は同じ改変がpassしていた＝偽陰性の実証）
- `npm test`: 185 test files / 1415 tests all pass（isDefaultCapExceeded単体6件・同期2件を含む）
- `npm run lint`: 0 errors, 0 warnings
- 両workflowファイルの構文チェック（async関数体としてパース）OK
- eval:workflows未実施（プロンプト文言の変更なし・制御ロジックのみのため対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)