### PR TITLE
test: Sweep recallに「1件目で止まると落ちる」fixtureを追加する

### DIFF
--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/expected.json
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/expected.json
@@ -1,0 +1,4 @@
+{
+  "expectedFilePathContains": "eval-fixture-recall-b/search-filter-panel.tsx",
+  "expectedKeywords": ["Suspense", "useSearchParams"]
+}

--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/alert-banner.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/alert-banner.tsx
@@ -1,0 +1,24 @@
+// issue #431のrecallベンチマーク用fixture（case-2の「囮」側）。
+// このファイルは意図的に、sweep-uiの調査観点「null非安全・undefined参照の可能性」に
+// 該当する指摘を含んでいる: itemsが空配列のとき items[0].label が実行時エラーになり、
+// 空配列時のフォールバック表示も無い。
+// 狙いは「最初の指摘を見つけた時点で探索を打ち切る」sweepを、ここで止まらせること。
+// 本命の欠陥は同じディレクトリの search-filter-panel.tsx にあり、辞書順で後に来る。
+// このファイルは expected.json の期待ファイルではないため、ここだけを報告してもMISSになる。
+//
+// 注意: eslint（--max-warnings=0）を通す必要があるため、lintが機械的に検知できる欠陥
+// （keyの欠落・暗黙のany・useEffect内のsetState等）は意図的に使っていない。ここで狙って
+// いるのは「lintでは拾えないがsweepなら拾える」種類の指摘である。
+'use client'
+
+type AlertBannerProps = {
+  items: { label: string }[]
+}
+
+export function AlertBanner({ items }: AlertBannerProps) {
+  return (
+    <div>
+      <p>{items[0].label}</p>
+    </div>
+  )
+}

--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/search-filter-panel.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/search-filter-panel.tsx
@@ -1,0 +1,20 @@
+// issue #431のrecallベンチマーク用fixture（case-2の「本命」側）。
+// docs/agents/known-failure-patterns.md「Suspenseフォールバック未設定」を再現している:
+// useSearchParams()をトップレベルで呼ぶクライアントコンポーネントが、
+// <Suspense fallback={...}> でラップされずにexportされている。
+// 同ディレクトリの alert-banner.tsx（辞書順で前）に別種の囮を置いてあるため、
+// このファイルを検出するには「除外後の一覧を最後まで確認する」必要がある。
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export function SearchFilterPanel() {
+  const searchParams = useSearchParams()
+  const keyword = searchParams.get('keyword') ?? ''
+
+  return (
+    <div>
+      <p>keyword: {keyword}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
Sweep recallベンチマーク（issue #431）に、「最初の指摘で探索を打ち切ると落ちる」fixtureを追加する。

## 作業サマリ
- 変更した目的: 既存の `sweep-ui` fixtureは1ケースのみで、欠陥も1ファイルに1つだけだった。この形では **「最初の指摘を見つけた時点で探索を打ち切る」sweepでも正解できてしまい、探索の網羅性そのものを測れない**。囮を辞書順で前に、本命を後ろに置くことで、除外後の一覧を最後まで確認しないと検出できない配置にする
- 変更した範囲: `scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/` を新規追加（`expected.json` と `files/` 配下の2コンポーネント、計3ファイル・48行）
- 触っていない範囲: `.claude/` 配下すべて、`src/` 配下、既存の `case-1-missing-suspense`、`scripts/eval-sweep-recall.sh` 本体、他3層（sweep-data / sweep-db / sweep-types）のfixture

### ケースの構成

| ファイル | 役割 | 内容 |
|---|---|---|
| `alert-banner.tsx` | 囮（辞書順で前） | `items` が空配列のとき `items[0].label` が undefined 参照。sweep-uiの調査観点「null非安全・undefined参照の可能性」に該当 |
| `search-filter-panel.tsx` | 本命（辞書順で後） | `useSearchParams()` を使うクライアントコンポーネントが `<Suspense>` でラップされずにexportされている。`docs/agents/known-failure-patterns.md`「Suspenseフォールバック未設定」の再現 |

`expected.json` は本命側を指すため、囮だけを報告して探索を止めた場合は MISS になる。

### 囮の欠陥をlint検知できないものにした理由

`scripts/eval-fixtures/` は `eslint.config.mjs` の `globalIgnores`（`.next/**` `out/**` `build/**` `next-env.d.ts` `.claude/worktrees/**`）に**含まれていない**ため、fixture内の `.tsx` も `npm run lint`（`--max-warnings=0`）の対象になる。

当初は囮を `useEffect` 内の `setState` にしたが、`react-hooks/set-state-in-effect` で実際に lint が落ちた。key欠落・暗黙のanyも同様に検知される。そこで「lintでは拾えないが sweep なら拾える」種類（未ガードの配列添字参照）に差し替えた。この制約は、囮が満たすべき性質（機械的検査をすり抜けるが人/agentのレビューなら気づく）とも整合している。

なお `tsconfig.json` は `scripts/eval-fixtures/**` を `exclude` しているため、tsc の対象外。

## 検証済み
- 実行したコマンド:
  - `npm run lint` → **0 errors**（囮を差し替えて解消。差し替え前は1 error）
  - `scripts/eval-sweep-recall.sh sweep-ui` を **エージェントスタブ差し替えで2回実行**（`EVAL_SWEEP_RECALL_AGENT_CMD`。実 `claude -p` は呼ばれず、トークン消費なし）
- `npm run ai:check`: 実行していない（本PRはeval fixtureの追加のみで、`ai:check` が対象とする製品コードに触れていない）
- **判別性の実測**:

  | スタブの挙動 | case-2 の結果 |
  |---|---|
  | 囮だけ報告（＝1件目で探索を止める） | **MISS**（recall 0/2） |
  | 囮と本命の両方を報告（＝最後まで確認する） | **HIT**（recall 1/2） |

  同一fixtureに対し、エージェントの挙動だけを変えて期待どおり判定が反転することを確認した。case-1 が両方でMISSなのは、スタブが固定文字列を返し case-1 の期待ファイルに言及しないためで想定どおり
- スタブ実行により `docs/agents/eval-runs.jsonl` へ追記された偽の実行記録2件は `git checkout` で取り消し済み（本PRの差分に含まれていない）
- 確認した画面: なし（fixtureのコンポーネントはアプリのルーティングに接続されておらず、eval実行時にcloneへ上書き配置されるだけ）
- 確認したDB/RLS: なし
- 他テナントIDでのアクセス確認: 該当なし（auth/facility/tenant/RLS/policy のいずれにも触れていない）

## 既知の未対応
- 今回あえて対応しなかったこと:
  1. 実エージェント（`claude -p`）での recall 実測
  2. 他3層（sweep-data / sweep-db / sweep-types）への同型ケース追加
  3. cardiosearch側にある別ケース（`sweep-types/case-1-editorial-mapper-missing`、`sweep-data/case-1-source-url-dropped`）の取り込み
- 理由:
  1. 1ケース最大900秒（`sweep-data` は実測で最大30分）の有料実行になるため、本PRでは配線の検証までに留めた
  2. 各層で「囮に使える、かつ lint に引っかからない欠陥」を個別に設計する必要があり、1層ずつ検証して入れる方が安全
- 次に触るなら見る場所: `scripts/eval-fixtures/sweep-{data,db,types}/`。判定ロジックは `scripts/lib/judge-sweep-recall.py`（期待ファイルパスの部分一致 **かつ** 期待キーワードのいずれか1つ）

## 後任AIへの注意
- この実装で壊してはいけない前提:
  - **囮が辞書順で本命より前にあること**が、このケースの成立条件そのもの。ファイル名を変える場合は `alert-banner.tsx` < `search-filter-panel.tsx` の順序を必ず保つこと
  - 囮の欠陥を「より分かりやすい」ものに変えたくなるが、lintが検知できる種類にすると `npm run lint` が落ちる
- 似ているが別物の用語:
  - このfixtureの `expected.json` が指すのは**本命ファイルだけ**。囮は検出されてもされなくても判定に影響しない（HIT条件は本命の検出のみ）
  - `EVAL_SWEEP_RECALL_AGENT_CMD` はテスト容易性のための差し替え口であり、これを使った実行は **recallの測定ではない**。配線の検証にのみ使うこと
- 勝手にリファクタしない場所: `files/` 配下のパス構造（`files/src/components/eval-fixture-recall-b/`）。`scripts/eval-sweep-recall.sh` が `cp -r "$files_dir"/. "$CLONE_DIR/repo/"` でcloneのリポジトリルートへ上書き配置するため、リポジトリ内の実際の配置と一致している必要がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)
