### PR TITLE
fix: ai:check未実行警告がtranscript全文grepで自己抑制されるバグを修正

### DIFF
--- a/scripts/ai-check-suggest.sh
+++ b/scripts/ai-check-suggest.sh
@@ -43,9 +43,18 @@ if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
   exit 0
 fi
 
-echo "$CURRENT_HASH" > "$STATE_FILE"
+# WHY: 以前はtranscript全文に対してgrepしていたため、警告文自体(MSG)に含まれる
+# "npm run ai:check"という文字列がtranscriptへ記録されると、次回以降のgrepが自分自身の
+# 警告文にマッチして「実行済み」と誤判定し、以降永久に警告が出なくなる自己抑制バグが
+# あった（issue #635）。実際に実行されたBashコマンド（tool_useブロックのinput.command）
+# だけを対象にすることで、警告文自体・会話中の言及（実行を伴わない）の両方を除外する。
+EXECUTED_COMMANDS="$(jq -r 'select(.message.content? != null) | .message.content[]? | select(.type=="tool_use" and .name=="Bash") | .input.command' "$TRANSCRIPT" 2>/dev/null || true)"
 
-if grep -qE 'npm run (ai:check|typecheck|lint|test)\b' "$TRANSCRIPT" 2>/dev/null; then
+if printf '%s' "$EXECUTED_COMMANDS" | grep -qE 'npm run (ai:check|typecheck|lint|test)\b'; then
+  # WHY: 状態ハッシュは「実行済みと確認できた場合のみ」書き込む（issue #635）。
+  # 未実行のまま書き込むと、同一diff状態での再Stopが30行目の早期returnで
+  # 無条件にスキップされ、警告が最大1回しか出なくなってしまう。
+  echo "$CURRENT_HASH" > "$STATE_FILE"
   echo '{"systemMessage": ""}'
 else
   MSG="ソースコード変更（.ts/.tsx/.sql）があるにもかかわらず、このセッションで npm run ai:check 相当のコマンド（typecheck/lint/test）が実行された痕跡が見当たりません。実行を検討してください。"

--- a/scripts/ai-check-suggest.test.sh
+++ b/scripts/ai-check-suggest.test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# WHY: issue #635向けのStop hook(scripts/ai-check-suggest.sh)の回帰テスト。
+# transcript全文に対するgrepではなく「実際に実行されたBashコマンド」のみを対象にすることで、
+# 警告文自体・会話中の言及に対する自己抑制/誤判定が起きないことを確認する。
+#
+# 対象スクリプトは`cd "$(dirname "$0")/.."`で自身の場所からrepo rootへ移動するため、
+# テストでは一時gitリポジトリ配下の`scripts/ai-check-suggest.sh`にコピーして実行する。
+#
+# 実行: bash scripts/ai-check-suggest.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/ai-check-suggest.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  NG: $label"
+    echo "      expected NOT to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  else
+    echo "  OK: $label"
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+# 一時gitリポジトリを作り、scripts/ai-check-suggest.shをコピーして配置する。
+setup_sandbox_repo() {
+  local sandbox="$1"
+  mkdir -p "$sandbox/scripts"
+  cp "$SCRIPT" "$sandbox/scripts/ai-check-suggest.sh"
+  (
+    cd "$sandbox"
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo "// initial" > dummy.ts
+    git add dummy.ts
+    git commit -q -m init
+    echo "// modified" >> dummy.ts
+  )
+}
+
+run_hook() {
+  local sandbox="$1" session_id="$2" transcript_path="$3"
+  local input
+  input="$(jq -n --arg sid "$session_id" --arg tp "$transcript_path" '{session_id: $sid, transcript_path: $tp}')"
+  (
+    cd "$sandbox"
+    printf '%s' "$input" | bash "scripts/ai-check-suggest.sh"
+  )
+}
+
+echo "=== scenario 1: 過去の警告文のみがtranscriptにある場合 → 自己マッチせず警告が出る(issue #635の主題) ==="
+SANDBOX1="$WORKDIR/sandbox1"
+setup_sandbox_repo "$SANDBOX1"
+TRANSCRIPT1="$WORKDIR/transcript_warning_only.jsonl"
+cat > "$TRANSCRIPT1" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"警告: ソースコード変更（.ts/.tsx/.sql）があるにもかかわらず、このセッションで npm run ai:check 相当のコマンド（typecheck/lint/test）が実行された痕跡が見当たりません。実行を検討してください。"}]}}
+EOF
+OUT="$(run_hook "$SANDBOX1" "session-warning-only" "$TRANSCRIPT1")"
+assert_contains "$OUT" "systemMessage" "systemMessageキーが存在する"
+assert_not_contains "$OUT" '"systemMessage": ""' "空文字列ではない(警告が出ている＝自己抑制されない)"
+
+echo "=== scenario 2: 会話中の言及のみ(実行なし) → 実行済み扱いにならず警告が出る ==="
+SANDBOX2="$WORKDIR/sandbox2"
+setup_sandbox_repo "$SANDBOX2"
+TRANSCRIPT2="$WORKDIR/transcript_mention_only.jsonl"
+cat > "$TRANSCRIPT2" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"次に npm run test を実行しましょう。"}]}}
+EOF
+OUT="$(run_hook "$SANDBOX2" "session-mention-only" "$TRANSCRIPT2")"
+assert_not_contains "$OUT" '"systemMessage": ""' "空文字列ではない(言及のみでは実行済み扱いにならない)"
+
+echo "=== scenario 3: 実際にBashでnpm run testが実行された → 実行済みと判定され警告は出ない ==="
+SANDBOX3="$WORKDIR/sandbox3"
+setup_sandbox_repo "$SANDBOX3"
+TRANSCRIPT3="$WORKDIR/transcript_executed.jsonl"
+cat > "$TRANSCRIPT3" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"npm run test"}}]}}
+EOF
+OUT="$(run_hook "$SANDBOX3" "session-executed" "$TRANSCRIPT3")"
+assert_contains "$OUT" '"systemMessage": ""' "空文字列である(実行済みのため警告なし)"
+
+echo "=== scenario 4: 未実行のまま同一sessionで再Stop → 状態ハッシュが書かれていないため再度警告が出る(issue #635) ==="
+SANDBOX4="$WORKDIR/sandbox4"
+setup_sandbox_repo "$SANDBOX4"
+TRANSCRIPT4="$WORKDIR/transcript_warning_only2.jsonl"
+cat > "$TRANSCRIPT4" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"text","text":"警告: npm run ai:check相当が未実行です。"}]}}
+EOF
+OUT1="$(run_hook "$SANDBOX4" "session-repeat" "$TRANSCRIPT4")"
+OUT2="$(run_hook "$SANDBOX4" "session-repeat" "$TRANSCRIPT4")"
+assert_not_contains "$OUT1" '"systemMessage": ""' "1回目: 警告が出る"
+assert_not_contains "$OUT2" '"systemMessage": ""' "2回目(未実行のまま再Stop): 依然として警告が出る(自己抑制されない)"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: riff-gearへのhooks移植PRレビューで判明した、`scripts/ai-check-suggest.sh`（Stop hook）の「ai:check未実行警告が一度出ると二度と出なくなる」自己抑制バグ（#635）を修正する
- 変更した範囲: `scripts/ai-check-suggest.sh`（grep対象をtranscript全文から「実際にtool_useとして実行されたBashコマンド」に限定し、状態ハッシュの書き込みタイミングを実行済み確認後に移動）、`scripts/ai-check-suggest.test.sh`（新規作成、4シナリオ）
- 触っていない範囲: `.claude/settings.json`（#636で別PR）、`scripts/check-direct-ddl-execution.sh`（#633/#634で別PR）、その他のhookスクリプト

## 検証済み
- 実行したコマンド: `bash scripts/ai-check-suggest.test.sh`（全4シナリオPASS）、`npm run ai:check` は未実行（本PRはscripts/配下のbashスクリプトのみでTS/SQLの変更が無いため対象外と判断）
- 確認した画面: なし（hookスクリプトのみの変更、UIなし）
- 確認したDB/RLS: 対象外
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（facility/tenant等のドメインに触れていない）

## 既知の未対応
- 今回あえて対応しなかったこと: 「同一diff状態での再Stopは毎回警告する」設計に変更したため、未実行のまま何度もStopすると毎回警告が出るようになる（以前は最大1回しか出なかった自己抑制バグの裏返し）
- 理由: issue #635の「やること2」に明記された修正方針をそのまま採用した。意図的なnag-onceにする場合は別issueでの検討が必要
- 次に触るなら見る場所: `scripts/ai-check-suggest.sh`のstate hash書き込み部分（46-57行目付近）

## 後任AIへの注意
- この実装で壊してはいけない前提: 警告文言(`MSG`)に`npm run ai:check`という文字列を含めたままにすると、将来また別の経路で自己マッチが再発しうる。grep対象は必ず「実行されたBashコマンド」のみに保つこと
- 似ているが別物の用語: 「transcript全文へのgrep」（旧・バグの原因）と「tool_useブロックのinput.commandへのgrep」（新）は似て非なるもの。前者に戻す変更は入れないこと
- 勝手にリファクタしない場所: `cd "$(dirname "$0")/.."`はhook実行時のcwdが不定であることへの対処（#636と同じ問題意識）。削除するとテストのsandbox構成も壊れる（`scripts/ai-check-suggest.test.sh`はスクリプトを一時repoの`scripts/`配下にコピーして実行する構成にしている）

Closes #635
