### PR TITLE
feat: 品質ゲートblocked集計に「一度もblockedを返していないagentType一覧」を追加 (#640)

### DIFF
--- a/docs/agents/observability-internals.md
+++ b/docs/agents/observability-internals.md
@@ -81,6 +81,11 @@ pass/failしか集計できず、`blocked`状態（Spec Check/Manifest Check等�
 journalAdapterが返すイベントを`status === 'blocked'`でフィルタしてagentType別に数えるだけの
 単純集計に留めている（blockedの有無・件数だけならagentId相関は不要なため。issue #569コメントが
 推奨した「スコープを絞った小さい一歩」の方針を踏襲）。
+issue #640で「journalに実行記録が1件以上あるがblockedが0件のagentType一覧」
+（`neverBlockedAgentTypes`）を同集計に追加した。issue #412が本来可視化したかった
+「一度も発火していないゲート（維持コストが純損失の候補）」の判別がこれで可能になる。
+分母はjournalソースのみ（agent-progress等にはblockedという値自体が存在しないため、
+混ぜると発火しようがないagentTypeがノイズとして並ぶ）。
 - 残タスク: 「復旧処理をcanonical event Module経由に寄せる」（recovery-queue系スクリプトは
   依然bashのみで完結しており、canonical-event.tsを経由していない）は未着手のまま
 

--- a/scripts/lib/gate-effectiveness-summary.test.ts
+++ b/scripts/lib/gate-effectiveness-summary.test.ts
@@ -20,9 +20,13 @@ function journalEvent(overrides: Partial<CanonicalEvent>): CanonicalEvent {
 }
 
 describe('summarizeBlockedGates', () => {
-  it('blockedが無い場合はtotalBlocked=0かつbyAgentTypeが空', () => {
+  it('blockedが無い場合はtotalBlocked=0かつbyAgentTypeが空、登場agentTypeは全てneverBlockedに載る', () => {
     const events = [journalEvent({ status: 'pass' }), journalEvent({ status: 'fail' })]
-    expect(summarizeBlockedGates(events)).toEqual({ totalBlocked: 0, byAgentType: {} })
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 0,
+      byAgentType: {},
+      neverBlockedAgentTypes: ['implementer'],
+    })
   })
 
   it('blockedをagentType別に集計する', () => {
@@ -35,12 +39,17 @@ describe('summarizeBlockedGates', () => {
     expect(summarizeBlockedGates(events)).toEqual({
       totalBlocked: 3,
       byAgentType: { implementer: 2, reviewer: 1 },
+      neverBlockedAgentTypes: [],
     })
   })
 
   it('agentTypeがnullの場合はunknownに集計する', () => {
     const events = [journalEvent({ agentType: null, status: 'blocked' })]
-    expect(summarizeBlockedGates(events)).toEqual({ totalBlocked: 1, byAgentType: { unknown: 1 } })
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 1,
+      byAgentType: { unknown: 1 },
+      neverBlockedAgentTypes: [],
+    })
   })
 
   it('journal以外のsourceは対象外(agent-progress/loop-observabilityにはblockedという値自体が来ない前提だが、念のため隔離を確認)', () => {
@@ -48,6 +57,45 @@ describe('summarizeBlockedGates', () => {
       journalEvent({ status: 'blocked' }),
       { ...journalEvent({ status: 'blocked' }), source: 'agent-progress' } as CanonicalEvent,
     ]
-    expect(summarizeBlockedGates(events)).toEqual({ totalBlocked: 1, byAgentType: { implementer: 1 } })
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 1,
+      byAgentType: { implementer: 1 },
+      neverBlockedAgentTypes: [],
+    })
+  })
+
+  it('journalに実行記録があるがblockedが0件のagentTypeをneverBlockedAgentTypesとしてソート済みで返す', () => {
+    const events = [
+      journalEvent({ agentId: 'a1', agentType: 'spec-check', status: 'pass' }),
+      journalEvent({ agentId: 'a2', agentType: 'manifest-check', status: 'pass' }),
+      journalEvent({ agentId: 'a3', agentType: 'manifest-check', status: 'fail' }),
+      journalEvent({ agentId: 'a4', agentType: 'integrator', status: 'blocked' }),
+    ]
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 1,
+      byAgentType: { integrator: 1 },
+      neverBlockedAgentTypes: ['manifest-check', 'spec-check'],
+    })
+  })
+
+  it('neverBlockedの分母はjournalソースのみで、他ソースにしか登場しないagentTypeは含めない', () => {
+    const events = [
+      journalEvent({ agentType: 'spec-check', status: 'pass' }),
+      { ...journalEvent({ agentType: 'sweep-ui', status: 'pass' }), source: 'agent-progress' } as CanonicalEvent,
+    ]
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 0,
+      byAgentType: {},
+      neverBlockedAgentTypes: ['spec-check'],
+    })
+  })
+
+  it('statusがnullのjournalイベントも実行記録として分母に含める', () => {
+    const events = [journalEvent({ agentType: 'coverage-check', status: null })]
+    expect(summarizeBlockedGates(events)).toEqual({
+      totalBlocked: 0,
+      byAgentType: {},
+      neverBlockedAgentTypes: ['coverage-check'],
+    })
   })
 })

--- a/scripts/lib/gate-effectiveness-summary.ts
+++ b/scripts/lib/gate-effectiveness-summary.ts
@@ -13,16 +13,25 @@ import { journalAdapter, type CanonicalEvent } from './canonical-event'
 export interface BlockedGateSummary {
   totalBlocked: number
   byAgentType: Record<string, number>
+  // journalに実行記録が1件以上あるがblockedが0件のagentType一覧（issue #640）。
+  // 分母をjournalソースに限定するのは、agent-progress等の他ソースにはblockedという
+  // 値自体が存在せず、混ぜると「発火しようがないagentType」がノイズとして並ぶため。
+  neverBlockedAgentTypes: string[]
 }
 
 export function summarizeBlockedGates(events: CanonicalEvent[]): BlockedGateSummary {
-  const blocked = events.filter((event) => event.source === 'journal' && event.status === 'blocked')
+  const journalEvents = events.filter((event) => event.source === 'journal')
+  const blocked = journalEvents.filter((event) => event.status === 'blocked')
   const byAgentType: Record<string, number> = {}
   for (const event of blocked) {
     const key = event.agentType ?? 'unknown'
     byAgentType[key] = (byAgentType[key] ?? 0) + 1
   }
-  return { totalBlocked: blocked.length, byAgentType }
+  const seenAgentTypes = new Set(journalEvents.map((event) => event.agentType ?? 'unknown'))
+  const neverBlockedAgentTypes = [...seenAgentTypes]
+    .filter((agentType) => !(agentType in byAgentType))
+    .sort()
+  return { totalBlocked: blocked.length, byAgentType, neverBlockedAgentTypes }
 }
 
 function main() {
@@ -43,13 +52,21 @@ function main() {
 
   if (asJson) {
     console.log(JSON.stringify(summary, null, 2))
-  } else if (summary.totalBlocked === 0) {
+    return
+  }
+  if (summary.totalBlocked === 0) {
     console.log('blocked状態のWorkflow実行はありません（journal.jsonlベース）。')
   } else {
     console.log(`blocked状態のWorkflow実行: ${summary.totalBlocked}件（journal.jsonlベース。issue #569）`)
     const sorted = Object.entries(summary.byAgentType).sort((a, b) => b[1] - a[1])
     for (const [agentType, count] of sorted) {
       console.log(`  - ${agentType}: ${count}件`)
+    }
+  }
+  if (summary.neverBlockedAgentTypes.length > 0) {
+    console.log(`一度もblockedを返していないagentType（journalに実行記録あり。issue #640）:`)
+    for (const agentType of summary.neverBlockedAgentTypes) {
+      console.log(`  - ${agentType}`)
     }
   }
 }


### PR DESCRIPTION
Closes #640

## 作業サマリ
- 変更した目的: issue #412が本来可視化したかった「一度も発火していないゲート（維持コストが純損失の候補）」の判別を可能にするため、journal.jsonlベースのblocked集計（issue #569）に `neverBlockedAgentTypes`（journalに実行記録が1件以上あるがblockedが0件のagentType一覧）を追加した
- 変更した範囲: `scripts/lib/gate-effectiveness-summary.ts`（集計ロジック＋CLI出力）、同テスト、`docs/agents/observability-internals.md`（判断記録の追記）
- 触っていない範囲: `scripts/log-loop-observability.sh`（当初案の `--result blocked` 追加は不採用。journal.jsonlの機械記録の方が自己申告より保証レベルが高く、canonical-event.tsの正規化方針にも沿うため）、`summarize-loop-observability.sh`、記録漏れ（5日分欠落事例）対策、プロダクトコード全般

## 検証済み
- 実行したコマンド: vitest（`gate-effectiveness-summary.test.ts` 7/7 pass、TDDでRED→GREEN確認）、`bash scripts/gate-effectiveness-monthly-check.test.sh`（6シナリオ ALL PASSED）、`npx tsc --noEmit` エラー0、`npm run lint` エラー0、`npm test` 185ファイル/1418テスト全pass。実データで `scripts/summarize-gate-blocked.sh`（テキスト・`--json` 両方）のスモーク確認済み
- 確認した画面: なし（UI変更なし）
- 確認したDB/RLS: なし（DB変更なし）
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外（auth/facility/RLS境界に触れていない）

## 既知の未対応
- 今回あえて対応しなかったこと: loop-observability.jsonl自体へのblocked記録追加、記録漏れ検知の強化
- 理由: journal.jsonlベースで既に機械記録されており、自己申告方式の追加は分散ログを増やすだけで保証レベルが下がるため（issue #640本文参照）
- 次に触るなら見る場所: `scripts/lib/canonical-event.ts`（journalAdapter）と `scripts/lib/gate-effectiveness-summary.ts`

## 後任AIへの注意
- この実装で壊してはいけない前提: `neverBlockedAgentTypes` の分母はjournalソース限定。agent-progress等の他ソースにはblockedという値自体が存在しないため、混ぜると発火しようがないagentTypeがノイズとして並ぶ
- 似ているが別物の用語: `summarize-loop-observability.sh`（loop-observability.jsonlの自己申告pass/fail集計）と `summarize-gate-blocked.sh`（journal.jsonlの機械記録blocked集計）は参照元も保証レベルも別物
- 勝手にリファクタしない場所: `gate-effectiveness-monthly-check.sh` のfail-open呼び出し（`summarize-gate-blocked.sh` 不在でもhookを落とさない設計）

🤖 Generated with [Claude Code](https://claude.com/claude-code)