### PR TITLE
ci: hooks-test(shellテスト39本)とbuildジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,31 @@ jobs:
     uses: ./.github/workflows/node-check.yml
     with:
       run-script: test
+
+  # WHY: typecheckが通ってもNext.jsの本番ビルド(next build)だけが失敗するケース
+  # (静的生成時のエラー等)はこれまでCIで検知できなかった。派生リポジトリ(riff-gear)では
+  # buildジョブが標準構成のため、本家にも同じ検知を持たせる。
+  # ローカル検証済み: env無し(.env.local不在)でも next build は成功する。
+  build:
+    uses: ./.github/workflows/node-check.yml
+    with:
+      run-script: build
+
+  # WHY: .claude/settings.json / .codex/hooks.json から呼ばれるhook・ガードスクリプトには
+  # 回帰テスト(scripts/**/*.test.sh、39本)があるが、npm test(vitest)にもCIにも載っておらず
+  # 全て手動実行依存だった(docs/agents/observability-internals.md にも明記)。これは
+  # 「起動トリガーは機械にする」(issue #411)の原則に検知網自身が反している状態のため、
+  # 派生リポジトリ(riff-gear)で実証済みのhooks-testジョブを逆輸入して全件を機械実行する。
+  # Codex設定分離の検証(codex-config-separation.test.sh等、対応スクリプトを持たない
+  # 設定検証テスト)もこのジョブで初めて機械化される。
+  hooks-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run hook script regression tests
+        run: |
+          for t in scripts/*.test.sh scripts/lib/*.test.sh; do
+            echo "::group::$t"
+            bash "$t"
+            echo "::endgroup::"
+          done

--- a/scripts/check-workflow-interruption.sh
+++ b/scripts/check-workflow-interruption.sh
@@ -91,7 +91,13 @@ while IFS= read -r -d '' wf_file; do
     # statが両OSとも失敗した場合はfail-open（staleness判定をスキップ）する。
     # PRレビュー指摘: 失敗時にepoch 0へフォールバックすると「無限に古い」扱いになり
     # warning側へ倒れてしまう（このスクリプトの他の箇所のfail-open方針と矛盾する）
-    MTIME_EPOCH="$(stat -f %m "$wf_file" 2>/dev/null || stat -c %Y "$wf_file" 2>/dev/null || true)"
+    # GNU stat(Linux)では`stat -f %m`が「失敗せず」ファイルシステム情報の文字列を返すため、
+    # BSD形式を先に試す従来の書き方だとLinuxで非数値が混入し、算術式がset -uでクラッシュした
+    # (CI hooks-test初回実行で検出)。GNU形式を先に試し、さらに数値でない値はfail-open扱いにする。
+    MTIME_EPOCH="$(stat -c %Y "$wf_file" 2>/dev/null || stat -f %m "$wf_file" 2>/dev/null || true)"
+    case "$MTIME_EPOCH" in
+      ''|*[!0-9]*) MTIME_EPOCH="" ;;
+    esac
     if [ -n "$MTIME_EPOCH" ]; then
       AGE_SECONDS=$((NOW_EPOCH - MTIME_EPOCH))
       [ "$AGE_SECONDS" -ge "$STALE_SECONDS" ] && IS_TARGET=1


### PR DESCRIPTION
## 概要
riff-gear（派生リポジトリ）で実証済みのCI構成を本家に逆輸入する。

- **hooks-testジョブ**: `scripts/**/*.test.sh`（39本）を全件実行。これまでshellテストはnpm testにもCIにも載っておらず全て手動実行依存で、「起動トリガーは機械にする」（issue #411）の原則に検知網自身が反していた（`docs/agents/observability-internals.md`にも明記あり）。対応スクリプトを持たない設定検証テスト（`codex-config-separation.test.sh`・`codex-agents-sandbox.test.sh`・`schema-drift-reconcile.test.sh`）もこのジョブで初めて機械化される
- **buildジョブ**: typecheckでは検知できないNext.js本番ビルド失敗を捕まえる。既存のreusable workflow（node-check.yml）に`run-script: build`を渡すだけの最小構成

## Test plan
- [x] ローカルでshellテスト39本（scripts/*.test.sh + scripts/lib/*.test.sh）を全件実行し全pass（macOS）
- [x] env無し（.env.local不在）の素の状態で`npm run build`成功を確認（CI環境相当）
- [ ] このPRのCIでhooks-test / buildジョブがLinux環境で通ること（初回実行）

## 補足
- Linux環境での初回実行のため、macOSとの差分でhooks-testが落ちる可能性は残る。落ちた場合はこのPR内で修正する

🤖 Generated with [Claude Code](https://claude.com/claude-code)