### PR TITLE
docs: 公式ドキュメント突き合わせレビューの軽量是正一式

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,9 +64,6 @@
       "Bash(claude mcp list*)",
       "Bash(claude mcp --help*)",
       "Bash(claude mcp add --help*)",
-      "Bash(ls /Users/masanori/.claude/plugins/cache/claude-plugins-official/superpowers/6.0.3/skills/subagent-driven-development/scripts/)",
-      "Read(//Users/masanori/.claude/plugins/cache/claude-plugins-official/superpowers/6.0.3/skills/subagent-driven-development/scripts/**)",
-      "Bash(/Users/masanori/.claude/plugins/cache/claude-plugins-official/superpowers/6.0.3/skills/subagent-driven-development/scripts/task-brief /Users/masanori/medical-inventory-vkumai/docs/superpowers/plans/2026-06-22-price-history.md 1)",
       "Bash(~/write_aidd_stats.sh *)",
       "Bash(scripts/log-loop-observability.sh *)",
       "Bash(/Users/masanori/medical-inventory-vkumai/scripts/log-loop-observability.sh *)",
@@ -100,8 +97,6 @@
       "Bash(git -C /Users/masanori/medical-inventory-vkumai rev-parse*)",
       "Bash(git -C /Users/masanori/medical-inventory-vkumai diff*)",
       "Bash(git merge-base *)",
-      "Bash(/Users/masanori/.claude/plugins/cache/claude-plugins-official/superpowers/6.0.3/skills/subagent-driven-development/scripts/review-package *)",
-      "Bash(/Users/masanori/.claude/plugins/cache/claude-plugins-official/superpowers/6.0.3/skills/subagent-driven-development/scripts/task-brief *)",
       "mcp__context7__resolve-library-id",
       "mcp__playwright__browser_navigate",
       "WebFetch(domain:code.claude.com)"

--- a/.claude/skills/e2e-runner/SKILL.md
+++ b/.claude/skills/e2e-runner/SKILL.md
@@ -2,10 +2,12 @@
 name: e2e-runner
 description: E2Eテストとスクリーンショットを生成・実行する。
   「E2Eを書いて」「画面の動作確認をして」のときに使う。
-allowed-tools: Read, Write, Bash
+allowed-tools: Read, Write, Bash(npx playwright *), Bash(${CLAUDE_SKILL_DIR}/screenshot.sh *)
 ---
 
 1. 仕様書の📸マークと撮影ポイントを対応させる
 2. Playwright でテストを生成し e2e/ に置く
-3. ./screenshot.sh で全画面を撮影し screenshots/ に保存する
-（screenshot.sh はこのスキルフォルダに同梱）
+3. ${CLAUDE_SKILL_DIR}/screenshot.sh <url> <name> で全画面を撮影し screenshots/ に保存する
+（screenshot.sh はこのスキルフォルダに同梱。`${CLAUDE_SKILL_DIR}` は実行時にスキルフォルダの
+絶対パスへ展開され、frontmatterの`allowed-tools`の許可ルールと同じ文字列になるため
+確認プロンプトなしで実行できる）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,19 @@
 - 詳細手順: [`docs/agents/parallel-agent-work.md`](docs/agents/parallel-agent-work.md) /
   設計原則: [`docs/agents/claude-codex-coexistence-template.md`](docs/agents/claude-codex-coexistence-template.md)
 
+## ビルド・テストコマンド
+
+パッケージマネージャは npm（`package-lock.json`）。
+
+| コマンド | 用途 |
+|---|---|
+| `npm run dev` | 開発サーバ起動（Next.js） |
+| `npm test` | ユニットテスト（vitest run） |
+| `npm run lint` | Lint（`eslint --max-warnings=0`） |
+| `npm run typecheck` | 型チェック（`tsc --noEmit`） |
+| `npm run test:e2e` | E2Eテスト（Playwright。テスト専用Supabase接続が前提。下記「テスト環境・データ衛生ルール」参照） |
+| `npm run ai:check` | typecheck→lint→test→test:e2e の一括実行。作業完了前に実行する |
+
 ## Codex 用設定（`.codex/`）
 
 | ファイル | 目的 |
@@ -51,7 +64,7 @@ Phase 1 調査(並列) → Phase 2 仕様書 → [停止① 人間レビュー]
 | `judge-panel` | sonnet | 複数の設計提案を評価・採点し、synthesis（統合提案）を作成。読み取り専用 | Phase 1深掘り |
 | `adversarial-verify` | opus | Sweep指摘に反論を試み、偽陽性を除去。読み取り専用 | Phase 1深掘り |
 | `contract-writer` | sonnet | src/types/ の型定義・APIインターフェース型を先行確定。implementerへの「契約」を書く | Phase 3 |
-| `implementer` | opus | TDD実装（RED→GREEN→REFACTOR）。テスト削除・期待値改ざん禁止 | Phase 3 |
+| `implementer` | sonnet | TDD実装（RED→GREEN→REFACTOR）。テスト削除・期待値改ざん禁止 | Phase 3 |
 | `integrator` | sonnet | マイグレーション適用確認・共有ファイルの結線・npm test/lint確認 | Phase 4 |
 | `reviewer` | sonnet | TDD品質規約検証・4観点指摘（正しさ/仕様カバレッジ/重複/型安全）読み取り専用 | Phase 5 |
 
@@ -62,6 +75,7 @@ Phase 1 調査(並列) → Phase 2 仕様書 → [停止① 人間レビュー]
 | `feature-spec` | `/feature-spec` | 調査結果から SPEC.md を生成（Phase 2） |
 | `structured-review` | `/structured-review` | 最終構造化レビュー（Phase 5 後・人間が起動） |
 | `e2e-runner` | `/e2e-runner` | E2Eテスト・スクリーンショット生成（随時） |
+| `handoff-format` | 作業完了報告（PR本文・セッション終了報告）を書くとき | 引き継ぎメモの必須フォーマット（issue #542） |
 
 ## TRI/RISK 機械判定基準（AIDDパイプライン採用条件）
 

--- a/docs/ai-config-map.md
+++ b/docs/ai-config-map.md
@@ -39,7 +39,7 @@ medical-inventory-vkumai/               ← このプロジェクト
     │   ├── sweep-types.md              ← Phase 1: 型整合性Sweep（haiku）
     │   ├── completeness-critic.md      ← Phase 1: 調査網羅チェック（sonnet）
     │   ├── contract-writer.md          ← Phase 3 前: 型定義・API契約確定（sonnet）
-    │   ├── implementer.md              ← Phase 3: TDD実装（opus）・契約参照前提
+    │   ├── implementer.md              ← Phase 3: TDD実装（sonnet）・契約参照前提
     │   ├── integrator.md               ← Phase 4: 統合ゲート（sonnet）
     │   ├── reviewer.md                 ← Phase 5: 品質レビュー4観点（sonnet）
     │   ├── adversarial-verify.md       ← 深掘り調査: 偽陽性除去（opus）
@@ -47,7 +47,8 @@ medical-inventory-vkumai/               ← このプロジェクト
     ├── skills/
     │   ├── feature-spec/SKILL.md       ← 仕様書生成（Phase 2）
     │   ├── structured-review/SKILL.md  ← 最終構造化レビュー（Phase 5後）
-    │   └── e2e-runner/SKILL.md         ← E2Eテスト・スクリーンショット
+    │   ├── e2e-runner/SKILL.md         ← E2Eテスト・スクリーンショット
+    │   └── handoff-format/SKILL.md     ← 作業完了時の引き継ぎメモフォーマット（issue #542）
     └── workflows/
         ├── aidd-phase1-router.js       ← Phase 1 入口。TRI/RISKキーワードでaidd-phase1/aidd-1-1-deep-task/メタ改修軽量ルート(issue #457)へ自動振り分け
         ├── aidd-phase1.js              ← Phase 1 調査ワークフロー（軽量Sweep。routerから呼ばれる）
@@ -154,6 +155,7 @@ frontmatterを変更しても実フローの挙動が変わらないケースが
 | `feature-spec` | Phase 2：調査結果から仕様書を生成するとき | `SPEC.md`（Part 1: 人間向け / Part 2: AI向け技術詳細） |
 | `structured-review` | Phase 5 後：最終構造化レビューを実施するとき（`/structured-review` で起動） | レビュー観点別の指摘リスト |
 | `e2e-runner` | E2Eテストやスクリーンショットが必要なとき（随時） | Playwright テスト + スクリーンショット |
+| `handoff-format` | 作業完了報告（PR本文・セッション終了報告・`docs/sessions/`記録）を書くとき | 引き継ぎメモ（作業サマリ/検証済み/既知の未対応/後任AIへの注意） |
 
 ---
 

--- a/docs/sessions/2026-08-25-repository-docs-review.md
+++ b/docs/sessions/2026-08-25-repository-docs-review.md
@@ -1,0 +1,33 @@
+# 2026-08-25 repository-docs-review
+
+公式ドキュメント（Anthropic: code.claude.com / OpenAI: developers.openai.com/codex・agents.md標準）と
+リポジトリのAI設定を突き合わせるレビューセッション。AIDDフロー（Phase 1-5）は実行していない
+（プロダクトコードに触れないドキュメント・設定の軽量是正のみのため）。
+
+## フロー実行統計
+
+AIDDフロー実行なし。調査サブエージェント2体（Anthropic公式Doc調査 / OpenAI Codex公式Doc調査）を
+並列起動し、報告を実ファイル・公式ドキュメント（WebFetch）で裏取りして是正を適用した。
+
+## Loop Observability要約
+このセッション中の新規記録なし（Workflow未実行）
+
+## 結果
+- うまくいったこと:
+  - 廃止機能・非推奨設定の使用はClaude側・Codex側ともゼロと確認（最新機能への追従度は高い）
+  - 軽量是正5件を適用: implementerモデル表記ドリフト修正（AGENTS.md/ai-config-map.md、実体はsonnet）、
+    handoff-formatスキルの一覧漏れ追加、AGENTS.mdへビルド・テストコマンド節追加（CodexはCLAUDE.mdを
+    読まないためnpm test等が伝わっていなかった）、settings.jsonのsuperpowers 6.0.3固定allow 5件削除
+    （個人絶対パスかつバージョン固定でsettings.local.jsonの`*`版が既に代替）、e2e-runnerの
+    allowed-toolsを`Bash`無制限から`Bash(npx playwright *)`+`Bash(${CLAUDE_SKILL_DIR}/screenshot.sh *)`へ最小化
+    （公式勧告: コミット済みスキルのallowed-toolsはワークスペース信頼でゲートされない）
+  - サブエージェント報告の偽陽性2件（「.claude/rules/未実装」「skills用triggered/onceフィールド」）を
+    公式ドキュメント直接確認で棄却できた
+- 問題・気になった点:
+  - AGENTS.md/ai-config-map.mdの手書きエージェント表は実体frontmatterとドリフトしやすい
+    （今回のimplementer opus/sonnet食い違いが実例。1ファイル内でも矛盾していた）
+  - Codex hooks実測メモ（invocation_id固定・block fail-open）に公式ドキュメントとの食い違いがあり要再実測
+- 次の課題（issue起票済み、pending_issues.jsonl経由）:
+  - subagent frontmatter新フィールド（skills:プリロード/permissionMode/maxTurns）の導入検討
+  - .codex/config.tomlで[features] hooks=true宣言 + Codex実測メモ3件の最新CLI再検証
+  - 低優先バックログ（memory:project / context:fork / Codex async hooks等）


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: Anthropic(code.claude.com)・OpenAI(developers.openai.com/codex、agents.md標準)の公式ドキュメントとリポジトリのAI設定を突き合わせ、ドリフト・陳腐化・公式推奨との乖離を是正する
- 変更した範囲:
  - AGENTS.md / docs/ai-config-map.md: implementerモデル表記をopus→sonnetに修正(実体frontmatterと一致させた。ai-config-map.mdは同一ファイル内でも矛盾していた)、handoff-formatスキルの一覧漏れを追加、AGENTS.mdに「ビルド・テストコマンド」節を追加(CodexはCLAUDE.mdを読まないためnpm test / npm run lint / ai:check等が伝わっていなかった。agents.md標準の最重要推奨セクション)
  - .claude/settings.json: superpowersプラグインの6.0.3バージョン固定allow 5件を削除(個人絶対パス+バージョン固定+うち1件は2026-06-22特定プランファイル引数付きの使い捨て。機能はgit管理外settings.local.jsonのワイルドカード版が既に代替)
  - .claude/skills/e2e-runner/SKILL.md: allowed-toolsをBash無制限から `Bash(npx playwright *)` + `Bash(${CLAUDE_SKILL_DIR}/screenshot.sh *)` に最小化(公式skills.mdの勧告「コミット済みスキルのallowed-toolsはワークスペース信頼でゲートされないためレビューせよ」に対応)。本文のscreenshot.sh参照も許可ルールと一致する${CLAUDE_SKILL_DIR}形式へ
  - docs/sessions/2026-08-25-repository-docs-review.md: セッション記録(hook自動生成の空テンプレを実内容で埋めた)
- 触っていない範囲: src/・supabase/・e2e/等のプロダクトコード全て、.claude/agents/・.claude/workflows/・.codex/の実装、docs/agents/配下の運用ドキュメント

## 検証済み
- 実行したコマンド: npm test(186 files / 1419 tests passed。プロンプト同期テスト群含む)、jq emptyでsettings.jsonの構文検証。npm run ai:checkは未実行(プロダクトコード・E2E対象の変更が無いため、typecheck/test:e2eは対象外と判断)
- 確認した画面: なし(UI変更なし)
- 確認したDB/RLS: なし(DB変更なし)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(facility/RLS境界に触れていない)
- 記載内容の裏取り: implementer等のモデル表記はgrepで実体frontmatterと突き合わせ、subagent/skillsのfrontmatter仕様はcode.claude.com/docs/en/sub-agents.md・skills.mdをWebFetchで直接確認、AGENTS.md推奨構成はagents.md標準とdevelopers.openai.com/codexを調査サブエージェント経由で確認

## 既知の未対応
- 今回あえて対応しなかったこと: (1) subagent frontmatter新フィールド(skills:プリロード/permissionMode/maxTurns)導入、(2) .codex/config.tomlでの[features] hooks=true宣言とCodex実測メモ3件の再検証、(3) 低優先項目(memory:project / context:fork / Codex async hooks等)
- 理由: (1)はagents設定変更のbaselineスナップショット手順(issue #429)と実機検証が必要、(2)はCodex CLI実機起動が必要、(3)は効果測定の設計が先。いずれも本セッションでissue起票済み(pending_issues.jsonl経由)
- 次に触るなら見る場所: 起票された3本のissue、docs/sessions/2026-08-25-repository-docs-review.md

## 後任AIへの注意
- この実装で壊してはいけない前提: judge-panel/adversarial-verifyのfrontmatter effort(xhigh)とWorkflow内インライン指定の意図的な差異(docs/ai-config-map.mdの対応表)。今回のsonnet表記統一はこの非対称に触れていない
- 似ているが別物の用語: Claude側 .claude/rules/(paths frontmatter)とCodex側Rules機能(.rules、実験的)は別物。Codexスキルの置き場所は .agents/skills/ であり .codex/skills/ ではない
- 勝手にリファクタしない場所: settings.local.json(git管理外・個人設定)、docs/agents/配下の棚卸しドキュメント構造(issue #486/#542の設計判断済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)