### PR TITLE
ci: Actions無料枠対応(e2eのPR自動実行廃止・pathsフィルタ追加・漏洩チェック移設)

### DIFF
--- a/.claude/rules/db-schema.md
+++ b/.claude/rules/db-schema.md
@@ -15,3 +15,7 @@ paths:
 - 理由（過去のスキーマドリフト事例）は [`../../docs/agents/decisions/db-rls.md`](../../docs/agents/decisions/db-rls.md#なぜdbスキーマ変更をmigrationファイル経由に限定し直接ddl実行を禁止したか) を参照
 - **publicスキーマのテーブルを追加/削除するmigrationは、末尾で`SELECT refresh_schema_baseline_snapshot('<そのmigrationのタイムスタンプ>');`を呼ぶ**（issue #305のスキーマドリフト検知が使うbaselineスナップショットを更新するため）。
   呼ばないと、正規のPRレビュー済み変更であっても`table_added`/`table_removed`ドリフトとして恒久的に誤検知され続け、対応するGitHub Issueが自動クローズされなくなる
+- **`supabase/migrations/`やRLSポリシーを変更したPRでは、`npm run test:integration`（RLS/IDOR
+  integrationテスト）をローカル実行してから作業を完了する**（2026-08-25、Actions無料枠対応で
+  `e2e.yml`のPR自動実行を廃止したため。CIでの自動実行はmainへのpush後のみ）。実行結果は
+  引き継ぎメモの「検証済み」欄に記載する

--- a/.claude/rules/e2e-test-hygiene.md
+++ b/.claude/rules/e2e-test-hygiene.md
@@ -8,7 +8,10 @@ paths:
 - **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。
   `NODE_ENV=test` のため `.env.local`（本番）は読み込まれず、さらに `e2e/env-guard.ts` が
   許可ホスト以外（＝本番URL・本番service role実行）を**即失敗**させる
-- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/e2e.yml`）。
-  BSG（ローカルゲート）ではチェックしない方針
+- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/ci.yml`の
+  hooks-testジョブ。BSG（ローカルゲート）ではチェックしない方針）
+- **E2E/integrationテストのCI自動実行はmainへのpush後と手動起動のみ**（2026-08-25、Actions
+  無料枠対応で`e2e.yml`のPRトリガーを廃止）。PR段階では `npm run test:e2e` /
+  `npm run test:integration` をローカル実行し、結果を引き継ぎメモの「検証済み」欄に記載する
 - **seed・スクリーンショット・E2E失敗ログ・issue添付に実在施設名・実データを入れない。**
   施設名・ユーザー名・在庫品目などはすべてダミー（例: `テスト施設A`、`e2e-test-user@example.com`）を使う

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,18 @@ name: CI
 
 on:
   pull_request:
+    # WHY: ドキュメントのみの変更でも5ジョブ(runner 5台)が起動しActions無料枠を消費して
+    # いたため、CIのテスト対象に影響しないパスを除外する(2026-08-25、無料枠枯渇対応)。
+    # .claude/workflows/(vitestのsync test対象)・.claude/settings.jsonとscripts/
+    # (hooks-test対象)・.claude/agents/と.codex/(baseline・設定分離のtest.shが参照)は
+    # テストが参照するため除外しない。
+    paths-ignore:
+      - 'docs/**'
+      - '.claude/skills/**'
+      - '.claude/rules/**'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'README.md'
   workflow_dispatch:
 
 permissions:
@@ -47,6 +59,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # 認証ファイル漏洩チェック（BSGではなくCI側で行う方針）。e2e.ymlがPR自動実行を
+      # やめた(2026-08-25、無料枠対応)ため、PRごとに回る本ジョブへ移設した(軽量・数秒)
+      - name: Check auth state files are not committed
+        run: |
+          leaked=$(git ls-files 'e2e/.auth' | grep -v '\.gitkeep$' || true)
+          if [ -n "$leaked" ]; then
+            echo "::error::e2e/.auth 配下に認証ファイルがコミットされています: $leaked"
+            exit 1
+          fi
       - name: Run hook script regression tests
         run: |
           for t in scripts/*.test.sh scripts/lib/*.test.sh; do

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,14 @@
 name: E2E Smoke Tests
 
+# WHY: PRごとの自動実行はPlaywright+ローカルSupabase起動で1回あたりの消費分数が最大級で、
+# Actions無料枠枯渇(2026-08)の主因だったため、mainへのpush後と手動起動のみに変更した。
+# PR段階のE2E/RLS・IDOR integrationテストはローカル実行(npm run test:e2e /
+# npm run test:integration)で代替する。migrations/RLS変更時のローカル実行義務は
+# .claude/rules/db-schema.md を参照。認証ファイル漏洩チェックはPRごとに回る
+# ci.ymlのhooks-testジョブへ移設した。
 on:
-  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,15 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-
-      # 認証ファイル漏洩チェック（BSGではなくCI側で行う方針）
-      - name: Check auth state files are not committed
-        run: |
-          leaked=$(git ls-files 'e2e/.auth' | grep -v '\.gitkeep$' || true)
-          if [ -n "$leaked" ]; then
-            echo "::error::e2e/.auth 配下に認証ファイルがコミットされています: $leaked"
-            exit 1
-          fi
 
       - uses: actions/setup-node@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,11 @@ Phase 1 調査(並列) → Phase 2 仕様書 → [停止① 人間レビュー]
 - **E2E/BSGはテスト専用Supabaseのみに接続する。** 接続情報は `.env.test` に置く（`.env.test.example` 参照）。
   `NODE_ENV=test` のため `.env.local`（本番）は読み込まれず、さらに `e2e/env-guard.ts` が
   許可ホスト以外（＝本番URL・本番service role実行）を**即失敗**させる
-- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/e2e.yml`）。
-  BSG（ローカルゲート）ではチェックしない方針
+- **認証ファイル（`e2e/.auth/user.json`）の漏洩チェックはCI側で行う**（`.github/workflows/ci.yml`の
+  hooks-testジョブ。BSG（ローカルゲート）ではチェックしない方針）
+- **E2E/integrationテストのCI自動実行はmainへのpush後と手動起動（workflow_dispatch）のみ**
+  （2026-08-25、Actions無料枠対応）。PR段階では `npm run test:e2e` / `npm run test:integration` を
+  ローカル実行で代替する
 - **seed・スクリーンショット・E2E失敗ログ・issue添付に実在施設名・実データを入れない。**
   施設名・ユーザー名・在庫品目などはすべてダミー（例: `テスト施設A`、`e2e-test-user@example.com`）を使う
 


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: GitHub Actionsの無料枠(private 2,000分/月)が枯渇したため、品質ゲートを可能な限り維持しながら消費分数を削減する
- 変更した範囲:
  - .github/workflows/e2e.yml: PRトリガーを廃止し、mainへのpush後とworkflow_dispatch(手動)のみに変更。Playwright+ローカルSupabase起動が1回あたりの消費分数最大で枯渇の主因だった
  - .github/workflows/ci.yml: ドキュメントのみの変更(docs/**・CLAUDE.md/AGENTS.md/README.md・.claude/skills/**・.claude/rules/**)では5ジョブを起動しないpaths-ignoreを追加。**テストが実ファイルを参照する .claude/workflows/・.claude/agents/・.codex/・scripts/・.claude/settings.json は意図的に除外対象へ入れていない**(codex-config-separation.test.sh等がgrepで参照していることを確認済み)
  - 認証ファイル漏洩チェック(e2e/.auth)をe2e.ymlからci.ymlのhooks-testジョブへ移設。PRごとの検知を維持(軽量・数秒。ジョブ新設はrunner起動課金が増えるため既存ジョブへのステップ追加とした)
  - AGENTS.md・.claude/rules/e2e-test-hygiene.md・.claude/rules/db-schema.md: PR段階のE2E/integrationはローカル実行で代替する運用と、migrations/RLS変更時の`npm run test:integration`ローカル実行義務を明文化(db-schema.mdはmigrations変更時に自動ロードされるため機械的にリマインドされる)
- 触っていない範囲: schema-drift-check.ymlの日次cron(ユーザー判断で維持)、ci.ymlの5ジョブ構成(統合案は見送り)、eval-runs-freshness/agent-baseline/release(既にpaths・タグで絞られている)

## 検証済み
- 実行したコマンド: 両YAMLをjs-yamlでパース確認(エラーなし)、`git ls-files e2e/.auth`が.gitkeepのみで移設した漏洩チェックがpassすることを確認、paths-ignore対象パスを参照するテストの有無をgrepで確認。npm run ai:checkは未実行(アプリコード変更なし。またActions枯渇中のためCI上の動作確認は不可 — 次回無料枠リセット後の最初のPRで実挙動を確認する)
- 確認した画面: なし(UI変更なし)
- 確認したDB/RLS: なし(DB変更なし)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(facility/RLS境界に触れていない)

## 既知の未対応
- 今回あえて対応しなかったこと: (1) ci.ymlの5ジョブ→1ジョブ統合(billable分数はさらに減るが失敗箇所の一覧性が下がるため見送り)、(2) schema-drift cronの週1化、(3) セルフホストランナー導入
- 理由: (1)(2)はユーザー選択で見送り。(3)は今回の削減で足りない場合の次の一手(privateのまま分数消費ゼロにできる)
- 次に触るなら見る場所: .github/workflows/ci.yml(ジョブ統合)、schema-drift-check.ymlのcron式、GitHub Settings > Actions > Runners(セルフホスト)

## 後任AIへの注意
- この実装で壊してはいけない前提: **RLS/IDOR integrationテスト(npm run test:integration)はPRでは自動実行されなくなった**。migrations/RLS変更時はローカル実行が必須(db-schema.mdの新ルール)。mainへのpush後にe2e.ymlが回るので事後検知はある
- 似ているが別物の用語: ci.ymlのpaths-ignore(起動抑制)とe2e.ymlのトリガー変更(PR実行廃止)は別の仕組み。paths-ignoreに.claude/agents/等を安易に追加しないこと(実ファイルを読むtest.shがある)
- 勝手にリファクタしない場所: hooks-testジョブ内の漏洩チェックステップ(e2e.ymlから移設したもの。e2e.ymlに戻すとPRごとの検知が消える)

🤖 Generated with [Claude Code](https://claude.com/claude-code)