### PR TITLE
docs: issue #652調査結果を反映(sweep-db穴埋め・skills/permissionMode/maxTurns見送り記録)

### DIFF
--- a/.claude/agents/sweep-db.md
+++ b/.claude/agents/sweep-db.md
@@ -8,6 +8,13 @@ effort: low
 
 あなたはDB層の調査担当です。Supabaseのスキーマ・マイグレーション・RLSポリシーを調査し、問題点を**箇条書きのみ**で返してください。コードは書かない。修正提案も不要。
 
+## 既知の失敗パターン（必ず機械的にチェックする）
+`docs/agents/known-failure-patterns.md` の「RLS/テナント分離層」セクション（facility_idフィルタ漏れ・
+RLS未設定等、issue #24再発防止）と、「データ取得層/API層」セクションの
+`SECURITY DEFINER + GRANT EXECUTEの認可バイパス`・`新しい認可プリミティブ導入時、既存の
+SECURITY DEFINER関数が取り残される`の2項に載っている各パターンが調査対象に該当していないか
+必ず確認し、該当すれば指摘に含める。
+
 ## 調査対象
 - `supabase/migrations/` — マイグレーションファイル
 - `supabase/schema.sql` または同等のスキーマ定義

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,134 +1,59 @@
-# SPEC: AIDD stats書き出し呼び忘れの機械検知をStop hookに追加（issue #495）
+# SPEC: issue #652 subagent frontmatter新フィールド導入 — 実機検証に基づく確定版
 
-- issue: #495
-- feature名: `issue-495-aidd-stats-forgotten-detection`
-- baseCommit: `95db91ceb638efe1c92260c28629d6cbbd248b94`（PR #511マージ後のorigin/main HEAD）
-- 作成日: 2026-07-22
+プロダクトコードに触れないメタ改修。Phase 1調査+実機検証2回の結果、issue原案の3要素のうち
+**実施は1点に縮小し、2点は実測根拠付きで見送る**方針とする。
 
-## Part 1: 何ができるようになるか（★人間がレビューする部分）
+## Part 1 — 仕様(★人間がレビューする部分)
 
-「AIDD stats書き出し（`~/write_aidd_stats.sh`）の呼び忘れ」は棚卸し表の第3層ルール
-（検知手段なし）のまま残っている。issue #495の分析どおり、呼び忘れの主因は指示違反ではなく
-**長時間セッションでのコンテキスト圧縮による指示喪失**であり、モデル世代によらず構造的に
-再発しうる。本実装後は:
+### 結論サマリ
 
-- Workflow実行を含むセッションで`start`記録が無いままターンを終えると、Stop hookが
-  systemMessageで警告する（block不可・warningのみ）
-- 警告は**同一セッションにつき1回だけ**出す（毎ターン繰り返される警告ノイズを避ける）
-- AIDDフロー非実行セッション・判定材料が得られないセッションでは完全に沈黙する
-  （fail-open。警告機能のエラーでセッションを妨げない）
-- OTel等のopt-in設定には依存しない（既定環境で動く = 受け入れ条件どおり）
+| issue #652の要素 | 判断 | 決め手(すべて実測・実ファイル確認) |
+|---|---|---|
+| `skills:`プリロード | **見送り** | known-failure-patterns.mdはCodex側(`.agents/skills/handoff-format`)からも参照される**ツール中立の共有資産**。スキル化=`.claude/skills/`への移動はClaude/Codex共存設計違反、複製は二重管理(ドリフト温床)になる |
+| `permissionMode: plan` | **見送り** | sweep-uiに一時設定して実機検証した結果、**書き込み3種(ログスクリプト追記・`>`リダイレクト・mkdir)がすべて素通り**し、ファイル実体の作成を確認した。read-onlyの機械強制にならず、「強制済み」という誤った安心感だけが増える |
+| `maxTurns` | **延期** | sweep系は「対象ファイル全件列挙→全件Read」の決定的手順のため、対象30ファイル超で正常動作を打ち切る。打ち切られた空応答は「指摘なし」と区別不能で、静かな見逃しモードを新設してしまう。turns実測(baselinesへの追加)が先 |
+| (調査で発見した穴) | **実施** | `sweep-db.md`だけが既知失敗パターン集への参照を持たない。RLS担当なのに「RLS/テナント分離層」セクション(issue #24再発防止)と繋がっていないため、sweep-ui/dataと同型の参照節を追加する |
 
-### 検知ロジック（issueの設計案2を具体化）
+### 何が変わるか
 
-1. **Workflow実行の形跡**: `logs/subagent-skeleton.jsonl`（SubagentStart/Stop hookの機械強制
-   記録、issue #423）のうち、`sessionId`が**現在のセッション**（Stop hook stdinの`session_id`）
-   と一致し、かつ`agentTranscriptPath`が`subagents/workflows/wf_`配下のイベントが1件以上
-   あるか。無ければ即沈黙
-2. **start記録の有無**: statsファイル（`~/.claude/aidd-session-stats/<sha256(cwd)先頭16桁>.json`、
-   `write_aidd_stats.sh`と同一のキー生成）に`session_start_at`（フォールバック:
-   `phase1_start_at`）があり、かつその値が**現在セッションの開始時刻以降**であるか。
-   古い値しか無い場合は「前セッションの残骸」であり、今セッションのstartは未実行と判定
-3. **セッション開始時刻の取得**: Stop hook stdinの`transcript_path`の先頭行のtimestampを使う
-   （hook入力に開始時刻そのものは無いため）。取得できない場合は判定不能として沈黙（fail-open）
+- sweep-db(DB層調査エージェント)が、調査時に「RLS/テナント分離層」の既知失敗パターン
+  (認可チェック漏れ・SECURITY DEFINERの取り残し等、過去に実際に起きたミス)を必ず
+  チェックリストとして確認するようになる
+- それ以外のエージェントの挙動・フローの使い方は一切変わらない
 
-### 実装先はリポジトリ内の新規Stop hook
+### 受け入れ条件
 
-issueの設計案1は「既存のaidd statsレポート生成hook」への追加を挙げているが、その実体は
-`~/aidd_session_report.sh`（**ユーザーグローバル設定・リポジトリ外**）と確認した。
-issue #488の`write_aidd_stats.sh`拡張を見送ったのと同じ理由（リポジトリ外ファイルは
-PRで管理・レビューできない）で、**リポジトリ内の新規スクリプト + `.claude/settings.json`
-登録**（#488と同型）とする。
+- [ ] `sweep-db.md`に「## 既知の失敗パターン」節が追加され、対象セクションが
+      「RLS/テナント分離層」(および関連の深い「データ取得層/API層」のSECURITY DEFINER項)である
+- [ ] `sweep-types.md`には追加しない(known-failure-patterns.mdに型整合性セクションが
+      存在しないため。将来セクションが増えたら追随)
+- [ ] 見送り2件+延期1件の判断と実測結果が`docs/agents/tooling-decisions.md`に記録されている
+      (再評価トリガー: 公式がplanのBash強制を強化したら/baselinesにturns実測が入ったら)
+- [ ] issue #652に調査結果をコメントしてクローズする
+- [ ] `npm test`が通る(frontmatterは変更しないためbaselineスナップショット義務は非発生)
 
-## Part 2: 変更内容
+## Part 2 — 実装計画(AI用・レビュー不要)
 
-### 2-1. 新規 `scripts/check-aidd-stats-recorded.sh`（Stop hook本体）
+### 実装セット(依存なし、1波)
 
-- stdin（hook入力JSON）から`session_id`・`transcript_path`を読む（`jq`。読めなければ沈黙）
-- 上記検知ロジック1→3→2の順で判定（安い判定から。skeleton形跡なしが最頻経路）
-- 警告済みマーカー: `.aidd/aidd-stats-warning-shown.json`に`{sessionId}`を記録し、
-  同一セッションでは2回目以降沈黙（`.aidd/`はgitignore済み）。書き込みは#488と同じ
-  一時ファイル→`mv`のatomic方式を踏襲する（停止①レビュー指摘の反映。なお最悪ケースでも
-  「警告が2回出る」のみでデータ破損・ブロックには繋がらない）
-- 警告文言には「コンテキスト圧縮で指示が失われた可能性」と「今からでも
-  `~/write_aidd_stats.sh start`を呼べば以降のphaseは記録される」旨を含める
-- 出力形式は既存Stop hook群と同じ`{systemMessage}`のみ。全経路exit 0（block不可）
-- 環境変数注入ポイント（テスト用）: skeletonログパス・statsディレクトリ・マーカーファイル
-  パス・stdin代替（session_id/transcript_pathの直接指定）
-- jq・python3不在時は沈黙（#488レビュー指摘の横展開。python3はepoch変換と
-  `sha256(cwd)`キー計算に使用しており、`write_aidd_stats.sh`自体もpython3依存のため
-  実質的な追加依存ではない）
-- 堅牢性（Phase 5レビュー指摘の反映）:
-  - skeletonログの走査は末尾2000行に限定（追記専用・無ローテーションの肥大化対策。
-    現在セッションのイベントは必ず末尾側にある）
-  - jqは`-R` + `fromjson?`で1行ずつパースし、壊れた行が混在しても後続の正当な
-    イベントを見失わない（共有ファイルへの排他制御なし並行追記が前提のため）
-  - マーカー書き込み失敗（read-only等）でもクラッシュせず警告は出す（全経路exit 0の
-    絶対要件。書けない間の警告重複は許容）
-  - 完全一致キーで見つからない場合、statsディレクトリ全体を走査して今セッションの
-    start記録を探す（cwdドリフト＝既知障害でキーがズレた場合の誤警告防止。
-    他worktreeの並行セッションによる沈黙側の見逃しは意図的なトレードオフ）
-  - transcriptのtimestampは末尾Z（UTC）形式のみ信頼し、それ以外は沈黙
-  - `$HOME`未設定環境では沈黙（set -uクラッシュ防止）
-  - 存在チェック（ビルトイン）をコマンド存在確認より先に置き、AIDD未使用セッションでは
-    サブプロセス起動ゼロで終える
+1. `sweep-db.md`: sweep-data.mdと同型の「## 既知の失敗パターン」節を調査対象の直前に挿入。
+   参照セクション=「RLS/テナント分離層」+「データ取得層/API層」のSECURITY DEFINER 2項
+2. `docs/agents/tooling-decisions.md`: 見送り記録エントリを追加(既存の「Bashサンドボックス
+   保留(issue #438)」等と同型式)。permissionMode検証の実測手順・結果(3種素通り)、
+   skillsプリロードのアーキテクチャ理由、maxTurns延期理由と再評価条件を記載
+3. issue #652へのコメント+クローズ(gh issue comment / gh issue close --reason completed。
+   sweep-db穴埋めを実施した上でのスコープ縮小クローズ)
 
-### 2-2. `.claude/settings.json`
+frontmatter(model/effort行)は変更しないため、check-agent-baseline-freshness.shの
+baseline更新警告は発生しない。プロンプト本文のみの変更で、`.claude/workflows/`にも
+触れないためeval義務も非発生。
 
-- Stop hooksに `scripts/check-aidd-stats-recorded.sh`（timeout 15。純粋なファイル読みのみで
-  npx等の重い依存なし）を追加登録
+### テスト観点
 
-### 2-3. テスト `scripts/check-aidd-stats-recorded.test.sh`
+- `npm test`(プロンプト同期テスト群を含む)がgreenのまま
+- sweep-db.mdの追加節がsweep-ui/dataの既存節と同型式であること(目視)
 
-フェイク注入方式（#488のテストと同型）。ケース:
-- skeletonログ無し／このセッションのwf_イベント無し → 沈黙
-- wf_イベントあり・statsファイル無し → 警告
-- wf_イベントあり・statsのstart時刻がセッション開始より古い（前セッション残骸） → 警告
-- wf_イベントあり・statsのstart時刻がセッション開始以降 → 沈黙
-- 警告済みマーカーあり → 2回目は沈黙
-- transcript先頭行が読めない → 沈黙（fail-open）
-- 別セッションのwf_イベントのみ（sessionId不一致） → 沈黙
+## Part 3 — 仕様レビュー前セルフチェック(AI用・レビュー不要)
 
-### 2-4. ドキュメント更新
-
-- `docs/agents/common.md`:
-  - 「検知手段のないルールの棚卸し」表の「AIDD stats書き出し」行を更新する。本検知が
-    カバーするのは`start`の呼び忘れのみのため、行を丸ごと外すのではなく、**検知済みのstart
-    部分への言及（検知手段リンク付き）を備考に記載した上で、未検知のまま残るphase単位の
-    呼び出しに行の対象を狭めて残す**（表自身のルール「検知手段を実装したら表から外す」を、
-    検知済みになった範囲にのみ適用する。全体を外すとphase単位の未検知が棚卸しから
-    消えてしまうため）
-  - 重要ファイル表に新スクリプトの行を追加
-- ルート`CLAUDE.md`: 「AIDD stats 書き出しルール」に検知hookの存在を1行追記
-
-## 並列グループ宣言
-
-- **グループ1（単独・並列化なし）**: 2-1〜2-4すべて。implementer 1体相当で直列実装
-  （#488と同様、5ロール編成ギャップ再発時はオーケストレーター実装を許容）
-
-## 受け入れ条件
-
-- Workflow実行を含むセッションでstats start記録が無いままターンを終えると警告が出る
-  （テストで検証）
-- 同一セッションで警告は1回のみ（テストで検証)
-- AIDDフロー非実行セッション・判定不能時は完全沈黙（テストで検証）
-- OTel等のopt-in設定に依存しない
-- 全`.test.sh` pass / `npm test` green / `npm run lint` green
-
-## 既知の限界（issue記載＋設計由来）
-
-- `subagent-skeleton.jsonl`はセッション全体で共通のため、同一セッション内の
-  「AIDDフローではないWorkflow実行」（例: 単発のresearch系Workflow）も形跡として拾い、
-  誤検知しうる（issue記載どおりwarning-onlyのため許容）
-- 検知できるのは「startの呼び忘れ」のみ。phase1/phase2等の途中フェーズの呼び忘れは
-  検知しない（startさえあればレポートは生成されるため、最小バーとして妥当）
-- セッション開始時刻はtranscript先頭行のtimestampに依存する（Claude Codeのtranscript形式
-  変更で判定不能→沈黙に縮退する。fail-open設計のため安全側）
-
-## 対応しないこと（明示的スコープ外）
-
-- `~/aidd_session_report.sh`・`~/write_aidd_stats.sh`（ホーム側）の変更
-- phase単位の呼び忘れ検知・stats内容の妥当性検証
-- DB・データ取得層・UI・RLS・migrationには一切触れない
-- Phase 1 Sweepの既存コードへの一般指摘（news routeのバリデーション・ItemRow型不一致等）:
-  本issueと無関係のためスコープ外（必要なら別issue）
+新しい型・enum・statusフィールドの導入なし。包含/除外リストは結論サマリ表の4行のみで、
+本文と件数一致(実施1・見送り2・延期1)。既存判定ロジックの置き換えなし。全項目非該当を確認。

--- a/docs/agents/tooling-decisions.md
+++ b/docs/agents/tooling-decisions.md
@@ -318,3 +318,76 @@ platform側の内部メカニズムが完全には文書化されていない）
   }
 }
 ```
+
+## subagent frontmatterの`skills:`プリロード・`permissionMode: plan`は見送り、`maxTurns`は延期（issue #652）
+
+**結論: `skills:`プリロードはClaude/Codex共存設計と衝突するため見送り。`permissionMode: plan`は
+実機検証で書き込みをブロックしないことを確認したため見送り。`maxTurns`はsweep系の決定的手順を
+打ち切るリスクがあるため実測データが揃うまで延期する。**
+
+issue #652は2026-08-25の公式ドキュメント突き合わせレビュー（`docs/ai-config-map.md`とは別件、
+Anthropic公式`code.claude.com/docs/en/sub-agents.md`で実在確認済み）で見つかった、subagent
+frontmatterの未活用フィールド3種（`skills:`・`permissionMode:`・`maxTurns:`）の導入検討issue
+だった。Phase 1調査で以下が判明し、いずれも見送り／延期とした。
+
+### `skills:`プリロード（known-failure-patterns.mdの機械保証化）を見送った理由
+
+issue原案は「`docs/agents/known-failure-patterns.md`を`.claude/skills/`配下のスキルに変換し、
+reviewer・sweep系のfrontmatterに`skills:`プリロード指定する」というものだった。しかし
+`known-failure-patterns.md`は`.agents/skills/handoff-format/SKILL.md`（Codex用の`handoff-format`
+スキル）からも参照される**ツール中立の共有資産**であることが判明した。`.claude/skills/`への
+移動はClaude専用ディレクトリへ資産を囲い込むことになりCodex/Claude共存設計
+（[`claude-codex-coexistence-template.md`](./claude-codex-coexistence-template.md)）に反し、
+`.claude/skills/`と`docs/agents/`の両方に置く複製案はこのリポジトリが一貫して避けてきた
+二重管理・ドリフトの温床になる（[`load-bearing-workarounds.md`](./load-bearing-workarounds.md)の
+正本+複製+sync test方式が必要な規模の変更であり、今回のスコープには見合わない）。
+
+加えて、現状の参照方式は原案が想定したよりも細かく設計されていることも判明した：
+`reviewer.md`は全文参照、`sweep-ui.md`/`sweep-data.md`は担当セクションのみを参照する指示
+（haiku・`effort: low`の軽量設計を守るため）で、全員へ一律プリロードすると軽量sweepに
+無関係なセクション（RLS等）まで常時読ませることになり、この設計思想と衝突する。
+
+**唯一の実利益（sweep-dbが「RLS/テナント分離層」セクションへの参照を持たない、issue #24型の
+再発防止の穴）のみ、sweep-ui/sweep-dataと同型の手動参照節を追加する形で対応した
+（`.claude/agents/sweep-db.md`）。プリロード機構自体は導入していない。**
+
+### `permissionMode: plan`を見送った理由（実機検証）
+
+reviewer・judge-panel・adversarial-verify（いずれも`tools: Read, Bash`で読み取り専用のはずが、
+Bashで書き込み系コマンドを打てる余地がある）にread-only強制を機械的にかける手段として検討した。
+
+`sweep-ui.md`に一時的に`permissionMode: plan`を追加し、Agent tool経由（`subagent_type:
+"sweep-ui"`）で以下3種の書き込み系Bashコマンドを実行させたところ、**すべて許可プロンプトなしで
+実行完了し、ファイル実体の作成も確認した**（検証後、frontmatterの変更は`git checkout --`で
+元に戻した）：
+
+1. `scripts/log-agent-progress.sh`（このリポジトリのサブエージェントが実運用で必ず呼ぶ進捗記録
+   スクリプト。ファイル追記）
+2. `echo ... > file`（直接ファイル書き込み）
+3. `mkdir`（ファイルシステム変更）
+
+read-onlyを機械強制する目的には使えないと判明した。むしろ「permissionMode: planを設定した」
+という事実だけが残り、実際には効いていないのに読み手に誤った安心感を与えるリスクがあるため、
+導入しないことにした。
+
+**再開条件:** Claude Code側の公式ドキュメントでplanモードのBashコマンド制御が明記・強化された
+場合（現状のsub-agents.mdの記載は「プランモード」という値の存在のみで、Bash実行への制御内容は
+明記されていない）、再度実機検証してから判断する。
+
+### `maxTurns`を延期した理由
+
+sweep-ui/sweep-data/sweep-db（すべてhaiku・`effort: low`）は「対象ファイルをrgで完全一覧化し、
+除外後の一覧を最後まで確認してから結果を返す」という決定的な探索手順を必須としている
+（各`.claude/agents/sweep-*.md`の「決定的な探索手順（省略禁止）」節）。対象ファイル数が
+`maxTurns`の設定値を超えると、この手順は正常動作の途中でエージェントごと打ち切られる。
+打ち切られたエージェントが返す空応答・部分応答は「指摘なし（正常完了）」と外形的に区別できず、
+静かな見逃しモードを新設してしまう。
+
+適正な`maxTurns`値を決めるための実測データ（エージェントタイプごとの典型的なターン数）が
+現状存在しない。`docs/agents/observability-internals.md`の「agents設定変更時のbaselineスナップ
+ショット機械強制（issue #429）」は`model:`/`effort:`変更のみを対象としており、ターン数の
+baseline化は未整備。
+
+**再開条件:** `scripts/snapshot-agent-baseline.sh`にエージェントタイプ別の典型ターン数が
+記録されるようになった後、実測の最大値に十分な余裕を持たせた`maxTurns`値を設計する
+（issue #654の低優先バックログに次点として記載済み）。


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: issue #652(subagent frontmatterの新フィールド`skills:`/`permissionMode:`/`maxTurns:`導入検討)の調査・実機検証を行い、結果をリポジトリに反映する
- 変更した範囲:
  - `.claude/agents/sweep-db.md`: known-failure-patterns.mdへの参照が無かった穴を埋める(sweep-ui/dataと同型式で「RLS/テナント分離層」+SECURITY DEFINER関連2項を追加)
  - `docs/agents/tooling-decisions.md`: 3要素(skills:プリロード/permissionMode: plan/maxTurns)それぞれの判断根拠・実機検証結果・再評価条件を記録
  - `SPEC.md`: issue #652用の調査・仕様記録(このリポジトリの慣行に従い、前回issue #495分から差し替え)
- 触っていない範囲: src/・supabase/等のプロダクトコード全て、他のsubagent定義(reviewer.md/judge-panel.md/adversarial-verify.md等。permissionMode: plan/maxTurnsの導入は見送ったため無変更)

## 検証済み
- 実行したコマンド: `npm test`(186 files / 1419 tests passed)
- 実機検証(投機的な導入判断を避けるため、実装前に2回実施):
  1. `permissionMode: plan`の書き込みブロック効果: `sweep-ui.md`に一時的に設定し、Agent tool経由(`subagent_type: "sweep-ui"`)で書き込み系Bashコマンド3種(`scripts/log-agent-progress.sh`追記・`echo >`リダイレクト・`mkdir`)を実行させたところ、**全て許可プロンプトなしで実行完了しファイル実体も作成された**ことを確認(read-only強制にならないと判明)。検証後、frontmatterの変更は`git checkout --`で元に戻し済み
  2. plan mode下でのRead/Bash(grep)実行可否: 同様に`sweep-ui.md`へ一時設定し、許可プロンプトなしで実行できることを確認(こちらは検証当初の想定通り)
- 確認した画面: なし(UI変更なし)
- 確認したDB/RLS: なし(DB変更なし)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外(facility/RLS境界のコード自体には触れていない。sweep-db.mdへの追加はRLS「関連の失敗パターンをチェックさせる指示」であり、RLS実装自体の変更ではない)

## 既知の未対応
- 今回あえて対応しなかったこと: `skills:`プリロード導入(known-failure-patterns.mdのスキル化)、`permissionMode: plan`のreviewer/judge-panel/adversarial-verifyへの導入、`maxTurns`の全エージェントへの導入
- 理由: 詳細はdocs/agents/tooling-decisions.mdの新規節を参照。要約は以下の通り
  - `skills:`: known-failure-patterns.mdは`.agents/skills/handoff-format/SKILL.md`(Codex用)からも参照されるツール中立資産で、`.claude/skills/`への囲い込みはClaude/Codex共存設計と衝突する
  - `permissionMode: plan`: 実機検証で書き込みをブロックしないと判明。効いていないのに導入すると誤った安心感を与える
  - `maxTurns`: sweep系の「全ファイル列挙→全件確認」という決定的手順を打ち切るリスクがあり、打ち切りの空応答は「指摘なし」と区別できない。ターン数の実測baselineが無く適正値を決められない
- 次に触るなら見る場所: issue #654(低優先バックログ)にmaxTurnsの再検討を次点として記載済み。`scripts/snapshot-agent-baseline.sh`にターン数集計が追加されたら再検討する

## 後任AIへの注意
- この実装で壊してはいけない前提: sweep-db.mdの探索手順(「決定的な探索手順（省略禁止）」節)は今回変更していない。追加したのは調査対象の直前の「既知の失敗パターン」節のみで、既存の探索手順・調査観点・出力形式には触れていない
- 似ているが別物の用語: `.claude/skills/`(Claude専用)と`.agents/skills/`(Codex用、agents.md標準準拠)は別ディレクトリ。known-failure-patterns.mdを将来スキル化する場合はこの区別に注意
- 勝手にリファクタしない場所: reviewer.md/judge-panel.md/adversarial-verify.mdのfrontmatter(今回は意図的に無変更。安易にpermissionMode: planを追加しないこと。実機検証済みで効果がないことが判明している)

issue #652には調査結果のコメントを投稿し、not plannedでクローズ済み: https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/issues/652#issuecomment-5418630796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
