### PR TITLE
docs: 設計提案のgreen方向のみ検証パターンをknown-failure-patterns.mdに追記

### DIFF
--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -137,6 +137,31 @@ globパターン（`*`等を含むパス）を渡していないか確認する�
 
 詳細: [`decisions/aidd-pipeline.md`](./decisions/aidd-pipeline.md#なぜissue-444のpretooluse-hookを警告のみdenyの二段構えにしたか)
 
+### 設計提案・機構追加をgreen方向のみ検証して人間レビューに出す
+
+**チェック内容:** 新しい強制機構（`permissionMode`等のagent frontmatterフィールド、feature flag、
+バリデーション、PreToolUse hookのブロック条件等）を追加する提案をする前に、「意図通り動く
+（green）」だけでなく「意図通り止める/防ぐ（red）」も実測したか確認する。片方向の検証だけで
+「導入してよい」と結論づけていないか、SPEC.md・PR本文・レビュー指摘のいずれかで書く前に
+自問する。
+
+**なぜ再発したか:** issue #652で、subagentの`permissionMode: plan`がread-only強制になるという
+提案を、Bash(grep)のような読み取り系コマンドが通ることの確認（green）だけで進めかけた。
+実際にはlog-agent-progress.sh呼び出し・`echo >`リダイレクト・`mkdir`のような書き込み系
+Bashコマンドも許可プロンプト無しで素通りしており、red方向（書き込みを本当に止めるか）を
+別途実測して初めて「効果がない」と判明した。green方向だけの確認は「動いた」ことしか
+証明せず、「防ぐはずのものを防いでいるか」は別に検証しないと分からない。
+
+**推奨:** 「新しい制御・ゲートを追加する」提案は、成功ケースの実測だけでなく、そのゲートが
+防ぐはずの失敗ケースを実際に発生させて防がれるか確認してから提示する。ただしこのチェック
+自体は自然言語ルールであり機械強制ではない（`docs/agents/undetectable-rules-inventory.md`
+参照）。効果があるのは、提案した本人とは別のエージェント・人間がレビュー時にこのファイルを
+参照する場合のみで、meta改修のSPEC自体を別エージェントがレビューする仕組みは現状無い
+（2026-08-26時点。将来`adversarial-verify`をmeta改修SPEC提示前にも呼ぶ運用に広げる案は
+issue化を検討）。
+
+詳細: [`tooling-decisions.md`](./tooling-decisions.md#subagent-frontmatterのskillsプリロードpermissionmode-planは見送りmaxturnsは延期issue-652)
+
 ## RLS/テナント分離層
 
 ### 「動いたからOK」でfacility_idフィルタ漏れ・RLS未設定を見逃す（issue #24再発防止）


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: issue #652の作業中に発覚した「新しい強制機構(permissionMode等)を提案する際、green方向のみ検証して人間レビューに出す」失敗パターンを、再発防止のチェックリストとして`docs/agents/known-failure-patterns.md`に記録する
- 変更した範囲: `docs/agents/known-failure-patterns.md`の「エージェント/hook運用層」セクションへの1項目追加のみ
- 触っていない範囲: src/・supabase/等のプロダクトコード全て、他のドキュメント・エージェント定義

## 検証済み
- 実行したコマンド: `npm test`(186 files / 1419 tests passed)
- 追記内の相互参照リンク(`tooling-decisions.md`への見出しアンカー)が実在することをgrepで確認

## 既知の未対応
- 今回あえて対応しなかったこと: meta改修のSPEC自体を別エージェント(adversarial-verify等)がレビューする仕組みの導入
- 理由: 本エントリは「reviewer/sweep-dbがコードレビュー時に参照する」既存の配線に乗るだけで、meta改修(SPEC.md提案)自体をレビューする仕組みは現状無く、別issue相当のスコープ。ユーザーとの会話で「軽量な①のみ先に進める」と合意した
- 次に触るなら見る場所: meta改修SPEC提示前にadversarial-verifyを挟む運用ルール化(issue化検討中、未起票)

## 後任AIへの注意
- この実装で壊してはいけない前提: 追記した項目はドキュメントのみで機械強制ではない(自然言語ルール)。「これを書いたから今後同種の見落としが起きない」と過信しないこと
- 似ているが別物の用語: 本エントリと`docs/agents/undetectable-rules-inventory.md`の「第3層ルール」は同じ性質(機械検知手段なし)。今後このエントリの実効性を確認したくなったら棚卸し表と合わせて見る
- 勝手にリファクタしない場所: 特になし(単純追記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
