### PR TITLE
chore: supabase/.temp/を.gitignoreに追加(過去にproject ref等の混入が判明)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ session-report-*.html
 
 # Supabase Studio SQL EditorがローカルDB調査時に自動保存するスニペット（デバッグ用・ローカル専用）
 /supabase/snippets/
+
+# Supabase CLI（supabase link/start等）がローカルに生成する作業状態。project ref・組織ID・
+# pooler接続文字列（パスワードは含まないが本番プロジェクトの識別情報）を含むため常に除外する。
+# 2026-08-26時点で過去に誤ってコミットされていたことが判明（履歴には残るが今後の再混入を防ぐ）
+/supabase/.temp/


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: public化の可否検討のため実施した履歴監査で、`supabase/.temp/`(Supabase CLIのローカル作業状態)が`.gitignore`に含まれておらず、過去のコミットで実際にproject ref・組織ID・pooler接続文字列が混入していたことが判明。今後の再混入を防ぐ
- 変更した範囲: `.gitignore`への1パターン追加のみ
- 触っていない範囲: git履歴自体(過去コミットの書き換えは行っていない。パスワードは含まれておらず、リポジトリがprivateのまま運用継続する前提のためユーザー確認の上で見送り)

## 検証済み
- 実行したコマンド: `npm test`(186 files / 1419 tests passed)
- `git add supabase/.temp/`(dry-run相当)を実行し、「ignored by .gitignore」として拒否されることを確認
- 混入していた内容の実機確認: `git log --all -p -- supabase/.temp/pooler-url`で該当コミット(7d10a9e)を特定し、パスワードが含まれていないことを確認済み(project ref・組織ID・リージョン情報のみ)

## 既知の未対応
- 今回あえて対応しなかったこと: 過去コミットの履歴書き換え(BFG Repo-Cleaner等)
- 理由: パスワード等の機密情報は含まれておらず、リポジトリはprivateのまま運用継続する前提のためユーザーと合意の上で見送った
- 次に触るなら見る場所: 将来リポジトリをpublic化する検討をする場合は、この履歴クリーンアップが前提になる

## 後任AIへの注意
- この実装で壊してはいけない前提: 特になし(単純な.gitignore追加)
- 似ているが別物の用語: `/supabase/snippets/`(既存の除外パターン、SQL Editorのスニペット)と`/supabase/.temp/`(今回追加、CLIの作業状態)は別物
- 勝手にリファクタしない場所: 特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
