### PR TITLE
chore: サンプル/テストファイルの実在Gmailアドレスをダミー値に置換

### DIFF
--- a/.claude/workflows/__fixtures__/fault-injection/tampered-spechash/run-manifest.json
+++ b/.claude/workflows/__fixtures__/fault-injection/tampered-spechash/run-manifest.json
@@ -4,7 +4,7 @@
   "baseCommit": "0000000000000000000000000000000000000000",
   "changedFiles": [],
   "approval": {
-    "approvedBy": "huuriekaiseki@gmail.com",
+    "approvedBy": "example-reviewer@example.com",
     "approvedAt": "2026-04-01T00:00:00+09:00"
   }
 }

--- a/.claude/workflows/lib/__tests__/manifest-check.test.js
+++ b/.claude/workflows/lib/__tests__/manifest-check.test.js
@@ -16,7 +16,7 @@ describe('classifyManifestCheck', () => {
   })
 
   it('approval.approvedAtが無ければblocked', () => {
-    const manifest = { specHash: 'abc123', approval: { approvedBy: 'huuriekaiseki@gmail.com' } }
+    const manifest = { specHash: 'abc123', approval: { approvedBy: 'example-reviewer@example.com' } }
     const result = classifyManifestCheck(manifest, 'abc123')
     expect(result.status).toBe('blocked')
     expect(result.detail).toContain('承認が記録されていません')
@@ -30,7 +30,7 @@ describe('classifyManifestCheck', () => {
   })
 
   it('specHashが無ければblocked', () => {
-    const manifest = { approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' } }
+    const manifest = { approval: { approvedBy: 'example-reviewer@example.com', approvedAt: '2026-07-10T05:00:00+09:00' } }
     const result = classifyManifestCheck(manifest, 'abc123')
     expect(result.status).toBe('blocked')
     expect(result.detail).toContain('specHashが記録されていません')
@@ -39,7 +39,7 @@ describe('classifyManifestCheck', () => {
   it('manifest.specHashとactualSpecHashが一致すればpass', () => {
     const manifest = {
       specHash: 'abc123',
-      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+      approval: { approvedBy: 'example-reviewer@example.com', approvedAt: '2026-07-10T05:00:00+09:00' },
     }
     const result = classifyManifestCheck(manifest, 'abc123')
     expect(result.status).toBe('pass')
@@ -49,7 +49,7 @@ describe('classifyManifestCheck', () => {
   it('manifest.specHashとactualSpecHashが不一致ならblocked（レビュー承認後にSPEC.mdが変更された）', () => {
     const manifest = {
       specHash: 'abc123',
-      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+      approval: { approvedBy: 'example-reviewer@example.com', approvedAt: '2026-07-10T05:00:00+09:00' },
     }
     const result = classifyManifestCheck(manifest, 'xyz789')
     expect(result.status).toBe('blocked')
@@ -66,7 +66,7 @@ describe('applyChangedFiles', () => {
       specHash: 'abc123',
       baseCommit: 'd1a7dbd',
       changedFiles: [],
-      approval: { approvedBy: 'huuriekaiseki@gmail.com', approvedAt: '2026-07-10T05:00:00+09:00' },
+      approval: { approvedBy: 'example-reviewer@example.com', approvedAt: '2026-07-10T05:00:00+09:00' },
     }
     const updated = applyChangedFiles(manifest, ['src/app/page.tsx', 'src/lib/foo.ts'])
     expect(updated.changedFiles).toEqual(['src/app/page.tsx', 'src/lib/foo.ts'])

--- a/docs/agents/run-manifest.example.json
+++ b/docs/agents/run-manifest.example.json
@@ -8,7 +8,7 @@
     "supabase/migrations/20260710000000_example_feature.sql"
   ],
   "approval": {
-    "approvedBy": "huuriekaiseki@gmail.com",
+    "approvedBy": "example-reviewer@example.com",
     "approvedAt": "2026-07-10T05:00:00+09:00"
   }
 }


### PR DESCRIPTION
## 作業サマリ
- 変更した目的: public化可否の監査中に発見した、ユーザー個人のGmailアドレスがサンプル/テストファイルに実在値として埋め込まれている問題を修正する
- 変更した範囲: `docs/agents/run-manifest.example.json`・`.claude/workflows/__fixtures__/fault-injection/tampered-spechash/run-manifest.json`・`.claude/workflows/lib/__tests__/manifest-check.test.js`の計3ファイル(5箇所)、いずれも`approvedBy`フィールドの例示値をダミーメール(`example-reviewer@example.com`)に置換
- 触っていない範囲: `docs/agents/run-manifest.md`(スキーマ本体。実在アドレスの記載なしを確認済み)、他のfault-injection関連スクリプト(`aidd-fault-injection-setup.sh`等。参照なしを確認済み)、過去のgit履歴(このアドレスは複数の過去コミットにも残っているが、履歴書き換えは別issue相当のためスコープ外)

## 検証済み
- 実行したコマンド: `npm test`(186 files / 1419 tests passed)、`grep -rln`で現在のツリー全体に実在アドレスが残っていないことを確認
- 確認した画面: なし(UI変更なし)
- 確認したDB/RLS: なし(DB変更なし)
- 他テナントのIDでアクセスし、弾かれることを確認したか: 対象外

## 既知の未対応
- 今回あえて対応しなかったこと: git履歴に残っている同アドレスの除去(過去コミットの書き換えが必要)
- 理由: 今回は「現在のHEADに存在する」問題への対応を優先した。履歴クリーンアップはリポジトリをpublic化する場合にまとめて対応する方針(supabase/.temp/の履歴混入と合わせて別途検討)
- 次に触るなら見る場所: public化を検討する際は、このアドレスとsupabase project ref(別PR #658で.gitignore対応済みだが履歴自体は未クリーンアップ)の両方を含めた履歴書き換えが前提になる

## 後任AIへの注意
- この実装で壊してはいけない前提: manifest-check.test.jsの各テストはapprovedByの値そのものを検証していない(存在確認のみ)ため、任意の文字列に置換して問題ない設計
- 似ているが別物の用語: `docs/agents/run-manifest.md`(スキーマ本体、実在アドレスなし)と`docs/agents/run-manifest.example.json`(サンプル、今回修正)は別ファイル
- 勝手にリファクタしない場所: 特になし(単純な値の置換)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
