### PR TITLE
feat: .codex/config.tomlに[features] hooks=trueを宣言する(issue #653・1/2)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,23 @@
+# WHY: issue #653。Codexのhooks機能はデフォルト無効(features.hooks=false)で、
+# .codex/hooks.jsonが実際に発火するかは各開発者の~/.codex/config.toml頼みになっていた。
+# featuresキーはプロジェクトスコープのこのファイルでも宣言可能(上書き不可キー一覧に
+# 含まれない、developers.openai.com/codex/config-reference確認済み)ため、ここで宣言し
+# チーム全体でhooks.jsonが確実に有効になるようにする。正名は`hooks`(`codex_hooks`は非推奨エイリアス)。
+[features]
+hooks = true
+
+[mcp_servers.context7]
+command = "npx"
+args = [
+    "-y",
+    "@upstash/context7-mcp@latest",
+]
+
+[mcp_servers.playwright]
+command = "npx"
+args = [
+    "-y",
+    "@playwright/mcp@latest",
+    "--isolated",
+    "--storage-state=e2e/.auth/user.json",
+]


### PR DESCRIPTION
## 作業サマリ
issue #653のうち、Claude Codeで対応可能な部分(1番)のみ実施。`.codex/config.toml`(これまで未追跡だったローカルファイル)を新規に追跡対象とし、`[features] hooks = true`を宣言した。これによりCodexのhooks機能がプロジェクトスコープでデフォルト有効になり、`.codex/hooks.json`の発火が各開発者の`~/.codex/config.toml`任せにならなくなる。

## 検証済み
- TOML構文をPythonのtomllibでパース検証(既存のmcp_servers設定を壊していないことを確認)

## 未対応(issue #653に残す。Codex CLIでの実機検証が必要なためスコープ外)
- invocation_id固定・block fail-open・SubagentStop多重発火の3件の実測メモ更新(最新CLI 0.149.0以降での再実測)
- subagent tomlの`model`キーによるロール別指定の実機確認
- hooks変更後のTerminalからのcodex CLI起動での実機検証(AGENTS.mdの既存ルール)

Closes: なし(issue #653は上記残タスクがあるためこのPRではクローズしない)