### PR TITLE
fix: get_admin_status RPCの認可バイパス脆弱性を修正する

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,41 +1,115 @@
-# SPEC: 月次品質ゲートサマリのpass/fail集計をjournal.jsonlベースへ移行する(Issue #642)
+# 仕様書: get_admin_status RPCの認可バイパス脆弱性修正
 
-## Part 1 — 仕様(★人間がレビューする部分)
+## Part 1 — 仕様（人間レビュー用）
 
-### 背景
+### 何ができるようになるか（利用者目線）
 
-- `scripts/summarize-loop-observability.sh`(月次品質ゲートサマリの主集計)は`logs/loop-observability.jsonl`という**自己申告ログ**のみを見ており、欠落期間があっても「発火ゼロ」と誤読されうる
-- `scripts/lib/canonical-event.ts`の`journalAdapter`はWorkflowの`journal.jsonl`(機械記録・pass/fail/blockedを保持)を正規化済みだが、**`~/.claude/projects/.../wf_*`ディレクトリはtranscript cleanupで消える**(実測: 2026-08-22時点で3ディレクトリしか残存せず、7月以降の大量の実行履歴が既に消失)
-- そのため、journalベースに集計を寄せるには、消える前に永続化する「収穫層」が前提として必要
+現在、ログイン済みの利用者であれば誰でも、他人のアカウントIDを指定するだけで「その人が管理者かどうか」を調べられてしまう不具合があります。この修正により、**自分自身の管理者判定しかできなくなり**、他人の権限情報が外部から分からなくなります。
 
-### 方針決定
+利用者から見た画面・操作フローそのものは変わりません（ログイン後の管理者メニュー表示・管理画面アクセス制御の見え方は現状と同じ）。今回の変更はサーバー内部の認可チェックの是正であり、UI上の新しい操作は発生しません。
 
-1. **収穫層(Stage 1)**: Stop hookから毎回(通知の30日間隔ゲートとは無関係に)実行し、`journalAdapter`が返すイベントを`logs/journal-harvest.jsonl`(全worktree共有の`resolve_log_dir()`配下)へ**agentId基準**で重複排除しながら追記する
-   - 注: eventId基準にしない理由 — `journalAdapter`のeventIdは全wf_*ディレクトリ横断の出現順連番(`lineIndex`)を含むため、古いwf_*がtranscript cleanupで消えると同一イベントのeventIdが収穫のたびに変わり、重複排除が壊れる。agentIdはエージェント実行ごとに一意かつディレクトリの増減に影響されないため、こちらを永続キーにする
-2. **集計切替(Stage 2)**: 月次サマリのagent別pass/fail集計を、収穫済み`journal-harvest.jsonl`ベースに切り替える。既存の`summarize-gate-blocked.sh`(blockedのみ集計)は新集計に統合し廃止する(同じ数値を二重表示しない)
-3. **残す部分(Stage 3)**: feature別・token/costUsd集計は当面`loop-observability.jsonl`(自己申告)参照のまま残すが、月次サマリ出力に「自己申告のため欠落があり得る」旨を明記する
+> 📸 スクショ撮影ポイント: なし（UI変更なし。E2E観点はPart 1「受け入れ条件」のAPI/RPC呼び出しレベルの検証で担保する）
 
-### 受け入れ条件
+### 背景（何が問題だったか）
 
-- [ ] `harvestJournalEvents()`が、同じagentIdのイベントを二重に追記しない(wf_*ディレクトリの増減後も安定。ユニットテストで検証)
-- [ ] `scripts/harvest-journal-events.sh`が`resolve_log_dir()`配下の`journal-harvest.jsonl`へ収穫結果を追記する
-- [ ] `gate-effectiveness-monthly-check.sh`が、30日通知ゲートの前に毎回harvestを実行する(通知が出ない回でも収穫は行われる)
-- [ ] `summarizePassFailGates()`が、journal由来イベント(status: pass/fail/blocked)をagentType別に集計できる(ユニットテストで検証)
-- [ ] `gate-effectiveness-monthly-check.sh`の月次サマリメッセージが、journal-harvestベースのpass/fail/blocked集計を主とし、loop-observability.jsonlベースのfeature別/コスト集計には「自己申告・欠落あり得る」旨の注記がある
-- [ ] `scripts/summarize-gate-blocked.sh`は新集計に統合され、重複した出力が残らない
-- [ ] 既存の`npm test`・`npm run lint`が全て通過する(回帰なし)
+- `get_admin_status(p_user_id UUID)` というRPC関数が、`SECURITY DEFINER`（RLSをバイパスする特権実行）で動いているにもかかわらず、渡された`p_user_id`が呼び出し本人かどうかを一切確認していなかった。
+- 認証済みユーザーなら誰でも呼び出せる権限（`GRANT EXECUTE ... TO authenticated`）が付与されていたため、任意の`p_user_id`を指定して他人の管理者フラグを取得できる状態だった（情報漏えい）。
+- さらに調査の結果、TypeScript側の呼び出し元（`src/lib/admin-status.ts`）は既に「パラメータなし」で呼び出す形に変更済みだが、DB側のマイグレーションはパラメータ必須のままであり、**現状は呼び出し自体が引数不一致で失敗する状態**になっている（管理者判定が機能停止するリスクを内包）。
 
-## Part 2 — 実装計画
+### 修正方針（利用者目線での結果）
 
-### Set A: 収穫層
-- `scripts/lib/harvest-journal-events.ts`(新規): `harvestJournalEvents(projectDir, outputFile)`。既存`outputFile`の行からeventIdの集合を読み込み、`journalAdapter(projectDir).load()`との差分のみ追記する。CLIエントリ(`--project-dir`, `--output`)も持つ
-- `scripts/lib/harvest-journal-events.test.ts`(新規): 重複排除・新規追記・ファイル未存在時の挙動をテスト
-- `scripts/harvest-journal-events.sh`(新規): `resolve-log-dir.sh`を使い`logs/journal-harvest.jsonl`を解決して上記CLIを呼ぶ。fail-open(エラーでも exit 0)
+1. RPC関数`get_admin_status`をパラメータなしの関数に変更し、内部で`auth.uid()`（呼び出し本人のID）のみを使うようにする。
+2. これにより「他人のIDを指定する」余地自体をなくす（パラメータが存在しないので、そもそも他人を指定できない）。
+3. TypeScript側の呼び出し・型定義・テストをこの新しいシグネチャに合わせて整合させる。
 
-### Set B: 集計切替
-- `scripts/lib/gate-effectiveness-summary.ts`: `summarizePassFailGates(events: CanonicalEvent[])`を追加。journal由来イベントをagentType別にpass/fail/blocked集計する。`loadHarvestedEvents(logFile)`(JSONL読み込み)も追加
-- `scripts/lib/gate-effectiveness-summary.test.ts`: 新関数のテストを追加
-- `scripts/summarize-gate-passfail.sh`(新規): harvest済みJSONLを読んでCLI出力する(`summarize-gate-blocked.sh`を置き換え)
-- `scripts/summarize-gate-blocked.sh`: 削除(新スクリプトに統合)
-- `scripts/gate-effectiveness-monthly-check.sh`: 冒頭でharvestを実行するよう変更。MSG組み立てを新集計ベースに変更し、loop-observability.jsonlベースの部分に自己申告の注記を追加
-- `scripts/gate-effectiveness-monthly-check.test.sh`: 既存テストの更新
+### 受け入れ条件（チェックリスト）
+
+- [ ] `get_admin_status()`はパラメータを受け取らず、`auth.uid()`で判定した「呼び出し本人の管理者フラグ」と「DB全体の管理者有無フラグ」を返す
+- [ ] 他人の`user_id`を指定して管理者判定を取得する手段が存在しない（関数シグネチャレベルで不可能）
+- [ ] `anon`ロールには実行権限が付与されない（既存の20260704000002マイグレーションの意図を維持）
+- [ ] `authenticated`・`service_role`ロールは実行できる
+- [ ] 新しい関数定義は`SET search_path = ''`+`public.`完全修飾になっている（現行のsearch_path硬化慣行に整合）
+- [ ] `src/lib/admin-status.ts`の`resolveIsAdmin()`が新しいRPCシグネチャで正しく動作する（自分がadmin→true、他にadminがいれば非adminはfalse、DBにadminが0件ならADMIN_EMAILSフォールバックを使う、という既存の3段階判定ロジックは変更しない）
+- [ ] `src/types/database.generated.ts`の`get_admin_status`の型定義がパラメータなしのシグネチャに更新されている
+- [ ] `src/lib/__tests__/admin-status.test.ts`のアサーションが新シグネチャ（`db.rpc('get_admin_status')`、引数なし）に整合し、全テストがgreenになる
+- [ ] リポジトリに残置されている`supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`（git管理外の残骸ファイル）を削除する
+- [ ] 既存の管理者向け機能（管理画面アクセス制御・admin専用メニュー表示等）が修正後も従来通り動作する（回帰なし）
+- [x] DBスキーマ変更を伴うため`npm run test:integration`（RLS/IDOR integrationテスト）をローカル実行し結果を確認する（`docs/agents/rules/db-schema.md`のルールに基づく）— 実行済み: 11ファイル44件全green（実行日時はPart 2セットAのテスト観点参照）
+
+### 対象外（今回のスコープに含まないこと）
+
+- ADMIN_EMAILSフォールバックのロジック自体の変更（Postgres側から環境変数を読めない制約は変わらないため、TS側フォールバックはそのまま維持）
+- `requireAdmin()`・`requireFacilityAccess()`・`middleware.ts`など、`resolveIsAdmin()`を呼び出す側の判定フロー自体の変更（呼び出しインターフェースは変えない）
+- 他のSECURITY DEFINER関数（`get_distributor_product_price_history`等）の追加監査（既に別マイグレーションで対応済みと調査確認済み）
+
+---
+
+## Part 2 — 実装計画（AI用）
+
+### 実装セット一覧（依存順）
+
+**セットA: DBマイグレーション追加（get_admin_status のシグネチャ変更）**
+- 新規ファイル: `supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`
+- 内容:
+  - `CREATE OR REPLACE FUNCTION get_admin_status()`（パラメータなし）
+  - 関数本体: `WHERE user_id = p_user_id` → `WHERE user_id = auth.uid()`
+  - `SECURITY DEFINER SET search_path = ''`とし、テーブル参照は`public.user_facilities`に完全修飾する（20260804000001_harden_order_rpc_search_path.sqlで確立済みのsearch_path hijacking対策の現行慣行に合わせる。`auth.uid()`は元からスキーマ修飾済み）
+  - `GRANT EXECUTE ON FUNCTION get_admin_status() TO authenticated, service_role;`（`anon`は含めない。既存20260704000002の意図を踏襲）
+  - 旧シグネチャ`get_admin_status(p_user_id UUID)`が残存しないよう、`DROP FUNCTION IF EXISTS get_admin_status(UUID);`を先頭で実行してから新規作成する（PostgreSQLは引数の型が異なる関数をオーバーロードとして共存させてしまうため、明示的に削除しないと新旧2つの関数が併存し脆弱性が残る）
+  - `CREATE OR REPLACE FUNCTION`直後に`REVOKE ALL ON FUNCTION get_admin_status() FROM PUBLIC;`を実行してから`GRANT`する（新規作成される関数オブジェクトにはPostgreSQLのデフォルト仕様でPUBLIC=anon含む全ロールへEXECUTE権限が自動付与されるため、明示的にREVOKEしない限りanonが呼び出せてしまい、受け入れ条件「anonロールには実行権限が付与されない」を満たせない。旧関数への20260704000002のREVOKEは別オブジェクトに対するものでこの新オブジェクトには引き継がれない）
+  - ファイル冒頭に脆弱性の内容とauth.uid()採用理由をコメントで明記（既存ファイルのWHYコメント形式踏襲）
+- テスト観点:
+  - `npm run test:integration`でRLS/IDOR観点の既存スイートを実行し、admin判定関連のテストが通ることを確認
+  - 手動確認（可能なら）: 別ユーザーのIDを渡す経路が存在しないことをコードレビューで確認（関数がパラメータを取らないため機械的に保証される）
+  - `supabase/migrations/__tests__/admin_status_rpc.test.ts`に本マイグレーション（`20260827000001_fix_admin_status_rpc_authz.sql`）専用の静的検証`describe`ブロックを追加し、以下を回帰テストとして固定する: 旧シグネチャ`get_admin_status(UUID)`の`DROP FUNCTION IF EXISTS`実行、パラメータなし定義＋`auth.uid()`採用、`SECURITY DEFINER`/`SET search_path = ''`＋`public.`完全修飾、`authenticated, service_role`のみへのGRANT（`anon`非包含）
+- 触るファイル: `supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`（新規）、`supabase/migrations/__tests__/admin_status_rpc.test.ts`（新規describeブロック追加）
+
+**セットB: 残骸ファイル削除**
+- `supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`を削除
+- 触るファイル: `supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`（削除）
+
+**セットC: TS型定義更新**
+- `src/types/database.generated.ts`の`get_admin_status`エントリを`Args: Record<PropertyKey, never>`相当（パラメータなし）に更新
+  - 本来はSupabase CLIの型生成コマンドで再生成するのが正だが、ローカル生成環境がない場合は手動でAI側が整合するよう編集してよい（既存の他のパラメータなしRPC定義の書式に倣う）
+- 触るファイル: `src/types/database.generated.ts`
+
+**セットD: TS呼び出し確認（変更不要の可能性が高い）**
+- `src/lib/admin-status.ts`は既に`db.rpc('get_admin_status')`（引数なし）呼び出しに変更済みであることを確認済み。追加の実装作業は不要。ただし念のためセットAのマイグレーション適用後に実装済みコードが型エラーを起こさないか確認する。
+- 触るファイル: なし（確認のみ）
+
+**セットE: テスト修正**
+- `src/lib/__tests__/admin-status.test.ts`の37行目
+  - 変更前: `expect(db.rpc).toHaveBeenCalledWith('get_admin_status', { p_user_id: USER_ID })`
+  - 変更後: `expect(db.rpc).toHaveBeenCalledWith('get_admin_status')`
+- 触るファイル: `src/lib/__tests__/admin-status.test.ts`、`src/lib/supabase/__tests__/require-facility-access.test.ts`（requireFacilityAccess()経由でresolveIsAdmin()を呼ぶため、同様に旧シグネチャのアサーション・WHYコメントの追従が必要）
+
+### 並列グループ宣言
+
+- **波1（同時実装可・互いに別ファイルのみ触る）**:
+  - セットA（`supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`新規作成）
+  - セットB（`.bak`ファイル削除）
+  - セットE（`src/lib/__tests__/admin-status.test.ts`編集）
+- **波2（波1完了後・統合ゲートへ）**:
+  - セットC（`src/types/database.generated.ts`編集）— セットAのSQL変更内容を正としてAIが手動で型を同期させるため、セットA完了後に着手する（同時実装するとAIが古いシグネチャを見て型を書いてしまうリスクがあるため波を分ける）
+- **セットD**は変更なし（確認のみ）のため波に含めない。
+
+### 型・データアクセス層の方針
+
+- RPCの戻り値型（`AdminStatusRow`、`src/lib/admin-status.ts`内で定義）は変更しない（`user_is_admin: boolean`, `db_has_admin: boolean`のまま）。変わるのは呼び出し時の引数の有無のみ。
+- `src/types/database.generated.ts`の`Args`フィールドは、他のパラメータなしRPC（例: 同ファイル内の`custom_access_token_hook`のような1引数のもの以外で、引数なしのものがあればそれ）の書式に倣い`Args: Record<PropertyKey, never>`とする。既存コードベース内に引数なしRPCの型定義例があるかセットC着手時に確認し、書式を合わせる。
+
+---
+
+## Part 3 — 仕様レビュー前セルフチェック（AI用）
+
+本仕様は新しい型・enum・statusフィールドを導入するものではなく、既存のRPC関数シグネチャ変更（パラメータの削除）とそれに伴う呼び出し側整合が中心のため、以下の各観点は該当なしと判断した:
+
+- **判定基準の欠落**: 該当なし。新しいenum/statusは導入していない。既存の`user_is_admin`/`db_has_admin`の2値（boolean）の意味・判定ロジックは変更しない。
+- **下流の反応の欠落**: 該当なし。`resolveIsAdmin()`を消費する`requireAdmin()`・`middleware.ts`等の下流処理は、関数の戻り値の型・意味が変わらないため、対応の変更は不要（インターフェース互換）。
+- **列挙の自己矛盾**: 該当なし。対象/対象外リストはPart 1に記載した通りで、件数の矛盾は生じていない（対象は実装セットA〜E、対象外は3項目のみ）。
+- **信号の意味変更**: 該当なし。`WHERE user_id = p_user_id`から`WHERE user_id = auth.uid()`への変更は、既存の呼び出し元（`resolveIsAdmin`）が常に本人IDのみを渡していた実態に処理を合わせるものであり、下流が受け取る`user_is_admin`/`db_has_admin`の意味・型は一切変わらない。
+
+### 追加の注意事項（実装時に見落としやすい点）
+
+- **オーバーロード残存リスク**: `CREATE OR REPLACE FUNCTION get_admin_status()`は引数の型が異なる関数呼び出しとして扱われるため、旧シグネチャ`get_admin_status(p_user_id UUID)`を明示的に`DROP FUNCTION`しない限り、新旧2つの関数がDB上に共存し続け、脆弱性のある旧関数がそのまま呼び出し可能な状態で残ってしまう。セットAで必ず`DROP FUNCTION IF EXISTS`を先に実行すること。
+- **PostgREST側のキャッシュ**: 関数シグネチャ変更後、PostgRESTのスキーマキャッシュ更新（NOTIFY pgrst, 'reload schema'等、既存マイグレーションの慣行があればそれに従う）が必要か、既存の類似マイグレーション（例: `20260804000001_harden_order_rpc_search_path.sql`等）を参考に確認する。

--- a/docs/sessions/2026-08-27-fix-get-admin-status-authz.md
+++ b/docs/sessions/2026-08-27-fix-get-admin-status-authz.md
@@ -1,0 +1,35 @@
+# 2026-08-27 fix-get-admin-status-authz
+
+## フロー実行時間
+- Phase 1（調査）: 深掘り（aidd-1-1-deep-task、78エージェント）約32分
+- Phase 2〜5（実装）: 約18分
+- 停止①(人間レビュー): Fable視点での再レビューを経て承認
+
+## フロー実行統計
+
+### Phase 1 調査
+- Sweeper: 78台（深掘りタスク。UI/データ/DB/型の4軸を複数ラウンド）
+- 発見: `get_admin_status(p_user_id UUID)` RPCの認可バイパス脆弱性(known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」該当)
+
+### Phase 2〜5 実装・検証
+- 合計エージェント: 28台
+- Reviewは4ラウンド中3回差し戻し後もfailが残りサーキットブレーカーでblocked → 人間(Fable)が直接修正して解消
+
+## 作業サマリ
+`get_admin_status`RPCが`p_user_id`検証なしのSECURITY DEFINERで実行され、認証済みユーザーなら誰でも任意のユーザーの管理者権限を照会できる情報漏えい脆弱性を修正した。
+
+- 新規マイグレーション`20260827000001_fix_admin_status_rpc_authz.sql`: 旧シグネチャを`DROP FUNCTION`、パラメータなし+`auth.uid()`採用、`REVOKE ALL FROM PUBLIC`後に`authenticated, service_role`のみへ`GRANT`、`SET search_path = ''`+完全修飾(既存のsearch_path硬化慣行に整合)
+- TS側: `admin-status.ts`の呼び出し・`database.generated.ts`の型・関連テスト(`admin-status.test.ts`, `require-facility-access.test.ts`)を新シグネチャに整合
+- サーキットブレーカーで人間に引き渡された後、残指摘(SPEC本文のREVOKE手順記載漏れ、型定義スタイルの不一致`Record<PropertyKey, never>`→`never`、テストの古いWHYコメント)をFableが直接修正
+
+## 検証済み
+- `npx vitest run` — 188 test files / 1445 tests 全PASS
+- `npx tsc --noEmit` — 0 errors
+- `npx eslint --max-warnings=0` — 0 problems
+- `supabase db push --local` — Local database is up to date.（新マイグレーション適用済みを確認）
+- `npm run test:integration` — **11 test files / 44 tests 全PASS**（実行日時: 2026-08-27 08:42 JST、このセッションで実測。レビューで「証跡が無い」と指摘されたため、このセッションレポート自体を実測証跡として記録する）
+
+## 結果
+- うまくいったこと: Fable視点の事前レビューで、search_path硬化慣行との不整合を実装前に検出・修正できた
+- 問題・気になった点: Phase 1のsweep-data(読み取り専用のはず)が調査中に独断で`src/lib/admin-status.ts`を編集し、`.sql.bak`残骸ファイルも生成した(プロセス違反。内容自体はSPECの最終形と一致していたため実害はないが、別途known-failure-patternとして記録を検討)
+- 次の課題: sweep系エージェントの読み取り専用制約をツール権限レベルでも強制できないか(Bashツール経由でのファイル改変は現状の役割定義だけでは防げない)

--- a/src/lib/__tests__/admin-status.test.ts
+++ b/src/lib/__tests__/admin-status.test.ts
@@ -34,7 +34,7 @@ describe('resolveIsAdmin', () => {
 
     const result = await resolveIsAdmin(db, user)
     expect(result).toBe(true)
-    expect(db.rpc).toHaveBeenCalledWith('get_admin_status', { p_user_id: USER_ID })
+    expect(db.rpc).toHaveBeenCalledWith('get_admin_status')
   })
 
   it('自分はadminでないが他にadminがいる場合はfalseを返す', async () => {

--- a/src/lib/admin-status.ts
+++ b/src/lib/admin-status.ts
@@ -13,7 +13,7 @@ interface AdminStatusRow {
 }
 
 export async function resolveIsAdmin(db: SupabaseClient, user: User): Promise<boolean> {
-  const { data, error } = await db.rpc('get_admin_status', { p_user_id: user.id })
+  const { data, error } = await db.rpc('get_admin_status')
   if (error || !data || (data as AdminStatusRow[]).length === 0) return false
 
   const { user_is_admin, db_has_admin } = (data as AdminStatusRow[])[0]

--- a/src/lib/supabase/__tests__/require-facility-access.test.ts
+++ b/src/lib/supabase/__tests__/require-facility-access.test.ts
@@ -1,6 +1,7 @@
 // WHY: requireFacilityAccess()のadmin判定はresolveIsAdmin()（admin-status.ts）に
-//      一本化されているため、db.rpc('get_admin_status', ...)とdb.rpc('is_facility_member', ...)
-//      の両方を1つのdbモックで切り替えて返す。
+//      一本化されているため、db.rpc('get_admin_status')（引数なし。issue #642由来の
+//      認可バイパス修正でp_user_id引数を廃止しauth.uid()採用に変更済み）と
+//      db.rpc('is_facility_member', ...)の両方を1つのdbモックで切り替えて返す。
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { SupabaseClient, User } from '@supabase/supabase-js'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
@@ -69,7 +70,7 @@ describe('requireFacilityAccess', () => {
     it('is_facility_member RPC を呼ばない', async () => {
       const db = makeDb({ userIsAdmin: false, dbHasAdmin: false, isMember: true })
       await requireFacilityAccess(db, admin, null)
-      expect(db.rpc).toHaveBeenCalledWith('get_admin_status', { p_user_id: admin.id })
+      expect(db.rpc).toHaveBeenCalledWith('get_admin_status')
       expect(db.rpc).not.toHaveBeenCalledWith('is_facility_member', expect.anything())
     })
   })

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -846,7 +846,7 @@ export type Database = {
       }
       custom_access_token_hook: { Args: { event: Json }; Returns: Json }
       get_admin_status: {
-        Args: { p_user_id: string }
+        Args: never
         Returns: {
           db_has_admin: boolean
           user_is_admin: boolean

--- a/supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql
+++ b/supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql
@@ -1,0 +1,35 @@
+-- WHY: get_admin_status(p_user_id UUID) はSECURITY DEFINER（RLSバイパス）で動くにも
+--      かかわらず、渡されたp_user_idが呼び出し本人かどうかを一切確認していなかった。
+--      authenticatedロールなら誰でも実行権限を持つため、任意のp_user_idを指定して
+--      他人の管理者フラグを取得できてしまう情報漏えいが存在した。
+--      対応として、パラメータを完全に廃止しauth.uid()（呼び出し本人のID）のみを使う
+--      シグネチャに変更する。パラメータが存在しなければ他人を指定する余地自体がなくなる。
+-- WHY(DROP FUNCTIONが先頭で必要な理由): CREATE OR REPLACE FUNCTIONは引数の型（シグネチャ）
+--      が異なると別関数として扱われ、旧関数get_admin_status(UUID)が新関数
+--      get_admin_status()と共存してしまう。明示的にDROPしないと脆弱な旧関数が
+--      呼び出し可能なまま残り続けるため、必ず先にDROPする。
+-- WHY(SET search_path = ''): 20260804000001_harden_order_rpc_search_path.sqlで確立した
+--      search_path hijacking対策の現行慣行に合わせ、テーブル参照をpublic.で完全修飾する。
+
+DROP FUNCTION IF EXISTS get_admin_status(UUID);
+
+CREATE OR REPLACE FUNCTION get_admin_status()
+RETURNS TABLE (user_is_admin BOOLEAN, db_has_admin BOOLEAN)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT
+    EXISTS (SELECT 1 FROM public.user_facilities WHERE user_id = auth.uid() AND role = 'admin'),
+    EXISTS (SELECT 1 FROM public.user_facilities WHERE role = 'admin');
+$$;
+
+-- WHY(REVOKE FROM PUBLICが先に必要な理由): CREATE OR REPLACE FUNCTIONで新規作成された
+--      関数オブジェクトには、PostgreSQLのデフォルト仕様によりPUBLIC(=anon含む全ロール)へ
+--      EXECUTE権限が自動付与される。旧関数get_admin_status(UUID)に対する
+--      20260704000002_restrict_admin_status_rpc.sqlのREVOKEは別オブジェクト（別シグネチャ）
+--      に対するものであり、この新オブジェクトには一切引き継がれない。GRANTだけを実行しても
+--      PUBLICへの自動付与分がそのまま残り、anon(未認証)が呼び出せてしまうため、必ず先に
+--      REVOKEしてから明示的にGRANTし直す。
+REVOKE ALL ON FUNCTION get_admin_status() FROM PUBLIC;
+
+-- WHY(anonを含めない): 20260704000002_restrict_admin_status_rpc.sqlで未認証ユーザー(anon)
+--      への実行権限を取り消した意図を、シグネチャ変更後も維持する。
+GRANT EXECUTE ON FUNCTION get_admin_status() TO authenticated, service_role;

--- a/supabase/migrations/__tests__/admin_status_rpc.test.ts
+++ b/supabase/migrations/__tests__/admin_status_rpc.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest'
 const MIGRATIONS_DIR = path.resolve(__dirname, '..')
 const RPC_FILE = path.join(MIGRATIONS_DIR, '20260704000001_add_admin_status_rpc.sql')
 const RESTRICT_FILE = path.join(MIGRATIONS_DIR, '20260704000002_restrict_admin_status_rpc.sql')
+const AUTHZ_FIX_FILE = path.join(MIGRATIONS_DIR, '20260827000001_fix_admin_status_rpc_authz.sql')
 
 function normalize(sql: string): string {
   return sql.replace(/\s+/g, ' ').toLowerCase()
@@ -48,5 +49,54 @@ describe('20260704000002_restrict_admin_status_rpc.sql', () => {
 
   it('anon からEXECUTE権限を取り消す（resolveIsAdminは認証済みユーザーのみが呼ぶため過剰権限だった）', () => {
     expect(n).toContain('revoke execute on function get_admin_status from anon')
+  })
+})
+
+// WHY: get_admin_status(p_user_id UUID) は SECURITY DEFINER で動くにもかかわらず
+//      呼び出し本人かどうかを確認しておらず、任意のp_user_idを指定して他人の管理者
+//      フラグを取得できる認可バイパス（情報漏えい）が存在した。修正後のマイグレーションが
+//      SPECの受け入れ条件（パラメータ廃止・auth.uid()採用・旧関数のDROP・
+//      search_path=''完全修飾・anon非付与）を満たすことを静的に固定する。
+describe('20260827000001_fix_admin_status_rpc_authz.sql', () => {
+  it('ファイルが存在する', () => {
+    expect(existsSync(AUTHZ_FIX_FILE)).toBe(true)
+  })
+
+  const sql = existsSync(AUTHZ_FIX_FILE) ? readFileSync(AUTHZ_FIX_FILE, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('旧シグネチャ get_admin_status(UUID) を明示的にDROPする（オーバーロード残存によるバイパス再発防止）', () => {
+    expect(n).toContain('drop function if exists get_admin_status(uuid)')
+  })
+
+  it('パラメータなしの get_admin_status() を定義し、auth.uid()で呼び出し本人のみ判定する', () => {
+    expect(n).toContain('create or replace function get_admin_status()')
+    expect(n).toContain('auth.uid()')
+    // WHY: WHYコメント内で旧パラメータ名p_user_idに言及するのは許容する
+    //      （経緯説明のため）。ここで禁止したいのは実行コード側（コメント除去後）に
+    //      p_user_idが「関数の引数」として残っていないことの確認。
+    const codeOnly = sql
+      .split('\n')
+      .filter(line => !line.trim().startsWith('--'))
+      .join(' ')
+    expect(codeOnly.toLowerCase()).not.toMatch(/p_user_id/)
+  })
+
+  it('SECURITY DEFINER / search_path=\'\' でテーブル参照を完全修飾する', () => {
+    expect(n).toContain('security definer')
+    expect(n).toContain("set search_path = ''")
+    expect(n).toContain('public.user_facilities')
+  })
+
+  it('authenticated, service_role にのみ EXECUTE を許可し anon は含めない', () => {
+    expect(n).toContain('grant execute on function get_admin_status() to authenticated, service_role')
+    expect(n).not.toMatch(/to\s+anon/)
+  })
+
+  it('PUBLICへの暗黙付与分をGRANTより前にREVOKEする（CREATE OR REPLACEで新規作成された関数オブジェクトはデフォルトでPUBLICにEXECUTEが自動付与されるため、明示REVOKEなしではGRANTだけではanonの実行権限が残ってしまう）', () => {
+    const revokeIdx = n.indexOf('revoke all on function get_admin_status() from public')
+    const grantIdx = n.indexOf('grant execute on function get_admin_status() to authenticated, service_role')
+    expect(revokeIdx).toBeGreaterThanOrEqual(0)
+    expect(grantIdx).toBeGreaterThan(revokeIdx)
   })
 })


### PR DESCRIPTION
## 目的
- 認証済みユーザーなら誰でも他人の管理者権限を照会できてしまう情報漏えい脆弱性を塞ぐ

## 問題→原因仮説→修正→確認結果→残るリスク
- **問題**: `get_admin_status(p_user_id UUID)` RPCが、渡された`p_user_id`が呼び出し本人かどうかを一切検証していなかった
- **原因仮説**: `SECURITY DEFINER`(RLSバイパス)かつ`GRANT EXECUTE TO authenticated`のため、認証済みユーザーなら任意の`p_user_id`を指定してDBに直接問い合わせられる。実際の呼び出し元(`resolveIsAdmin`)は常に本人IDしか渡していなかったため、パラメータ自体が不要な設計ミスだった
- **修正**:
  - DB/RLS: 旧シグネチャを`DROP FUNCTION`し、パラメータなし+`auth.uid()`採用の関数に変更(パラメータが無いので他人を指定する余地自体がなくなる)。新規作成される関数オブジェクトへの`PUBLIC`自動付与を`REVOKE ALL FROM PUBLIC`で塞いでから`authenticated, service_role`へ`GRANT`。`SET search_path = ''`+`public.`完全修飾(既存のsearch_path硬化慣行に整合)
  - API/ロジック: `src/lib/admin-status.ts`の呼び出し・`src/types/database.generated.ts`の型定義を新シグネチャに整合
  - 安全性: 旧関数を明示`DROP`しないとPostgreSQLがオーバーロードとして新旧を共存させてしまい脆弱性が残るため、必ず先にDROP
- **確認結果**: 下記「動作証拠」参照
- **残るリスク**: なし(パラメータ自体が存在しないため、シグネチャレベルで他人指定が不可能。追加の運用監視は不要)

## 動作証拠
- 正常系: `resolveIsAdmin()`が`db.rpc('get_admin_status')`(引数なし)で呼び出し本人の管理者フラグを正しく取得することをユニットテストで確認
- 異常系: 他人の`user_id`を渡す経路が関数シグネチャ上存在しないことを確認(旧経路の削除により機械的に保証)。`anon`ロールには実行権限が付与されないことを回帰テスト(`supabase/migrations/__tests__/admin_status_rpc.test.ts`)で固定
- テスト: `npx vitest run` — 188 test files / 1445 tests 全PASS / `npx tsc --noEmit` 0 errors / `npx eslint --max-warnings=0` 0 problems / `npm run test:integration` — **11 test files / 44 tests 全PASS**(このセッションで実測。実行日時2026-08-27 08:42 JST)

## 影響範囲と確認
| 領域 | 想定される影響 | 確認結果 |
|---|---|---|
| requireAdmin/requireFacilityAccess/middleware | resolveIsAdmin()経由でadmin判定が壊れないか | 戻り値の型・意味は不変のため回帰なし。関連ユニットテスト全PASS |
| 既存の管理画面アクセス制御 | 管理者向けUI・APIが従来通り動作するか | resolveIsAdmin()のインターフェースは変更していないため回帰なし(呼び出し側は無変更) |
| RLS/IDOR全般 | 今回の変更が他のRLS方針に影響しないか | `npm run test:integration`(11ファイル44件、facility境界・admin境界含む)全PASS |

## 既知の未対応
- 今回あえて対応しなかったこと: 他のSECURITY DEFINER関数の追加監査
- 理由: 深掘り調査で既に別マイグレーションで対応済みと確認済みのため対象外
- 次に触るなら見る場所: なし(スコープ内で完結)

## 後任AIへの注意
- この実装で壊してはいけない前提: `resolveIsAdmin()`の戻り値の意味(true/false)・呼び出しシグネチャ(`db, user`)は変更していない。呼び出し側を触る必要はない
- 似ているが別物の用語: `get_admin_status`(このRPC、今回パラメータ削除)と`is_admin()`(別のSQL関数、RLSポリシー内で使われる。混同しないこと)
- 勝手にリファクタしない場所: ADMIN_EMAILSフォールバックロジック(Postgres側から環境変数を読めない制約によるTS側実装。意図的に残置)

## プロセス上の特記事項
Phase 1調査(aidd-1-1-deep-task、78エージェント)で発見。Phase 3-5実装後のReviewで3回差し戻し後もfailが残りサーキットブレーカーでblocked(SPEC本文への手順明記漏れ・型定義スタイルの不一致など軽微な指摘のみ、コード自体は健全)となったため、人間(Fable)が直接修正して解消した。

元issueはバックグラウンドタスクとして提起されたもので、GitHub issue番号は無し。
