### PR TITLE
fix: price_historiesのFK欠落とE2Eの脆いセレクタによるUUID undefinedバグを修正する

### DIFF
--- a/e2e/consumable-orders.spec.ts
+++ b/e2e/consumable-orders.spec.ts
@@ -21,7 +21,11 @@ test.describe('消耗品登録（issue #647）', () => {
   test('登録した消耗品が一覧に即座に反映される', async ({ page }) => {
     await page.goto('/facilities')
     await page.waitForLoadState('networkidle')
-    const firstFacilityLink = page.getByRole('link').filter({ hasText: /./ }).first()
+    // WHY: page全体を対象にすると、headerのロゴリンク（href="/"）が「表示テキストを持つ
+    // 最初のリンク」として先に一致してしまい、facilityIdがJSのundefinedになって
+    // /facilities/undefined/... へ遷移する不具合があった（issue #669）。
+    // 施設一覧の行リンクは<main>内にしか存在しないため、mainに限定して確実に一覧行を拾う。
+    const firstFacilityLink = page.locator('main').getByRole('link').filter({ hasText: /./ }).first()
     // 施設一覧から最初の施設の詳細IDを取得し、その消耗品発注ページへ遷移する
     const href = await firstFacilityLink.getAttribute('href')
     test.skip(!href, '施設一覧に遷移可能な施設が存在しない')
@@ -51,7 +55,7 @@ test.describe('消耗品登録（issue #647）', () => {
   test('品名・用途が空白のみの場合はエラー表示され登録されない', async ({ page }) => {
     await page.goto('/facilities')
     await page.waitForLoadState('networkidle')
-    const href = await page.getByRole('link').filter({ hasText: /./ }).first().getAttribute('href')
+    const href = await page.locator('main').getByRole('link').filter({ hasText: /./ }).first().getAttribute('href')
     test.skip(!href, '施設一覧に遷移可能な施設が存在しない')
 
     const facilityId = href!.split('/').filter(Boolean).pop()
@@ -77,8 +81,13 @@ test.describe('消耗品登録の施設間境界（issue #647）', () => {
     await page.waitForLoadState('networkidle')
 
     // src/app/api/consumable-orders/route.ts・src/app/api/consumables/route.ts の
-    // requireFacilityAccess が403を返し、一覧取得が失敗表示になることを確認する
-    await expect(page.getByText('一覧の取得に失敗しました')).toBeVisible()
+    // requireFacilityAccess が403を返し、一覧取得が失敗表示になることを確認する。
+    // WHY: 発注履歴側は「一覧の取得に失敗しました」、消耗品側は「消耗品一覧の取得に失敗しました」で
+    // 後者が前者を部分文字列として含むため、getByText(exact指定なし)だと2要素にマッチして
+    // strict mode violationになる（issue #669）。両方が独立した防御として効いていることを
+    // exact指定でそれぞれ検証する。
+    await expect(page.getByText('一覧の取得に失敗しました', { exact: true })).toBeVisible()
+    await expect(page.getByText('消耗品一覧の取得に失敗しました', { exact: true })).toBeVisible()
 
     await context.close()
   })

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -617,7 +617,15 @@ export type Database = {
           new_value?: number | null
           old_value?: number | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "price_histories_distributor_product_id_fkey"
+            columns: ["distributor_product_id"]
+            isOneToOne: false
+            referencedRelation: "distributor_products"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       product_compatibilities: {
         Row: {
@@ -1050,3 +1058,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/supabase/migrations/20260827000002_add_price_histories_distributor_product_fk.sql
+++ b/supabase/migrations/20260827000002_add_price_histories_distributor_product_fk.sql
@@ -1,0 +1,23 @@
+-- supabase/migrations/20260827000002_add_price_histories_distributor_product_fk.sql
+
+-- WHY: issue #669。price_histories.distributor_product_id にFK制約が無く、
+-- PostgRESTのスキーマキャッシュが price_histories ⇔ distributor_products の関係を
+-- 解決できなかった（"Could not find a relationship between 'price_histories' and
+-- 'distributor_products' in the schema cache"）。src/lib/price-histories/repository.ts の
+-- listRecentPriceHistories() が select('...,distributor_products(name)') という
+-- PostgRESTの埋め込みJOIN構文を使っているが、これはFK制約が無いと解決できない。
+--
+-- 既存データに孤児行（参照先のdistributor_productsが後から削除された行）が
+-- 混ざっている可能性があるため、20260626000000_fix_fk_and_indexes.sqlと同じ方針で
+-- NOT VALID で追加し、新規行のみ即座に検証する（既存行は将来VALIDATE CONSTRAINTで検証可能）。
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'price_histories_distributor_product_id_fkey'
+  ) THEN
+    ALTER TABLE price_histories
+      ADD CONSTRAINT price_histories_distributor_product_id_fkey
+        FOREIGN KEY (distributor_product_id) REFERENCES distributor_products (id) NOT VALID;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: E2E Smoke Testsの継続失敗(issue #669)を修正。price_histories⇔distributor_productsのFK欠落と、E2Eテストの脆いリンクセレクタに起因するUUID undefinedバグの2件
- リスク: 中（`supabase/migrations/`配下のスキーマ変更を含むため、このリポジトリのTRI/RISK基準でM/L扱い）
- 変更領域: DB（migration・生成型）、テスト（E2E）
- 証拠状態: 実測5件（DB reset実行結果・PostgREST実測・E2E実行結果2種・型生成チェック）/ サンプル0件
- 影響範囲: ダッシュボードの「最近の価格改定」表示、消耗品登録のE2Eテスト3件
- ロールバック可能性: 可能（本コミットのrevertで戻せる。FKはNOT VALIDで追加のため既存データへの影響もなし）

レビューしてほしい点:
1. `price_histories_distributor_product_id_fkey`をNOT VALIDで追加した判断（既存孤児データがあり得るための保守的選択）が妥当か
2. E2Eのセレクタ修正（`main`スコープ）が今後別のUIレイアウト変更でも壊れにくい書き方になっているか

## 00 目的・影響範囲・対象外
- 目的: issue #669。mainへのpush時に継続していたE2E Smoke Testsの失敗を解消する
- 変更範囲:
  - `supabase/migrations/20260827000002_add_price_histories_distributor_product_fk.sql`（FK追加）
  - `src/types/database.generated.ts`（型再生成。上記FK追加に伴う自動差分）
  - `e2e/consumable-orders.spec.ts`（セレクタ・アサーションの修正）
- 対象外: `POST /api/consumables`自体のエラーハンドリングは変更していない（元々正しく動いていた。呼び出し元のE2Eテストが誤った施設IDを渡していたのが原因）
- 作業中に見つけた別件: なし（issue #669自体が前回セッションで切り出した別件）

## 01 画面がどう変わったか（UI証拠）
対象外（UIコンポーネント自体の変更なし）

## 02 内部でどう守っているか（ロジック証拠）
対象外（アプリケーションロジックの変更なし。原因はDBスキーマとテストコードのみ）

## 03 誰が操作できるか（RLS/権限証拠）
対象外（RLSポリシー自体は変更していない。FK制約はデータ整合性の話でRLS権限とは別軸）

## 04 どう確認したか（テスト・検証）
- 原因の実測: 修正前に`npx playwright test e2e/consumable-orders.spec.ts`を実行し、issue #669のログと同じ`invalid input syntax for type uuid: "undefined"`エラーを再現
- FK追加の実測: `supabase db reset`でmigration適用後、`curl`でPostgRESTの`distributor_products(name)`埋め込みJOINを直接叩き、エラーなく応答することを確認
- 型定義の実測: `supabase gen types typescript --local`で再生成した`database.generated.ts`の`price_histories.Relationships`が`[]`から実際のFK情報付きに変わったことを確認（git diffで提示済み）
- E2E実測: 修正後`npx playwright test e2e/consumable-orders.spec.ts` 4件全てpass、`npx playwright test`（全22件）も全てpass
- `npm run test:integration`: 11 files / 44 tests all pass
- `npm test`: 188 files / 1445 tests all pass
- `npm run lint`: 0 errors, 0 warnings
- `npm run typecheck`: エラーなし
- 他テナントのIDでアクセスし、弾かれることを確認したか: 本PRはRLSポリシー自体を変更していないため必須ではないが、修正したE2Eテスト自体が施設間境界(cross-facility)の403拒否を検証する内容であり、そのテストが正しく通ることを確認済み

## 05 何かあったらどうするか（観測・ロールバック）
- 見るもの: 次回mainへのpush後、E2E Smoke Testsワークフローが実際にgreenになるか
- 異常の判断基準: 同じ`price_histories`関連エラー、または`consumable-orders`関連のE2E失敗が再発する場合
- ロールバック手順: 本コミットをrevertする。migrationはNOT VALIDのFK追加のみで破壊的変更を含まないため、revert自体も安全

## 後任AIへの注意
- この実装で壊してはいけない前提: `price_histories_distributor_product_id_fkey`はNOT VALIDで追加した。将来的に全行検証（`VALIDATE CONSTRAINT`）する場合は、孤児データ（参照先distributor_productsが削除された行）の扱いを先に決めること
- 似ているが別物の用語: `price_histories.entity_id`は引き続きポリモーフィック列でFKなし（意図的な設計、repository.tsのWHYコメント参照）。今回FKを追加したのは`distributor_product_id`列のみ
- 勝手にリファクタしない場所: `e2e/consumable-orders.spec.ts`の`page.locator('main')`によるスコープ限定は、ヘッダーの共通ロゴリンクを誤って拾わないための意図的な書き方。他のE2Eファイルで同種の脆いセレクタを見つけても、本PRのスコープ外なので個別に確認してから直すこと

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)