### PR TITLE
test: .claude/skills/と.agents/skills/のファイル構成一致を機械検知する

### DIFF
--- a/scripts/lib/claude-codex-skills-parity.test.ts
+++ b/scripts/lib/claude-codex-skills-parity.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+// WHY: .agents/skills/handoff-format/ が丸ごとコミットされておらず、全worktreeで
+// git statusにuntrackedファイルとして表示され続ける不具合があった(PR #676)。
+// .claude/skills/ と .agents/skills/ は同じスキル群をClaude/Codex双方に提供する
+// ミラー構成（docs/agents/tooling-decisions.md「ツール中立の共有資産」参照）であり、
+// 中身は`allowed-tools`等ツール固有の記法差があるため一致しないが、
+// 「どのスキルフォルダ・どのファイルが存在するか」は必ず一致するべき不変条件である。
+// これはfacility/RLS等のドメインコードではなくリポジトリ衛生のテストなので、
+// npm testに含めてCIで機械的に検知する。
+
+const ROOT = path.resolve(__dirname, '../..')
+const CLAUDE_SKILLS_DIR = path.join(ROOT, '.claude/skills')
+const AGENTS_SKILLS_DIR = path.join(ROOT, '.agents/skills')
+
+function listFilesRelative(baseDir: string): string[] {
+  const result: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full)
+      } else {
+        result.push(path.relative(baseDir, full))
+      }
+    }
+  }
+  walk(baseDir)
+  return result.sort()
+}
+
+describe('.claude/skills/ と .agents/skills/ のファイル構成一致(issue #676再発防止)', () => {
+  const claudeFiles = listFilesRelative(CLAUDE_SKILLS_DIR)
+  const agentsFiles = listFilesRelative(AGENTS_SKILLS_DIR)
+
+  it('両ディレクトリのファイル一覧が一致する', () => {
+    expect(agentsFiles).toEqual(claudeFiles)
+  })
+})


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: PR #676で修正した「.agents/skills/handoff-format/がコミットされずuntracked表示され続けた」事故の再発防止テストを追加
- リスク: 低（テストコード追加のみ。既存機能・DB・設定は無変更）
- 変更領域: テスト
- 証拠状態: 実測3件（正常系green・fault injectionでのred確認・全体テスト/lint実行結果）/ サンプル0件
- 影響範囲: `npm test`の対象に1ファイル追加
- ロールバック可能性: 可能（ファイル削除で戻せる。既存テストへの影響なし）

レビューしてほしい点:
1. ファイル構成一致のみをチェックし内容一致を見ない範囲設定が妥当か（e2e-runnerはallowed-tools記法がツールごとに異なるため、内容比較にすると誤検知する）

## 00 目的・影響範囲・対象外
- 目的: `.claude/skills/`と`.agents/skills/`のミラー構成が今後もドリフトしない（片方だけコミット漏れが起きない）ことを機械保証する
- 変更範囲: `scripts/lib/claude-codex-skills-parity.test.ts`の新規追加のみ
- 対象外: 内容の完全一致チェック（e2e-runnerのようなツール固有差分があるため意図的に対象外とした）
- 作業中に見つけた別件: なし

## 01 画面がどう変わったか（UI証拠）
対象外

## 02 内部でどう守っているか（ロジック証拠）
- `.claude/skills/`と`.agents/skills/`それぞれのファイル一覧を再帰的に取得し`toEqual`で比較するだけの単純なテスト（該当コード: scripts/lib/claude-codex-skills-parity.test.ts:16-40）

## 03 誰が操作できるか（RLS/権限証拠）
対象外

## 04 どう確認したか（テスト・検証）
- 正常系: `npx vitest run scripts/lib/claude-codex-skills-parity.test.ts` → 1 passed
- fault injection: `.agents/skills/handoff-format/SKILL.md`を一時的に退避 → 同テストが「今回と同じ形」で失敗することを確認 → 復元してgreenに戻ることを確認（実測。この一連の作業でファイルが失われていないことは`git status`で確認済み）
- `npm test`: 189 files / 1446 tests all pass（新テスト含む）
- `npm run lint`: 0 errors, 0 warnings

## 05 何かあったらどうするか（観測・ロールバック）
- 見るもの: 今後`.claude/skills/`か`.agents/skills/`のどちらかにファイルを追加・削除するPRで、このテストが正しく検知するか
- 異常の判断基準: 意図的な片方だけの変更（ツール固有スキル等、将来ありうる）でこのテストが誤って落ちる場合は、テスト側の対象範囲調整が必要
- ロールバック手順: 本コミットをrevert

## 後任AIへの注意
- この実装で壊してはいけない前提: このテストは「ファイルの存在一致」のみを見る。内容比較に変えると、e2e-runnerのようなツール固有記法差を持つスキルで誤検知する
- 似ているが別物の用語: なし
- 勝手にリファクタしない場所: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)