### PR TITLE
fix: 短貸返却(loan_return)の二重登録を防止する(issue #675)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,46 +1,41 @@
-# 仕様書: get_admin_status RPCの認可バイパス脆弱性修正
+# 仕様書: 短貸返却(loan_return)の二重登録を防止する(issue #675)
 
 ## Part 1 — 仕様（人間レビュー用）
 
 ### 何ができるようになるか（利用者目線）
 
-現在、ログイン済みの利用者であれば誰でも、他人のアカウントIDを指定するだけで「その人が管理者かどうか」を調べられてしまう不具合があります。この修正により、**自分自身の管理者判定しかできなくなり**、他人の権限情報が外部から分からなくなります。
-
-利用者から見た画面・操作フローそのものは変わりません（ログイン後の管理者メニュー表示・管理画面アクセス制御の見え方は現状と同じ）。今回の変更はサーバー内部の認可チェックの是正であり、UI上の新しい操作は発生しません。
-
-> 📸 スクショ撮影ポイント: なし（UI変更なし。E2E観点はPart 1「受け入れ条件」のAPI/RPC呼び出しレベルの検証で担保する）
+同じ短貸発注(loan_order)に対して返却登録を誤って2回行おうとした場合（ダブルクリック・ネットワーク再送・複数タブでの同時操作など）、2件目の登録がエラーとして拒否されるようになります。エラー時には生のDBエラーではなく「既に返却済みです」等の分かりやすいメッセージが表示されます。
 
 ### 背景（何が問題だったか）
 
-- `get_admin_status(p_user_id UUID)` というRPC関数が、`SECURITY DEFINER`（RLSをバイパスする特権実行）で動いているにもかかわらず、渡された`p_user_id`が呼び出し本人かどうかを一切確認していなかった。
-- 認証済みユーザーなら誰でも呼び出せる権限（`GRANT EXECUTE ... TO authenticated`）が付与されていたため、任意の`p_user_id`を指定して他人の管理者フラグを取得できる状態だった（情報漏えい）。
-- さらに調査の結果、TypeScript側の呼び出し元（`src/lib/admin-status.ts`）は既に「パラメータなし」で呼び出す形に変更済みだが、DB側のマイグレーションはパラメータ必須のままであり、**現状は呼び出し自体が引数不一致で失敗する状態**になっている（管理者判定が機能停止するリスクを内包）。
+`create_loan_return_atomic` RPC（`supabase/migrations/20260726120000_add_loan_order_id_to_loan_return_atomic_rpc.sql`）は `loan_returns.loan_order_id` を保存するが、この列にUNIQUE制約が無い。そのため同じ `loan_order_id` に対して返却登録を2回実行すると、`loan_returns` に重複行が作られてしまう。
 
-### 修正方針（利用者目線での結果）
+実測（`src/app/facilities/[id]/loan-returns/new/page.tsx`）で確認した現状:
+- 返却フォームの「対象の短貸発注」プルダウンは、`unreturned`（未返却）な `loan_order` のみを選択肢に表示する（`src/lib/orders/repository.ts:171` の `unreturned = status === 'submitted' && returns.length === 0`）ため、**画面を開いた時点で返却済みのものは選択肢に出ない**。
+- 送信ボタンは `disabled={submitting}` により、送信中は再クリックできない。
 
-1. RPC関数`get_admin_status`をパラメータなしの関数に変更し、内部で`auth.uid()`（呼び出し本人のID）のみを使うようにする。
-2. これにより「他人のIDを指定する」余地自体をなくす（パラメータが存在しないので、そもそも他人を指定できない）。
-3. TypeScript側の呼び出し・型定義・テストをこの新しいシグネチャに合わせて整合させる。
+したがって「同一ブラウザでの単純な連打」は既存UIで概ね防がれているが、以下のケースはすり抜ける:
+- 2つのタブ/ウィンドウで同じ画面を開いたまま片方が先に返却登録し、もう片方が（未返却のまま見えている）同じ `loan_order` を選んで送信する
+- ネットワーク再送（クライアントの二重fetch等）
 
-### 受け入れ条件（チェックリスト）
-
-- [ ] `get_admin_status()`はパラメータを受け取らず、`auth.uid()`で判定した「呼び出し本人の管理者フラグ」と「DB全体の管理者有無フラグ」を返す
-- [ ] 他人の`user_id`を指定して管理者判定を取得する手段が存在しない（関数シグネチャレベルで不可能）
-- [ ] `anon`ロールには実行権限が付与されない（既存の20260704000002マイグレーションの意図を維持）
-- [ ] `authenticated`・`service_role`ロールは実行できる
-- [ ] 新しい関数定義は`SET search_path = ''`+`public.`完全修飾になっている（現行のsearch_path硬化慣行に整合）
-- [ ] `src/lib/admin-status.ts`の`resolveIsAdmin()`が新しいRPCシグネチャで正しく動作する（自分がadmin→true、他にadminがいれば非adminはfalse、DBにadminが0件ならADMIN_EMAILSフォールバックを使う、という既存の3段階判定ロジックは変更しない）
-- [ ] `src/types/database.generated.ts`の`get_admin_status`の型定義がパラメータなしのシグネチャに更新されている
-- [ ] `src/lib/__tests__/admin-status.test.ts`のアサーションが新シグネチャ（`db.rpc('get_admin_status')`、引数なし）に整合し、全テストがgreenになる
-- [ ] リポジトリに残置されている`supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`（git管理外の残骸ファイル）を削除する
-- [ ] 既存の管理者向け機能（管理画面アクセス制御・admin専用メニュー表示等）が修正後も従来通り動作する（回帰なし）
-- [x] DBスキーマ変更を伴うため`npm run test:integration`（RLS/IDOR integrationテスト）をローカル実行し結果を確認する（`docs/agents/rules/db-schema.md`のルールに基づく）— 実行済み: 11ファイル44件全green（実行日時はPart 2セットAのテスト観点参照）
+これらのケースは正規の操作からでも発生しうるため、**DB制約による最終防御**が必要（issue本文が参照するRiffGearの知見「DB制約は認可ではない。権限のある処理からでも、不正なデータ状態そのものを保存させない最後のルール」）。
 
 ### 対象外（今回のスコープに含まないこと）
 
-- ADMIN_EMAILSフォールバックのロジック自体の変更（Postgres側から環境変数を読めない制約は変わらないため、TS側フォールバックはそのまま維持）
-- `requireAdmin()`・`requireFacilityAccess()`・`middleware.ts`など、`resolveIsAdmin()`を呼び出す側の判定フロー自体の変更（呼び出しインターフェースは変えない）
-- 他のSECURITY DEFINER関数（`get_distributor_product_price_history`等）の追加監査（既に別マイグレーションで対応済みと調査確認済み）
+- `loan_order_id` を指定しない返却（従来通り無制限に複数回登録できる。対象外の値なのでUNIQUE制約の対象にしない）
+- 「返却済み」ラベルをプルダウン内に表示する対応（現状は選択肢から除外する設計になっており、これ自体は今回のスコープでは変更しない。除外の代わりにラベル表示へ変更する要望は別issueとする）
+- 返却の取り消し・再オープン機能
+
+### 受け入れ条件（チェックリスト）
+
+- [ ] `loan_returns.loan_order_id` に、NULLを除外した部分UNIQUEインデックスが追加されている（`loan_order_id IS NOT NULL` の行のみ一意）
+- [ ] 同一 `loan_order_id` を指定して `create_loan_return_atomic` RPCを2回連続で呼ぶと、1回目は成功、2回目はエラーになる
+- [ ] 2回目のエラーがAPIレスポンスとして返る際、生のPostgresエラー（制約名・テーブル名を含む文字列）ではなく「既に返却済みです」等のクライアント向けメッセージになっており、HTTPステータスは400（クライアント起因）である
+- [ ] `loan_order_id` を指定しない返却（対象を選ばない返却登録）は、従来通り何回でも登録できる（回帰なし）
+- [ ] 同じ `loan_order_id` へ返却登録を2件同時送信した場合、成功1件・失敗1件になり、`loan_returns` に対応する行が1件だけ残る（同時実行時もDB制約で最終的に1件に収束する）
+- [ ] 既存の `add_loan_order_id_to_loan_return_atomic_rpc.test.ts`（静的SQL検証）が引き続きgreenである
+- [ ] `supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts` 等の既存integrationテストが引き続きgreenである
+- [x] DBスキーマ変更を伴うため `npm run test:integration`（RLS/IDOR integrationテスト）をローカル実行し結果を確認する（`.claude/rules/db-schema.md`のルール）— 実装完了後に実行し、結果をPRの引き継ぎメモに記載する
 
 ---
 
@@ -48,68 +43,62 @@
 
 ### 実装セット一覧（依存順）
 
-**セットA: DBマイグレーション追加（get_admin_status のシグネチャ変更）**
-- 新規ファイル: `supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`
-- 内容:
-  - `CREATE OR REPLACE FUNCTION get_admin_status()`（パラメータなし）
-  - 関数本体: `WHERE user_id = p_user_id` → `WHERE user_id = auth.uid()`
-  - `SECURITY DEFINER SET search_path = ''`とし、テーブル参照は`public.user_facilities`に完全修飾する（20260804000001_harden_order_rpc_search_path.sqlで確立済みのsearch_path hijacking対策の現行慣行に合わせる。`auth.uid()`は元からスキーマ修飾済み）
-  - `GRANT EXECUTE ON FUNCTION get_admin_status() TO authenticated, service_role;`（`anon`は含めない。既存20260704000002の意図を踏襲）
-  - 旧シグネチャ`get_admin_status(p_user_id UUID)`が残存しないよう、`DROP FUNCTION IF EXISTS get_admin_status(UUID);`を先頭で実行してから新規作成する（PostgreSQLは引数の型が異なる関数をオーバーロードとして共存させてしまうため、明示的に削除しないと新旧2つの関数が併存し脆弱性が残る）
-  - `CREATE OR REPLACE FUNCTION`直後に`REVOKE ALL ON FUNCTION get_admin_status() FROM PUBLIC;`を実行してから`GRANT`する（新規作成される関数オブジェクトにはPostgreSQLのデフォルト仕様でPUBLIC=anon含む全ロールへEXECUTE権限が自動付与されるため、明示的にREVOKEしない限りanonが呼び出せてしまい、受け入れ条件「anonロールには実行権限が付与されない」を満たせない。旧関数への20260704000002のREVOKEは別オブジェクトに対するものでこの新オブジェクトには引き継がれない）
-  - ファイル冒頭に脆弱性の内容とauth.uid()採用理由をコメントで明記（既存ファイルのWHYコメント形式踏襲）
-- テスト観点:
-  - `npm run test:integration`でRLS/IDOR観点の既存スイートを実行し、admin判定関連のテストが通ることを確認
-  - 手動確認（可能なら）: 別ユーザーのIDを渡す経路が存在しないことをコードレビューで確認（関数がパラメータを取らないため機械的に保証される）
-  - `supabase/migrations/__tests__/admin_status_rpc.test.ts`に本マイグレーション（`20260827000001_fix_admin_status_rpc_authz.sql`）専用の静的検証`describe`ブロックを追加し、以下を回帰テストとして固定する: 旧シグネチャ`get_admin_status(UUID)`の`DROP FUNCTION IF EXISTS`実行、パラメータなし定義＋`auth.uid()`採用、`SECURITY DEFINER`/`SET search_path = ''`＋`public.`完全修飾、`authenticated, service_role`のみへのGRANT（`anon`非包含）
-- 触るファイル: `supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`（新規）、`supabase/migrations/__tests__/admin_status_rpc.test.ts`（新規describeブロック追加）
+**セットA: DB — UNIQUE制約追加（独立・最優先）**
+- 新規マイグレーション（例: `supabase/migrations/2026xxxxxxxxxx_add_unique_loan_order_id_to_loan_returns.sql`）
+  ```sql
+  CREATE UNIQUE INDEX loan_returns_loan_order_id_unique
+    ON loan_returns (loan_order_id)
+    WHERE loan_order_id IS NOT NULL;
+  ```
+  （`loan_order_id` はNULL許容のFKであり、大多数の既存行はNULLのまま。部分インデックスでNULLを除外しないと「NULL同士は不一致」というPostgresのUNIQUE制約の挙動に依存する必要がなくなり意図が明確になる）
+- publicスキーマのテーブル追加/削除ではない（インデックス追加のみ）ため `refresh_schema_baseline_snapshot` の呼び出しは不要（`.claude/rules/db-schema.md`の対象は「テーブルを追加/削除するmigration」）
+- テスト観点: `supabase/migrations/__tests__/` に静的SQL検証テストを追加し、`CREATE UNIQUE INDEX ... WHERE loan_order_id IS NOT NULL` を含むことを確認する（`add_loan_order_id_to_loan_return_atomic_rpc.test.ts`と同じ静的検証パターン）
+- 触るファイル: 新規migrationファイル1つ、対応する`__tests__/*.test.ts`1つ
 
-**セットB: 残骸ファイル削除**
-- `supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`を削除
-- 触るファイル: `supabase/migrations/20260704000001_add_admin_status_rpc.sql.bak`（削除）
+**セットB: ロジック/API — UNIQUE制約違反(23505)のエラー翻訳（セットA完了後）**
+- `src/lib/loan-returns/repository.ts` の `createLoanReturn` 内、`db.rpc('create_loan_return_atomic', ...)` のエラーハンドリング（現在 `if (error) throw new Error(error.message)` の箇所、107-137行目付近）に、`consumables/repository.ts:53` と同じパターンで分岐を追加する:
+  ```ts
+  if (error) {
+    if (error.code === '23505') throw new ClientVisibleError('この短貸発注は既に返却登録されています')
+    throw new Error(error.message)
+  }
+  ```
+- `src/app/api/loan-returns/route.ts` のPOSTハンドラのcatch節を、`consumables/route.ts:62` と同じ `instanceof ClientVisibleError` チェックに統一する（現状は `error.message === LOAN_ORDER_NOT_FOUND_ERROR` という文字列比較のみで、`ClientVisibleError` の型チェックをしていない）:
+  ```ts
+  } catch (error) {
+    if (error instanceof ClientVisibleError) return apiError(error.message, 400)
+    return apiError(toClientErrorMessage(error, '返却に失敗しました'))
+  }
+  ```
+  この変更により、既存の `LOAN_ORDER_NOT_FOUND_ERROR`（`ClientVisibleError`として投げられている）と、新規追加する重複エラーの両方が同じ経路で400として扱われる（`LOAN_ORDER_NOT_FOUND_ERROR`という個別のimport・文字列比較は不要になり削除する）
+- テスト観点（unit）: `src/lib/loan-returns/__tests__/repository.test.ts` に、RPCエラーの `code` が `'23505'` のときに `ClientVisibleError('この短貸発注は既に返却登録されています')` がthrowされることを検証するテストを追加。`src/app/api/loan-returns/__tests__/route.test.ts` に、`ClientVisibleError` がthrowされた場合にPOSTが400+当該メッセージを返すことを検証するテストを追加
+- 触るファイル: `src/lib/loan-returns/repository.ts`, `src/app/api/loan-returns/route.ts`, 上記2つの `__tests__/*.test.ts`
 
-**セットC: TS型定義更新**
-- `src/types/database.generated.ts`の`get_admin_status`エントリを`Args: Record<PropertyKey, never>`相当（パラメータなし）に更新
-  - 本来はSupabase CLIの型生成コマンドで再生成するのが正だが、ローカル生成環境がない場合は手動でAI側が整合するよう編集してよい（既存の他のパラメータなしRPC定義の書式に倣う）
-- 触るファイル: `src/types/database.generated.ts`
+**セットC: UI — 二重送信の追加防御確認（独立・小規模、既存実装の確認が主）**
+- 実測の通り、送信ボタンは既に `disabled={submitting}` で二重送信防止済み、プルダウンは既に未返却のもの（`unreturned`）のみを表示している。**この2点についてはコード変更不要**
+- 追加対応: セットBで新設したエラーメッセージ（「この短貸発注は既に返却登録されています」）が、`src/app/facilities/[id]/loan-returns/new/page.tsx` の `handleSubmit` 内の既存エラー表示（`error` state、87行目）にそのまま表示されることを確認する（コードの変更は不要。API側が `{ error: string }` 形式で返す既存の仕組みに乗るため）
+- テスト観点（E2E, 任意）: 2つのタブ/ウィンドウで同一 `loan_order` に対して返却登録を試み、片方が成功しもう片方がエラーメッセージ表示になることを確認する。E2Eでの多重タブ再現が難しい場合は、integrationテスト（セットD）の同時実行テストで代替してよい
+- 触るファイル: なし（確認のみ）。E2Eを追加する場合は `e2e/` 配下に1ファイル追加
 
-**セットD: TS呼び出し確認（変更不要の可能性が高い）**
-- `src/lib/admin-status.ts`は既に`db.rpc('get_admin_status')`（引数なし）呼び出しに変更済みであることを確認済み。追加の実装作業は不要。ただし念のためセットAのマイグレーション適用後に実装済みコードが型エラーを起こさないか確認する。
-- 触るファイル: なし（確認のみ）
-
-**セットE: テスト修正**
-- `src/lib/__tests__/admin-status.test.ts`の37行目
-  - 変更前: `expect(db.rpc).toHaveBeenCalledWith('get_admin_status', { p_user_id: USER_ID })`
-  - 変更後: `expect(db.rpc).toHaveBeenCalledWith('get_admin_status')`
-- 触るファイル: `src/lib/__tests__/admin-status.test.ts`、`src/lib/supabase/__tests__/require-facility-access.test.ts`（requireFacilityAccess()経由でresolveIsAdmin()を呼ぶため、同様に旧シグネチャのアサーション・WHYコメントの追従が必要）
+**セットD: テスト — RLS/integration・同時実行テスト（セットA完了後、B/Cと並行可）**
+- `supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts` に以下を追加:
+  - 同一 `loan_order_id` を指定して `create_loan_return_atomic` を2回連続で呼び、1回目success・2回目errorになることを確認するテスト
+  - 同一 `loan_order_id` を指定して `Promise.all` で2件同時に `create_loan_return_atomic` を呼び、`results.filter(r => r.error === null).length === 1` かつ、その後 `loan_returns` を `loan_order_id` で絞り込むと1件だけ返ることを確認するテスト（`e2e-test-hygiene.md`のテストデータ衛生ルールに従うこと）
+- テスト観点: 上記2件（連続呼び出し・同時呼び出し）
+- 触るファイル: `supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts`（既存ファイルへの追記）
 
 ### 並列グループ宣言
 
-- **波1（同時実装可・互いに別ファイルのみ触る）**:
-  - セットA（`supabase/migrations/20260827000001_fix_admin_status_rpc_authz.sql`新規作成）
-  - セットB（`.bak`ファイル削除）
-  - セットE（`src/lib/__tests__/admin-status.test.ts`編集）
-- **波2（波1完了後・統合ゲートへ）**:
-  - セットC（`src/types/database.generated.ts`編集）— セットAのSQL変更内容を正としてAIが手動で型を同期させるため、セットA完了後に着手する（同時実装するとAIが古いシグネチャを見て型を書いてしまうリスクがあるため波を分ける）
-- **セットD**は変更なし（確認のみ）のため波に含めない。
-
-### 型・データアクセス層の方針
-
-- RPCの戻り値型（`AdminStatusRow`、`src/lib/admin-status.ts`内で定義）は変更しない（`user_is_admin: boolean`, `db_has_admin: boolean`のまま）。変わるのは呼び出し時の引数の有無のみ。
-- `src/types/database.generated.ts`の`Args`フィールドは、他のパラメータなしRPC（例: 同ファイル内の`custom_access_token_hook`のような1引数のもの以外で、引数なしのものがあればそれ）の書式に倣い`Args: Record<PropertyKey, never>`とする。既存コードベース内に引数なしRPCの型定義例があるかセットC着手時に確認し、書式を合わせる。
+- **波1（同時実装可）**: セットA（DBマイグレーション）
+- **波2（セットA完了後、同時実装可）**: セットB（ロジック/API） / セットD（integrationテスト）
+- **波3（セットB完了後）**: セットC（UI確認・任意のE2E追加）
+- **統合ゲート**: 全セット完了後、`npm test` と `npm run test:integration` を実行しgreenであることを確認する
 
 ---
 
 ## Part 3 — 仕様レビュー前セルフチェック（AI用）
 
-本仕様は新しい型・enum・statusフィールドを導入するものではなく、既存のRPC関数シグネチャ変更（パラメータの削除）とそれに伴う呼び出し側整合が中心のため、以下の各観点は該当なしと判断した:
-
-- **判定基準の欠落**: 該当なし。新しいenum/statusは導入していない。既存の`user_is_admin`/`db_has_admin`の2値（boolean）の意味・判定ロジックは変更しない。
-- **下流の反応の欠落**: 該当なし。`resolveIsAdmin()`を消費する`requireAdmin()`・`middleware.ts`等の下流処理は、関数の戻り値の型・意味が変わらないため、対応の変更は不要（インターフェース互換）。
-- **列挙の自己矛盾**: 該当なし。対象/対象外リストはPart 1に記載した通りで、件数の矛盾は生じていない（対象は実装セットA〜E、対象外は3項目のみ）。
-- **信号の意味変更**: 該当なし。`WHERE user_id = p_user_id`から`WHERE user_id = auth.uid()`への変更は、既存の呼び出し元（`resolveIsAdmin`）が常に本人IDのみを渡していた実態に処理を合わせるものであり、下流が受け取る`user_is_admin`/`db_has_admin`の意味・型は一切変わらない。
-
-### 追加の注意事項（実装時に見落としやすい点）
-
-- **オーバーロード残存リスク**: `CREATE OR REPLACE FUNCTION get_admin_status()`は引数の型が異なる関数呼び出しとして扱われるため、旧シグネチャ`get_admin_status(p_user_id UUID)`を明示的に`DROP FUNCTION`しない限り、新旧2つの関数がDB上に共存し続け、脆弱性のある旧関数がそのまま呼び出し可能な状態で残ってしまう。セットAで必ず`DROP FUNCTION IF EXISTS`を先に実行すること。
-- **PostgREST側のキャッシュ**: 関数シグネチャ変更後、PostgRESTのスキーマキャッシュ更新（NOTIFY pgrst, 'reload schema'等、既存マイグレーションの慣行があればそれに従う）が必要か、既存の類似マイグレーション（例: `20260804000001_harden_order_rpc_search_path.sql`等）を参考に確認する。
+- 新しいenum/status型の導入なし
+- 列挙・包含/除外リストなし（UNIQUE制約はNULLを除外する部分インデックスのみ）
+- 判定基準の明記: `loan_order_id IS NOT NULL` の行のみを対象にUNIQUE制約を課す。NULL（対象を選ばない返却）は制約対象外で従来通り複数回許可
+- 信号の意味変更に該当する箇所: なし（既存の `unreturned` 判定・エラーレスポンス形式 `{ error: string }` は変更しない。エラーメッセージの翻訳経路を `instanceof ClientVisibleError` に統一する変更のみで、既存の `LOAN_ORDER_NOT_FOUND_ERROR` の外部向け挙動（メッセージ文言・400ステータス）は変わらない）

--- a/src/app/api/loan-returns/__tests__/route.test.ts
+++ b/src/app/api/loan-returns/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
 import { GET, POST } from '../route'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 
 const mockGetUser = vi.fn()
 const mockRequireFacilityAccess = vi.fn()
@@ -179,7 +180,7 @@ describe('POST /api/loan-returns', () => {
   //      区別して返すことを確認する
   it('loanOrderIdが自施設に存在しない場合は400を返す', async () => {
     authenticated()
-    mockCreateLoanReturn.mockRejectedValue(new Error('指定された短貸発注が見つかりません'))
+    mockCreateLoanReturn.mockRejectedValue(new ClientVisibleError('指定された短貸発注が見つかりません'))
     const res = await POST(makeRequest({
       facilityId: 'f1',
       returnDatetime: '2026-06-24T15:00:00Z',
@@ -189,5 +190,22 @@ describe('POST /api/loan-returns', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('指定された短貸発注が見つかりません')
+  })
+
+  // WHY: 同一loan_order_idへの返却二重登録はDB側のUNIQUE制約違反(23505)として検知され、
+  //      repository層がClientVisibleErrorに翻訳する（issue #675）。route側は他の
+  //      ClientVisibleErrorと同様に400として返すことを確認する
+  it('同一短貸発注へ返却済みの場合は400を返す', async () => {
+    authenticated()
+    mockCreateLoanReturn.mockRejectedValue(new ClientVisibleError('この短貸発注は既に返却登録されています'))
+    const res = await POST(makeRequest({
+      facilityId: 'f1',
+      returnDatetime: '2026-06-24T15:00:00Z',
+      loanOrderId: 'lo-1',
+      items: [{ jan: '490001', quantity: 1 }],
+    }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('この短貸発注は既に返却登録されています')
   })
 })

--- a/src/app/api/loan-returns/route.ts
+++ b/src/app/api/loan-returns/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 import { requireAuth } from '@/lib/supabase/require-auth'
 import { requireFacilityAccess } from '@/lib/supabase/require-facility-access'
-import { listLoanReturns, createLoanReturn, LOAN_ORDER_NOT_FOUND_ERROR } from '@/lib/loan-returns/repository'
+import { listLoanReturns, createLoanReturn } from '@/lib/loan-returns/repository'
 import { apiError, toClientErrorMessage } from '@/lib/api-error'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 import { parsePagination } from '@/lib/api-pagination'
 import type { LoanReturnInput } from '@/types/order'
 
@@ -63,11 +64,12 @@ export async function POST(request: NextRequest) {
     const loanReturn = await createLoanReturn(db, body.facilityId, input, body.loanOrderId)
     return NextResponse.json({ loanReturn }, { status: 201 })
   } catch (error) {
-    // WHY: loanOrderId が自施設のloan_orderに存在しない場合はクライアント起因の入力エラーであり、
-    //      500(サーバーエラー)ではなく400として区別する（issue #20 レビュー指摘: critical fix）
-    if (error instanceof Error && error.message === LOAN_ORDER_NOT_FOUND_ERROR) {
-      return apiError(LOAN_ORDER_NOT_FOUND_ERROR, 400)
-    }
+    // WHY: ClientVisibleError は repository層が「クライアントに見せてよいと翻訳済み」と
+    //      保証したエラー（loanOrderIdが自施設に存在しない場合の LOAN_ORDER_NOT_FOUND_ERROR、
+    //      および今回追加されたUNIQUE制約違反(23505)時の重複返却エラーの両方を含む）。
+    //      consumables/route.ts と同じ経路に統一し、個別の文字列比較を廃止する
+    //      （issue #675 Part2 セットB）
+    if (error instanceof ClientVisibleError) return apiError(error.message, 400)
     return apiError(toClientErrorMessage(error, '返却に失敗しました'))
   }
 }

--- a/src/lib/loan-returns/__tests__/repository.test.ts
+++ b/src/lib/loan-returns/__tests__/repository.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createLoanReturn, listLoanReturns, LOAN_ORDER_NOT_FOUND_ERROR } from '@/lib/loan-returns/repository'
+import { ClientVisibleError } from '@/lib/client-visible-error'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeChainableQuery(result: { data: unknown; error: unknown }): any {
@@ -106,6 +107,29 @@ describe('createLoanReturn', () => {
         items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
       })
     ).rejects.toThrow('insert failed')
+  })
+
+  // WHY: loan_returns.loan_order_id にUNIQUE制約(部分インデックス)を追加した(issue #675 セットA)。
+  //      同一loan_order_idへの2回目の返却登録はPostgresの一意制約違反(23505)になる。
+  //      生のPostgresエラー(制約名・テーブル名を含む)をそのままthrowするとスキーマ情報が
+  //      漏洩し得るため、ClientVisibleErrorとして翻訳しroute側で400として扱えるようにする
+  //      (consumables/repository.ts:53 と同じパターン)
+  it('RPCが23505(UNIQUE制約違反)エラーを返した場合はClientVisibleErrorに翻訳する', async () => {
+    const { db } = makeMockRpcDb({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "loan_returns_loan_order_id_unique"' } })
+
+    await expect(
+      createLoanReturn(db, 'f-1', {
+        returnDatetime: '2026-06-24T15:00:00Z',
+        items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+      })
+    ).rejects.toThrow('この短貸発注は既に返却登録されています')
+
+    await expect(
+      createLoanReturn(db, 'f-1', {
+        returnDatetime: '2026-06-24T15:00:00Z',
+        items: [{ jan: '490001', lot: 'L001', ubd: '2027-01', quantity: 1 }],
+      })
+    ).rejects.toBeInstanceOf(ClientVisibleError)
   })
 
   it('loanOrderIdを指定すると RPC の p_header.loan_order_id として渡る（未返却誤判定バグの修正）', async () => {

--- a/src/lib/loan-returns/repository.ts
+++ b/src/lib/loan-returns/repository.ts
@@ -134,7 +134,15 @@ export async function createLoanReturn(db: SupabaseClient, facilityId: string, i
       quantity: item.quantity,
     })),
   })
-  if (error) throw new Error(error.message)
+  if (error) {
+    // WHY: loan_returns.loan_order_id には部分UNIQUEインデックス(loan_order_id IS NOT NULL)
+    //      が追加されている(issue #675 セットA)。同一loan_order_idへの2回目の返却登録は
+    //      Postgresの一意制約違反(23505)になる。生のPostgresエラー(制約名・テーブル名を
+    //      含む文字列)をそのままthrowするとスキーマ情報が漏洩しうるため、ClientVisibleError
+    //      として翻訳しroute側で400として扱えるようにする(consumables/repository.ts:53と同じパターン)
+    if (error.code === '23505') throw new ClientVisibleError('この短貸発注は既に返却登録されています')
+    throw new Error(error.message)
+  }
   if (!data) throw new ClientVisibleError('loan_returns の作成に失敗しました')
 
   const r = data as LoanReturnRow & { items?: unknown }

--- a/supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts
@@ -78,4 +78,81 @@ describe('loan_returns RLS/IDOR', () => {
     expect(data).not.toBeNull()
     expect((data as { facility_id?: string })?.facility_id).toBe(fixtures.facilityA.id)
   })
+
+  // WHY(issue #675): loan_returns.loan_order_id には部分UNIQUEインデックス
+  //  (loan_returns_loan_order_id_unique, migration 20260828000001)を追加した。
+  //  同一loan_order_idへの2回目の返却登録が実際にDBレベルで拒否されることを、
+  //  静的SQL検証（migrations/__tests__）ではなく本物のローカルSupabaseへの
+  //  RPC呼び出しで確認する。
+  describe('loan_order_id の重複登録防止 (issue #675)', () => {
+    async function createLoanOrderForFacilityA(): Promise<string> {
+      const { data, error } = await fixtures.userA.client.rpc('create_loan_order_atomic', {
+        p_facility_id: fixtures.facilityA.id,
+        p_procedure_name: '重複返却テスト術式',
+        p_maker: '重複返却テストメーカー',
+        p_items: [{ name: '重複返却テスト器材', quantity: 1 }],
+      })
+      if (error || !data) {
+        throw new Error(`[loan-returns dedup test] loan_orders シード作成失敗: ${error?.message}`)
+      }
+      return (data as { id: string }).id
+    }
+
+    it('同一loan_order_idへ返却登録を2回連続で行うと、1回目は成功・2回目はエラーになる', async () => {
+      const loanOrderId = await createLoanOrderForFacilityA()
+
+      const first = await fixtures.userA.client.rpc('create_loan_return_atomic', {
+        p_header: {
+          facility_id: fixtures.facilityA.id,
+          return_datetime: new Date().toISOString(),
+          loan_order_id: loanOrderId,
+        },
+        p_items: [],
+      })
+      expect(first.error).toBeNull()
+      expect(first.data).not.toBeNull()
+
+      const second = await fixtures.userA.client.rpc('create_loan_return_atomic', {
+        p_header: {
+          facility_id: fixtures.facilityA.id,
+          return_datetime: new Date().toISOString(),
+          loan_order_id: loanOrderId,
+        },
+        p_items: [],
+      })
+      expect(second.data).toBeNull()
+      expect(second.error).not.toBeNull()
+      // WHY: 「何らかのエラー」ではなく、実際にUNIQUE制約違反(23505)であることまで確認する
+      //      （コネクション失敗等の無関係なエラーでもテストが通ってしまうのを防ぐ）
+      expect(second.error?.code).toBe('23505')
+    })
+
+    it('同一loan_order_idへ返却登録を2件同時送信すると、成功1件・失敗1件になり、loan_returns該当行は1件だけ残る', async () => {
+      const loanOrderId = await createLoanOrderForFacilityA()
+
+      const callRpc = () =>
+        fixtures.userA.client.rpc('create_loan_return_atomic', {
+          p_header: {
+            facility_id: fixtures.facilityA.id,
+            return_datetime: new Date().toISOString(),
+            loan_order_id: loanOrderId,
+          },
+          p_items: [],
+        })
+
+      const results = await Promise.all([callRpc(), callRpc()])
+      const succeeded = results.filter((r) => r.error === null)
+      const failed = results.filter((r) => r.error !== null)
+      expect(succeeded.length).toBe(1)
+      expect(failed.length).toBe(1)
+      expect(failed[0].error?.code).toBe('23505')
+
+      const { data: rows, error } = await fixtures.userA.client
+        .from('loan_returns')
+        .select('id')
+        .eq('loan_order_id', loanOrderId)
+      expect(error).toBeNull()
+      expect(rows?.length).toBe(1)
+    })
+  })
 })

--- a/supabase/migrations/20260828000001_add_unique_loan_order_id_to_loan_returns.sql
+++ b/supabase/migrations/20260828000001_add_unique_loan_order_id_to_loan_returns.sql
@@ -1,0 +1,10 @@
+-- issue #675: 短貸返却(loan_return)の二重登録を防止する
+-- WHY: create_loan_return_atomic RPCはloan_returns.loan_order_idを保存するが、
+--      この列にUNIQUE制約が無いため、同じloan_order_idに対して返却登録を2回実行すると
+--      loan_returnsに重複行が作られてしまう。DB制約による最終防御として部分UNIQUEインデックスを追加する。
+--      loan_order_idはNULL許容のFKであり、大多数の既存行はNULLのまま（対象を選ばない返却は
+--      従来通り無制限に複数回登録できる）。部分インデックスでNULLを除外することで、
+--      「NULL同士は不一致」というPostgresのUNIQUE制約の挙動に依存せず意図を明確にする。
+CREATE UNIQUE INDEX loan_returns_loan_order_id_unique
+  ON loan_returns (loan_order_id)
+  WHERE loan_order_id IS NOT NULL;

--- a/supabase/migrations/__tests__/add_unique_loan_order_id_to_loan_returns.test.ts
+++ b/supabase/migrations/__tests__/add_unique_loan_order_id_to_loan_returns.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// WHY: ローカルSupabaseが無いため実DB適用は出来ない。
+//      代わりに生成したSQLマイグレーションの中身が仕様(issue #675)を満たすかを静的に検証することで、
+//      回帰テストとして固定する(add_loan_order_id_to_loan_return_atomic_rpc.test.tsと同じ静的検証パターン)
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase()
+}
+
+function findMigrationFile(): string | undefined {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('_add_unique_loan_order_id_to_loan_returns.sql'))
+    .sort()
+    .at(-1)
+}
+
+describe('*_add_unique_loan_order_id_to_loan_returns.sql', () => {
+  const fileName = findMigrationFile()
+
+  it('ファイルが存在する', () => {
+    expect(fileName).toBeDefined()
+  })
+
+  const filePath = fileName ? path.join(MIGRATIONS_DIR, fileName) : ''
+  const sql = filePath && existsSync(filePath) ? readFileSync(filePath, 'utf-8') : ''
+  const n = normalize(sql)
+
+  it('loan_returns.loan_order_idにUNIQUEインデックスを作成する', () => {
+    expect(n).toContain('create unique index loan_returns_loan_order_id_unique')
+    expect(n).toContain('on loan_returns (loan_order_id)')
+  })
+
+  it('NULLを除外した部分インデックスである(対象を選ばない返却は制約対象外)', () => {
+    expect(n).toContain('where loan_order_id is not null')
+  })
+})


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: `loan_returns.loan_order_id`へのUNIQUE制約追加と、違反時のエラーメッセージ翻訳・対応テストの追加
- リスク: 低（新規インデックス追加のみ。既存NULL行は制約対象外で影響なし）
- 変更領域: DB / ロジック / テスト（UIはコード変更なし。既存実装で要件を満たしていたことを確認）
- 証拠状態: 実測5件（unit/integration実行結果・ローカルSupabaseへのmigration適用結果）
- 影響範囲: `create_loan_return_atomic` RPC経由の返却登録フロー全体（`POST /api/loan-returns`、`src/app/facilities/[id]/loan-returns/new`）
- ロールバック可能性: 高（インデックス追加1本のマイグレーション。`DROP INDEX`で即時ロールバック可能。コード側も差分は数十行）

レビューしてほしい点:
1. 部分UNIQUEインデックス（`WHERE loan_order_id IS NOT NULL`）の設計が、既存の「対象を選ばない返却」を無制限に許可する仕様と整合しているか
2. エラー翻訳経路を`LOAN_ORDER_NOT_FOUND_ERROR`の文字列比較から`instanceof ClientVisibleError`へ統一した変更が、他のエラーケースに回帰を生んでいないか

## 00 目的・影響範囲・対象外
- 目的: 同じ短貸発注(loan_order)に対する返却登録の二重登録（ダブルクリック・複数タブ・ネットワーク再送）を、DB制約で最終的に防止する（issue #675）
- 変更範囲:
  - `supabase/migrations/20260828000001_add_unique_loan_order_id_to_loan_returns.sql`（新規）
  - `src/lib/loan-returns/repository.ts`（23505エラーの翻訳）
  - `src/app/api/loan-returns/route.ts`（エラーハンドリングの統一）
  - テスト一式（migration静的検証・repository unit・route unit・RLS/IDOR integration）
- 対象外（今回あえて触らない）: プルダウンに「返却済み」ラベルを表示する対応（現状は選択肢から除外する設計になっており、これ自体は変更していない）
- 作業中に見つけた別件: Phase 1深掘り調査ワークフロー（`aidd-1-1-deep-task`）のSweepサブエージェントが、taskDescriptionを無視してコードベース全体を汎用監査してしまう挙動を確認した。今回はこの自動生成結果を破棄し手動調査に切り替えて対応したが、ワークフロー自体の設計課題として別途issue化を検討する

## 01 画面がどう変わったか（UI証拠）
対象外。実測の結果、送信ボタンの二重送信防止（`disabled={submitting}`）とプルダウンでの返却済みloan_order除外は既に実装済みだったため、UIのコード変更は無し。

## 02 内部でどう守っているか（ロジック証拠）
- DB制約: `supabase/migrations/20260828000001_add_unique_loan_order_id_to_loan_returns.sql`
  - `CREATE UNIQUE INDEX loan_returns_loan_order_id_unique ON loan_returns (loan_order_id) WHERE loan_order_id IS NOT NULL;`
- エラー翻訳: `src/lib/loan-returns/repository.ts`（`error.code === '23505'` → `ClientVisibleError('この短貸発注は既に返却登録されています')`。既存の`consumables/repository.ts`の23503翻訳と同じパターン）
- API層: `src/app/api/loan-returns/route.ts`（catch節を`instanceof ClientVisibleError`チェックに統一し400を返す）

## 03 誰が操作できるか（RLS/権限証拠）
今回のRLS/権限変更なし（既存の`facility_member_or_admin`ポリシーのまま）。UNIQUE制約はテナント境界とは無関係な一意性制約のため、他施設からのアクセス可否には影響しない。既存の`loan-returns-rls-idor.integration.test.ts`のIDORテスト（施設Bユーザーが施設AのRPCを呼ぶと拒否される）は今回の変更後も引き続きgreen。

## 04 どう確認したか（テスト・検証）
- この変更に直接対応するテスト:
  - `supabase/migrations/__tests__/add_unique_loan_order_id_to_loan_returns.test.ts`（静的SQL検証、3件）
  - `src/lib/loan-returns/__tests__/repository.test.ts`（23505翻訳のunitテスト追加）
  - `src/app/api/loan-returns/__tests__/route.test.ts`（重複返却時400のテスト追加）
  - `supabase/__tests__/integration/loan-returns-rls-idor.integration.test.ts`（実DBでの連続呼び出し・同時実行テスト2件を追加。`error.code`が実際に`'23505'`であることまで検証）
- 全体テストの実行結果（実測、ローカル実行）:
  - `npx vitest run`: 190 test files / 1451 tests all pass
  - `npm run test:integration`（ローカルSupabase、`supabase db reset`でmigration適用後）: 11 test files / 46 tests all pass
  - `npx tsc --noEmit`: 0 errors
  - `npm run lint`: 0 errors
- コードレビュー: `code-reviewer`エージェントによる品質/設計/セキュリティ/パフォーマンス4軸レビューを実施。1件の改善提案（統合テストで`error.code`を`'23505'`と明示検証する）を反映済み
- 上記はすべて実測（本セッション内でローカル実行して確認）。CI実行結果は未確認（このPR作成後にCIで確認予定）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: `/api/loan-returns` POSTの400率（重複登録の発生頻度の指標になる）
- 異常の判断基準: `create_loan_return_atomic`呼び出しが想定外に23505を返し続ける場合、フロントのプルダウンフィルタ（`unreturned`判定）が壊れている可能性がある
- ロールバック手順: `DROP INDEX loan_returns_loan_order_id_unique;`を含むmigrationを追加するか、本PRをrevertする（コード側の変更もrevertで安全に戻せる）

## 後任AIへの注意
- この実装で壊してはいけない前提: `loan_order_id`がNULLの返却（対象を選ばない返却）は今回のUNIQUE制約の対象外であり、従来通り何回でも登録できる。ここを「NULLも含めて一意」に変更すると既存の主要ユースケースが壊れる
- 似ているが別物の用語: `LOAN_ORDER_NOT_FOUND_ERROR`（loan_orderが自施設に存在しない場合）と、今回追加した「既に返却登録されています」（UNIQUE制約違反）は別のエラーで、どちらも`ClientVisibleError`経由で400になるが原因は異なる
- 勝手にリファクタしない場所: `src/lib/loan-returns/repository.ts`の`createLoanReturn`内のRPCエラーハンドリング分岐は、`consumables/repository.ts`の23503翻訳パターンと意図的に揃えてある。片方だけ変えると一貫性が崩れる

Closes #675
