### PR TITLE
feat: DB制約・RLS・admin境界の「未検証の穴」を怪しい順に機械検知し、新規発生を止める(issue #675の根本原因対策)

### DIFF
--- a/.claude/workflows/lib/__tests__/constraint-coverage.test.js
+++ b/.claude/workflows/lib/__tests__/constraint-coverage.test.js
@@ -1,0 +1,359 @@
+import { describe, it, expect } from 'vitest'
+import {
+  assessRisk,
+  findRlsTablesWithoutIdorTest,
+  findUncoveredConstraintMigrations,
+  findUndeclaredCardinality,
+} from '../constraint-coverage.js'
+
+const run = (migrations, integrationSource = '') =>
+  findUncoveredConstraintMigrations({ migrations, integrationSource })
+
+describe('findUncoveredConstraintMigrations', () => {
+  it('制約を導入していないmigrationは判定対象に数えない', () => {
+    const result = run([
+      { name: '001_add_column.sql', sql: 'ALTER TABLE orders ADD COLUMN memo text;' },
+    ])
+    expect(result.total).toBe(0)
+    expect(result.uncovered).toEqual([])
+  })
+
+  it('制約を導入し、そのテーブルが統合テストに登場すればuncoveredにしない', () => {
+    const result = run(
+      [
+        {
+          name: '002_unique.sql',
+          sql: 'CREATE UNIQUE INDEX foo ON loan_returns (loan_order_id);',
+        },
+      ],
+      "await db.from('loan_returns').select('*')",
+    )
+    expect(result.total).toBe(1)
+    expect(result.uncovered).toEqual([])
+  })
+
+  it('制約を導入したのにテーブルがどの統合テストにも登場しなければuncoveredにする', () => {
+    // WHY: #675 と同じ形。静的SQL検証しか無い制約は「破ろうとしたら拒否される」を
+    //      一度も確かめていないため、実DB統合テストの欠落を検知する必要がある
+    const result = run(
+      [
+        {
+          name: '003_compat.sql',
+          sql: `CREATE TABLE product_compatibilities (
+                  product_id_1 uuid NOT NULL REFERENCES products(id),
+                  CONSTRAINT ordered_pair CHECK (product_id_1 < product_id_2),
+                  UNIQUE (category_id, product_id_1, product_id_2)
+                );`,
+        },
+      ],
+      "await db.from('loan_returns').select('*')",
+    )
+    expect(result.uncovered).toEqual([
+      {
+        name: '003_compat.sql',
+        kinds: ['UNIQUE', 'FK', 'CHECK'],
+        tables: ['product_compatibilities'],
+        constraintCount: 3,
+      },
+    ])
+  })
+
+  it('コメント中のCHECK・UNIQUE等は制約として拾わない', () => {
+    const result = run([
+      {
+        name: '004_comment_only.sql',
+        sql: `-- product_id_1 < product_id_2 の CHECK 制約により (a,b) と (b,a) を同一視する
+              /* UNIQUE にはしない */
+              ALTER TABLE orders ADD COLUMN memo text;`,
+      },
+    ])
+    expect(result.total).toBe(0)
+  })
+
+  it('opt-outマーカーがあればuncoveredにせず、理由をoptedOutへ記録する', () => {
+    const result = run([
+      {
+        name: '005_internal.sql',
+        sql: `-- integration-coverage: not-required スキーマ監視用の内部テーブルで業務データを持たない
+              CREATE TABLE schema_drift_log (
+                id uuid PRIMARY KEY,
+                kind text NOT NULL CHECK (kind IN ('added','removed'))
+              );`,
+      },
+    ])
+    expect(result.uncovered).toEqual([])
+    expect(result.optedOut).toEqual([
+      {
+        name: '005_internal.sql',
+        reason: 'スキーマ監視用の内部テーブルで業務データを持たない',
+      },
+    ])
+  })
+
+  it('テーブル名を抽出できないmigration（ポリシーのみ等）は判定対象外にする', () => {
+    // WHY: 「どのテーブルを守るのか」が特定できない以上、カバレッジの有無を主張できない。
+    //      偽陽性で警告を出すより黙る側に倒す（warning-onlyの信頼を保つため）
+    const result = run([
+      {
+        name: '006_policy.sql',
+        sql: "CREATE POLICY p ON x FOR SELECT USING (is_admin()) WITH CHECK (is_admin());",
+      },
+    ])
+    expect(result.total).toBe(1)
+    expect(result.uncovered).toEqual([])
+  })
+})
+
+describe('assessRisk（怪しさの機械判定）', () => {
+  // WHY: フラットな一覧では「6件あります」で終わって結局放置される。
+  //      どれから見るべきかを機械で決めるところまでが検知の仕事（issue #675の教訓）
+  const assess = (o) =>
+    assessRisk({ tables: [], constraintCount: 0, appSource: '', allMigrationSql: '', ...o })
+
+  it('アプリのコードが一度も触っていないテーブルはlow（裏方テーブル）', () => {
+    const result = assess({
+      tables: ['schema_drift_log'],
+      constraintCount: 5,
+      appSource: "await db.from('loan_returns').select()",
+    })
+    expect(result.level).toBe('low')
+    expect(result.reasons[0]).toContain('裏方テーブル')
+  })
+
+  it('アプリが触っていて制約が3個以上あればhigh', () => {
+    const result = assess({
+      tables: ['product_compatibilities'],
+      constraintCount: 7,
+      appSource: "await db.from('product_compatibilities').select()",
+    })
+    expect(result.level).toBe('high')
+  })
+
+  it('アプリが触っていて facility_id を持てば、制約が少なくてもhigh（施設境界）', () => {
+    const result = assess({
+      tables: ['loan_returns'],
+      constraintCount: 1,
+      appSource: "await db.from('loan_returns').select()",
+      allMigrationSql: 'CREATE TABLE loan_returns (id uuid, facility_id uuid NOT NULL);',
+    })
+    expect(result.level).toBe('high')
+    expect(result.reasons.join()).toContain('施設境界')
+  })
+
+  it('facility_id列を持たなくても、RLSポリシーが is_facility_member を使えば施設境界扱いにする', () => {
+    // WHY: 明細テーブル（loan_return_items 等）は facility_id 列を持たず、親経由の
+    //      EXISTS で施設スコープになる。列だけを見ると施設境界を取りこぼし、
+    //      本来 high のものを medium に過小評価する（実際に踏んだ）
+    const result = assess({
+      tables: ['loan_return_items'],
+      constraintCount: 1,
+      appSource: "await db.from('loan_return_items').select()",
+      allMigrationSql: `
+        CREATE TABLE loan_return_items (id uuid, loan_return_id uuid);
+        CREATE POLICY "facility_member_or_admin" ON loan_return_items
+          FOR ALL TO authenticated
+          USING (EXISTS (SELECT 1 FROM loan_returns o
+            WHERE o.id = loan_return_items.loan_return_id
+              AND (is_facility_member(o.facility_id) OR is_admin())));`,
+    })
+    expect(result.level).toBe('high')
+    expect(result.reasons.join()).toContain('親経由で施設境界')
+  })
+
+  it('別テーブルのFK参照先として名前が出るだけでは施設境界扱いにしない', () => {
+    // WHY: `create table[^;]*\bt\b[^;]*facility_id` と緩く書くと、
+    //      hospital_prices の `references distributor_products(id)` に一致して
+    //      facility_id を持たない distributor_products まで施設境界扱いになる（実際に踏んだ）
+    const result = assess({
+      tables: ['distributor_products'],
+      constraintCount: 1,
+      appSource: "await db.from('distributor_products').select()",
+      allMigrationSql: `
+        CREATE TABLE distributor_products (id uuid, maker text);
+        CREATE TABLE hospital_prices (
+          distributor_product_id uuid REFERENCES distributor_products(id),
+          facility_id uuid NOT NULL
+        );`,
+    })
+    expect(result.level).toBe('medium')
+    expect(result.reasons.join()).not.toContain('施設境界')
+  })
+
+  it('アプリが触っているが制約も少なく施設境界にも関わらなければmedium', () => {
+    const result = assess({
+      tables: ['consumable_order_items'],
+      constraintCount: 1,
+      appSource: "await db.from('consumable_order_items').select()",
+    })
+    expect(result.level).toBe('medium')
+  })
+})
+
+describe('findRlsTablesWithoutIdorTest（認可側への応用）', () => {
+  const sql = `
+    CREATE POLICY loan_returns_select ON loan_returns FOR SELECT USING (is_facility_member(facility_id));
+    CREATE POLICY hospital_prices_select ON public.hospital_prices FOR SELECT USING (is_facility_member(facility_id));
+  `
+
+  it('IDOR統合テストに登場しないテーブルだけをuncoveredにする', () => {
+    const result = findRlsTablesWithoutIdorTest({
+      allMigrationSql: sql,
+      idorTestSource: "it('ユーザーBは施設Aのloan_returnsを1件も取得できない', ...)",
+    })
+    expect(result.policyTables).toEqual(['hospital_prices', 'loan_returns'])
+    expect(result.uncovered).toEqual(['hospital_prices'])
+  })
+
+  it('IDORテストが空なら、ポリシーを持つ全テーブルがuncoveredになる', () => {
+    const result = findRlsTablesWithoutIdorTest({ allMigrationSql: sql, idorTestSource: '' })
+    expect(result.uncovered).toEqual(['hospital_prices', 'loan_returns'])
+  })
+
+  it('notRequired に挙げたテーブルはuncoveredから外れる（検知条件の訂正）', () => {
+    // WHY: categories 等のマスタは意図的にテナント非分離で、施設境界の約束がそもそも無い。
+    //      IDORの概念が無いテーブルを負債として数え続けると、リストの信用が落ちる
+    const result = findRlsTablesWithoutIdorTest({
+      allMigrationSql: sql,
+      idorTestSource: '',
+      notRequired: ['hospital_prices'],
+    })
+    expect(result.policyTables).toEqual(['hospital_prices', 'loan_returns'])
+    expect(result.uncovered).toEqual(['loan_returns'])
+  })
+
+  it('ポリシーが1つも無ければ空を返す', () => {
+    const result = findRlsTablesWithoutIdorTest({
+      allMigrationSql: 'CREATE TABLE foo (id uuid);',
+      idorTestSource: '',
+    })
+    expect(result).toEqual({ policyTables: [], uncovered: [] })
+  })
+})
+
+describe('findUndeclaredCardinality', () => {
+  const alterAddFk = {
+    name: '20260714000005_orders_history_prereqs.sql',
+    sql: `ALTER TABLE loan_returns
+            ADD COLUMN loan_order_id UUID REFERENCES loan_orders(id) ON DELETE SET NULL;`,
+  }
+
+  it('後付けFK列にUNIQUEが無ければundeclaredにする（#675の発生時点を再現）', () => {
+    // WHY: これが #675 の本体。2026-07-14 にこの列が追加された時点で
+    //      「loan_order 1件に返却は何件までか」が宣言されず、そのまま6週間残った
+    const result = findUndeclaredCardinality({ migrations: [alterAddFk] })
+    expect(result.added).toBe(1)
+    expect(result.undeclared).toEqual([
+      {
+        name: '20260714000005_orders_history_prereqs.sql',
+        table: 'loan_returns',
+        column: 'loan_order_id',
+      },
+    ])
+  })
+
+  it('後から別migrationでUNIQUEが追加されればundeclaredにしない（#675の修正後）', () => {
+    const result = findUndeclaredCardinality({
+      migrations: [
+        alterAddFk,
+        {
+          name: '20260828000001_add_unique.sql',
+          sql: `CREATE UNIQUE INDEX loan_returns_loan_order_id_unique
+                  ON loan_returns (loan_order_id) WHERE loan_order_id IS NOT NULL;`,
+        },
+      ],
+    })
+    expect(result.undeclared).toEqual([])
+  })
+
+  it('無関係なテーブルの複合UNIQUEを宣言済みと誤判定しない', () => {
+    // WHY: 列名だけで照合すると product_compatibilities の UNIQUE (category_id, ...) が
+    //      distributor_products.category_id の宣言として誤って一致する（実装中に実際に踏んだ）
+    const result = findUndeclaredCardinality({
+      migrations: [
+        {
+          name: '001_add_categories.sql',
+          sql: 'ALTER TABLE distributor_products ADD COLUMN category_id uuid REFERENCES categories(id);',
+        },
+        {
+          name: '002_compat.sql',
+          sql: `CREATE TABLE product_compatibilities (
+                  UNIQUE (category_id, product_id_1, product_id_2)
+                );`,
+        },
+      ],
+    })
+    expect(result.undeclared).toEqual([
+      { name: '001_add_categories.sql', table: 'distributor_products', column: 'category_id' },
+    ])
+  })
+
+  it('`-- cardinality: many <理由>` があれば1対多の明示としてdeclaredManyに記録する', () => {
+    const result = findUndeclaredCardinality({
+      migrations: [
+        {
+          name: '001_add_categories.sql',
+          sql: `-- cardinality: many 1カテゴリに複数の取扱商品がぶら下がる
+                ALTER TABLE distributor_products ADD COLUMN category_id uuid REFERENCES categories(id);`,
+        },
+      ],
+    })
+    expect(result.undeclared).toEqual([])
+    expect(result.declaredMany).toEqual([
+      {
+        name: '001_add_categories.sql',
+        column: 'category_id',
+        reason: '1カテゴリに複数の取扱商品がぶら下がる',
+      },
+    ])
+  })
+
+  it('`<table>.<column>` を明示すれば別のmigrationからでも1対多を宣言できる', () => {
+    // WHY: 適用済みのmigrationを後から編集したくないケースの逃げ道。
+    //      列を明示させることで、無関係な宣言が誤って効くことを防ぐ
+    const result = findUndeclaredCardinality({
+      migrations: [
+        {
+          name: '001_add_categories.sql',
+          sql: 'ALTER TABLE distributor_products ADD COLUMN category_id uuid REFERENCES categories(id);',
+        },
+        {
+          name: '999_declarations.sql',
+          sql: '-- cardinality: many distributor_products.category_id 1カテゴリに複数の取扱商品',
+        },
+      ],
+    })
+    expect(result.undeclared).toEqual([])
+    expect(result.declaredMany[0].reason).toBe('1カテゴリに複数の取扱商品')
+  })
+
+  it('別の列に対する宣言は流用されない', () => {
+    const result = findUndeclaredCardinality({
+      migrations: [
+        {
+          name: '001_add_categories.sql',
+          sql: 'ALTER TABLE distributor_products ADD COLUMN category_id uuid REFERENCES categories(id);',
+        },
+        {
+          name: '999_declarations.sql',
+          sql: '-- cardinality: many loan_returns.loan_order_id 別の列の宣言',
+        },
+      ],
+    })
+    expect(result.undeclared).toEqual([
+      { name: '001_add_categories.sql', table: 'distributor_products', column: 'category_id' },
+    ])
+  })
+
+  it('CREATE TABLE内のFKは対象外（最初から多対1として設計されたものが大半でノイズになる）', () => {
+    const result = findUndeclaredCardinality({
+      migrations: [
+        {
+          name: '001_create.sql',
+          sql: 'CREATE TABLE loan_order_items (loan_order_id uuid REFERENCES loan_orders(id));',
+        },
+      ],
+    })
+    expect(result.added).toBe(0)
+    expect(result.undeclared).toEqual([])
+  })
+})

--- a/.claude/workflows/lib/__tests__/constraint-coverage.test.js
+++ b/.claude/workflows/lib/__tests__/constraint-coverage.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   assessRisk,
+  findAdminOnlyTablesWithoutTest,
   findRlsTablesWithoutIdorTest,
   findUncoveredConstraintMigrations,
   findUndeclaredCardinality,
@@ -227,6 +228,54 @@ describe('findRlsTablesWithoutIdorTest（認可側への応用）', () => {
       idorTestSource: '',
     })
     expect(result).toEqual({ policyTables: [], uncovered: [] })
+  })
+})
+
+describe('findAdminOnlyTablesWithoutTest（認可のもう一方の軸）', () => {
+  const adminOnly = `
+    CREATE POLICY "categories_write" ON categories
+      FOR ALL TO authenticated USING (is_admin()) WITH CHECK (is_admin());
+  `
+  // adminは「追加の許可」であって境界ではないケース
+  const facilityOrAdmin = `
+    CREATE POLICY "facility_writer_or_admin" ON loan_orders
+      FOR ALL TO authenticated
+      USING (is_facility_writer(facility_id) OR is_admin());
+  `
+
+  it('adminだけが書けるテーブルを拾う', () => {
+    const result = findAdminOnlyTablesWithoutTest({
+      allMigrationSql: adminOnly,
+      adminTestSource: '',
+    })
+    expect(result.adminOnlyTables).toEqual(['categories'])
+    expect(result.uncovered).toEqual(['categories'])
+  })
+
+  it('is_facility_member / is_facility_writer との OR は対象外にする', () => {
+    // WHY: この区別を入れないと15テーブルが該当してノイズだらけになる（実測で確認）。
+    //      これらは「adminは追加の許可」であって admin境界ではない
+    const result = findAdminOnlyTablesWithoutTest({
+      allMigrationSql: adminOnly + facilityOrAdmin,
+      adminTestSource: '',
+    })
+    expect(result.adminOnlyTables).toEqual(['categories'])
+  })
+
+  it('SELECTのみのポリシーは書き込み境界ではないので対象外', () => {
+    const result = findAdminOnlyTablesWithoutTest({
+      allMigrationSql: `CREATE POLICY "p" ON products FOR SELECT TO authenticated USING (is_admin());`,
+      adminTestSource: '',
+    })
+    expect(result.adminOnlyTables).toEqual([])
+  })
+
+  it('admin境界テストに登場していればuncoveredにしない', () => {
+    const result = findAdminOnlyTablesWithoutTest({
+      allMigrationSql: adminOnly,
+      adminTestSource: "it('staffはcategoriesを作成できない', ...)",
+    })
+    expect(result.uncovered).toEqual([])
   })
 })
 

--- a/.claude/workflows/lib/constraint-coverage.js
+++ b/.claude/workflows/lib/constraint-coverage.js
@@ -1,0 +1,420 @@
+// issue: 短貸返却(loan_return)の二重登録(#675)の根本原因検知。
+//
+// WHY: #675 は「loan_order 1件に返却は1件まで」というカーディナリティの約束が
+//      どこにも宣言されず、migration のテストが「実装で書いた SQL 文字列を同じ文字列で
+//      照合する」静的検証だけだったため、PR #573(2026-07-26)から修正(2026-08-28)まで
+//      84コミット・CI 173本を通過し続けても検出されなかった。
+//
+//      DB制約(UNIQUE / FK / CHECK)は「約束を破る操作が拒否されること」でしか検証できない。
+//      静的SQL検証は原理的にそれを確かめられない(Act も 否定形の Assert も持てない)ため、
+//      制約を導入する migration には実DBを使う統合テストの対応が要る。
+//
+//      ここでは「制約を導入しているのに、そのテーブルがどの統合テストにも一度も
+//      登場しない migration」を機械検知する。判定は近似であり warning-only で運用する
+//      (docs/agents/actuator-inventory.md)。
+//
+// 既知の限界:
+//   - テーブル名が統合テストに登場すること = その制約が検証されていること、ではない。
+//     つまり偽陰性(見逃し)は残る。「一度も登場しない」の側だけを高い確度で拾う設計。
+//   - 意図的に統合テストを持たない migration は、SQL 内に
+//     `-- integration-coverage: not-required <理由>` と書くことで除外できる
+//     (「該当なしでも理由を書く」= 判断を記録に残す)。
+
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const OPT_OUT_PATTERN = /--\s*integration-coverage:\s*not-required\b(.*)$/im
+
+/** SQL から行コメント・ブロックコメントを除去する（コメント中の CHECK 等を拾わないため） */
+function stripComments(sql) {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ')
+}
+
+/** この migration が導入している制約の種類を返す */
+function detectConstraintKinds(sqlWithoutComments) {
+  const s = sqlWithoutComments.toLowerCase()
+  const kinds = []
+  if (/\bunique\b/.test(s)) kinds.push('UNIQUE')
+  if (/\breferences\s+/.test(s)) kinds.push('FK')
+  if (/\bcheck\s*\(/.test(s)) kinds.push('CHECK')
+  return kinds
+}
+
+/** 制約の「個数」を数える（種類ではなく実際の出現数。書き忘れの余地の大きさの代理指標） */
+function countConstraints(sqlWithoutComments) {
+  const s = sqlWithoutComments.toLowerCase()
+  const count = (re) => (s.match(re) ?? []).length
+  return count(/\bunique\b/g) + count(/\breferences\s+/g) + count(/\bcheck\s*\(/g)
+}
+
+/** この migration が触るテーブル名を粗く抽出する */
+function extractTables(sqlWithoutComments) {
+  const s = sqlWithoutComments.toLowerCase()
+  const tables = new Set()
+  const patterns = [
+    /(?:create table(?:\s+if not exists)?|alter table(?:\s+if exists)?)\s+(?:public\.)?"?([a-z_][a-z0-9_]*)"?/g,
+    /create\s+(?:unique\s+)?index[^;]*?\bon\s+(?:public\.)?"?([a-z_][a-z0-9_]*)"?/g,
+  ]
+  for (const re of patterns) {
+    for (const m of s.matchAll(re)) tables.add(m[1])
+  }
+  return [...tables]
+}
+
+/**
+ * 制約を導入しているのに統合テストの対応が無い migration を洗い出す。
+ *
+ * @param {{migrations: {name: string, sql: string}[], integrationSource: string}} options
+ *   options.integrationSource は統合テスト全ファイルを連結した文字列
+ * @returns {{total: number,
+ *            uncovered: {name: string, kinds: string[], tables: string[], constraintCount: number}[],
+ *            optedOut: {name: string, reason: string}[]}}
+ */
+export function findUncoveredConstraintMigrations({ migrations, integrationSource }) {
+  const haystack = String(integrationSource ?? '').toLowerCase()
+  const uncovered = []
+  const optedOut = []
+  let total = 0
+
+  for (const { name, sql } of migrations) {
+    const optOut = OPT_OUT_PATTERN.exec(sql)
+    const body = stripComments(sql)
+    const kinds = detectConstraintKinds(body)
+    if (kinds.length === 0) continue
+    total += 1
+
+    if (optOut) {
+      optedOut.push({ name, reason: optOut[1].trim() })
+      continue
+    }
+
+    const tables = extractTables(body)
+    // テーブル名を1つも抽出できなかった migration（RLSポリシーのみ等）は判定対象外にする。
+    // 「どのテーブルを守るのか」が分からない以上、カバレッジの有無を主張できないため。
+    if (tables.length === 0) continue
+
+    const covered = tables.some((t) => haystack.includes(t))
+    if (!covered) uncovered.push({ name, kinds, tables, constraintCount: countConstraints(body) })
+  }
+
+  return { total, uncovered, optedOut }
+}
+
+/**
+ * 検知した「穴」に怪しさ（高/中/低）を付ける。
+ *
+ * WHY: 検知結果をフラットな一覧で出すと「6件あります」で終わり、結局どれから見ればよいか
+ *      分からず放置される。#675 が6週間残ったのは検知が無かったからだけでなく、
+ *      仮に一覧があっても優先順位が付かず埋もれたはずだから。
+ *      「怪しい/怪しくない」を機械で判定して並べ替えるところまでが検知の仕事とする。
+ *
+ * 判定材料はすべて機械的に取れるものだけを使う（人の申告に依存しない）:
+ *   - usedByApp      : そのテーブルをアプリのコード(src/)が実際に読み書きしているか。
+ *                      触っていないテーブル = システム自身の裏方（スキーマ監視等）で、
+ *                      業務データが壊れるリスクが無い。最も効く信号。
+ *   - facilityScoped : facility_id を持つか = 施設境界（医療データのテナント分離）に関わる
+ *   - constraintCount: 制約の個数。多いほど「書き忘れの余地」が大きい
+ *
+ * @param {{tables: string[], constraintCount: number, appSource: string, allMigrationSql: string}} options
+ * @returns {{level: 'high'|'medium'|'low', reasons: string[]}}
+ */
+export function assessRisk({ tables, constraintCount, appSource, allMigrationSql }) {
+  const app = String(appSource ?? '').toLowerCase()
+  const all = String(allMigrationSql ?? '').toLowerCase()
+
+  const usedByApp = tables.some((t) => app.includes(t))
+  // `create table <t>` に固定して探す。`create table[^;]*\bt\b` のように緩めると、
+  // 別テーブルの定義内にFK参照先として現れた名前（例: hospital_prices の
+  // `references distributor_products(id)`）に一致し、facility_id を持たないテーブルまで
+  // 施設境界扱いになる（実装中に実際に踏んだ誤検知）
+  let facilityScopeKind = null
+  const facilityScoped = tables.some((t) => {
+    const hasColumn = new RegExp(
+      `create table\\s+(?:if not exists\\s+)?(?:public\\.)?"?${t}"?\\s*\\([^;]*facility_id`,
+      's',
+    ).test(all)
+    // 明細テーブル（case_order_items / loan_return_items 等）は facility_id 列を持たず、
+    // 親テーブル経由の EXISTS で施設スコープになる。列だけを見ると施設境界を
+    // 取りこぼして medium に過小評価する（実際に踏んだ）。ポリシー本文で
+    // is_facility_member を使っているかも併せて見る
+    const policyScoped = new RegExp(
+      `create policy[^;]*\\son\\s+(?:public\\.)?"?${t}"?[^;]*is_facility_member`,
+      's',
+    ).test(all)
+    if (hasColumn) facilityScopeKind = 'column'
+    else if (policyScoped) facilityScopeKind = 'policy'
+    return hasColumn || policyScoped
+  })
+
+  const reasons = []
+  if (!usedByApp) {
+    reasons.push('アプリのコード(src/)がこのテーブルを一度も読み書きしていない（裏方テーブル）')
+    return { level: 'low', reasons }
+  }
+
+  reasons.push('アプリのコード(src/)が実際に読み書きしている（業務データ）')
+  if (facilityScopeKind === 'column') {
+    reasons.push('facility_id を持つ＝施設境界（テナント分離）に関わる')
+  } else if (facilityScopeKind === 'policy') {
+    reasons.push('RLSポリシーが is_facility_member を使う＝親経由で施設境界に関わる')
+  }
+  if (constraintCount >= 3) reasons.push(`制約が${constraintCount}個あり、書き忘れの余地が大きい`)
+
+  const level = facilityScoped || constraintCount >= 3 ? 'high' : 'medium'
+  return { level, reasons }
+}
+
+const CARDINALITY_OPT_OUT = /--\s*cardinality:\s*many\b(.*)$/im
+
+/**
+ * 既存テーブルへ後付けで追加されたFK列のうち、カーディナリティ(1対1か1対多か)が
+ * どこにも宣言されていないものを洗い出す。
+ *
+ * WHY: #675 の発生源は 20260714000005_orders_history_prereqs.sql の
+ *      `ALTER TABLE loan_returns ADD COLUMN loan_order_id UUID REFERENCES loan_orders(id)` で、
+ *      ここで「loan_order 1件に返却は何件まで許すのか」が一度も宣言されなかった。
+ *      宣言されなかったので仕様書にも書かれず、テストにも出ず、レビューでも問われなかった。
+ *      「関係を後付けする」操作はリポジトリ全体で数件しかないため、ここを塞ぐのは安い。
+ *
+ * 宣言済みとみなす条件は次のいずれか:
+ *   - その列に UNIQUE 制約 / UNIQUE インデックスがある（= 1対1）
+ *   - SQL 内に `-- cardinality: many <理由>` と書かれている（= 1対多だと明示した）
+ *
+ * @param {{migrations: {name: string, sql: string}[]}} options
+ * @returns {{added: number, undeclared: {name: string, table: string, column: string}[],
+ *            declaredMany: {name: string, column: string, reason: string}[]}}
+ */
+export function findUndeclaredCardinality({ migrations }) {
+  const allStatements = migrations
+    .map((m) => stripComments(m.sql))
+    .join('\n')
+    .toLowerCase()
+    .split(';')
+
+  const undeclared = []
+  const declaredMany = []
+  let added = 0
+
+  for (const { name, sql } of migrations) {
+    const body = stripComments(sql).toLowerCase()
+    // 同じファイル内の宣言（そのmigrationを書いている最中の通常ケース）
+    const optOut = CARDINALITY_OPT_OUT.exec(sql)
+
+    // `ALTER TABLE <t> ... ADD COLUMN <col> <type> ... REFERENCES` を拾う。
+    // CREATE TABLE 内のFKは「最初から多対1として設計された」ものが大半でノイズになるため対象外。
+    for (const m of body.matchAll(
+      /alter table\s+(?:if exists\s+)?(?:public\.)?"?([a-z_][a-z0-9_]*)"?[\s\S]*?add column\s+"?([a-z_][a-z0-9_]*)"?[^;]*?\breferences\b[^;]*?;/g,
+    )) {
+      const [, table, column] = m
+      added += 1
+
+      if (optOut) {
+        declaredMany.push({ name, column, reason: optOut[1].trim() })
+        continue
+      }
+
+      // 既に適用済みのmigrationを後から編集したくない場合のために、
+      // `-- cardinality: many <table>.<column> <理由>` と列を明示すれば
+      // **別のmigrationからでも**宣言できる（適用済みファイルを触らずに済ませる逃げ道）
+      const remote = new RegExp(
+        `--\\s*cardinality:\\s*many\\s+${table}\\.${column}\\b(.*)$`,
+        'im',
+      ).exec(migrations.map((mm) => mm.sql).join('\n'))
+      if (remote) {
+        declaredMany.push({ name, column, reason: remote[1].trim() })
+        continue
+      }
+
+      // UNIQUE 宣言はこの migration 内とは限らない（#675 は1ヶ月後の別 migration で追加された）
+      // ため、リポジトリ全体のSQLを文単位で見る。ただし「同じ文が当該テーブルと当該列の
+      // 両方に言及していること」を要求する。列名だけで照合すると、無関係なテーブルの
+      // 複合UNIQUE（例: product_compatibilities の UNIQUE (category_id, ...)）に
+      // 誤って一致して宣言済みと誤判定する。
+      const hasUnique = allStatements.some(
+        (stmt) =>
+          stmt.includes(table) &&
+          new RegExp(`\\bunique\\b[^(]*\\([^)]*\\b${column}\\b`).test(stmt),
+      )
+
+      if (!hasUnique) undeclared.push({ name, table, column })
+    }
+  }
+
+  return { added, undeclared, declaredMany }
+}
+
+/**
+ * RLSポリシーを持つのに、IDOR統合テスト（他人のIDでアクセスして弾かれることの確認）に
+ * 一度も登場しないテーブルを洗い出す。
+ *
+ * WHY: constraint-coverage と同じ型の穴を、認可の側で探す。
+ *      「ポリシーを書いた」＝「他人から守られている」ではない。守られていることは
+ *      **他人のIDで実際に叩いて弾かれる**ことでしか確かめられず、
+ *      `known-failure-patterns.md`の「動いたからOKでfacility_idフィルタ漏れ・RLS未設定を
+ *      見逃す（issue #24再発防止）」はまさにこれが起きた記録である。
+ *
+ * `notRequired` は「守るべき施設境界の約束がそもそも無い」テーブルの除外リスト。
+ * 例: categories / distributor_products のようなマスタは意図的にテナント非分離で、
+ * `USING (true)` の SELECT ポリシーを持つ。ここに IDOR の概念は無く、守る約束は
+ * 施設境界ではなく admin 境界である。**これは負債の免除ではなく検知条件の訂正**であり、
+ * 理由とセットでレビュー可能な場所（baseline）に置く。
+ *
+ * @param {{allMigrationSql: string, idorTestSource: string, notRequired?: string[]}} options
+ * @returns {{policyTables: string[], uncovered: string[]}}
+ */
+export function findRlsTablesWithoutIdorTest({ allMigrationSql, idorTestSource, notRequired = [] }) {
+  const sql = String(allMigrationSql ?? '').toLowerCase()
+  const idor = String(idorTestSource ?? '').toLowerCase()
+
+  const policyTables = new Set()
+  for (const m of sql.matchAll(
+    /create policy[^;]*?\bon\s+(?:public\.)?"?([a-z_][a-z0-9_]*)"?/g,
+  )) {
+    policyTables.add(m[1])
+  }
+
+  const excluded = new Set(notRequired)
+  const tables = [...policyTables].sort()
+  return {
+    policyTables: tables,
+    uncovered: tables.filter((t) => !idor.includes(t) && !excluded.has(t)),
+  }
+}
+
+// ---- CLI ----
+
+const LEVEL_ORDER = { high: 0, medium: 1, low: 2 }
+const LEVEL_LABEL = {
+  high: '【怪しい】  ',
+  medium: '【要確認】  ',
+  low: '【放置でよい】',
+}
+
+/** 指定ディレクトリ配下のソースを再帰的に連結する（業務データ判定の材料） */
+function collectSource(dirs, extensions) {
+  const chunks = []
+  const walk = (dir) => {
+    if (!existsSync(dir)) return
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (extensions.some((ext) => entry.name.endsWith(ext))) chunks.push(readFileSync(full, 'utf-8'))
+    }
+  }
+  dirs.forEach(walk)
+  return chunks.join('\n').toLowerCase()
+}
+
+function main() {
+  const repoRoot = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)))
+  const migDir = path.join(repoRoot, 'supabase/migrations')
+  const intDir = path.join(repoRoot, 'supabase/__tests__/integration')
+
+  const migrations = readdirSync(migDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+    .map((f) => ({ name: f, sql: readFileSync(path.join(migDir, f), 'utf-8') }))
+
+  const integrationSource = existsSync(intDir)
+    ? readdirSync(intDir)
+        .filter((f) => f.endsWith('.ts'))
+        .map((f) => readFileSync(path.join(intDir, f), 'utf-8'))
+        .join('\n')
+    : ''
+
+  // 業務データかどうかの判定材料: アプリ本体のソース（生成物である型定義は除く）
+  const appSource = collectSource(
+    [
+      path.join(repoRoot, 'src/lib'),
+      path.join(repoRoot, 'src/app'),
+      path.join(repoRoot, 'src/components'),
+    ],
+    ['.ts', '.tsx'],
+  )
+  const allMigrationSql = migrations.map((m) => m.sql).join('\n')
+
+  const cardinality = findUndeclaredCardinality({ migrations })
+  const coverage = findUncoveredConstraintMigrations({ migrations, integrationSource })
+
+  const ranked = coverage.uncovered
+    .map((u) => ({
+      ...u,
+      risk: assessRisk({
+        tables: u.tables,
+        constraintCount: u.constraintCount,
+        appSource,
+        allMigrationSql,
+      }),
+    }))
+    .sort((a, b) => LEVEL_ORDER[a.risk.level] - LEVEL_ORDER[b.risk.level])
+
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({ cardinality, integrationCoverage: { ...coverage, ranked } }, null, 2))
+    return
+  }
+
+  console.log('=== DB制約の穴（怪しい順） ===\n')
+
+  console.log('■ 何回までOKかを宣言していない後付けFK列')
+  if (cardinality.undeclared.length === 0) {
+    console.log('  なし\n')
+  } else {
+    for (const u of cardinality.undeclared) {
+      console.log(`  [要対応] ${u.table}.${u.column}  (${u.name})`)
+      console.log('           → 1対1なら UNIQUE を追加、1対多なら `-- cardinality: many <理由>` を書く')
+    }
+    console.log('')
+  }
+
+  const idorSource = existsSync(intDir)
+    ? readdirSync(intDir)
+        .filter((f) => f.includes('idor'))
+        .map((f) => readFileSync(path.join(intDir, f), 'utf-8'))
+        .join('\n')
+    : ''
+  // 「守る約束がそもそも無い」テーブルの除外リストはbaselineが正本（理由付き）
+  const baselinePath = path.join(repoRoot, 'supabase/migrations/__tests__/constraint-coverage-baseline.json')
+  const notRequired = existsSync(baselinePath)
+    ? (JSON.parse(readFileSync(baselinePath, 'utf-8')).rlsIdorNotRequired ?? []).map((e) => e.table)
+    : []
+  const rls = findRlsTablesWithoutIdorTest({
+    allMigrationSql,
+    idorTestSource: idorSource,
+    notRequired,
+  })
+  const rlsRanked = rls.uncovered
+    .map((t) => ({
+      table: t,
+      risk: assessRisk({ tables: [t], constraintCount: 0, appSource, allMigrationSql }),
+    }))
+    .sort((a, b) => LEVEL_ORDER[a.risk.level] - LEVEL_ORDER[b.risk.level])
+
+  console.log(
+    `■ RLSポリシーはあるが、他人のIDで叩いて弾かれることを一度も試していない（${rls.uncovered.length}/${rls.policyTables.length}テーブル）`,
+  )
+  if (rlsRanked.length === 0) {
+    console.log('  なし\n')
+  } else {
+    for (const r of rlsRanked) {
+      console.log(`  ${LEVEL_LABEL[r.risk.level]} ${r.table}`)
+      for (const reason of r.risk.reasons) console.log(`           - ${reason}`)
+    }
+    console.log('')
+  }
+
+  console.log('■ 制約を作ったが、実DBで効くか一度も試していない')
+  if (ranked.length === 0) {
+    console.log('  なし')
+  } else {
+    for (const r of ranked) {
+      console.log(`  ${LEVEL_LABEL[r.risk.level]} ${r.tables.join(', ')}  (制約${r.constraintCount}個: ${r.kinds.join('/')})`)
+      console.log(`           ${r.name}`)
+      for (const reason of r.risk.reasons) console.log(`           - ${reason}`)
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/.claude/workflows/lib/constraint-coverage.js
+++ b/.claude/workflows/lib/constraint-coverage.js
@@ -282,6 +282,40 @@ export function findRlsTablesWithoutIdorTest({ allMigrationSql, idorTestSource, 
   }
 }
 
+/**
+ * 「adminだけが書ける」テーブルのうち、非adminが書けないことを一度も試していないものを探す。
+ *
+ * WHY: RLS/IDOR軸で `categories` / `distributor_products` / `product_compatibilities` を
+ *      「施設境界の約束がそもそも無い」として除外したが、**代わりに admin 境界という
+ *      別の約束が存在する**。除外したまま admin 側の軸を作らないと、
+ *      「面倒な指摘を除外リストに逃がしただけ」になる。
+ *
+ *      `is_facility_member` / `is_facility_writer` との OR がある場合は
+ *      「adminは追加の許可」であって admin境界ではないため対象外にする。
+ *      （この区別を入れないと15テーブルが該当し、ノイズだらけになる。実測で確認）
+ *
+ * @param {{allMigrationSql: string, adminTestSource: string}} options
+ * @returns {{adminOnlyTables: string[], uncovered: string[]}}
+ */
+export function findAdminOnlyTablesWithoutTest({ allMigrationSql, adminTestSource }) {
+  const sql = String(allMigrationSql ?? '').toLowerCase()
+  const tested = String(adminTestSource ?? '').toLowerCase()
+
+  const tables = new Set()
+  for (const m of sql.matchAll(
+    /create policy[^;]*?\son\s+(?:public\.)?"?([a-z_][a-z0-9_]*)"?([^;]*)/g,
+  )) {
+    const [, table, rest] = m
+    const isWrite = /for\s+(all|insert|update|delete)/.test(rest)
+    const hasFacilityAlternative =
+      rest.includes('is_facility_member') || rest.includes('is_facility_writer')
+    if (isWrite && rest.includes('is_admin') && !hasFacilityAlternative) tables.add(table)
+  }
+
+  const adminOnlyTables = [...tables].sort()
+  return { adminOnlyTables, uncovered: adminOnlyTables.filter((t) => !tested.includes(t)) }
+}
+
 // ---- CLI ----
 
 const LEVEL_ORDER = { high: 0, medium: 1, low: 2 }
@@ -397,6 +431,33 @@ function main() {
     console.log('  なし\n')
   } else {
     for (const r of rlsRanked) {
+      console.log(`  ${LEVEL_LABEL[r.risk.level]} ${r.table}`)
+      for (const reason of r.risk.reasons) console.log(`           - ${reason}`)
+    }
+    console.log('')
+  }
+
+  const adminTestSource = existsSync(intDir)
+    ? readdirSync(intDir)
+        .filter((f) => f.includes('admin'))
+        .map((f) => readFileSync(path.join(intDir, f), 'utf-8'))
+        .join('\n')
+    : ''
+  const admin = findAdminOnlyTablesWithoutTest({ allMigrationSql, adminTestSource })
+  const adminRanked = admin.uncovered
+    .map((t) => ({
+      table: t,
+      risk: assessRisk({ tables: [t], constraintCount: 0, appSource, allMigrationSql }),
+    }))
+    .sort((a, b) => LEVEL_ORDER[a.risk.level] - LEVEL_ORDER[b.risk.level])
+
+  console.log(
+    `■ adminだけが書けるはずだが、非adminで書けないことを試していない（${admin.uncovered.length}/${admin.adminOnlyTables.length}テーブル）`,
+  )
+  if (adminRanked.length === 0) {
+    console.log('  なし\n')
+  } else {
+    for (const r of adminRanked) {
       console.log(`  ${LEVEL_LABEL[r.risk.level]} ${r.table}`)
       for (const reason of r.risk.reasons) console.log(`           - ${reason}`)
     }

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -42,6 +42,7 @@
 | Stop | `check-aidd-phase-stats-recorded.sh` | warning-only | AIDD stats phase1/phase2呼び忘れの警告（issue #524） |
 | Stop | `check-handoff-format.sh` | warning-only | PR本文の引き継ぎフォーマット必須見出し欠如の警告（issue #524。PR本文経由のみ対象） |
 | Stop | `check-find-av-precision-recorded.sh` | warning-only | find-av-precisionログ記録漏れの警告（issue #522） |
+| （参考）`npm test`（CI含む） | `supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts` | **block**（テスト失敗、ただしCI上の強制力はプラン依存） | issue #675。カーディナリティ未宣言の後付けFK列・統合テスト対応の無い制約migrationの**新規発生**を止める（既知分はbaselineに固定するratchet方式）。hookではなくテストなので、ローカル`npm test`とCIの両方で機械的に起動する。ただし本リポジトリはFreeプランでCI失敗がマージを阻止しないため、実効的な強制力はローカル実行時に限る |
 | （参考）per-edit | security-guidanceプラグイン（`possible_real_facility_name`等） | warning-only | issue #440。Claude Code公式プラグイン経由、上記`.claude/settings.json`のhooksとは別経路 |
 
 （`SubagentStart`/`SubagentStop`の`log-subagent-hook-skeleton.sh`は検知ではなく記録専用のため

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -228,6 +228,8 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | `scripts/lib/canonical-event.ts` | hook/journal/agent-progress/loop-observabilityの4ログを正規化する読み取り専用Adapter層（issue #569） |
 | `scripts/harvest-journal-events.sh` / `scripts/lib/harvest-journal-events.ts` | Workflow journal(wf_*)をtranscript cleanupで消える前に`logs/journal-harvest.jsonl`へ収穫（Stop hook契機・source+agentIdで重複排除。issue #642） |
 | `scripts/summarize-gate-passfail.sh` / `scripts/lib/gate-effectiveness-summary.ts` | 収穫済みjournalベースでagentType別pass/fail/blockedを集計し月次品質ゲートサマリへ出力（旧summarize-gate-blocked.sh=blockedのみ集計を統合。issue #569・#642） |
+| `.claude/workflows/lib/constraint-coverage.js` | DB制約の2つの穴（後付けFK列のカーディナリティ未宣言・制約migrationの実DB統合テスト欠落）の判定ロジック正本（issue #675） |
+| `scripts/check-constraint-coverage.sh` | 現存する穴を**怪しい順**に表示（怪しさは機械判定：業務データか裏方か・施設境界に関わるか・制約の個数）。新規発生の阻止は`supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts`が`npm test`で行う |
 | `scripts/check-agent-progress-gap.sh` | agent-progress記録漏れの機械検知（issue #339） |
 | `scripts/record-gap-check-state.sh` | gap check用before/expected件数の記録（issue #488。オーケストレーター専用） |
 | `scripts/check-gap-check-state.sh` | Stop hookによるgap checkの自動実行（issue #488） |

--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -89,6 +89,14 @@ DB制約は「破ろうとしたら拒否される」ことでしか検証でき
 `CREATE POLICY` を持つのに `*-rls-idor.integration.test.ts` に一度も登場しないテーブルを
 同じく怪しい順に出し、新規発生をratchetで止める（下記「issue #24再発防止」と対になる機構）。
 
+さらに**admin境界**（`findAdminOnlyTablesWithoutTest`）も同じ型で検知する。
+`categories` / `distributor_products` / `products` / `product_compatibilities` / `facilities` は
+SELECTが `USING (true)` でテナント非分離のため施設境界の軸からは除外されるが、
+**書き込みだけが `is_admin()` に限定される**という別の約束を持つ。除外したまま
+admin側の軸を作らないと「面倒な指摘を除外リストに逃がしただけ」になるため対で運用する。
+`is_facility_member` / `is_facility_writer` との OR は「adminは追加の許可」であって
+境界ではないので対象外（この区別を入れないと15テーブルが該当しノイズになる。実測確認済み）。
+
 **リストの読み方（重要）**: このリストは「**ここは確かめていない**」と言っているだけで、
 「**ここ以外は確かめてある**」とは言っていない。障害時に「載っているからまず疑う」に使うのは
 正しいが、「載っていないから違う」に使うと調査が遅れる。カバレッジ%と同じ誤読に注意する。

--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -46,6 +46,53 @@ Next.js API Route（`requireFacilityAccess`等）を経由せず直接呼び出�
 
 詳細: [`decisions/db-rls.md`](./decisions/db-rls.md#なぜ施設分離をrls--is_facility_member関数で実現したか)
 
+### 後付けFK列のカーディナリティを宣言しないまま放置する（issue #675）
+
+**チェック内容:** 既存テーブルへ `ALTER TABLE ... ADD COLUMN ... REFERENCES` で
+関係を後付けしたら、その場で「**1対1か1対多か**」を宣言する。
+1対1なら同じPRで UNIQUE 制約/部分UNIQUEインデックスを追加し、1対多なら SQL に
+`-- cardinality: many <理由>` と書く。
+
+**実際に起きたこと:** 2026-07-14 の `20260714000005_orders_history_prereqs.sql` が
+`loan_returns` へ `loan_order_id UUID REFERENCES loan_orders(id)` を追加したが、
+「loan_order 1件に返却は1件まで」というカーディナリティを誰も宣言しなかった。
+宣言されなかったので仕様書にも書かれず、テストにも現れず、レビューでも問われず、
+**84コミット・CI 1400本超を6週間通過し続けた**（2026-08-28 の issue #675 で発覚）。
+
+**なぜテストで気づけなかったか:** 当該RPCの migration テスト
+（`add_loan_order_id_to_loan_return_atomic_rpc.test.ts`）は
+`expect(sql).toContain('insert into loan_returns (facility_id, return_datetime, loan_order_id)')`
+という**実装で書いたSQL文字列を同じ文字列で照合する静的検証**だった。
+実装の鏡になっているため、書き忘れたものは原理的に検出できない。
+また `loan_returns` の統合テスト4本はすべて「**誰が**アクセスできるか」（RLS/IDOR）で、
+「**何件まで**許すか」の軸が1つも無かった。
+
+**教訓:** Assert は「あるべきものがある」だけでなく「**あってはならないものが無い**」を書く。
+DB制約は「破ろうとしたら拒否される」ことでしか検証できず、静的SQL検証では原理的に確かめられない。
+
+**機械検知:** `supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts`
+（`npm test` に含まれる）が、①カーディナリティ未宣言の後付けFK列、②制約を導入したのに
+そのテーブルが実DB統合テストに一度も登場しない migration、の2つを ratchet 方式で止める
+（既知の未対応分は `constraint-coverage-baseline.json` に固定し、新規発生のみを失敗させる）。
+判定ロジックは `.claude/workflows/lib/constraint-coverage.js`。
+
+`scripts/check-constraint-coverage.sh` は現存する穴を**怪しい順**に表示する。怪しさは
+機械判定（人の申告に依存しない）で、材料は「アプリのコード(`src/`)がそのテーブルを実際に
+読み書きしているか（＝業務データか裏方か）」「`facility_id` を持つか（＝施設境界に関わるか）」
+「制約の個数（＝書き忘れの余地の大きさ）」の3つ。判定結果は
+`constraint-coverage-baseline.json` にも書き写され、機械判定とズレるとratchetテストが落ちる
+（負債リストが「書いたきり陳腐化する」ことを防ぐ）。
+
+同じ検知の型を**認可の側にも適用**している（`findRlsTablesWithoutIdorTest`）。
+「RLSポリシーを書いた」＝「他人から守られている」ではなく、守られていることは
+**他人（別施設のユーザー）のIDで実際に叩いて弾かれる**ことでしか確かめられない。
+`CREATE POLICY` を持つのに `*-rls-idor.integration.test.ts` に一度も登場しないテーブルを
+同じく怪しい順に出し、新規発生をratchetで止める（下記「issue #24再発防止」と対になる機構）。
+
+**リストの読み方（重要）**: このリストは「**ここは確かめていない**」と言っているだけで、
+「**ここ以外は確かめてある**」とは言っていない。障害時に「載っているからまず疑う」に使うのは
+正しいが、「載っていないから違う」に使うと調査が遅れる。カバレッジ%と同じ誤読に注意する。
+
 ### 新しい認可プリミティブ導入時、既存のSECURITY DEFINER関数が取り残される（issue #458）
 
 **チェック内容:** `is_admin()`のような新しい認可プリミティブを導入し、既存のRLSポリシーを

--- a/scripts/check-constraint-coverage.sh
+++ b/scripts/check-constraint-coverage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DB制約に関する2つの穴を機械検知する（warning-only）。#675 の再発防止。
+#
+# 1. cardinality        : 既存テーブルへ後付けしたFK列に、1対1(UNIQUE)か1対多かの宣言が無い
+# 2. integrationCoverage: 制約を導入したのに、そのテーブルが実DB統合テストに一度も登場しない
+#
+# どちらも近似判定であり、ブロックせず警告のみ出す（docs/agents/actuator-inventory.md）。
+# 誤検知だと判断した場合は、migration の SQL に理由付きのマーカーを書いて除外する:
+#   -- cardinality: many <理由>
+#   -- integration-coverage: not-required <理由>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 既定は人間向けの「怪しい順」レポート。--json で機械可読な生データを出す。
+exec node "$REPO_ROOT/.claude/workflows/lib/constraint-coverage.js" "$@"

--- a/supabase/__tests__/integration/helpers/seed-rls-idor.ts
+++ b/supabase/__tests__/integration/helpers/seed-rls-idor.ts
@@ -407,3 +407,399 @@ export async function seedLoanReturnsRlsIdorFixtures(): Promise<SeedLoanReturnsR
 export async function cleanupLoanReturnsRlsIdorFixtures(fixtures: SeedLoanReturnsRlsIdorFixtures): Promise<void> {
   await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
 }
+
+export interface SeedOrderItemsRlsIdorFixtures {
+  facilityA: { id: string; name: string }
+  facilityB: { id: string; name: string }
+  userA: SeededUser
+  userB: SeededUser
+  /** 施設Aの親（明細のRLSはこの親経由のEXISTSで効く） */
+  parents: { caseOrderId: string; consumableOrderId: string; loanReturnId: string }
+  /** 施設Aの明細1件ずつ */
+  items: { caseOrderItemId: string; consumableOrderItemId: string; loanReturnItemId: string }
+  /** 明細をこの親にぶら下げようとする＝施設Aへの書き込みになる（insert検証用） */
+  consumableId: string
+  /** case_order_items.jan / loan_return_items.jan は products.jan へのFK */
+  jan: string
+  productId: string
+}
+
+/**
+ * 施設A・施設B、それぞれのユーザー、および施設Aの
+ * case_order_items / consumable_order_items / loan_return_items を1件ずつ作成する。
+ *
+ * WHY: これら3つの明細テーブルは **facility_id 列を持たない**。
+ *      施設境界は親テーブル経由の `EXISTS (... is_facility_member(o.facility_id) ...)`
+ *      で守られている（supabase/migrations/20260628010001_update_rls_admin.sql:71/85/113）。
+ *      親（case_orders / consumable_orders / loan_returns）にはIDOR統合テストがあるのに、
+ *      **子の明細には無かった**（`findRlsTablesWithoutIdorTest` の検知で発覚）。
+ *      親が守られていることは子が守られていることを意味しない。子は親をJOINせずに
+ *      直接叩けるため、独立した検証が要る。
+ *      `loan_order_items` だけは既にテストがあり、同型3件の横展開漏れだった。
+ */
+export async function seedOrderItemsRlsIdorFixtures(): Promise<SeedOrderItemsRlsIdorFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facilityA = await createFacility(serviceClient, `テスト施設A-${runId}`)
+  const facilityB = await createFacility(serviceClient, `テスト施設B-${runId}`)
+
+  const userA = await createSeededUser(serviceClient, 'rls-idor-order-items-user-a', facilityA.id)
+  const userB = await createSeededUser(serviceClient, 'rls-idor-order-items-user-b', facilityB.id)
+
+  const insertOne = async <T extends string>(table: T, row: Record<string, unknown>) => {
+    const { data, error } = await serviceClient.from(table).insert(row).select('id').single()
+    if (error || !data) {
+      throw new Error(`[seed-rls-idor] ${table} シード作成失敗: ${error?.message}`)
+    }
+    return data.id as string
+  }
+
+  const caseOrderId = await insertOne('case_orders', {
+    facility_id: facilityA.id,
+    case_datetime: new Date().toISOString(),
+    procedure_name: 'シード用術式',
+    patient_id: 'IDOR-TEST-PATIENT-0000',
+    patient_initials: 'IDORテスト患者',
+    gender: 'other',
+    doctor_name: 'IDORテスト医師',
+  })
+  const consumableOrderId = await insertOne('consumable_orders', { facility_id: facilityA.id })
+  const loanReturnId = await insertOne('loan_returns', {
+    facility_id: facilityA.id,
+    return_datetime: new Date().toISOString(),
+  })
+  const consumableId = await insertOne('consumables', {
+    facility_id: facilityA.id,
+    name: `シード用消耗品-${runId}`,
+    purpose: 'IDORテスト',
+  })
+
+  // case_order_items.jan / loan_return_items.jan は products.jan へのFK
+  // （20260714000004_link_consumables_jan_and_validate_fk.sql）。実在する製品が要る
+  const jan = `jan-items-${runId}`
+  const productId = await insertOne('products', {
+    jan,
+    ref: `ref-items-${runId}`,
+    name: `シード用製品-${runId}`,
+  })
+
+  const caseOrderItemId = await insertOne('case_order_items', {
+    case_order_id: caseOrderId,
+    jan,
+    quantity: 1,
+  })
+  const consumableOrderItemId = await insertOne('consumable_order_items', {
+    consumable_order_id: consumableOrderId,
+    consumable_id: consumableId,
+    quantity: 1,
+  })
+  const loanReturnItemId = await insertOne('loan_return_items', {
+    loan_return_id: loanReturnId,
+    jan,
+    quantity: 1,
+  })
+
+  return {
+    facilityA,
+    facilityB,
+    userA,
+    userB,
+    parents: { caseOrderId, consumableOrderId, loanReturnId },
+    items: { caseOrderItemId, consumableOrderItemId, loanReturnItemId },
+    consumableId,
+    jan,
+    productId,
+  }
+}
+
+export async function cleanupOrderItemsRlsIdorFixtures(
+  fixtures: SeedOrderItemsRlsIdorFixtures
+): Promise<void> {
+  const serviceClient = createServiceRoleClient()
+  // facilities の削除で親（case_orders等）が消え、明細もCASCADEで消える。
+  // products は施設に紐づかないので個別に消す（明細が消えた後でないとFKで残る）
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
+  await serviceClient.from('products').delete().eq('id', fixtures.productId)
+}
+
+export interface SeedPriceHistoriesFixtures extends SeedHospitalPricesRlsIdorFixtures {
+  /** entity_type='hospital_price'（施設Aの価格の履歴＝施設Bから見えてはいけない） */
+  facilityScopedHistory: { id: string }
+  /** entity_type='distributor_product'（マスタの履歴＝全員が見てよい。設計どおり） */
+  masterHistory: { id: string }
+}
+
+/**
+ * price_histories の RLS/CHECK 検証用シード。hospital_prices のシードを土台にする。
+ *
+ * WHY: price_histories はポリモーフィックで、entity_type によって施設スコープの
+ *      有無が変わる（20260628010001_update_rls_admin.sql:130）。
+ *        - 'hospital_price'      → 親 hospital_prices の施設をチェック（＝施設スコープあり）
+ *        - 'distributor_product' → true（＝マスタなので全員可）
+ *      施設ごとの仕入価格の**変更履歴**であり、現在値と同じ機微度を持つのに
+ *      RLS/IDOR統合テストもCHECK制約の実DB検証も無かった。
+ *      INSERT はトリガー（SECURITY DEFINER）経由のみで、シードは service role で行う。
+ */
+export async function seedPriceHistoriesFixtures(): Promise<SeedPriceHistoriesFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const base = await seedHospitalPricesRlsIdorFixtures()
+
+  // price_histories への直接INSERTは service_role でも不可（GRANT が SELECT のみ）。
+  // 履歴は SECURITY DEFINER トリガー経由でしか作られないため、親を実際に更新して作る。
+  // 結果として「本番と同じ経路」でシードすることになる。
+  const findHistory = async (entityType: string, entityId: string) => {
+    const { data, error } = await serviceClient
+      .from('price_histories')
+      .select('id')
+      .eq('entity_type', entityType)
+      .eq('entity_id', entityId)
+      .limit(1)
+      .single()
+    if (error || !data) {
+      throw new Error(
+        `[seed-rls-idor] price_histories がトリガーで作られていない (${entityType}): ${error?.message}`
+      )
+    }
+    return { id: data.id as string }
+  }
+
+  const { error: hpUpdateError } = await serviceClient
+    .from('hospital_prices')
+    .update({ purchase_price: base.hospitalPriceA.purchasePrice + 1 })
+    .eq('id', base.hospitalPriceA.id)
+  if (hpUpdateError) {
+    throw new Error(`[seed-rls-idor] hospital_prices 更新失敗: ${hpUpdateError.message}`)
+  }
+
+  const { error: dpUpdateError } = await serviceClient
+    .from('distributor_products')
+    .update({ reimbursement_price: 999 })
+    .eq('id', base.distributorProduct.id)
+  if (dpUpdateError) {
+    throw new Error(`[seed-rls-idor] distributor_products 更新失敗: ${dpUpdateError.message}`)
+  }
+
+  const facilityScopedHistory = await findHistory('hospital_price', base.hospitalPriceA.id)
+  const masterHistory = await findHistory('distributor_product', base.distributorProduct.id)
+
+  return { ...base, facilityScopedHistory, masterHistory }
+}
+
+export async function cleanupPriceHistoriesFixtures(
+  fixtures: SeedPriceHistoriesFixtures
+): Promise<void> {
+  const serviceClient = createServiceRoleClient()
+  // price_histories は hospital_prices/distributor_products へのCASCADEを持たない
+  // （FKは NOT VALID で ON DELETE 指定なし）ため、先に自分で消す
+  await serviceClient
+    .from('price_histories')
+    .delete()
+    .eq('distributor_product_id', fixtures.distributorProduct.id)
+  await cleanupHospitalPricesRlsIdorFixtures(fixtures)
+}
+
+export interface SeedProductCompatibilitiesFixtures {
+  categoryA: { id: string }
+  categoryB: { id: string }
+  /** UUID文字列の辞書順で small < large になるよう並べ替え済み */
+  productSmall: { id: string }
+  productLarge: { id: string }
+}
+
+/**
+ * product_compatibilities のDB制約検証用に、カテゴリ2件と製品2件を作成する。
+ *
+ * WHY: product_compatibilities は CHECK 2つ・複合UNIQUE・FK 3つを持ちながら、
+ *      実DBでの検証が一度も無かった（`findUncoveredConstraintMigrations` の検知で発覚）。
+ *      特に `ordered_pair CHECK (product_id_1 < product_id_2)` は「(a,b)と(b,a)を
+ *      同一視する」という効きの強い不変条件で、静的SQL検証では
+ *      「その文字列が書いてある」ことしか確かめられない。
+ *      制約はRLSと異なり service role でもバイパスされないため、ユーザーは不要。
+ */
+export async function seedProductCompatibilitiesFixtures(): Promise<SeedProductCompatibilitiesFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const insertCategory = async (suffix: string) => {
+    const { data, error } = await serviceClient
+      .from('categories')
+      .insert({ name: `テストカテゴリ${suffix}-${runId}` })
+      .select('id')
+      .single()
+    if (error || !data) {
+      throw new Error(`[seed-rls-idor] categories シード作成失敗: ${error?.message}`)
+    }
+    return { id: data.id as string }
+  }
+
+  const insertProduct = async (suffix: string) => {
+    const { data, error } = await serviceClient
+      .from('products')
+      .insert({
+        jan: `jan-compat-${suffix}-${runId}`,
+        ref: `ref-compat-${suffix}-${runId}`,
+        name: `テスト製品${suffix}-${runId}`,
+      })
+      .select('id')
+      .single()
+    if (error || !data) {
+      throw new Error(`[seed-rls-idor] products シード作成失敗: ${error?.message}`)
+    }
+    return { id: data.id as string }
+  }
+
+  const categoryA = await insertCategory('A')
+  const categoryB = await insertCategory('B')
+  const p1 = await insertProduct('1')
+  const p2 = await insertProduct('2')
+
+  // ordered_pair CHECK は UUID の大小比較なので、採番結果に依存せず
+  // 「小さい方」「大きい方」を確定させておく
+  const [productSmall, productLarge] = p1.id < p2.id ? [p1, p2] : [p2, p1]
+
+  return { categoryA, categoryB, productSmall, productLarge }
+}
+
+export async function cleanupProductCompatibilitiesFixtures(
+  fixtures: SeedProductCompatibilitiesFixtures
+): Promise<void> {
+  const serviceClient = createServiceRoleClient()
+  // products / categories の削除で product_compatibilities は CASCADE で消える
+  await serviceClient
+    .from('products')
+    .delete()
+    .in('id', [fixtures.productSmall.id, fixtures.productLarge.id])
+  await serviceClient
+    .from('categories')
+    .delete()
+    .in('id', [fixtures.categoryA.id, fixtures.categoryB.id])
+}
+
+export interface SeedHospitalPricesRlsIdorFixtures {
+  facilityA: { id: string; name: string }
+  facilityB: { id: string; name: string }
+  userA: SeededUser
+  userB: SeededUser
+  distributorProduct: { id: string }
+  /**
+   * insert検証専用の別商品。
+   * WHY: hospital_prices は unique(distributor_product_id, facility_id) を持つため、
+   *      シード済みと同じ組み合わせでinsertを試すと**誰が呼んでもUNIQUE違反**になり、
+   *      「RLSで拒否された」ことを検証できない（実際にこの罠を踏んだ）。
+   *      未使用の組み合わせを使うことで、拒否の理由をRLSに限定する。
+   */
+  distributorProductForInsert: { id: string }
+  /** 後始末用（facilities のCASCADEでは消えないマスタ系） */
+  masters: { productId: string; categoryId: string }
+  hospitalPriceA: { id: string; purchasePrice: number }
+}
+
+/**
+ * 施設A・施設B、それぞれのユーザー、および施設Aの hospital_prices 1件を作成する。
+ *
+ * WHY: hospital_prices は「施設ごとの購入価格・納入価格」という、施設をまたいで
+ *      漏れてはいけない代表的なデータでありながら、RLS/IDOR統合テストが欠落していた
+ *      （`findRlsTablesWithoutIdorTest` の検知で発覚）。
+ *      hospital_prices は distributor_products → products / categories を必要とするため、
+ *      他のシードより前提マスタが1段深い。
+ */
+export async function seedHospitalPricesRlsIdorFixtures(): Promise<SeedHospitalPricesRlsIdorFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facilityA = await createFacility(serviceClient, `テスト施設A-${runId}`)
+  const facilityB = await createFacility(serviceClient, `テスト施設B-${runId}`)
+
+  const userA = await createSeededUser(serviceClient, 'rls-idor-hospital-price-user-a', facilityA.id)
+  const userB = await createSeededUser(serviceClient, 'rls-idor-hospital-price-user-b', facilityB.id)
+
+  const { data: category, error: categoryError } = await serviceClient
+    .from('categories')
+    .insert({ name: `テストカテゴリ-${runId}` })
+    .select('id')
+    .single()
+  if (categoryError || !category) {
+    throw new Error(`[seed-rls-idor] categories シード作成失敗: ${categoryError?.message}`)
+  }
+
+  const { data: product, error: productError } = await serviceClient
+    .from('products')
+    .insert({ jan: `jan-${runId}`, ref: `ref-${runId}`, name: `テスト製品-${runId}` })
+    .select('id')
+    .single()
+  if (productError || !product) {
+    throw new Error(`[seed-rls-idor] products シード作成失敗: ${productError?.message}`)
+  }
+
+  const { data: distributorProduct, error: dpError } = await serviceClient
+    .from('distributor_products')
+    .insert({
+      product_id: product.id as string,
+      category_id: category.id as string,
+      maker: 'テストメーカー',
+      supplier: 'テスト販売業者',
+      name: `テスト取扱商品-${runId}`,
+    })
+    .select('id')
+    .single()
+  if (dpError || !distributorProduct) {
+    throw new Error(`[seed-rls-idor] distributor_products シード作成失敗: ${dpError?.message}`)
+  }
+
+  const { data: dpForInsert, error: dpForInsertError } = await serviceClient
+    .from('distributor_products')
+    .insert({
+      product_id: product.id as string,
+      category_id: category.id as string,
+      maker: 'テストメーカー',
+      supplier: 'テスト販売業者',
+      name: `テスト取扱商品(insert検証用)-${runId}`,
+    })
+    .select('id')
+    .single()
+  if (dpForInsertError || !dpForInsert) {
+    throw new Error(
+      `[seed-rls-idor] distributor_products(insert検証用) シード作成失敗: ${dpForInsertError?.message}`
+    )
+  }
+
+  // 施設Aの価格。施設Bのユーザーからは一切見えてはいけない値。
+  const purchasePrice = 12345
+  const { data: hospitalPrice, error: hpError } = await serviceClient
+    .from('hospital_prices')
+    .insert({
+      distributor_product_id: distributorProduct.id as string,
+      facility_id: facilityA.id,
+      purchase_price: purchasePrice,
+      delivery_price: 23456,
+    })
+    .select('id')
+    .single()
+  if (hpError || !hospitalPrice) {
+    throw new Error(`[seed-rls-idor] hospital_prices シード作成失敗: ${hpError?.message}`)
+  }
+
+  return {
+    facilityA,
+    facilityB,
+    userA,
+    userB,
+    distributorProduct: { id: distributorProduct.id as string },
+    distributorProductForInsert: { id: dpForInsert.id as string },
+    masters: { productId: product.id as string, categoryId: category.id as string },
+    hospitalPriceA: { id: hospitalPrice.id as string, purchasePrice },
+  }
+}
+
+export async function cleanupHospitalPricesRlsIdorFixtures(
+  fixtures: SeedHospitalPricesRlsIdorFixtures
+): Promise<void> {
+  const serviceClient = createServiceRoleClient()
+  // facilities の削除で hospital_prices は CASCADE で消えるが、
+  // products / categories は施設に紐づかないため個別に消す（products の削除で
+  // distributor_products も CASCADE で消える）
+  await cleanupFacilitiesAndUsers(fixtures.userA, fixtures.userB, fixtures.facilityA, fixtures.facilityB)
+  await serviceClient.from('products').delete().eq('id', fixtures.masters.productId)
+  await serviceClient.from('categories').delete().eq('id', fixtures.masters.categoryId)
+}

--- a/supabase/__tests__/integration/helpers/seed-rls-idor.ts
+++ b/supabase/__tests__/integration/helpers/seed-rls-idor.ts
@@ -85,7 +85,9 @@ export async function createFacility(serviceClient: SupabaseClient, dummyName: s
 export async function createSeededUser(
   serviceClient: SupabaseClient,
   emailPrefix: string,
-  facilityId: string
+  facilityId: string,
+  /** 既定は staff（従来の呼び出し側の挙動を変えない）。is_admin() は role='admin' で真になる */
+  role: 'staff' | 'admin' | 'viewer' = 'staff'
 ): Promise<SeededUser> {
   const email = `${emailPrefix}-${randomUUID()}@example.test`
 
@@ -101,7 +103,7 @@ export async function createSeededUser(
 
   const { error: linkError } = await serviceClient
     .from('user_facilities')
-    .insert({ user_id: userId, facility_id: facilityId, role: 'staff' })
+    .insert({ user_id: userId, facility_id: facilityId, role })
   if (linkError) {
     throw new Error(`[seed-rls-idor] user_facilities作成失敗 (${email}): ${linkError.message}`)
   }
@@ -597,6 +599,102 @@ export async function cleanupPriceHistoriesFixtures(
     .delete()
     .eq('distributor_product_id', fixtures.distributorProduct.id)
   await cleanupHospitalPricesRlsIdorFixtures(fixtures)
+}
+
+export interface SeedAdminBoundaryFixtures {
+  facility: { id: string; name: string }
+  /** role='admin'。is_admin() が真になる */
+  adminUser: SeededUser
+  /** role='staff'。施設のメンバーだが admin ではない */
+  staffUser: SeededUser
+  /** 既存行の更新・削除を試すための種 */
+  existing: { categoryId: string; productId: string; distributorProductId: string }
+  /**
+   * product_compatibilities の insert検証用。UUID辞書順で small < large に整列済み。
+   * WHY: 同じ製品IDを2つ渡すと `no_self_compat` CHECK で**誰が呼んでも失敗**し、
+   *      「adminでないから拒否された」ことを検証できない（実際にこの罠を踏んだ）。
+   *      逆順でも `ordered_pair` CHECK で同様に失敗するため、正しい順序で渡す。
+   */
+  compatPair: { small: string; large: string }
+  productId2: string
+  runId: string
+}
+
+/**
+ * admin境界（adminだけが書けるマスタ）の検証用シード。
+ *
+ * WHY: categories / distributor_products / products / product_compatibilities / facilities は
+ *      SELECT が `USING (true)`（テナント非分離）で、書き込みだけが `is_admin()` に限定される。
+ *      施設境界の約束が無いのでIDOR軸からは除外したが、**代わりに admin 境界という別の
+ *      約束がある**。そこを一度も試していなかった（`findAdminOnlyTablesWithoutTest` で発覚）。
+ *      is_admin() は user_facilities.role='admin' を見るだけなので、シードは role 違いの
+ *      ユーザーを2人作るだけでよい。
+ */
+export async function seedAdminBoundaryFixtures(): Promise<SeedAdminBoundaryFixtures> {
+  const serviceClient = createServiceRoleClient()
+  const runId = randomUUID()
+
+  const facility = await createFacility(serviceClient, `テスト施設-${runId}`)
+  const adminUser = await createSeededUser(serviceClient, 'admin-boundary-admin', facility.id, 'admin')
+  const staffUser = await createSeededUser(serviceClient, 'admin-boundary-staff', facility.id, 'staff')
+
+  const insertOne = async (table: string, row: Record<string, unknown>) => {
+    const { data, error } = await serviceClient.from(table).insert(row).select('id').single()
+    if (error || !data) {
+      throw new Error(`[seed-rls-idor] ${table} シード作成失敗: ${error?.message}`)
+    }
+    return data.id as string
+  }
+
+  const categoryId = await insertOne('categories', { name: `admin境界テストカテゴリ-${runId}` })
+  const productId = await insertOne('products', {
+    jan: `jan-admin-${runId}`,
+    ref: `ref-admin-${runId}`,
+    name: `admin境界テスト製品-${runId}`,
+  })
+  const distributorProductId = await insertOne('distributor_products', {
+    product_id: productId,
+    category_id: categoryId,
+    maker: 'テストメーカー',
+    supplier: 'テスト販売業者',
+    name: `admin境界テスト取扱商品-${runId}`,
+  })
+
+  // product_compatibilities の insert検証には**別の製品**が要る（自己参照禁止のため）
+  const productId2 = await insertOne('products', {
+    jan: `jan-admin2-${runId}`,
+    ref: `ref-admin2-${runId}`,
+    name: `admin境界テスト製品2-${runId}`,
+  })
+  const [small, large] =
+    productId < productId2 ? [productId, productId2] : [productId2, productId]
+
+  return {
+    facility,
+    adminUser,
+    staffUser,
+    existing: { categoryId, productId, distributorProductId },
+    compatPair: { small, large },
+    productId2,
+    runId,
+  }
+}
+
+export async function cleanupAdminBoundaryFixtures(
+  fixtures: SeedAdminBoundaryFixtures
+): Promise<void> {
+  const serviceClient = createServiceRoleClient()
+  await serviceClient.auth.admin.deleteUser(fixtures.adminUser.id)
+  await serviceClient.auth.admin.deleteUser(fixtures.staffUser.id)
+  await serviceClient.from('facilities').delete().eq('id', fixtures.facility.id)
+  // products の削除で distributor_products / product_compatibilities も CASCADE で消える
+  await serviceClient
+    .from('products')
+    .delete()
+    .in('id', [fixtures.existing.productId, fixtures.productId2])
+  await serviceClient.from('categories').delete().eq('id', fixtures.existing.categoryId)
+  // adminが対照テストで作った行（名前に runId を含む）も後始末する
+  await serviceClient.from('categories').delete().like('name', `%${fixtures.runId}%`)
 }
 
 export interface SeedProductCompatibilitiesFixtures {

--- a/supabase/__tests__/integration/hospital-prices-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/hospital-prices-rls-idor.integration.test.ts
@@ -1,0 +1,142 @@
+// supabase/__tests__/integration/hospital-prices-rls-idor.integration.test.ts
+// WHY: hospital_prices は「施設ごとの購入価格・納入価格」であり、他の医療機関に
+//      漏れてはいけない代表的なデータ。RLSポリシー facility_member_or_admin
+//      （supabase/migrations/20260628010001_update_rls_admin.sql:35）は書かれていたが、
+//      **他人（別施設のユーザー）のIDで実際に叩いて弾かれることを一度も確かめていなかった**
+//      （`findRlsTablesWithoutIdorTest` の検知で発覚。
+//        docs/agents/known-failure-patterns.md「後付けFK列のカーディナリティ…（issue #675）」
+//        および「動いたからOKで…見逃す（issue #24再発防止）」参照）。
+//
+//      「ポリシーを書いた」＝「守られている」ではない。守られていることは、
+//      破ろうとして弾かれることでしか確かめられない。
+//      モック・静的SQL検証ではなく、本物のローカルSupabaseへの接続を伴う。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupHospitalPricesRlsIdorFixtures,
+  seedHospitalPricesRlsIdorFixtures,
+  type SeedHospitalPricesRlsIdorFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('hospital_prices RLS/IDOR', () => {
+  let fixtures: SeedHospitalPricesRlsIdorFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedHospitalPricesRlsIdorFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupHospitalPricesRlsIdorFixtures(fixtures)
+    }
+  })
+
+  describe('他施設のユーザー（ユーザーB）から見えない・触れない', () => {
+    it('施設Aの仕入価格を1件も取得できない', async () => {
+      const { data, error } = await fixtures.userB.client
+        .from('hospital_prices')
+        .select('*')
+        .eq('facility_id', fixtures.facilityA.id)
+
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('主キーを直接指定しても取得できない（IDを知っていても漏れない）', async () => {
+      // WHY: facility_id で絞らず id 直指定 = 典型的なIDOR。行フィルタではなく
+      //      RLSで止まっていることを確認する
+      const { data, error } = await fixtures.userB.client
+        .from('hospital_prices')
+        .select('*')
+        .eq('id', fixtures.hospitalPriceA.id)
+
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('施設Aの価格を書き換えられない（更新が1行も反映されない）', async () => {
+      const { data: updated } = await fixtures.userB.client
+        .from('hospital_prices')
+        .update({ purchase_price: 1 })
+        .eq('id', fixtures.hospitalPriceA.id)
+        .select('id')
+
+      expect(updated ?? []).toEqual([])
+
+      // 実際に元の値が保たれていることを、権限のあるユーザーA側から確認する
+      const { data: after } = await fixtures.userA.client
+        .from('hospital_prices')
+        .select('purchase_price')
+        .eq('id', fixtures.hospitalPriceA.id)
+        .single()
+
+      expect(after?.purchase_price).toBe(fixtures.hospitalPriceA.purchasePrice)
+    })
+
+    it('施設Aの価格を削除できない（削除後も行が残る）', async () => {
+      await fixtures.userB.client
+        .from('hospital_prices')
+        .delete()
+        .eq('id', fixtures.hospitalPriceA.id)
+
+      const { data: after } = await fixtures.userA.client
+        .from('hospital_prices')
+        .select('id')
+        .eq('id', fixtures.hospitalPriceA.id)
+
+      expect(after).toHaveLength(1)
+    })
+
+    it('施設Aを指定して新しい価格を作成できない（WITH CHECKで拒否される）', async () => {
+      // WHY: シード済みと同じ distributor_product を使うと unique(distributor_product_id,
+      //      facility_id) 違反で**誰が呼んでも失敗**し、RLSを検証できない（実際に踏んだ）。
+      //      未使用の商品を使い、さらにエラーコードが 42501（権限不足）であることまで
+      //      確認して、拒否の理由をRLSに限定する
+      const { data, error } = await fixtures.userB.client
+        .from('hospital_prices')
+        .insert({
+          distributor_product_id: fixtures.distributorProductForInsert.id,
+          facility_id: fixtures.facilityA.id,
+          purchase_price: 99,
+          delivery_price: 99,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+  })
+
+  describe('自施設のユーザー（ユーザーA）は通常どおり扱える', () => {
+    it('自施設の価格を取得でき、シード済みの値が読める', async () => {
+      // WHY: 件数で断定すると、同じdescribe内の作成テストが先に走った場合に壊れる
+      //      （テスト順序に依存させない）。シード済みの行が含まれることを見る
+      const { data, error } = await fixtures.userA.client
+        .from('hospital_prices')
+        .select('id, purchase_price')
+        .eq('facility_id', fixtures.facilityA.id)
+
+      expect(error).toBeNull()
+      const seeded = data?.find((row) => row.id === fixtures.hospitalPriceA.id)
+      expect(seeded?.purchase_price).toBe(fixtures.hospitalPriceA.purchasePrice)
+    })
+
+    it('自施設を指定した新規作成は成功する（拒否がRLS由来であることの対照）', async () => {
+      // WHY: 上の「ユーザーBは作成できない」が本当にRLSのせいかを保証する対照実験。
+      //      これが無いと、payloadの不備で常に失敗しているだけでも気づけない
+      const { data, error } = await fixtures.userA.client
+        .from('hospital_prices')
+        .insert({
+          distributor_product_id: fixtures.distributorProductForInsert.id,
+          facility_id: fixtures.facilityA.id,
+          purchase_price: 111,
+          delivery_price: 222,
+        })
+        .select('id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.id).toBeTruthy()
+    })
+  })
+})

--- a/supabase/__tests__/integration/master-tables-admin-boundary.integration.test.ts
+++ b/supabase/__tests__/integration/master-tables-admin-boundary.integration.test.ts
@@ -1,0 +1,146 @@
+// supabase/__tests__/integration/master-tables-admin-boundary.integration.test.ts
+// WHY: categories / distributor_products / products / product_compatibilities / facilities は
+//      SELECT が `USING (true)`（意図的にテナント非分離）で、**書き込みだけが is_admin() に
+//      限定される**。施設境界の約束が無いためRLS/IDOR軸からは除外したが、
+//      「除外して終わり」にすると面倒な指摘を逃がしただけになる。
+//      これらが実際に守っているのは **admin境界** であり、そこを一度も試していなかった
+//      （`findAdminOnlyTablesWithoutTest` で5/5テーブル未検証と判明）。
+//
+//      is_admin() は user_facilities.role='admin' を見るだけなので
+//      （20260628010000_add_role_to_user_facilities.sql:30）、
+//      施設のメンバーではあるが admin ではない staff ユーザーとの差分で検証する。
+//      「施設外だから書けない」ではなく「adminでないから書けない」ことを見る点が
+//      IDORテストとの違い。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupAdminBoundaryFixtures,
+  seedAdminBoundaryFixtures,
+  type SeedAdminBoundaryFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('マスタテーブルのadmin境界', () => {
+  let fixtures: SeedAdminBoundaryFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedAdminBoundaryFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupAdminBoundaryFixtures(fixtures)
+    }
+  })
+
+  describe('staff（施設メンバーだがadminではない）は書き込めない', () => {
+    it('categories を作成できない', async () => {
+      const { data, error } = await fixtures.staffUser.client
+        .from('categories')
+        .insert({ name: `staffが作ったカテゴリ-${fixtures.runId}` })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+
+    it('categories を更新できない（更新が1行も反映されない）', async () => {
+      const { data: updated } = await fixtures.staffUser.client
+        .from('categories')
+        .update({ description: 'staffによる改ざん' })
+        .eq('id', fixtures.existing.categoryId)
+        .select('id')
+
+      expect(updated ?? []).toEqual([])
+    })
+
+    it('products を作成できない', async () => {
+      const { data, error } = await fixtures.staffUser.client
+        .from('products')
+        .insert({
+          jan: `jan-staff-${fixtures.runId}`,
+          ref: `ref-staff-${fixtures.runId}`,
+          name: 'staffが作った製品',
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+
+    it('distributor_products を更新できない（価格の改ざんが通らない）', async () => {
+      // WHY: reimbursement_price はトリガーで price_histories に履歴が残る値。
+      //      ここが通ると、権限のないユーザーが償還価格を書き換えられる
+      const { data: updated } = await fixtures.staffUser.client
+        .from('distributor_products')
+        .update({ reimbursement_price: 1 })
+        .eq('id', fixtures.existing.distributorProductId)
+        .select('id')
+
+      expect(updated ?? []).toEqual([])
+    })
+
+    it('product_compatibilities を作成できない', async () => {
+      // WHY: 同じ製品IDを2つ渡すと no_self_compat CHECK で誰が呼んでも失敗し、
+      //      「adminでないから拒否された」ことを検証できない（実際にこの罠を踏んだ）。
+      //      正しい順序の別製品ペアを使い、エラーコードが 42501（権限不足）であることまで見る
+      const { data, error } = await fixtures.staffUser.client
+        .from('product_compatibilities')
+        .insert({
+          category_id: fixtures.existing.categoryId,
+          product_id_1: fixtures.compatPair.small,
+          product_id_2: fixtures.compatPair.large,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+
+    it('facilities を作成できない（admin_insert ポリシー）', async () => {
+      const { data, error } = await fixtures.staffUser.client
+        .from('facilities')
+        .insert({ name: `staffが作った施設-${fixtures.runId}` })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+
+    it('マスタの参照はできる（テナント非分離。設計どおり）', async () => {
+      // WHY: これが取れないなら「adminでないから書けない」ではなく
+      //      「そもそも何もできない」だけで、上の6件は何も証明していない
+      const { data, error } = await fixtures.staffUser.client
+        .from('categories')
+        .select('id')
+        .eq('id', fixtures.existing.categoryId)
+
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+  })
+
+  describe('adminは書き込める（対照）', () => {
+    it('categories を作成できる', async () => {
+      const { data, error } = await fixtures.adminUser.client
+        .from('categories')
+        .insert({ name: `adminが作ったカテゴリ-${fixtures.runId}` })
+        .select('id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.id).toBeTruthy()
+    })
+
+    it('distributor_products を更新できる', async () => {
+      const { data, error } = await fixtures.adminUser.client
+        .from('distributor_products')
+        .update({ reimbursement_price: 777 })
+        .eq('id', fixtures.existing.distributorProductId)
+        .select('id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.id).toBe(fixtures.existing.distributorProductId)
+    })
+  })
+})

--- a/supabase/__tests__/integration/order-items-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/order-items-rls-idor.integration.test.ts
@@ -1,0 +1,144 @@
+// supabase/__tests__/integration/order-items-rls-idor.integration.test.ts
+// WHY: case_order_items / consumable_order_items / loan_return_items は
+//      **facility_id 列を持たない**。施設境界は親テーブル経由の
+//      `EXISTS (... is_facility_member(o.facility_id) ...)` だけで守られている
+//      （supabase/migrations/20260628010001_update_rls_admin.sql:71/85/113）。
+//
+//      親（case_orders / consumable_orders / loan_returns）にはIDOR統合テストがあるのに、
+//      子の明細3つには一つも無かった（`findRlsTablesWithoutIdorTest` の検知で発覚。
+//      `loan_order_items` だけテストがあり、同型3件の横展開漏れだった）。
+//      **親が守られていることは、子が守られていることを意味しない**。
+//      子は親をJOINせずPostgREST経由で直接叩けるため、独立した検証が要る。
+//
+//      なお怪しさ判定は当初これらを medium と誤って過小評価していた
+//      （facility_id 列の有無しか見ていなかったため）。ポリシー本文の
+//      is_facility_member も見るよう修正済み。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupOrderItemsRlsIdorFixtures,
+  seedOrderItemsRlsIdorFixtures,
+  type SeedOrderItemsRlsIdorFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('明細テーブル（親経由で施設スコープ）RLS/IDOR', () => {
+  let fixtures: SeedOrderItemsRlsIdorFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedOrderItemsRlsIdorFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupOrderItemsRlsIdorFixtures(fixtures)
+    }
+  })
+
+  // WHY: 3テーブルを describe.each で回すため、テーブル名と行の型の対応が失われる。
+  //      行は列構成が異なるので、共通の緩い型に寄せる（テストの意図は型検査ではない）
+  type ItemCase = {
+    table: 'case_order_items' | 'consumable_order_items' | 'loan_return_items'
+    itemIdOf: (f: SeedOrderItemsRlsIdorFixtures) => string
+    newRowFor: (f: SeedOrderItemsRlsIdorFixtures) => Record<string, unknown>
+  }
+
+  const cases: ItemCase[] = [
+    {
+      table: 'case_order_items' as const,
+      itemIdOf: (f: SeedOrderItemsRlsIdorFixtures) => f.items.caseOrderItemId,
+      newRowFor: (f: SeedOrderItemsRlsIdorFixtures) => ({
+        case_order_id: f.parents.caseOrderId,
+        jan: f.jan,
+        quantity: 1,
+      }),
+    },
+    {
+      table: 'consumable_order_items' as const,
+      itemIdOf: (f: SeedOrderItemsRlsIdorFixtures) => f.items.consumableOrderItemId,
+      newRowFor: (f: SeedOrderItemsRlsIdorFixtures) => ({
+        consumable_order_id: f.parents.consumableOrderId,
+        consumable_id: f.consumableId,
+        quantity: 1,
+      }),
+    },
+    {
+      table: 'loan_return_items' as const,
+      itemIdOf: (f: SeedOrderItemsRlsIdorFixtures) => f.items.loanReturnItemId,
+      newRowFor: (f: SeedOrderItemsRlsIdorFixtures) => ({
+        loan_return_id: f.parents.loanReturnId,
+        jan: f.jan,
+        quantity: 1,
+      }),
+    },
+  ]
+
+  describe.each(cases)('$table', ({ table, itemIdOf, newRowFor }) => {
+    it('他施設のユーザーは1件も取得できない', async () => {
+      const { data, error } = await fixtures.userB.client.from(table).select('*')
+
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('他施設のユーザーは主キー直指定でも取得できない（IDを知っていても漏れない）', async () => {
+      const { data, error } = await fixtures.userB.client
+        .from(table)
+        .select('*')
+        .eq('id', itemIdOf(fixtures))
+
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('他施設のユーザーは更新できない（更新が1行も反映されない）', async () => {
+      // WHY: 3テーブルとも quantity を持つ。ポリシーは FOR ALL なので
+      //      SELECT/INSERT/DELETE だけ確かめて UPDATE を落とすとカバー範囲が不揃いになる
+      const { data: updated } = await fixtures.userB.client
+        .from(table)
+        .update({ quantity: 999 })
+        .eq('id', itemIdOf(fixtures))
+        .select('id')
+
+      expect(updated ?? []).toEqual([])
+
+      const { data: after } = await fixtures.userA.client
+        .from(table)
+        .select('quantity')
+        .eq('id', itemIdOf(fixtures))
+        .single()
+      expect(after?.quantity).toBe(1) // シード時の値
+    })
+
+    it('他施設のユーザーは削除できない（削除後も行が残る）', async () => {
+      await fixtures.userB.client.from(table).delete().eq('id', itemIdOf(fixtures))
+
+      const { data: after } = await fixtures.userA.client
+        .from(table)
+        .select('id')
+        .eq('id', itemIdOf(fixtures))
+      expect(after).toHaveLength(1)
+    })
+
+    it('他施設のユーザーは施設Aの親にぶら下げて作成できない（WITH CHECKで拒否）', async () => {
+      const { data, error } = await fixtures.userB.client
+        .from(table)
+        .insert(newRowFor(fixtures))
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+
+    it('自施設のユーザーはシード済みの明細を取得できる（対照）', async () => {
+      // WHY: 上の「見えない」が本当にRLSのせいかを保証する対照実験。
+      //      これが無いと、テーブルが空なだけでも全部greenになる
+      const { data, error } = await fixtures.userA.client
+        .from(table)
+        .select('id')
+        .eq('id', itemIdOf(fixtures))
+
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+  })
+})

--- a/supabase/__tests__/integration/price-histories-rls-idor.integration.test.ts
+++ b/supabase/__tests__/integration/price-histories-rls-idor.integration.test.ts
@@ -1,0 +1,149 @@
+// supabase/__tests__/integration/price-histories-rls-idor.integration.test.ts
+// WHY: price_histories は「施設ごとの仕入価格の変更履歴」であり、現在値
+//      （hospital_prices）と同じ機微度を持つ。にもかかわらず RLS/IDOR統合テストも
+//      CHECK制約の実DB検証も無かった（`findRlsTablesWithoutIdorTest` と
+//      `findUncoveredConstraintMigrations` の両方に出ていた唯一のテーブル）。
+//
+//      ポリシーはポリモーフィックで、entity_type によって施設スコープの有無が変わる
+//      （20260628010001_update_rls_admin.sql:130）:
+//        - 'hospital_price'      → 親 hospital_prices の施設をチェックする
+//        - 'distributor_product' → true（マスタなので全員可。設計どおり）
+//      「全部見えない」でも「全部見える」でもない**分岐**なので、両方を確かめる。
+//
+//      さらに、この表には古い許可ポリシー price_histories_select（USING(true)）が
+//      20260622 に作られ 20260626001000_enable_rls.sql:51 で DROP されている。
+//      PostgreSQLの permissive ポリシーは OR で合成されるため、この DROP が
+//      効いていなければ施設チェックは丸ごとバイパスされる。
+//      SQLを読むだけでは「DROPが書いてある」ことしか分からないので、実DBで確かめる。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupPriceHistoriesFixtures,
+  createServiceRoleClient,
+  seedPriceHistoriesFixtures,
+  type SeedPriceHistoriesFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('price_histories RLS/IDOR・DB制約', () => {
+  let fixtures: SeedPriceHistoriesFixtures
+
+  beforeAll(async () => {
+    fixtures = await seedPriceHistoriesFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupPriceHistoriesFixtures(fixtures)
+    }
+  })
+
+  describe('施設スコープの履歴（entity_type = hospital_price）', () => {
+    it('他施設のユーザーは取得できない', async () => {
+      const { data, error } = await fixtures.userB.client
+        .from('price_histories')
+        .select('id')
+        .eq('id', fixtures.facilityScopedHistory.id)
+
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('自施設のユーザーは取得できる（対照。古い許可ポリシーの残存検知も兼ねる）', async () => {
+      const { data, error } = await fixtures.userA.client
+        .from('price_histories')
+        .select('id')
+        .eq('id', fixtures.facilityScopedHistory.id)
+
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+  })
+
+  describe('マスタの履歴（entity_type = distributor_product）', () => {
+    it('他施設のユーザーでも取得できる（テナント非分離。設計どおり）', async () => {
+      // WHY: これが取れないなら、ポリシーが「全部拒否」に倒れているだけで
+      //      上の「他施設から見えない」は何も証明していない
+      const { data, error } = await fixtures.userB.client
+        .from('price_histories')
+        .select('id')
+        .eq('id', fixtures.masterHistory.id)
+
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+  })
+
+  describe('書き込みはトリガー経由のみ', () => {
+    it('自施設のユーザーでも直接INSERTできない（price_histories_no_insert）', async () => {
+      const { data, error } = await fixtures.userA.client
+        .from('price_histories')
+        .insert({
+          entity_type: 'hospital_price',
+          entity_id: fixtures.hospitalPriceA.id,
+          distributor_product_id: fixtures.distributorProduct.id,
+          field_name: 'purchase_price',
+          old_value: 1,
+          new_value: 2,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('42501')
+    })
+  })
+
+  describe('唯一の書き込み経路（SECURITY DEFINERトリガー）が正しい値を残す', () => {
+    // WHY: price_histories の CHECK 制約（entity_type / field_name の許可値）は、
+    //      **どのクライアント経路からも違反させられない**。GRANT が SELECT のみで、
+    //      service_role でも直接INSERTできず（実測: permission denied）、
+    //      唯一の書き手である SECURITY DEFINER トリガーは固定リテラルを渡すため。
+    //      よって「制約を破ろうとして弾かれる」形の検証は成立しない。
+    //      代わりに、実際に守るべき約束＝**トリガーが正しい履歴を残すこと**を確かめる。
+    //      （CHECK制約自体は将来の書き手に対する多層防御として残る）
+    const db = createServiceRoleClient()
+
+    it('hospital_prices の購入価格を変えると、施設スコープの履歴が正しい内容で残る', async () => {
+      const before = fixtures.hospitalPriceA.purchasePrice + 1 // シードで1度更新済み
+      const after = before + 500
+
+      const { error: updateError } = await db
+        .from('hospital_prices')
+        .update({ purchase_price: after })
+        .eq('id', fixtures.hospitalPriceA.id)
+      expect(updateError).toBeNull()
+
+      const { data } = await db
+        .from('price_histories')
+        .select('entity_type, field_name, old_value, new_value')
+        .eq('entity_id', fixtures.hospitalPriceA.id)
+        .eq('new_value', after)
+        .single()
+
+      expect(data).toMatchObject({
+        entity_type: 'hospital_price',
+        field_name: 'purchase_price',
+        old_value: before,
+        new_value: after,
+      })
+    })
+
+    it('価格を変えない更新では履歴が増えない（IS DISTINCT FROM の確認）', async () => {
+      // WHY: これが無いと、更新のたびに履歴が増える実装でも上のテストは通ってしまう
+      const countRows = async () => {
+        const { data } = await db
+          .from('price_histories')
+          .select('id')
+          .eq('entity_id', fixtures.hospitalPriceA.id)
+        return data?.length ?? 0
+      }
+
+      const before = await countRows()
+      await db
+        .from('hospital_prices')
+        .update({ delivery_price: 23456 }) // シードと同じ値＝実質変化なし
+        .eq('id', fixtures.hospitalPriceA.id)
+
+      expect(await countRows()).toBe(before)
+    })
+  })
+})

--- a/supabase/__tests__/integration/product-compatibilities-constraints.integration.test.ts
+++ b/supabase/__tests__/integration/product-compatibilities-constraints.integration.test.ts
@@ -1,0 +1,125 @@
+// supabase/__tests__/integration/product-compatibilities-constraints.integration.test.ts
+// WHY: product_compatibilities は CHECK 2つ・複合UNIQUE・FK 3つを持ちながら、
+//      実DBでの検証が一度も無かった（`findUncoveredConstraintMigrations` の検知で発覚。
+//      docs/agents/known-failure-patterns.md「後付けFK列のカーディナリティ…（issue #675）」参照）。
+//
+//      DB制約は「破ろうとしたら拒否される」ことでしか検証できない。
+//      既存の create_product_compatibilities.test.ts は静的SQL検証であり、
+//      「その文字列がSQLに書いてある」ことしか確かめておらず、
+//      **実装で書いた文字列を同じ文字列で照合する鏡**になっている（#675と同じ形）。
+//
+//      制約はRLSと違い service role でもバイパスされないため、ここでは
+//      service role client で直接 insert して弾かれることを見る（認可の検証ではない）。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  cleanupProductCompatibilitiesFixtures,
+  createServiceRoleClient,
+  seedProductCompatibilitiesFixtures,
+  type SeedProductCompatibilitiesFixtures,
+} from './helpers/seed-rls-idor'
+
+describe('product_compatibilities DB制約', () => {
+  let fixtures: SeedProductCompatibilitiesFixtures
+  const db = createServiceRoleClient()
+
+  beforeAll(async () => {
+    fixtures = await seedProductCompatibilitiesFixtures()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (fixtures) {
+      await cleanupProductCompatibilitiesFixtures(fixtures)
+    }
+  })
+
+  describe('あってはならない行が作れない', () => {
+    it('同じ商品同士のペアは登録できない（no_self_compat）', async () => {
+      const { data, error } = await db
+        .from('product_compatibilities')
+        .insert({
+          category_id: fixtures.categoryA.id,
+          product_id_1: fixtures.productSmall.id,
+          product_id_2: fixtures.productSmall.id,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('23514') // check_violation
+      expect(error?.message).toContain('no_self_compat')
+    })
+
+    it('大小が逆順のペアは登録できない（ordered_pair。(a,b)と(b,a)の二重登録を防ぐ本体）', async () => {
+      // WHY: この制約が効いていないと、同じ組み合わせが (a,b) と (b,a) の2行として
+      //      登録でき、複合UNIQUEをすり抜ける。#675 の「1つの貸出に返却2件」と同じ形
+      const { data, error } = await db
+        .from('product_compatibilities')
+        .insert({
+          category_id: fixtures.categoryA.id,
+          product_id_1: fixtures.productLarge.id,
+          product_id_2: fixtures.productSmall.id,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('23514')
+      expect(error?.message).toContain('ordered_pair')
+    })
+
+    it('存在しないカテゴリを指定すると登録できない（FK）', async () => {
+      const { data, error } = await db
+        .from('product_compatibilities')
+        .insert({
+          category_id: '00000000-0000-0000-0000-000000000000',
+          product_id_1: fixtures.productSmall.id,
+          product_id_2: fixtures.productLarge.id,
+        })
+        .select('id')
+
+      expect(data).toBeNull()
+      expect(error?.code).toBe('23503') // foreign_key_violation
+    })
+  })
+
+  describe('同じペアは同一カテゴリ内で1回だけ（複合UNIQUE）', () => {
+    it('1回目は成功し、2回目は拒否される', async () => {
+      const row = {
+        category_id: fixtures.categoryA.id,
+        product_id_1: fixtures.productSmall.id,
+        product_id_2: fixtures.productLarge.id,
+      }
+
+      const first = await db.from('product_compatibilities').insert(row).select('id').single()
+      expect(first.error).toBeNull()
+      expect(first.data?.id).toBeTruthy()
+
+      const second = await db.from('product_compatibilities').insert(row).select('id')
+      expect(second.data).toBeNull()
+      expect(second.error?.code).toBe('23505') // unique_violation
+
+      // 結果としてDBに残る行は1件だけ
+      const { data: rows } = await db
+        .from('product_compatibilities')
+        .select('id')
+        .eq('category_id', fixtures.categoryA.id)
+      expect(rows).toHaveLength(1)
+    })
+
+    it('カテゴリが違えば同じペアを登録できる（UNIQUEがcategory_id込みであることの対照）', async () => {
+      // WHY: これが無いと、UNIQUEの範囲が (product_id_1, product_id_2) だけに
+      //      狭まっていても上のテストは通ってしまう
+      const { data, error } = await db
+        .from('product_compatibilities')
+        .insert({
+          category_id: fixtures.categoryB.id,
+          product_id_1: fixtures.productSmall.id,
+          product_id_2: fixtures.productLarge.id,
+        })
+        .select('id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.id).toBeTruthy()
+    })
+  })
+})

--- a/supabase/migrations/20260620000000_add_categories.sql
+++ b/supabase/migrations/20260620000000_add_categories.sql
@@ -14,6 +14,7 @@ create trigger categories_updated_at
 grant all on table public.categories to postgres, anon, authenticated, service_role;
 
 -- distributor_products.category(text) → category_id(uuid FK)
+-- cardinality: many 1つのカテゴリに複数の取扱商品がぶら下がる（カテゴリはマスタ側）
 alter table distributor_products
   add column category_id uuid references categories(id);
 

--- a/supabase/migrations/__tests__/constraint-coverage-baseline.json
+++ b/supabase/migrations/__tests__/constraint-coverage-baseline.json
@@ -1,0 +1,30 @@
+{
+  "_why": "issue #675 の再発防止。既知の未対応分をここに固定し、新規発生のみをテストで止める（ratchet）。riskは機械判定の結果を書き写したもので、ズレるとテストが落ちる（放置しても陳腐化しないようにするため）。既存分を解消したら該当行を削除すること。",
+  "_riskの意味": {
+    "high": "アプリのコードが読み書きする業務データで、制約が多いか施設境界に関わる。優先して統合テストを書く",
+    "medium": "アプリのコードが読み書きするが、制約が少なく施設境界にも関わらない",
+    "low": "アプリのコードが一度も触っていない裏方テーブル。実DBで試す必要は薄い"
+  },
+  "_rlsIdorNotRequiredとは": "「他施設から見えてはいけない」という約束がそもそも無いテーブル。負債の免除ではなく検知条件の訂正であり、理由を必須にする。約束が後から変わったら（施設スコープを導入したら）ここから外すこと。下記3件は 2026-08-30 にリポジトリ所有者が『施設非分離でよい』と業務要件として確認済み（SQLの読み取りだけでなく人の承認を得ている）",
+  "rlsIdorNotRequired": [
+    {
+      "table": "categories",
+      "reason": "マスタ。意図的にテナント非分離で SELECT は USING(true)。守る約束は施設境界ではなくadmin境界（categories_write が is_admin()）"
+    },
+    {
+      "table": "distributor_products",
+      "reason": "マスタ。同上（distributor_products_select が USING(true)、write が is_admin()）"
+    },
+    {
+      "table": "product_compatibilities",
+      "reason": "マスタ。migration に「本機能はテナント非分離＝施設スコープなし」と明記。compat_select が USING(true)、compat_write が is_admin()"
+    }
+  ],
+  "rlsWithoutIdorTest": [],
+  "undeclaredCardinality": [],
+  "_既知の偽陰性": "この軸は『テーブル名が統合テストに登場するか』で判定するため、登場さえすれば消える。実際 price_histories の CHECK 制約（entity_type/field_name の許可値）は、GRANTがSELECTのみで service_role でも直接INSERTできず、唯一の書き手であるSECURITY DEFINERトリガーが固定リテラルを渡すため、**どのクライアント経路からも違反させられない**（実測確認済み）。代わりにトリガーが正しい履歴を残すことを price-histories-rls-idor.integration.test.ts で検証している",
+  "uncoveredIntegration": [
+    { "migration": "20260714000001_create_schema_drift_detection.sql", "risk": "low" },
+    { "migration": "20260714000003_schema_drift_v1_hardening.sql", "risk": "low" }
+  ]
+}

--- a/supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts
+++ b/supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { describe, it, expect } from 'vitest'
 import {
   assessRisk,
+  findAdminOnlyTablesWithoutTest,
   findRlsTablesWithoutIdorTest,
   findUndeclaredCardinality,
   findUncoveredConstraintMigrations,
@@ -91,6 +92,17 @@ const actualRlsRisk = new Map(
   ]),
 )
 
+const adminTestSource = existsSync(INTEGRATION_DIR)
+  ? readdirSync(INTEGRATION_DIR)
+      .filter((f) => f.includes('admin'))
+      .map((f) => readFileSync(path.join(INTEGRATION_DIR, f), 'utf-8'))
+      .join('\n')
+  : ''
+const adminUncovered: string[] = findAdminOnlyTablesWithoutTest({
+  allMigrationSql,
+  adminTestSource,
+}).uncovered
+
 /** 業務データ判定の材料としてアプリ本体のソースを集める（生成物の型定義は含めない） */
 function collectSource(dirs: string[]): string {
   const chunks: string[] = []
@@ -130,6 +142,15 @@ describe('DB制約カバレッジのratchet（issue #675 再発防止）', () =>
     //   （known-failure-patterns.md「動いたからOKで…見逃す（issue #24再発防止）」参照）
     const added = rlsUncovered.filter((t) => !baselineRlsTables.includes(t))
     expect(added).toEqual([])
+  })
+
+  it('adminだけが書けるのに非adminで試していないテーブルが無い', () => {
+    // WHY: RLS/IDOR軸で「施設境界の約束が無い」として除外したマスタ群は、
+    //      代わりに admin境界を守っている。そちらの軸を持たないと
+    //      「面倒な指摘を除外リストに逃がしただけ」になる。
+    //      直し方: *-admin-boundary.integration.test.ts に
+    //      「非adminでは書けない／adminなら書ける」の対照テストを追加する
+    expect(adminUncovered).toEqual([])
   })
 
   it('rlsIdorNotRequired の各行に理由が書かれている', () => {

--- a/supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts
+++ b/supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts
@@ -1,0 +1,178 @@
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+import {
+  assessRisk,
+  findRlsTablesWithoutIdorTest,
+  findUndeclaredCardinality,
+  findUncoveredConstraintMigrations,
+} from '../../../.claude/workflows/lib/constraint-coverage.js'
+
+// WHY: issue #675（短貸返却の二重登録）は、2026-07-14 に loan_returns へ loan_order_id を
+//      後付けした時点で「1対1か1対多か」が宣言されず、migrationのテストが「実装で書いたSQLを
+//      同じ文字列で照合する」静的検証だけだったため、84コミット・CI 173本を通過し続けても
+//      検出されなかった。
+//
+//      再発防止としてratchet（歯止め）方式を採る: 既知の未対応分は
+//      constraint-coverage-baseline.json に固定し、**新規発生のみ**をテストで止める。
+//      既存の技術的負債の返済を強制せず、同じ穴が増えることだけを防ぐ。
+//
+//      既存分を解消したらbaselineから該当行を削除すること。削除し忘れ（もう存在しないのに
+//      baselineに残っている）も下の「baselineに不要な行が残っていない」で検知する。
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..')
+const INTEGRATION_DIR = path.resolve(__dirname, '../../__tests__/integration')
+const BASELINE_PATH = path.join(__dirname, 'constraint-coverage-baseline.json')
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as {
+  undeclaredCardinality: string[]
+  uncoveredIntegration: { migration: string; risk: 'high' | 'medium' | 'low' }[]
+  rlsWithoutIdorTest: { table: string; risk: 'high' | 'medium' | 'low' }[]
+  rlsIdorNotRequired: { table: string; reason: string }[]
+}
+const baselineMigrations = baseline.uncoveredIntegration.map((e) => e.migration)
+const baselineRlsTables = baseline.rlsWithoutIdorTest.map((e) => e.table)
+
+const migrations = readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith('.sql'))
+  .sort()
+  .map((f) => ({ name: f, sql: readFileSync(path.join(MIGRATIONS_DIR, f), 'utf-8') }))
+
+const integrationSource = existsSync(INTEGRATION_DIR)
+  ? readdirSync(INTEGRATION_DIR)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => readFileSync(path.join(INTEGRATION_DIR, f), 'utf-8'))
+      .join('\n')
+  : ''
+
+const cardinalityKeys: string[] = findUndeclaredCardinality({ migrations }).undeclared.map(
+  (u: { name: string; table: string; column: string }) => `${u.name}:${u.table}.${u.column}`,
+)
+const appSource = collectSource([
+  path.resolve(__dirname, '../../../src/lib'),
+  path.resolve(__dirname, '../../../src/app'),
+  path.resolve(__dirname, '../../../src/components'),
+])
+const allMigrationSql = migrations.map((m) => m.sql).join('\n')
+
+const uncovered: {
+  name: string
+  tables: string[]
+  constraintCount: number
+}[] = findUncoveredConstraintMigrations({ migrations, integrationSource }).uncovered
+const coverageKeys = uncovered.map((u) => u.name)
+const actualRisk = new Map(
+  uncovered.map((u) => [
+    u.name,
+    assessRisk({
+      tables: u.tables,
+      constraintCount: u.constraintCount,
+      appSource,
+      allMigrationSql,
+    }).level,
+  ]),
+)
+
+const idorTestSource = existsSync(INTEGRATION_DIR)
+  ? readdirSync(INTEGRATION_DIR)
+      .filter((f) => f.includes('idor'))
+      .map((f) => readFileSync(path.join(INTEGRATION_DIR, f), 'utf-8'))
+      .join('\n')
+  : ''
+const rlsUncovered: string[] = findRlsTablesWithoutIdorTest({
+  allMigrationSql,
+  idorTestSource,
+  notRequired: baseline.rlsIdorNotRequired.map((e) => e.table),
+}).uncovered
+const actualRlsRisk = new Map(
+  rlsUncovered.map((t) => [
+    t,
+    assessRisk({ tables: [t], constraintCount: 0, appSource, allMigrationSql }).level,
+  ]),
+)
+
+/** 業務データ判定の材料としてアプリ本体のソースを集める（生成物の型定義は含めない） */
+function collectSource(dirs: string[]): string {
+  const chunks: string[] = []
+  const walk = (dir: string) => {
+    if (!existsSync(dir)) return
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (/\.tsx?$/.test(entry.name)) chunks.push(readFileSync(full, 'utf-8'))
+    }
+  }
+  dirs.forEach(walk)
+  return chunks.join('\n').toLowerCase()
+}
+
+describe('DB制約カバレッジのratchet（issue #675 再発防止）', () => {
+  it('カーディナリティ未宣言の後付けFK列が新規に増えていない', () => {
+    // 増えていた場合の直し方:
+    //   1対1なら UNIQUE 制約/インデックスを同じPRで追加する
+    //   1対多なら migration の SQL に `-- cardinality: many <理由>` を書く
+    const added = cardinalityKeys.filter((k) => !baseline.undeclaredCardinality.includes(k))
+    expect(added).toEqual([])
+  })
+
+  it('実DB統合テストの対応が無い制約migrationが新規に増えていない', () => {
+    // 増えていた場合の直し方:
+    //   supabase/__tests__/integration/ に「制約を破る操作が拒否される」テストを追加する
+    //   統合テストが不要と判断したなら `-- integration-coverage: not-required <理由>` を書く
+    const added = coverageKeys.filter((k) => !baselineMigrations.includes(k))
+    expect(added).toEqual([])
+  })
+
+  it('RLSポリシーを持つのにIDORテストが無いテーブルが新規に増えていない', () => {
+    // 増えていた場合の直し方:
+    //   supabase/__tests__/integration/*-rls-idor.integration.test.ts に
+    //   「他人（別施設のユーザー）で叩くと弾かれる」テストを追加する
+    //   （known-failure-patterns.md「動いたからOKで…見逃す（issue #24再発防止）」参照）
+    const added = rlsUncovered.filter((t) => !baselineRlsTables.includes(t))
+    expect(added).toEqual([])
+  })
+
+  it('rlsIdorNotRequired の各行に理由が書かれている', () => {
+    // WHY: 除外は「負債の免除」ではなく「検知条件の訂正」。理由の無い除外を許すと、
+    //      面倒な指摘をここに逃がすだけの穴になる（怪しいリストが空になって安心する罠）
+    const withoutReason = baseline.rlsIdorNotRequired.filter((e) => !e.reason?.trim())
+    expect(withoutReason).toEqual([])
+  })
+
+  it('rlsIdorNotRequired に、RLSポリシーを持たないテーブルが混ざっていない', () => {
+    // WHY: テーブル名の打ち間違いや、ポリシーが消えた後の残骸を検知する
+    const policyTables = findRlsTablesWithoutIdorTest({ allMigrationSql, idorTestSource: '' })
+      .policyTables
+    const unknown = baseline.rlsIdorNotRequired
+      .map((e) => e.table)
+      .filter((t) => !policyTables.includes(t))
+    expect(unknown).toEqual([])
+  })
+
+  it('baselineに、既に解消済みの行が残っていない', () => {
+    // WHY: 負債を返済したのにbaselineへ残し続けると、次に同じ穴が空いても検知されなくなる
+    const staleCardinality = baseline.undeclaredCardinality.filter(
+      (k) => !cardinalityKeys.includes(k),
+    )
+    const staleCoverage = baselineMigrations.filter((k) => !coverageKeys.includes(k))
+    const staleRls = baselineRlsTables.filter((t) => !rlsUncovered.includes(t))
+    expect({ staleCardinality, staleCoverage, staleRls }).toEqual({
+      staleCardinality: [],
+      staleCoverage: [],
+      staleRls: [],
+    })
+  })
+
+  it('baselineに書かれたriskが、現在の機械判定と一致している', () => {
+    // WHY: 負債リストを「怪しい順」に見せるための risk が、書いたきり陳腐化しないようにする。
+    //      裏方テーブル(low)をアプリが使い始めた等でriskが上がった場合、ここが落ちて気づける
+    //      ＝「表面に出てこないまま放置される」を防ぐのがこのテストの役目
+    const drifted = baseline.uncoveredIntegration
+      .filter((e) => actualRisk.has(e.migration) && actualRisk.get(e.migration) !== e.risk)
+      .map((e) => ({ migration: e.migration, baseline: e.risk, actual: actualRisk.get(e.migration) }))
+    const driftedRls = baseline.rlsWithoutIdorTest
+      .filter((e) => actualRlsRisk.has(e.table) && actualRlsRisk.get(e.table) !== e.risk)
+      .map((e) => ({ table: e.table, baseline: e.risk, actual: actualRlsRisk.get(e.table) }))
+    expect({ drifted, driftedRls }).toEqual({ drifted: [], driftedRls: [] })
+  })
+})


### PR DESCRIPTION
## 30秒サマリー
- **変更概要**: issue #675 の根本原因（未検証の穴が誰にも気づかれず放置される構造）を4軸で機械検知し、検知が見つけた穴を実DBテストで塞いだ
- **リスク**: 低〜中（プロダクションコードの変更ゼロ。適用済みmigration 1本にコメント1行を追加 ← 要確認）
- **変更領域**: テスト基盤 / RLS検証 / DB制約検証 / ドキュメント
- **証拠状態**: 実測18件 / 未検証4件
- **影響範囲**: `npm test` に +5件、`npm run test:integration` に +33件（11ファイル58件 → 16ファイル91件）
- **ロールバック可能性**: 高（新規9ファイルの削除＋既存5ファイルのrevert）

**レビューしてほしい点**
1. 適用済みmigration `20260620000000_add_categories.sql` へのコメント1行追加（下記05参照）
2. `rlsIdorNotRequired` の3件を除外した判断（施設非分離マスタ。承認済みだが記録として）

## 00 目的・影響範囲・対象外

**目的**: issue #675（短貸返却の二重登録）が84コミット・6週間見つからなかったのは、テストやレビューが個別に甘かったからではなく、**確認する機構（CI・レビュー）ばかりで発見する機構が無かった**ため。仕様が沈黙している事柄はテストにもレビューにも現れない。この構造を塞ぐ。

**変更範囲**: 新規9ファイル / 既存5ファイル更新。プロダクションコード（`src/`）の変更はゼロ。

**対象外**: DB制約・RLS・admin境界の3領域のみ。アプリ層の `facility_id` フィルタ漏れ、RPC内部の認可、API層のバリデーションは検知対象外。

## 01 画面がどう変わったか

対象外（UI変更なし）

## 02 内部でどう守っているか

**検知**（`.claude/workflows/lib/constraint-coverage.js`）— 4軸、すべて機械判定：

| 軸 | 何を探すか |
|---|---|
| `findUndeclaredCardinality` | 後付けFK列に1対1/1対多の宣言が無いもの（**#675の直接の再発防止**） |
| `findUncoveredConstraintMigrations` | 制約を導入したのにテーブルが実DB統合テストに一度も登場しないもの |
| `findRlsTablesWithoutIdorTest` | RLSポリシーはあるがIDOR統合テストに一度も登場しないテーブル |
| `findAdminOnlyTablesWithoutTest` | adminだけが書けるのに非adminで試していないテーブル |

**怪しさのランク付け**（`assessRisk`）— 判定材料はすべて機械的に取得し、人の申告に依存しない：

- アプリのコード（`src/`）がそのテーブルを読み書きするか（業務データか裏方か）
- 施設境界に関わるか（`facility_id` 列**と**ポリシー本文の `is_facility_member` の両方を見る）
- 制約の個数（書き忘れの余地の大きさ）

**歯止め**（`supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts`）：

- 既知分は `constraint-coverage-baseline.json` に固定し、**新規発生のみ** `npm test` で落とす
- baseline から手で消せない（消すには実体を直すか、理由付きで除外するしかない）
- baseline の risk が機械判定とズレたら落ちる（リストの陳腐化防止）
- 除外に理由が無ければ落ちる（面倒な指摘を逃がす穴を塞ぐ）

**塞いだ穴**（実DBテスト）:

- `hospital_prices`（施設ごとの購入・納入価格）RLS/IDOR 7ケース
- `case_order_items` / `consumable_order_items` / `loan_return_items` 18ケース（`facility_id` 列を持たず親経由で施設スコープ。`loan_order_items` だけ既存の横展開漏れ）
- `price_histories` RLS/IDOR + トリガー検証 6ケース
- `product_compatibilities` DB制約 5ケース
- マスタ5テーブルの admin境界 9ケース

## 03 誰が操作できるか

migration・ポリシーの**実体は一切変更していない**（検証を足しただけ）。

他テナントのIDでアクセスして弾かれることの確認: **実施済み**。`hospital_prices` / 明細3件 / `price_histories` について、別施設ユーザーで SELECT・主キー直指定・UPDATE・DELETE・INSERT を試し、いずれも弾かれることを実DBで確認。加えて各テストに**対照実験**（権限のあるユーザーなら成功する）を置き、拒否がRLS由来であることを保証している。

## 04 どう確認したか

**RED検証**（すべて実測、一時ファイルは削除済み）:

| 検証 | 結果 |
|---|---|
| #675発生時点の再現（修正migrationを除外） | `loan_returns.loan_order_id` を検知 = 2026-07-14に止められていた |
| 同型の新migration | ratchetテストが RED |
| RLS軸の歯止め | 新テーブルを検知して RED |
| 怪しさのドリフト（baseline改竄） | RED、差分を明示 |
| 各IDORテストの権限反転 | 期待どおり失敗（下記の空回り3件を除く） |

**全体**:

- `npm test`: 192ファイル **1486件 green**
- `npm run test:integration`: 16ファイル **91件 green**（実ローカルSupabase接続）
- `npm run lint` / `npm run typecheck`: クリーン
- `npm run ai:check`: **未実行**
- eval: `.claude/workflows/lib/` のプロンプト変更を含まないため対象外

**実装中に踏んだ想定外（5件、すべて対応済み）**:

| 何が起きたか | 原因 | 対応 |
|---|---|---|
| `hospital_prices` の insert拒否テストが空回り | `unique(distributor_product_id, facility_id)` 違反で誰が呼んでも失敗 | 未使用商品＋`42501` assert＋対照実験 |
| `price_histories` の CHECK制約テストが成立しない | `GRANT` がSELECTのみで**どの経路からも違反させられない** | トリガーが正しい履歴を残す検証へ方針変更 |
| `product_compatibilities` の拒否テストが空回り | 同じ製品IDを2つ渡し `no_self_compat` で誰でも失敗 | 正しい順序の別製品ペア＋`42501` assert |
| 怪しさ判定の誤検知2件 | テーブル名の部分一致（別テーブルの複合UNIQUE / FK参照先） | 文単位・`create table <名前>` に固定＋回帰テスト |
| 明細4件を medium に過小評価 | `facility_id` 列の有無しか見ていなかった | ポリシー本文の `is_facility_member` も見る |

**「テストが別の理由で通る」型のミスが3回**出ています。3回とも「権限側を反転させて必ず落ちるか」の確認で捕まえました。逆に言えば、この確認を省いた否定テストは3回中3回とも壊れていました。

## 05 何かあったらどうするか

**リリース後に見るもの**: `scripts/check-constraint-coverage.sh` の出力。障害時は「そのテーブルがリストに載っているか」を最初に見る。

**異常の判断基準**: baseline が頻繁に増えるなら、負債が増えたのではなく**検知が甘い**サイン。件数が増えたら条件を狭める。

**リストの読み方（重要）**: 「ここは確かめていない」と言っているだけで「ここ以外は確かめてある」とは言っていない。障害時に「載っているから疑う」に使うのは正しいが、「載っていないから違う」に使うと調査が遅れる。

**ロールバック**: 新規9ファイル削除＋既存5ファイルrevert。プロダクション影響なし。

**要確認**: `20260620000000_add_categories.sql`（2026-06-20適用済み）にコメント1行を追加している。SQL挙動に影響はなく、このファイルを参照・ハッシュ化するテストも存在しないことは確認済み。ただし Supabase のリモート履歴が statements を比較するかは未検証（このローカル環境は `linked_project: null`）。気になる場合のため、**別のmigrationから宣言できる逃げ道**（`-- cardinality: many <table>.<column> <理由>`）を実装済みで、1行を移せる。

## 後任AIへの注意

- **壊してはいけない前提**: ratchet は「既存負債を許し、新規のみ止める」設計。baseline に既存分を残すのは意図的
- **似ているが別物**: `findUndeclaredCardinality`（#675の直接の再発防止）と `findUncoveredConstraintMigrations`（同種の穴の棚卸し）は別物。**後者は #675 を検出できない**（発生源migrationに制約キーワードが無いため）
- **似ているが別物その2**: 施設境界（`is_facility_member` / `is_facility_writer`）と admin境界（`is_admin()` 単独）。両者の OR は「adminは追加の許可」であって境界ではない。この区別を外すと15テーブルが該当しノイズになる
- **勝手にリファクタしない**: `hasUnique` の文単位スコープ判定、`facilityScoped` の `create table <名前>` 固定。どちらも緩めると誤検知が復活する（実際に踏んだ）

## 未検証

- CI未実行（本PRが初回）
- 本番Supabaseスキーマとローカルの一致
- `has_aal2()` はMFA未登録ユーザーに `true` を返す設計のため、AAL2要件そのものは未検証
- `npm run ai:check` 未実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
