### PR TITLE
ci: 高リスクパスに触れたPRだけRLS/IDOR統合テストをマージ前ゲートにする

### DIFF
--- a/.claude/rules/db-schema.md
+++ b/.claude/rules/db-schema.md
@@ -17,5 +17,10 @@ paths:
   呼ばないと、正規のPRレビュー済み変更であっても`table_added`/`table_removed`ドリフトとして恒久的に誤検知され続け、対応するGitHub Issueが自動クローズされなくなる
 - **`supabase/migrations/`やRLSポリシーを変更したPRでは、`npm run test:integration`（RLS/IDOR
   integrationテスト）をローカル実行してから作業を完了する**（2026-08-25、Actions無料枠対応で
-  `e2e.yml`のPR自動実行を廃止したため。CIでの自動実行はmainへのpush後のみ）。実行結果は
-  引き継ぎメモの「検証済み」欄に記載する
+  `e2e.yml`のPR自動実行を廃止したため）。実行結果は引き継ぎメモの「検証済み」欄に記載する
+  - **このうちパスで表せる範囲は、`integration-gate.yml`がPR時点で機械的にゲートする**
+    （`supabase/migrations/**`・`supabase/__tests__/**`・`src/lib/supabase/**`・`**/middleware.ts`）。
+    従来は`push:[main]`のみで、壊れたRLS変更をマージ前に止められなかった
+  - **ただしローカル実行義務は無くならない**。`paths`はファイルパスしか見られず、TRI/RISK基準の
+    内容ベース判定（auth / facility / tenant / organization / inventory / RLS / policy に
+    関わる変更）は表現できないため、上記パス外でRLSの約束に触れる変更はゲートに掛からない

--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -1,27 +1,39 @@
-name: E2E Smoke Tests
+name: RLS/DB Integration Gate
 
-# WHY: PRごとの自動実行はPlaywright+ローカルSupabase起動で1回あたりの消費分数が最大級で、
-# Actions無料枠枯渇(2026-08)の主因だったため、mainへのpush後と手動起動のみに変更した。
-# PR段階のE2Eはローカル実行(npm run test:e2e)で代替する。
-# RLS/IDOR integrationテストについては、**高リスクパスに触れたPRに限り**
-# integration-gate.yml がPR時点で必須ゲートとして走る（全PRではないので消費分数は抑えられる）。
-# それ以外のPRおよび内容ベースの高リスク判定は、引き続き .claude/rules/db-schema.md の
-# ローカル実行義務に依存する。認証ファイル漏洩チェックはPRごとに回る
-# ci.ymlのhooks-testジョブへ移設した。
+# WHY: RLS/IDOR統合テスト(npm run test:integration)は e2e.yml で回っているが、
+# トリガーが push:[main] のみのため **マージ前に壊れたRLS変更を止められない**
+# （mainへ入った後で初めて鳴る火災報知器になっている）。
+#
+# 一方で全PRでローカルSupabase起動を伴うジョブを回すと、Actions無料枠の枯渇
+# （2026-08、e2e.yml をPRトリガーから外した理由）を再発させる。
+#
+# 折衷として、docs/agents/common.md「TRI/RISK 機械判定基準」の高リスクパスに
+# 触れたPRだけをゲート対象にする。Playwrightのインストールとe2e実行は行わず、
+# 統合テストのみを走らせることで、e2e.yml より消費分数を抑える。
+#
+# 既知の限界: paths フィルタはファイルパスしか見られないため、TRI/RISK基準のうち
+# 「auth / facility / tenant / organization / inventory / RLS / policy に関わる変更」
+# という**内容ベースの判定は表現できない**。パスで表せる範囲のみをここでゲートし、
+# 内容ベースの判定は引き続き .claude/rules/db-schema.md のローカル実行義務に依存する。
 on:
-  push:
-    branches: [main]
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/__tests__/**'
+      - 'src/lib/supabase/**'
+      - '**/middleware.ts'
+      - '.github/workflows/integration-gate.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  group: integration-gate-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  e2e:
+  integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -33,9 +45,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
 
       - uses: supabase/setup-cli@v3
         with:
@@ -64,14 +73,3 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ env.SUPABASE_API_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ env.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ env.SUPABASE_SERVICE_ROLE_KEY }}
-
-      - name: Run E2E smoke tests
-        run: npm run test:e2e
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ env.SUPABASE_API_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ env.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ env.SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_SITE_URL: http://localhost:3000
-          # WHY: ダミーデータ規約（docs/agents/common.md）に合わせた固定のテスト用メール。
-          #      ローカルSupabaseは毎回まっさらな状態なので機密情報ではなくsecrets化不要
-          E2E_TEST_EMAIL: e2e-test-user@example.com

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -42,6 +42,7 @@
 | Stop | `check-aidd-phase-stats-recorded.sh` | warning-only | AIDD stats phase1/phase2呼び忘れの警告（issue #524） |
 | Stop | `check-handoff-format.sh` | warning-only | PR本文の引き継ぎフォーマット必須見出し欠如の警告（issue #524。PR本文経由のみ対象） |
 | Stop | `check-find-av-precision-recorded.sh` | warning-only | find-av-precisionログ記録漏れの警告（issue #522） |
+| （参考）`pull_request`（高リスクパス限定） | `.github/workflows/integration-gate.yml` | **block**（PRチェック失敗。ただしFreeプランのためマージは阻止されない） | `supabase/migrations/**`・`supabase/__tests__/**`・`src/lib/supabase/**`・`**/middleware.ts` に触れたPRでのみ `npm run test:integration` を実行する。従来 `e2e.yml` は `push:[main]` のみで、**壊れたRLS変更をマージ前に止められなかった**（mainへ入った後で初めて鳴る）。全PRで回すとActions無料枠が枯渇するため（2026-08の実績）、パスで絞った。**既知の限界**: `paths`はファイルパスしか見られないため、TRI/RISK基準のうち内容ベースの判定（auth/facility/tenant等のドメイン）は表現できず、そこは引き続き`.claude/rules/db-schema.md`のローカル実行義務に依存する |
 | （参考）`npm test`（CI含む） | `supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts` | **block**（テスト失敗、ただしCI上の強制力はプラン依存） | issue #675。カーディナリティ未宣言の後付けFK列・統合テスト対応の無い制約migrationの**新規発生**を止める（既知分はbaselineに固定するratchet方式）。hookではなくテストなので、ローカル`npm test`とCIの両方で機械的に起動する。ただし本リポジトリはFreeプランでCI失敗がマージを阻止しないため、実効的な強制力はローカル実行時に限る |
 | （参考）per-edit | security-guidanceプラグイン（`possible_real_facility_name`等） | warning-only | issue #440。Claude Code公式プラグイン経由、上記`.claude/settings.json`のhooksとは別経路 |
 


### PR DESCRIPTION
## 30秒サマリー
- **変更概要**: 高リスクパスに触れたPRだけ、RLS/IDOR統合テストをマージ前の必須チェックにする
- **リスク**: 低（CI設定の追加のみ。プロダクションコード・migration・テストの変更ゼロ）
- **変更領域**: CI設定 / ドキュメント
- **証拠状態**: 実測3件 / 未検証2件（うち1件は**本PRのチェック結果がそのまま実測になる**）
- **影響範囲**: 対象パスに触れたPRのみジョブが1本増える。それ以外のPRは変化なし
- **ロールバック可能性**: 高（新規1ファイル削除＋既存3ファイルrevert）

**レビューしてほしい点**
1. パスの選び方（`docs/agents/common.md` のTRI/RISK高リスクパスから、`paths`で表せるものだけを採った）
2. ローカル実行義務（`.claude/rules/db-schema.md`）を撤廃せず併存させた判断

## 00 目的・影響範囲・対象外

**目的**: `npm run test:integration`（RLS/IDOR統合テスト91件）は `e2e.yml` で回っているが、トリガーが `push: [main]` のみ。つまり**壊れたRLS変更をマージ前に止められず、mainへ入った後で初めて鳴る火災報知器**になっていた。

これは事故ではなく意図的なトレードオフ（Actions無料枠の枯渇、2026-08）。代替として「PR段階はローカル実行で担保」とされていたが、それは自然言語ルールであり、守られなくても機械的に気づけない。

**対象外**: 全PRでの統合テスト実行（無料枠を再び枯渇させるため）。E2Eの PR 実行（据え置き）。

## 01 画面がどう変わったか

対象外（UI変更なし）

## 02 内部でどう守っているか

`integration-gate.yml` を追加。`pull_request` かつ以下のパスに触れた場合のみ実行：

| パス | なぜ対象か |
|---|---|
| `supabase/migrations/**` | TRI/RISK 高リスクパス |
| `supabase/__tests__/**` | 統合テスト自体の変更 |
| `src/lib/supabase/**` | TRI/RISK 高リスクパス |
| `**/middleware.ts` | TRI/RISK 高リスクパス |
| `.github/workflows/integration-gate.yml` | 自身の変更を自身で検証するため |

Playwright のインストールと E2E 実行は行わず、統合テストのみを走らせるため `e2e.yml` より軽い。

## 03 誰が操作できるか

RLS・ポリシー・migration の**実体は一切変更していない**（CI設定のみ）。

`e2e.yml` と同じく、GitHub Secrets を使わず `supabase start` で起動したローカルSupabaseの接続情報だけを使う（`e2e/env-guard.ts` の許可ホストが `127.0.0.1`/`localhost` のみのため、本番Supabaseの接続情報がCIに渡ることはない）。

## 04 どう確認したか

| 検証 | 結果 |
|---|---|
| ワークフローYAMLが意図どおりパースされるか | `npx js-yaml` で確認。`on.pull_request.paths` が5件、`workflow_dispatch` も有効 |
| 既存テストへの影響 | `npm test` 192ファイル **1486件 green** |
| lint | クリーン |

**未検証（重要）**: **このゲートがPR上で実際に発火するか**は、まだ確かめていません。本PRは `.github/workflows/integration-gate.yml` を自身の `paths` に含めているため、**本PRのチェック結果がそのまま初回の実測**になります。「RLS/DB Integration Gate」が走って通れば発火とテスト実行の両方が確認できます。

## 05 何かあったらどうするか

**異常の判断基準**: 対象パスに触れていないPRでこのジョブが走っていたら `paths` が広すぎる。逆に migration を変更したPRで走っていなければ `paths` が漏れている。

**ロールバック**: `integration-gate.yml` を削除し、3ファイルをrevert。プロダクション影響なし。

**既知の限界（意図的に残す）**: `paths` フィルタはファイルパスしか見られないため、TRI/RISK基準のうち**内容ベースの判定**（auth / facility / tenant / organization / inventory / RLS / policy に関わる変更）は表現できません。上記パス外でRLSの約束に触れる変更はゲートに掛からないため、`.claude/rules/db-schema.md` のローカル実行義務は**撤廃せず併存**させています。

また本リポジトリはFreeプランのため、チェック失敗はマージを機械的に阻止しません（レビュアーが見て止める前提。`docs/agents/actuator-inventory.md` に記載）。

## 後任AIへの注意

- **ローカル実行義務を消さないこと**: このゲートは「パスで表せる範囲」しかカバーしない。`.claude/rules/db-schema.md` のルールと**併存が前提**であり、片方を消すと内容ベースの高リスク変更が素通りする
- **`paths` を広げるときは消費分数とセット**で考える。全PRで回すと2026-08の無料枠枯渇を再発させる
- **似ているが別物**: `e2e.yml`（main push後、E2E含む重いジョブ）と `integration-gate.yml`（PR時、パス限定、統合テストのみ）。前者を消して後者に一本化しないこと（後者はE2Eを回さない）

## 未検証

- 本ゲートのPR上での発火（本PRのチェック結果が初回の実測）
- 対象パス外のPRで**走らないこと**（今後のPRで観測して確認する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
