### PR TITLE
test: CIゲートのnegative検証（対象外パスで integration が発火しないこと）

### DIFF
--- a/docs/agents/GATE_NEGATIVE_PROBE.md
+++ b/docs/agents/GATE_NEGATIVE_PROBE.md
@@ -1,0 +1,9 @@
+# CIゲートの negative 検証用の一時ファイル
+
+integration-gate.yml の `paths` フィルタが、**対象外のパスでは発火しない**ことを
+確かめるためだけに置いた一時ファイル。確認後に削除する。
+
+このファイルは `docs/agents/` 配下であり、ゲートの対象パス
+（`supabase/migrations/**`・`supabase/__tests__/**`・`src/lib/supabase/**`・
+`**/middleware.ts`・`.github/workflows/integration-gate.yml`）のいずれにも該当しない。
+したがって、このファイルだけを変更したPRでは `integration` ジョブが**現れないはず**。


### PR DESCRIPTION
検証専用の一時PR。マージしない。

## 目的

`integration-gate.yml` の `paths` フィルタが、**対象外のパスでは発火しない**ことを確認する。

## なぜベースを main にしないか

`pull_request` イベントで使われるワークフロー定義はベースブランチ側のもの。main にはまだゲートが無いため、main をベースにすると「フィルタが除外した」のか「ワークフローが存在しない」のか区別できない。ベースを `claude/pr-integration-gate` にすることで、ワークフローは存在し、差分だけが対象外という条件を作る。

## 期待する結果

差分は `docs/agents/GATE_NEGATIVE_PROBE.md` の1ファイルのみで、対象パス（`supabase/migrations/**`・`supabase/__tests__/**`・`src/lib/supabase/**`・`**/middleware.ts`・`.github/workflows/integration-gate.yml`）のいずれにも該当しない。

したがって **`integration` ジョブがチェック一覧に現れないこと**が期待値。現れた場合は `paths` が広すぎる。

確認後、このPRとブランチは削除する。