### PR TITLE
fix: domain.md/decisions.md提案のStop hookをagent型からcommand型へ置き換える(issue #685)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -226,9 +226,9 @@
       {
         "hooks": [
           {
-            "type": "agent",
-            "prompt": "$ARGUMENTS のtranscript_pathをReadツールで読み、このセッション中にEdit/Write/MultiEditツールで変更されたファイルパスをGrepツールで抽出してください（tool_useブロックのnameとinput.file_pathを探す）。\n\n変更ファイルが1件もない場合、または変更ファイルの中に以下のいずれにも実質的に該当しないものしかない場合は、何も返さず終了してください（発火しない）:\n- supabase/migrations/ 配下\n- src/lib/supabase/ 配下\n- middleware.ts\n- ファイルパスまたは実際の変更内容がfacility/tenant/organization/inventory/RLS/policy/authのいずれかのドメインに実質的に関わるもの\n\n該当ファイルがある場合は、それぞれReadツールで現在の内容を確認し、単なるコメント修正・タイポ修正・変数名変更など設計判断を含まない変更か、それとも後戻りしづらい・記録がないと後から理由が分からなくなる・本当にトレードオフがあった設計判断（例: RLSポリシーの新規追加や変更方針、権限境界の変更、DBスキーマ変更の理由）を含む変更かを判断してください。単にキーワードに一致するだけでは発火条件にしないこと。\n\n後者に該当する場合のみ、docs/agents/domain.mdとdocs/agents/decisions.mdをReadツールで確認し、その設計判断がまだ記録されていないことを確認してください。\n\n重複通知の抑止: 同じtranscript_pathをGrepし、「domain.md（新しいドメイン用語）とdocs/agents/decisions.md」という文言を含むsystemMessageが既にこのセッション内に出力されていないか確認してください。存在する場合は今回は発火しないでください。\n\n通知すべきと判断した場合は、次の日本語メッセージのみを返してください（説明や前置きは不要）:\n「このセッションはfacility/tenant/RLS等のドメインに触れています。docs/agents/domain.md（新しいドメイン用語）とdocs/agents/decisions.md（後戻りしづらい・トレードオフのある設計判断）に追記すべき内容がないか確認してください。」\n\n通知すべきでないと判断した場合は、何も返さないでください。",
-            "statusMessage": "domain.md/decisions.md更新候補を確認中(agent hook)..."
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-domain-decisions-suggest.sh",
+            "timeout": 15
           },
           {
             "type": "command",

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ session-report-*.html
 
 # Stop hookのセッション内重複提案抑止用の一時状態（ローカル専用）
 /.claude/.ai-check-suggest-state/
+/.claude/.domain-decisions-suggest-state/
 /.claude/.verify-state/
 /.claude/.gate-effectiveness-state/
 /.claude/.doc-suggest-state/

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -34,7 +34,7 @@
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |
-| Stop | agent型（domain.md/decisions.md提案） | warning-only | 高リスクドメイン変更時のドキュメント反映漏れ提案 |
+| Stop | `check-domain-decisions-suggest.sh` | warning-only | 高リスクドメイン変更時のドキュメント反映漏れ提案。**issue #685でagent型からcommand型へ置き換えた**（agent版は抑止条件に該当する場面でも毎ターンサブエージェントを起動し、「何も返さない」指示に反して判定理由を返し続けていた）。重複抑止はマーカーファイルで決定的に行い、「設計判断かどうか」の判断だけをメインループへ委ねる。**これによりagent型hookは0本になった** |
 | Stop | `ai-check-suggest.sh` | warning-only | `npm run ai:check`実行有無の警告 |
 | Stop | `verify-claims.sh` | **block**（retry上限3回のエスケープ付き） | 未解消の指摘があれば`emit_block`で`exit 2`しStopをブロックする。3回試行しても解消しなければ人間介入待ちのメッセージでブロックし続ける |
 | Stop | `gate-effectiveness-monthly-check.sh` | warning-only | 品質ゲート月次サマリの提示 |

--- a/scripts/check-domain-decisions-suggest.sh
+++ b/scripts/check-domain-decisions-suggest.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hookから呼ばれる。高リスクドメイン（facility/tenant/RLS等）に触れたセッションで、
+# docs/agents/domain.md・decisions.md への追記漏れがないかを促す。
+#
+# WHY（agent型からcommand型へ置き換えた理由・issue #685）:
+# 元は type:"agent" のStop hookで、サブエージェントがtranscript全文を読んで
+#   (1) 変更ファイルの抽出
+#   (2) 「設計判断を含むか」の判断
+#   (3) 同一セッション内の重複通知の抑止
+# を全部やっていた。しかし (1)(3) は機械的に決まる判定であり、LLMに任せる必要がない。
+# 実際、抑止条件に該当して「発火しない」と判断する場面でも毎ターンサブエージェントが
+# 起動し、しかも「何も返さないでください」という指示に反して判定理由を返し続けていた
+# （2026-08-30のセッションで10回以上観測）。鳴り続ける通知は読まれなくなる。
+#
+# 本スクリプトは (1)(3) をシェルで決定的に処理し、(2) の「設計判断かどうか」の判断だけを
+# メインループ側へ委ねる。メインループは変更の文脈を既に持っているため、transcriptを
+# 読み直すサブエージェントより安く、かつ正確に判断できる。
+#
+# 既知の限界: 元のagent版は「ファイルパスだけでなく実際の変更内容が
+# facility/tenant/... に関わるか」も見ていた。本スクリプトはパスとファイル名までしか
+# 見ないため、無関係なパスに置かれたドメイン変更は拾えない（偽陰性）。
+# その代わり偽陽性（毎ターンの空振り）を無くし、通知が読まれる状態を保つ方を優先した。
+
+cd "$(dirname "$0")/.."
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
+
+silent() {
+  echo '{"systemMessage": ""}'
+  exit 0
+}
+
+STATE_DIR=".claude/.domain-decisions-suggest-state"
+mkdir -p "$STATE_DIR"
+STATE_FILE="$STATE_DIR/${SESSION_ID}.done"
+
+# 7日より古い状態ファイルは掃除する（セッションごとに増え続けるのを防ぐ）
+find "$STATE_DIR" -name '*.done' -mtime +7 -delete 2>/dev/null || true
+
+# WHY: 重複抑止はマーカーファイルで行う。transcript本文をgrepする方式は、警告文自体が
+#      transcriptに記録されて次回以降マッチする自己抑制バグを生む（issue #635の再発防止）。
+if [ -f "$STATE_FILE" ]; then
+  silent
+fi
+
+CHANGED_FILES="$( { git diff --name-only HEAD; git status --porcelain | awk '{print $2}'; } 2>/dev/null || true)"
+if [ -z "$CHANGED_FILES" ]; then
+  silent
+fi
+
+# docs/agents/common.md「TRI/RISK 機械判定基準」の高リスクパスに合わせる
+MATCHED="$(printf '%s' "$CHANGED_FILES" | grep -E \
+  -e '^supabase/migrations/' \
+  -e '^src/lib/supabase/' \
+  -e '(^|/)middleware\.ts$' \
+  -e '(facilit|tenant|organization|inventor|rls|polic|auth)' || true)"
+# WHY: 語尾変化を拾うため語幹で照合する。`facility` と書くと `facilities/` に一致せず
+#      取りこぼす（テストで検出）。`polic`→policy/policies、`inventor`→inventory/inventories
+
+if [ -z "$MATCHED" ]; then
+  silent
+fi
+
+FILE_LIST="$(printf '%s' "$MATCHED" | sort -u | head -10 | tr '\n' ' ')"
+
+MSG="このセッションは高リスクドメイン（facility/tenant/RLS等）のファイルに触れています: ${FILE_LIST}
+その変更が、単なるコメント修正・タイポ・変数名変更ではなく、後戻りしづらい／記録がないと後から理由が分からなくなる／本当にトレードオフがあった設計判断（RLSポリシーの方針、権限境界の変更、DBスキーマ変更の理由など）を含むなら、docs/agents/domain.md（新しいドメイン用語）と docs/agents/decisions.md（設計判断）への追記を検討してください。該当しなければ対応は不要です。"
+
+touch "$STATE_FILE"
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'

--- a/scripts/check-domain-decisions-suggest.test.sh
+++ b/scripts/check-domain-decisions-suggest.test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# WHY: scripts/check-domain-decisions-suggest.sh(Stop hook)の回帰テスト。
+# 実物のgitに依存させず、テスト用のフェイクgitをPATHの先頭に注入して決定的に検証する。
+#
+# このhookはissue #685で type:"agent" から type:"command" へ置き換えたもの。
+# agent版は「発火しない」場面でも毎ターンサブエージェントを起動し、判定理由を返し続けて
+# いた。置き換えの要点は次の3つで、本テストはそれぞれに対応する:
+#   1. 高リスクパスに触れていなければ沈黙する（毎ターンの空振りを無くす）
+#   2. 触れていれば1回だけ通知する
+#   3. 同一セッション内の2回目以降は沈黙する（重複抑止をマーカーファイルで決定的に行う）
+#
+# 実行: bash scripts/check-domain-decisions-suggest.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-domain-decisions-suggest.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_silent() {
+  local actual="$1" label="$2"
+  # 沈黙は systemMessage が空文字であること（Stop hookの出力契約）
+  if [ "$(printf '%s' "$actual" | tr -d '[:space:]')" = '{"systemMessage":""}' ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+
+FAKE_BIN="$(mktemp -d)"
+STATE_DIR="$REPO_ROOT/.claude/.domain-decisions-suggest-state"
+# WHY: 実行前に既存のマーカーが残っていると、通知されるべきケースが沈黙して誤判定になる。
+#      テスト用sessionのマーカーのみを対象に、前後で掃除する
+clean_markers() {
+  rm -f "$STATE_DIR"/hooktest-*.done
+}
+cleanup() {
+  rm -rf "$FAKE_BIN"
+  clean_markers
+}
+trap cleanup EXIT
+# 前回の失敗で残ったマーカーがあると、通知されるべきケースが沈黙して誤判定になる
+clean_markers
+
+setup_fake_git() {
+  # $1 に git diff --name-only HEAD の出力を渡す（git status --porcelain は空にする）
+  local changed="$1"
+  cat > "$FAKE_BIN/git" <<EOF
+#!/bin/bash
+if [ "\$1" = "diff" ]; then
+  printf '%s' "$changed"
+  if [ -n "$changed" ]; then echo; fi
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$FAKE_BIN/git"
+}
+
+run_hook() {
+  local session_id="$1"
+  printf '{"session_id":"%s","transcript_path":""}' "$session_id" \
+    | PATH="$FAKE_BIN:$PATH" bash "$SCRIPT"
+}
+
+echo "== 1. 変更ファイルが無ければ沈黙する =="
+setup_fake_git ""
+assert_silent "$(run_hook hooktest-empty)" "変更なし → 沈黙"
+
+echo "== 2. 高リスクパス以外だけなら沈黙する（毎ターンの空振りを無くす） =="
+setup_fake_git "README.md"
+assert_silent "$(run_hook hooktest-lowrisk)" "README.mdのみ → 沈黙"
+
+echo "== 3. supabase/migrations/ に触れたら通知する =="
+setup_fake_git "supabase/migrations/20260101000000_x.sql"
+out="$(run_hook hooktest-migration)"
+assert_contains "$out" "高リスクドメイン" "migration変更 → 通知"
+assert_contains "$out" "supabase/migrations/20260101000000_x.sql" "通知に対象ファイル名が含まれる"
+assert_contains "$out" "docs/agents/decisions.md" "通知に追記先が含まれる"
+
+echo "== 4. 同一セッションの2回目は沈黙する（重複抑止） =="
+assert_silent "$(run_hook hooktest-migration)" "同じsession_idの再実行 → 沈黙"
+
+echo "== 5. セッションが変われば再び通知する =="
+out2="$(run_hook hooktest-migration-2)"
+assert_contains "$out2" "高リスクドメイン" "別session_id → 通知"
+
+echo "== 6. src/lib/supabase/ と middleware.ts も対象 =="
+setup_fake_git "src/lib/supabase/server.ts"
+assert_contains "$(run_hook hooktest-libsupabase)" "高リスクドメイン" "src/lib/supabase/ → 通知"
+setup_fake_git "middleware.ts"
+assert_contains "$(run_hook hooktest-middleware)" "高リスクドメイン" "middleware.ts → 通知"
+
+echo "== 7. ファイル名にドメイン語を含む場合も対象 =="
+setup_fake_git "src/lib/facilities/repository.ts"
+assert_contains "$(run_hook hooktest-domainword)" "高リスクドメイン" "facility を含むパス → 通知"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "PASSED"


### PR DESCRIPTION
## 30秒サマリー
- **変更概要**: 毎ターンLLMを起動していた Stop hook を、シェルの決定的判定へ置き換える
- **リスク**: 低〜中（`.claude/settings.json` の変更は全セッションに影響する。ただしプロダクションコードの変更はゼロ）
- **変更領域**: hook設定 / スクリプト / ドキュメント
- **証拠状態**: 実測5件 / 未検証1件
- **影響範囲**: Stop hook 1本の実装。**agent型 hook は 0 本になり、Stop hook 9本すべてが command型**に
- **ロールバック可能性**: 高（新規2ファイル削除＋既存3ファイルrevert）

**レビューしてほしい点**
1. 「設計判断かどうか」の判断をサブエージェントからメインループへ移した判断
2. 内容ベース判定を諦めた（偽陰性を許容した）トレードオフ

## 00 目的・影響範囲・対象外

**目的**: このhookは `type: "agent"` で、サブエージェントがtranscript全文を読んで ①変更ファイルの抽出 ②「設計判断を含むか」の判断 ③重複通知の抑止 を全部やっていた。しかし①③は機械的に決まる判定で、LLMに任せる必要がない。

実際、抑止条件に該当して「発火しない」と判断する場面でも**毎ターンサブエージェントが起動**し、しかもプロンプトの「何も返さないでください」という指示に**反して判定理由を返し続けていた**（2026-08-30のセッションで10回以上観測）。

**対象外**: 他8本の Stop hook（既に command型）。通知内容そのものの見直し。

## 01 画面がどう変わったか

対象外（UI変更なし）

## 02 内部でどう守っているか

| | 変更前（agent型） | 変更後（command型） |
|---|---|---|
| 毎ターンの動作 | サブエージェントを起動し transcript 全文を Read + Grep | シェルが `git diff` を見るだけ |
| 抑止されたとき | 「発火しない」という判定理由を返し続ける（指示違反） | `{"systemMessage": ""}` で完全に沈黙 |
| 重複抑止 | LLM が transcript を grep して自己判定 | セッションIDごとのマーカーファイル（決定的） |
| 「設計判断か」の判断 | サブエージェント（文脈を持たない） | メインループ（変更の文脈を既に持っている） |

重複抑止にマーカーファイルを使うのは、transcript本文をgrepする方式が**警告文自体にマッチする自己抑制バグ**を生むため（issue #635 の再発防止）。

## 03 誰が操作できるか

RLS・権限・migration の変更なし。hook はシェル実行のみで、外部送信や書き込み先の変更はありません。

## 04 どう確認したか

新規回帰テスト `scripts/check-domain-decisions-suggest.test.sh` — **10ケース全通過**（CIの `hooks-test` ジョブが `scripts/*.test.sh` を全件実行するため自動で回る）。

| ケース | 期待 | 結果 |
|---|---|---|
| 変更ファイルなし | 沈黙 | OK |
| `README.md` のみ | 沈黙 | OK |
| `supabase/migrations/` 変更 | 通知（ファイル名・追記先を含む） | OK |
| 同一 session_id の2回目 | 沈黙 | OK |
| 別 session_id | 再通知 | OK |
| `src/lib/supabase/` / `middleware.ts` | 通知 | OK |
| `src/lib/facilities/` | 通知 | OK |

その他:
- 実物の hook としても手動で3ケース実行（沈黙 / 通知 / 重複抑止）
- `settings.json` がパースでき、Stop hook 9本すべてが `command` 型になったことを確認
- `npm test`: 192ファイル **1486件 green**

**実装中に踏んだ想定外**: ドメイン語の照合が `src/lib/facilities/` を取りこぼしていた（`facility` は `facilities` の部分文字列ではない）。**回帰テストのケース7が RED になって検出**し、語幹照合（`facilit` / `polic` / `inventor`）へ修正。設定に入れる前にテストが捕まえた形です。

## 05 何かあったらどうするか

**異常の判断基準**: 高リスクパスを触ったのに通知が出ない → `paths` 相当の正規表現が漏れている。逆に無関係な変更で通知が出る → 語幹照合が広すぎる（`auth` が `author` に一致する等）。

**ロールバック**: 新規2ファイル削除＋3ファイルrevert。`.claude/settings.json` を元の agent 型定義に戻せば完全復旧。

**既知の限界（意図的なトレードオフ）**: agent版は「パスだけでなく**実際の変更内容**がドメインに関わるか」も見ていました。シェル版はパスとファイル名までしか見ないため、無関係なパスに置かれたドメイン変更は拾えません（偽陰性）。その代わり偽陽性（毎ターンの空振り）がゼロになります。**鳴り続けて読まれなくなるより、たまに鳴らない方がマシ**という判断です。

## 後任AIへの注意

- **ドメイン語は語幹で照合すること**。`facility` と書くと `facilities/` に一致せず取りこぼす（実際に踏んだ）
- **重複抑止に transcript grep を使わないこと**。警告文自体がtranscriptに残り、次回以降マッチして永久に黙る自己抑制バグになる（issue #635）
- **偽陰性は意図的**。内容ベース判定を戻したくなったら、まず「毎ターンLLMを起動するコスト」と「通知が読まれなくなる副作用」を天秤にかけ直すこと

## 未検証

- **実セッションでの挙動**。このセッションは起動時の設定で動いているため、差し替えは反映されていない可能性が高い。次回セッションで確認する（issue #685 はそのため open のまま残す）

Refs #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
