### PR TITLE
feat: worktree・ローカルブランチ残骸の定期検知をSessionStart hookに追加する(issue #674)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,8 @@
       "Bash(bash scripts/check-blocked-issues-staleness.test.sh*)",
       "Bash(scripts/check-fault-injection-drill-staleness.sh *)",
       "Bash(bash scripts/check-fault-injection-drill-staleness.test.sh*)",
+      "Bash(scripts/check-stale-worktrees.sh*)",
+      "Bash(bash scripts/check-stale-worktrees.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -184,6 +186,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-recovery-queue.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-stale-worktrees.sh",
+            "timeout": 20
           }
         ]
       }

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -33,6 +33,7 @@
 | SessionStart | `check-automode-config.sh` | warning-only | autoMode(hard_deny)未設定の警告（個人設定のため機械強制不可） |
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
+| SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）を警告。削除は不可逆に近い操作のため意図的にwarning-only |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |
 | Stop | `check-domain-decisions-suggest.sh` | warning-only | 高リスクドメイン変更時のドキュメント反映漏れ提案。**issue #685でagent型からcommand型へ置き換えた**（agent版は抑止条件に該当する場面でも毎ターンサブエージェントを起動し、「何も返さない」指示に反して判定理由を返し続けていた）。重複抑止はマーカーファイルで決定的に行い、「設計判断かどうか」の判断だけをメインループへ委ねる。**これによりagent型hookは0本になった** |
 | Stop | `ai-check-suggest.sh` | warning-only | `npm run ai:check`実行有無の警告 |
@@ -55,11 +56,11 @@
 - ask: 1件
 - 自動復旧（queue、うち登録側）: 2件（`check-workflow-interruption.sh`・`check-gap-check-state.sh`）
 - 自動復旧（queue、表示側）: 1件（`check-recovery-queue.sh`）
-- warning-only: 14件
+- warning-only: 15件
 
-約20件の検知hookのうち、機械的に実行を止める・確認を強制する（block/ask）のは3件。
+約21件の検知hookのうち、機械的に実行を止める・確認を強制する（block/ask）のは3件。
 recovery-queue接続によって「次回セッション冒頭で機械的に目の前に出る」までは自動化されている
-ものが3件。残る14件はすべて、systemMessageが出力された後の是正判断・実行タイミングを完全に
+ものが3件。残る15件はすべて、systemMessageが出力された後の是正判断・実行タイミングを完全に
 人（またはそれを読んだセッション）に委ねている。
 
 （2026-08-10訂正: `verify-claims.sh`は当初この表でwarning-onlyと誤記されていたが、実装は

--- a/scripts/check-stale-worktrees.sh
+++ b/scripts/check-stale-worktrees.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: 本スクリプトは警告専用（ブロックしない）hookである。jq未インストール環境では
+# jq呼び出しがexit 127でスクリプトごと死に、警告が出せなくなる（issue #636と同種の対策）。
+# ブロックしないスクリプトなので実害は無音のfail-open（警告が出ないだけ）であり、
+# エラーノイズだけを消す目的でjq/git/gh不在時は静かにexit 0する。
+command -v jq >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+
+# WHY: issue #674。2026-08-27の棚卸しで、worktree13個中8個が用済み（対応PRマージ済み）、
+# ローカルブランチ96件が残骸（リモート削除済みのgone）と判明した。既存のSessionStart hook
+# （check-branch-pr-status.sh・check-local-main-freshness.sh）は「今いるブランチ」しか
+# 見ておらず、リポジトリ全体の残骸蓄積は検知対象外だった。
+#
+# 検知内容:
+# 1. `git worktree list`の各worktreeのブランチについて、対応PRがマージ/クローズ済みかを
+#    gh pr listで確認し、該当worktree数を警告する（API呼び出しはworktree数に上限を設けて抑制）
+# 2. `git branch -vv`の「gone」表示（リモート追跡先が削除済み）ブランチ数が閾値を超えたら
+#    件数警告する
+#
+# 設計方針:
+# - fail-open: git/gh/jq不在・API失敗・タイムアウトはすべて沈黙する。警告機能の故障で
+#   セッションを妨げない
+# - 警告は同一セッションにつき1回のみ（.aidd/check-stale-worktrees-warning-shown.json の
+#   マーカーで抑止。書き込みは一時ファイル→mvのatomic方式。既存4スクリプト
+#   （check-aidd-stats-recorded.sh等）と同一パターン）
+# - 全経路 exit 0（blockしない）。是正（worktree削除・ブランチ削除）の実行は完全に人間の
+#   裁量に委ねる（worktree/ブランチの削除は不可逆に近い操作のため機械強制しない）
+#
+# 環境変数（テスト用の注入ポイント）:
+#   STALE_WORKTREES_SESSION_ID     hook stdinのsession_idの代替
+#   STALE_WORKTREES_MARKER_FILE    警告済みマーカー（既定 .aidd/check-stale-worktrees-warning-shown.json）
+#   STALE_WORKTREES_MAX_CHECK      PR状態を確認するworktree数の上限（既定10、API呼び出し抑制）
+#   STALE_WORKTREES_GONE_THRESHOLD goneブランチ数の警告閾値（既定10）
+
+cd "$(dirname "$0")/.."
+
+MARKER_FILE="${STALE_WORKTREES_MARKER_FILE:-.aidd/check-stale-worktrees-warning-shown.json}"
+MAX_CHECK="${STALE_WORKTREES_MAX_CHECK:-10}"
+GONE_THRESHOLD="${STALE_WORKTREES_GONE_THRESHOLD:-10}"
+
+# hook入力（stdin JSON）からsession_idを取得（テスト時は環境変数で代替）
+if [ -z "${STALE_WORKTREES_SESSION_ID:-}" ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+  SESSION_ID="$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+else
+  SESSION_ID="$STALE_WORKTREES_SESSION_ID"
+fi
+[ -n "$SESSION_ID" ] || exit 0
+
+# 警告済みマーカー: 同一セッションでは2回目以降沈黙
+if [ -f "$MARKER_FILE" ]; then
+  WARNED_SESSION="$(jq -r '.sessionId // empty' "$MARKER_FILE" 2>/dev/null || true)"
+  if [ "$WARNED_SESSION" = "$SESSION_ID" ]; then
+    exit 0
+  fi
+fi
+
+# 1. worktreeごとにマージ/クローズ済みPRの有無を確認する（1worktreeあたりAPI呼び出し1回。
+#    --state all + jqでの絞り込みにより merged/closed を1リクエストにまとめる）
+STALE_WORKTREE_COUNT=0
+CHECKED=0
+set +e
+WORKTREE_LIST="$(git worktree list --porcelain 2>/dev/null)"
+while IFS= read -r line; do
+  case "$line" in
+    "branch refs/heads/"*)
+      BRANCH="${line#branch refs/heads/}"
+      if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+        continue
+      fi
+      if [ "$CHECKED" -ge "$MAX_CHECK" ]; then
+        continue
+      fi
+      CHECKED=$((CHECKED + 1))
+      PRS="$(gh pr list --head "$BRANCH" --state all --json state --limit 5 2>/dev/null)"
+      [ -z "$PRS" ] && PRS='[]'
+      DONE_COUNT="$(printf '%s' "$PRS" | jq '[.[] | select(.state == "MERGED" or .state == "CLOSED")] | length' 2>/dev/null)"
+      if [ -n "$DONE_COUNT" ] && [ "$DONE_COUNT" != "0" ]; then
+        STALE_WORKTREE_COUNT=$((STALE_WORKTREE_COUNT + 1))
+      fi
+      ;;
+  esac
+done <<EOF
+$WORKTREE_LIST
+EOF
+set -e
+
+# 2. goneブランチ（リモート追跡先が削除済み）の数。
+# WHY: grep -c はマッチ0件でも標準出力に"0"を返す（終了コードは1になるが、これは
+# 「マッチ0件」を示すだけで異常ではない）。ここで || echo 0 を足すと、grep自体は
+# 正常終了しているのに"0"が二重出力される（0\n0 のような複数行）ため付けない。
+# git自体が失敗した場合（コマンド不在等）のみ次行のデフォルト代入で0にする。
+set +e
+GONE_COUNT="$(git branch -vv 2>/dev/null | grep -c ': gone\]')"
+set -e
+[ -z "$GONE_COUNT" ] && GONE_COUNT=0
+
+# どちらも該当なしなら何も出さず終了
+if [ "$STALE_WORKTREE_COUNT" -eq 0 ] 2>/dev/null && [ "$GONE_COUNT" -lt "$GONE_THRESHOLD" ] 2>/dev/null; then
+  exit 0
+fi
+
+# 警告前に、マーカーをatomicに書いてから1回だけ警告する
+write_marker() {
+  local dir tmp
+  dir="$(dirname "$MARKER_FILE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(mktemp "$dir/.check-stale-worktrees-warning.XXXXXX" 2>/dev/null)" || return 1
+  jq -n --arg sid "$SESSION_ID" '{sessionId: $sid}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  return 0
+}
+set +e
+write_marker
+set -e
+
+LINES=""
+if [ "$STALE_WORKTREE_COUNT" -gt 0 ] 2>/dev/null; then
+  LINES="${LINES}- 対応PRがマージ/クローズ済みのworktreeが${STALE_WORKTREE_COUNT}件あります（確認対象は先頭${CHECKED}件まで）。\`git worktree list\`で確認し、不要なら\`git worktree remove\`で削除してください。
+"
+fi
+if [ "$GONE_COUNT" -ge "$GONE_THRESHOLD" ] 2>/dev/null; then
+  LINES="${LINES}- リモート追跡先が削除済み（gone）のローカルブランチが${GONE_COUNT}件あります。\`git branch -vv | grep gone\`で確認し、不要なら\`git branch -D\`で削除してください。
+"
+fi
+
+MSG="リポジトリ内にworktree・ローカルブランチの残骸が蓄積している可能性があります（issue #674）。
+${LINES}この警告はセッションにつき1回のみ表示されます。削除は不可逆に近い操作のため、対応PRの状態やコミットの有無を確認してから行ってください。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'
+
+exit 0

--- a/scripts/check-stale-worktrees.test.sh
+++ b/scripts/check-stale-worktrees.test.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# WHY: scripts/check-stale-worktrees.sh(SessionStart hook)の回帰テスト。
+# 実物のgit/gh/マーカーファイルに依存させず、テスト用のフェイクgit/ghをPATHの先頭に注入し、
+# マーカーファイルもテンポラリディレクトリへ切り替えて決定的に検証する。
+#
+# 実行: bash scripts/check-stale-worktrees.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-stale-worktrees.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (expected=$expected actual=$actual)"
+    fail=1
+  fi
+}
+
+FAKE_BIN="$(mktemp -d)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN" "$WORK_DIR"' EXIT
+BASH_BIN="$(command -v bash)"
+
+# git worktree list --porcelain / git branch -vv の両方をフェイクgitで切り替える。
+# gh pr list --state all --json state --limit 5 の応答は $1 の内容次第で固定JSONを返す。
+setup_fakes() {
+  local worktree_porcelain="$1" branch_vv="$2" gh_json="$3"
+
+  cat > "$FAKE_BIN/git" <<EOF
+#!/bin/bash
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
+  cat <<'WT_EOF'
+$worktree_porcelain
+WT_EOF
+  exit 0
+fi
+if [ "\$1" = "branch" ] && [ "\$2" = "-vv" ]; then
+  cat <<'BR_EOF'
+$branch_vv
+BR_EOF
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$FAKE_BIN/git"
+
+  cat > "$FAKE_BIN/gh" <<EOF
+#!/bin/bash
+echo '$gh_json'
+EOF
+  chmod +x "$FAKE_BIN/gh"
+}
+
+run_hook() {
+  local session_id="$1"
+  set +e
+  OUT="$(cd "$WORK_DIR" && STALE_WORKTREES_SESSION_ID="$session_id" \
+    STALE_WORKTREES_MARKER_FILE="$WORK_DIR/.aidd/marker.json" \
+    STALE_WORKTREES_MAX_CHECK=10 STALE_WORKTREES_GONE_THRESHOLD=10 \
+    PATH="$FAKE_BIN:$PATH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+WT_NONE="worktree /repo
+HEAD abc123
+branch refs/heads/main"
+
+WT_STALE="worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/.claude/worktrees/foo
+HEAD def456
+branch refs/heads/issue-1-foo"
+
+WT_STALE_WITH_DETACHED="worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/.codex/worktrees/1/foo
+HEAD 999def
+detached
+
+worktree /repo/.claude/worktrees/foo
+HEAD def456
+branch refs/heads/issue-1-foo"
+
+BR_NONE="* main abc123 commit"
+BR_GONE_MANY="  b1 aaa [origin/b1: gone] c
+  b2 aaa [origin/b2: gone] c
+  b3 aaa [origin/b3: gone] c
+  b4 aaa [origin/b4: gone] c
+  b5 aaa [origin/b5: gone] c
+  b6 aaa [origin/b6: gone] c
+  b7 aaa [origin/b7: gone] c
+  b8 aaa [origin/b8: gone] c
+  b9 aaa [origin/b9: gone] c
+  b10 aaa [origin/b10: gone] c
+* main aaa commit"
+
+echo "=== scenario 1: 残骸なし → 何も出力しない ==="
+setup_fakes "$WT_NONE" "$BR_NONE" '[]'
+run_hook "session-1"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: マージ済みPRを持つworktreeあり → 警告を出す ==="
+setup_fakes "$WT_STALE" "$BR_NONE" '[{"state":"MERGED"}]'
+run_hook "session-2"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "issue #674" "issue番号が含まれる"
+
+echo "=== scenario 3: goneブランチが閾値以上 → 警告を出す ==="
+setup_fakes "$WT_NONE" "$BR_GONE_MANY" '[]'
+run_hook "session-3"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "10件" "gone件数が含まれる"
+
+echo "=== scenario 3b: detached worktreeが混在していてもクラッシュせず処理される ==="
+setup_fakes "$WT_STALE_WITH_DETACHED" "$BR_NONE" '[{"state":"MERGED"}]'
+run_hook "session-3b"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "detached混在でもbranch持ちworktreeは検知される"
+
+echo "=== scenario 4: 同一セッションで2回目 → 沈黙する ==="
+setup_fakes "$WT_STALE" "$BR_NONE" '[{"state":"MERGED"}]'
+run_hook "session-4"
+assert_contains "$OUT" "systemMessage" "1回目は警告を出す"
+run_hook "session-4"
+assert_empty "$OUT" "2回目は沈黙する"
+
+echo "=== scenario 5: 別セッションIDなら再度警告する ==="
+setup_fakes "$WT_STALE" "$BR_NONE" '[{"state":"MERGED"}]'
+run_hook "session-5"
+assert_contains "$OUT" "systemMessage" "session-5は警告を出す"
+run_hook "session-6"
+assert_contains "$OUT" "systemMessage" "別セッションsession-6も警告を出す"
+
+echo "=== scenario 6: ghコマンドが無い環境 → 何も出力しない(fail-open) ==="
+setup_fakes "$WT_STALE" "$BR_NONE" '[{"state":"MERGED"}]'
+rm -f "$FAKE_BIN/gh"
+# 実PATH上のghディレクトリだけを取り除く(dirname/jq等の他coreutilsは実PATH由来のまま使わせる)
+REAL_GH="$(command -v gh || true)"
+GH_DIR="$(dirname "$REAL_GH" 2>/dev/null || true)"
+PATH_WITHOUT_GH="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vF "$GH_DIR" | tr '\n' ':')"
+set +e
+OUT="$(cd "$WORK_DIR" && STALE_WORKTREES_SESSION_ID="session-7" \
+  STALE_WORKTREES_MARKER_FILE="$WORK_DIR/.aidd/marker-no-gh.json" \
+  PATH="$FAKE_BIN:$PATH_WITHOUT_GH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
+EXIT_CODE=$?
+set -e
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: マージ/クローズ済みPRに対応するworktree・goneブランチの蓄積を、セッション開始時に警告するhookを新規追加した
- リスク: 低(warning-onlyのhook追加のみ。プロダクトコード・DB・RLSには一切触れない)
- 変更領域: ロジック(hookスクリプト)・設定(.claude/settings.json)・ドキュメント
- 証拠状態: 実測4件(新規テスト7件green・全hookテスト(CIのhooks-testと同範囲)green・実リポジトリでの手動実行で実際の残骸検知を確認・lint/tsc green)
- 影響範囲: セッション開始時の警告メッセージが1つ増えるのみ。ブロック・自動削除は一切しない
- ロールバック可能性: 容易(settings.jsonのフック登録を1行外すかrevertで即座に戻せる)

レビューしてほしい点:
1. gh API呼び出し数抑制のためworktree確認数に上限(既定10)を設けているが、この上限値・timeout(20秒)が実運用で妥当か
2. warning-onlyとした判断(worktree/ブランチ削除は不可逆に近い操作なのでblock/queue化せず人間の裁量に委ねる)への異論の有無

## 00 目的・影響範囲・対象外
- 目的: issue #674。2026-08-27の棚卸しで、worktree13個中8個が用済み・ローカルブランチ96件が残骸と判明したが、既存hookは「今いるブランチ」しか見ておらずリポジトリ全体の残骸蓄積は検知対象外だった。この機械検知の穴を埋める
- 変更範囲: `scripts/check-stale-worktrees.sh`(新規)・`scripts/check-stale-worktrees.test.sh`(新規)・`.claude/settings.json`(SessionStartフック登録+Bash許可リスト)・`docs/agents/actuator-inventory.md`(棚卸し表への登録)
- 対象外(今回あえて触らない): 検知後の自動削除(worktree remove・branch -D)。不可逆に近い操作のため意図的に人間判断に委ねる
- 作業中に見つけた別件: なし

## 01 画面がどう変わったか（UI証拠）
対象外。UI変更なし。SessionStart時のシステムメッセージが1種類増えるのみ。

## 02 内部でどう守っているか（ロジック証拠）
- [`scripts/check-stale-worktrees.sh`](scripts/check-stale-worktrees.sh): `git worktree list --porcelain`の各worktreeのブランチについて`gh pr list --head <branch> --state all --json state --limit 5`でMERGED/CLOSED状態のPRの有無を確認、`git branch -vv`の`gone]`表示ブランチ数をカウント
- fail-open: jq/git/gh不在・API失敗はすべて沈黙してexit 0(全経路)
- セッション1回スロットリング: `.aidd/check-stale-worktrees-warning-shown.json`にsessionIdを記録。既存の`check-aidd-stats-recorded.sh`等と同一のatomicマーカー方式を踏襲

## 03 誰が操作できるか（RLS/権限証拠）
対象外。auth/RLS/facility境界には一切触れない。

## 04 どう確認したか（テスト・検証）
- この変更に直接対応するテスト: `bash scripts/check-stale-worktrees.test.sh` → 7シナリオ(残骸なし/worktree残骸あり/goneブランチ閾値超/detached worktree混在時の非クラッシュ/セッション内2回目の沈黙/別セッションでの再警告/gh不在時のfail-open) 全件green(実測)
- 全体テストの実行結果(実測、2026-08-30ローカル実行):
  - `scripts/*.test.sh scripts/lib/*.test.sh`全件(CIの`hooks-test`ジョブと同範囲) → 全件green
  - `npm run lint` → エラーなし
  - `npx tsc --noEmit` → エラーなし
- 実リポジトリでの手動実行(実測): 環境変数でsession_idを注入して本物のgit/ghで実行し、実際に既にマージ済みのPRに対応する残存worktree・10件以上のgoneブランチを正しく検知することを確認
- fault injection: 未実施(warning-onlyのhookでありblock系ロジックがないため対象外)
- code-reviewerによる読み取り専用レビューを実施。指摘2件(goneカウントロジックの可読性、detached worktreeのテストカバレッジ)を反映。うち1件はレビュー提案(grep -c失敗時にフォールバックを追加する案)がテスト実行で誤りと判明し(grep -cはマッチ0件でも正常終了して"0"を返すため二重出力になる)、提案を鵜呑みにせず元の実装を維持した

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 本PRは監視対象システムを持たない(hookのsystemMessage出力のみ)
- 異常の判断基準: セッション開始時に想定外のエラーメッセージやクラッシュが出た場合。fail-open設計のため通常は沈黙するはず
- ロールバック手順: `.claude/settings.json`のSessionStartフック配列から`check-stale-worktrees.sh`のエントリを削除するか、本PRをrevertすれば即座に元の状態に戻る

## 後任AIへの注意
- この実装で壊してはいけない前提: 全経路でexit 0を返すこと(warning-onlyのhookがブロックしてはならない)。git/gh/jq不在時やAPI失敗時は沈黙するfail-open設計を維持すること
- 似ているが別物の用語: 「gone」(リモート追跡先が削除済みのローカルブランチ)と「detached」(worktreeがブランチに紐付いていない状態、`git worktree list --porcelain`では別行として出る)は別概念。本実装はdetachedを検知対象にしていない(意図的、稀なケースのため)
- 勝手にリファクタしない場所: 他のSessionStart hook(`check-branch-pr-status.sh`等)のマーカーファイル方式・fail-openパターンは、複数スクリプトで意図的に統一されている設計。本PRもそれを踏襲した

Closes #674
