### PR TITLE
feat: CLAUDE.md/common.mdの行数肥大化をSessionStart hookで警告する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,8 @@
       "Bash(bash scripts/check-blocked-issues-staleness.test.sh*)",
       "Bash(scripts/check-fault-injection-drill-staleness.sh *)",
       "Bash(bash scripts/check-fault-injection-drill-staleness.test.sh*)",
+      "Bash(scripts/check-claude-md-size.sh *)",
+      "Bash(bash scripts/check-claude-md-size.test.sh*)",
       "Bash(curl -s http://localhost:*)",
       "Bash(sort *)",
       "Bash(ps *)",
@@ -184,6 +186,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-recovery-queue.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-claude-md-size.sh",
+            "timeout": 5
           }
         ]
       }

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -33,6 +33,7 @@
 | SessionStart | `check-automode-config.sh` | warning-only | autoMode(hard_deny)未設定の警告（個人設定のため機械強制不可） |
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
+| SessionStart | `check-claude-md-size.sh` | warning-only | CLAUDE.md/docs/agents/common.mdの行数肥大化を警告（トークン効率化。common.mdは機械検知ルール集のため「短ければ良い」わけではなく、削除判断は人間に委ねる） |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |
 | Stop | `check-domain-decisions-suggest.sh` | warning-only | 高リスクドメイン変更時のドキュメント反映漏れ提案。**issue #685でagent型からcommand型へ置き換えた**（agent版は抑止条件に該当する場面でも毎ターンサブエージェントを起動し、「何も返さない」指示に反して判定理由を返し続けていた）。重複抑止はマーカーファイルで決定的に行い、「設計判断かどうか」の判断だけをメインループへ委ねる。**これによりagent型hookは0本になった** |
 | Stop | `ai-check-suggest.sh` | warning-only | `npm run ai:check`実行有無の警告 |

--- a/scripts/check-claude-md-size.sh
+++ b/scripts/check-claude-md-size.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: SessionStart hookから呼ばれる。CLAUDE.md / docs/agents/common.md
+# （@importでCLAUDE.mdに実質連結される正本）は毎メッセージのプリロードとして
+# 課金対象になるため、肥大化に気づかず膨張し続けるリスクがある。
+# ただしこのリポジトリのcommon.mdは意図的に構造化されたAIDDフレームワークの
+# 機械検知ルール集であり、「短ければ良い」わけではない（削除の判断は人間に委ねる）。
+# block（session開始そのものの停止）はできない前提のためwarningのみ。
+#
+# 閾値は環境変数で上書き可能（デフォルトはCLAUDE.md=200行、common.md=300行。
+# common.mdは@importで別ファイルとして分離されている実態を踏まえ、CLAUDE.md本体より
+# 緩めの閾値にした）。
+
+command -v wc >/dev/null 2>&1 || exit 0
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CLAUDE_MD_LIMIT="${CLAUDE_MD_LINE_LIMIT:-200}"
+COMMON_MD_LIMIT="${COMMON_MD_LINE_LIMIT:-300}"
+
+CLAUDE_MD_PATH="$PROJECT_DIR/CLAUDE.md"
+COMMON_MD_PATH="$PROJECT_DIR/docs/agents/common.md"
+
+WARNINGS=()
+
+if [ -f "$CLAUDE_MD_PATH" ]; then
+  LINES=$(wc -l < "$CLAUDE_MD_PATH" | tr -d ' ')
+  if [ "$LINES" -gt "$CLAUDE_MD_LIMIT" ]; then
+    WARNINGS+=("CLAUDE.mdが${LINES}行（閾値${CLAUDE_MD_LIMIT}行）を超えています。全メッセージでプリロードされるため、不要な記述が無いか見直しを検討してください。")
+  fi
+fi
+
+if [ -f "$COMMON_MD_PATH" ]; then
+  LINES=$(wc -l < "$COMMON_MD_PATH" | tr -d ' ')
+  if [ "$LINES" -gt "$COMMON_MD_LIMIT" ]; then
+    WARNINGS+=("docs/agents/common.mdが${LINES}行（閾値${COMMON_MD_LIMIT}行）を超えています。CLAUDE.mdへの@importで全メッセージにプリロードされるため、既存ルールの棚卸しファイルへの分離（issue #486と同様の対応）を検討してください。")
+  fi
+fi
+
+if [ "${#WARNINGS[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+MSG=$(printf '%s\n' "${WARNINGS[@]}")
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg msg "$MSG" '{
+    systemMessage: $msg,
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: $msg
+    }
+  }'
+else
+  echo "$MSG" >&2
+fi

--- a/scripts/check-claude-md-size.test.sh
+++ b/scripts/check-claude-md-size.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# WHY: scripts/check-claude-md-size.sh(SessionStart hook)の回帰テスト。
+# CLAUDE.md / docs/agents/common.mdの行数が閾値を超えたら警告し、超えなければ
+# 何も出力しないことを確認する。CLAUDE_PROJECT_DIR/CLAUDE_MD_LINE_LIMIT/
+# COMMON_MD_LINE_LIMITでテスト用に差し替える（本物のCLAUDE.mdを書き換えないため）。
+#
+# 実行: bash scripts/check-claude-md-size.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-claude-md-size.sh"
+
+fail=0
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+mkdir -p "$TMPDIR_TEST/docs/agents"
+
+echo "=== scenario 1: どちらも閾値以下 → 何も出力しない ==="
+seq 1 50 > "$TMPDIR_TEST/CLAUDE.md"
+seq 1 50 > "$TMPDIR_TEST/docs/agents/common.md"
+OUT="$(CLAUDE_PROJECT_DIR="$TMPDIR_TEST" bash "$SCRIPT")"
+assert_empty "$OUT" "行数が閾値以下なら警告なし"
+
+echo "=== scenario 2: CLAUDE.mdが閾値超過 → 警告する ==="
+seq 1 250 > "$TMPDIR_TEST/CLAUDE.md"
+seq 1 50 > "$TMPDIR_TEST/docs/agents/common.md"
+OUT="$(CLAUDE_PROJECT_DIR="$TMPDIR_TEST" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "CLAUDE.md" "CLAUDE.mdへの言及がある"
+
+echo "=== scenario 3: common.mdが閾値超過 → 警告する ==="
+seq 1 50 > "$TMPDIR_TEST/CLAUDE.md"
+seq 1 350 > "$TMPDIR_TEST/docs/agents/common.md"
+OUT="$(CLAUDE_PROJECT_DIR="$TMPDIR_TEST" bash "$SCRIPT")"
+assert_contains "$OUT" "common.md" "common.mdへの言及がある"
+
+echo "=== scenario 4: 環境変数で閾値を変更できる ==="
+seq 1 50 > "$TMPDIR_TEST/CLAUDE.md"
+seq 1 50 > "$TMPDIR_TEST/docs/agents/common.md"
+OUT="$(CLAUDE_PROJECT_DIR="$TMPDIR_TEST" CLAUDE_MD_LINE_LIMIT=10 bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "閾値を下げると50行でも警告される"
+
+echo "=== scenario 5: ファイルが存在しない → クラッシュせず何も出力しない ==="
+EMPTY_DIR="$(mktemp -d)"
+OUT="$(CLAUDE_PROJECT_DIR="$EMPTY_DIR" bash "$SCRIPT")"
+assert_empty "$OUT" "ファイル不在でもクラッシュしない"
+rm -rf "$EMPTY_DIR"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー

トークン効率化のNotion記事をきっかけに、プリロード対象（CLAUDE.md/docs/agents/common.md）が
気づかず肥大化するリスクをSessionStart hookで機械的に警告する仕組みを追加した。加えて
issue #446で既に実装済みだった個人opt-in statuslineを自分の`settings.local.json`で有効化した
（settings.local.jsonはgitignore対象のためこのPRには含まれない）。

危険度: 低（新規hookはwarning-onlyで、既存の挙動を変更しない）。

## 何が変わったか

- `scripts/check-claude-md-size.sh`（新規）: SessionStart hookとして、CLAUDE.md/common.mdが
  それぞれ200行/300行を超えたらsystemMessageで警告する。ブロックはしない
- `scripts/check-claude-md-size.test.sh`（新規）: 5シナリオの回帰テスト
- `.claude/settings.json`: 上記hookをSessionStartに登録、permissions allowリストに追加
- `docs/agents/actuator-inventory.md`: 検知hook棚卸し表に新hookを追記、warning-only件数を更新

検討したが実装しなかったもの: PostToolUseによるコマンド出力トリミング。公式ドキュメントで
「PostToolUseフックはツール出力自体を書き換えられない」と明記されており技術的に不可能なため
見送った。

## どう確認したか

- `bash scripts/check-claude-md-size.test.sh` で新規テスト5シナリオ全PASSを確認
- 実際のCLAUDE.md/common.mdに対して実行し、現状値（95行/250行）では警告が出ないことを確認
- `npm test` で全192ファイル・1486テストがPASSすることを確認（マージコミット後）
- `jq empty .claude/settings.json` で構文妥当性を確認

## 後任AI・レビュアーへの注意点

- common.mdは機械検知ルール集であり「短ければ良い」わけではない。将来この警告が発火しても
  機械的にトリムせず、内容を精査してから判断すること
- 本PRはmain（issue #674のcheck-stale-worktrees.sh追加）とのマージコンフリクトを手動解決済み

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>