### PR TITLE
feat: docs/sessionsの空テンプレセッションレポートをSessionStart hookで検知する(issue #673)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -198,6 +198,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-stale-worktrees.sh",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-empty-session-report.sh",
+            "timeout": 10
           }
         ]
       }

--- a/scripts/check-empty-session-report.sh
+++ b/scripts/check-empty-session-report.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: 本スクリプトは警告専用（ブロックしない）hookである。jq未インストール環境では
+# jq呼び出しがexit 127でスクリプトごと死に、警告が出せなくなっていた（issue #636と同型の
+# 予防策）。ブロックしないスクリプトなので実害は無音のfail-open（警告が出ないだけ）であり、
+# エラーノイズだけを消す目的でjq不在時は静かにexit 0する。
+command -v jq >/dev/null 2>&1 || exit 0
+
+# WHY: issue #673。docs/sessions/配下のセッションレポートは ~/aidd_session_report.sh
+# （リポジトリ外・Stop hook）が自動生成するが、2026-06-28以降「結果」欄（うまくいったこと/
+# 問題・気になった点/次の課題）が全空のまま放置されるテンプレが27ファイル中18件（67%）
+# 蓄積していた実測がある（PR #672でtracked分16件削除済み）。
+# 生成元スクリプト側にはfeature未記録・phase未実行時に生成自体をスキップするガードを
+# 追加済みだが、そのガード自体にバグがあった場合や別経路で空テンプレが紛れ込んだ場合に
+# 機械的に気づく手段が無いままだった（docs/agents/decisions.mdの「検知手段を先に決める」
+# 原則）。本スクリプトはSessionStart hookとして、前回セッション終了後に残った空テンプレを
+# 検知する（Stop hookではなくSessionStartにした理由: レポート生成自体がリポジトリ外の
+# Stop hookで行われるため、同一Stop hookイベント内での実行順序に依存せず、次回セッション
+# 開始時に確実に検知できるタイミングを選んだ）。
+#
+# 検知ロジック:
+# - git status --porcelain で docs/sessions/ 配下の未コミット（untracked/modified）な
+#   .mdファイルを列挙する（コミット済みで既に人間がレビューを終えたファイルは対象外）
+# - 各ファイルの「## 結果」セクション以下、うまくいったこと/問題・気になった点/次の課題の
+#   3行がいずれも「- 見出し:」のまま（コロンの後に内容が無い）ならテンプレ未記入とみなす
+#
+# 既知の限界:
+# - 「## 結果」という見出し文言・3項目の文言が変わった場合は追従できない（部分文字列一致）
+# - コミット済みファイルは対象外のため、うっかりgit addしてしまった空テンプレは検知しない
+#   （その場合はレビュー時の目視に依存する）
+#
+# 環境変数（テスト用の注入ポイント。check-local-main-freshness.shと同型）:
+#   EMPTY_SESSION_REPORT_PROJECT_DIR  対象プロジェクトディレクトリの代替（既定: このスクリプトの親）
+
+command -v git >/dev/null 2>&1 || exit 0
+
+PROJECT_DIR="${EMPTY_SESSION_REPORT_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+[ -d docs/sessions ] || exit 0
+
+UNCOMMITTED_FILES="$(git status --porcelain -- docs/sessions/ 2>/dev/null | awk '{print $NF}' | grep -E '\.md$' || true)"
+[ -n "$UNCOMMITTED_FILES" ] || exit 0
+
+EMPTY_FILES=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  [ -f "$f" ] || continue
+  # 「## 結果」以降の本文を取り出し、3項目すべてが空（コロン直後に何も無い）かを判定する
+  RESULT_BODY="$(awk '/^## 結果/{flag=1; next} flag' "$f")"
+  [ -n "$RESULT_BODY" ] || continue
+  if printf '%s\n' "$RESULT_BODY" | grep -qE '^- (うまくいったこと|問題・気になった点|次の課題): *\S'; then
+    continue
+  fi
+  EMPTY_FILES="${EMPTY_FILES}${f}\n"
+done <<< "$UNCOMMITTED_FILES"
+
+[ -n "$EMPTY_FILES" ] || exit 0
+
+FILE_LIST="$(printf '%b' "$EMPTY_FILES" | sed '/^$/d')"
+
+MSG="docs/sessions/配下に「結果」欄が未記入のまま残っているセッションレポートがあります（issue #673）。生成元（~/aidd_session_report.sh）は既にガード済みのため今後は新規生成が抑制される見込みですが、既存の未コミットファイルは手動での記入・削除を検討してください。
+${FILE_LIST}"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-empty-session-report.test.sh
+++ b/scripts/check-empty-session-report.test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# WHY: scripts/check-empty-session-report.sh(SessionStart hook、issue #673)の回帰テスト。
+# 実物のリポジトリのdocs/sessions/を汚さず、EMPTY_SESSION_REPORT_PROJECT_DIRで
+# フェイクのgitリポジトリを指すよう差し替えて決定的に検証する
+# （check-local-main-freshness.test.shと同型）。
+#
+# 実行: bash scripts/check-empty-session-report.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-empty-session-report.sh"
+
+fail=0
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+REPO="$WORKDIR/fake-repo"
+mkdir -p "$REPO/docs/sessions"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "test"
+echo "init" > "$REPO/README.md"
+echo "placeholder" > "$REPO/docs/sessions/.gitkeep"
+git -C "$REPO" add README.md docs/sessions/.gitkeep
+git -C "$REPO" commit -q -m "init"
+
+run_hook() {
+  set +e
+  OUT="$(EMPTY_SESSION_REPORT_PROJECT_DIR="$REPO" bash "$SCRIPT" < /dev/null)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: docs/sessions/が空 → 何も出力しない ==="
+run_hook
+assert_empty "$OUT" "セッションレポートが無ければ沈黙する"
+
+echo "=== scenario 2: 結果欄が全空の未コミットファイル → 警告する ==="
+cat > "$REPO/docs/sessions/2099-01-01-empty.md" <<'EOF'
+# 2099-01-01 empty
+
+## 結果
+- うまくいったこと:
+- 問題・気になった点:
+- 次の課題:
+EOF
+run_hook
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "2099-01-01-empty.md" "空テンプレのファイル名が含まれる"
+rm -f "$REPO/docs/sessions/2099-01-01-empty.md"
+
+echo "=== scenario 3: 結果欄が記入済みの未コミットファイル → 警告しない ==="
+cat > "$REPO/docs/sessions/2099-01-01-filled.md" <<'EOF'
+# 2099-01-01 filled
+
+## 結果
+- うまくいったこと: 動いた
+- 問題・気になった点: 特になし
+- 次の課題: なし
+EOF
+run_hook
+assert_empty "$OUT" "記入済みファイルは警告されない"
+rm -f "$REPO/docs/sessions/2099-01-01-filled.md"
+
+echo "=== scenario 4: 空テンプレがコミット済み → 警告しない(対象外) ==="
+cat > "$REPO/docs/sessions/2099-01-01-committed-empty.md" <<'EOF'
+# 2099-01-01 committed-empty
+
+## 結果
+- うまくいったこと:
+- 問題・気になった点:
+- 次の課題:
+EOF
+git -C "$REPO" add docs/sessions/2099-01-01-committed-empty.md
+git -C "$REPO" commit -q -m "add committed empty template"
+run_hook
+assert_empty "$OUT" "コミット済みの空テンプレは検知対象外"
+
+echo "=== scenario 5: 一部項目だけ記入済み → 3項目全空ではないので警告しない ==="
+cat > "$REPO/docs/sessions/2099-01-02-partial.md" <<'EOF'
+# 2099-01-02 partial
+
+## 結果
+- うまくいったこと: 一部だけ書いた
+- 問題・気になった点:
+- 次の課題:
+EOF
+run_hook
+assert_empty "$OUT" "1項目でも記入済みなら未記入テンプレ扱いにしない(偽陽性回避)"
+rm -f "$REPO/docs/sessions/2099-01-02-partial.md"
+
+echo "=== scenario 6: docs/sessionsディレクトリ自体が無い → クラッシュせず沈黙する ==="
+NO_SESSIONS_REPO="$WORKDIR/no-sessions-repo"
+mkdir -p "$NO_SESSIONS_REPO"
+git -C "$NO_SESSIONS_REPO" init -q
+git -C "$NO_SESSIONS_REPO" config user.email "test@example.com"
+git -C "$NO_SESSIONS_REPO" config user.name "test"
+echo "init" > "$NO_SESSIONS_REPO/README.md"
+git -C "$NO_SESSIONS_REPO" add README.md
+git -C "$NO_SESSIONS_REPO" commit -q -m "init"
+set +e
+OUT="$(EMPTY_SESSION_REPORT_PROJECT_DIR="$NO_SESSIONS_REPO" bash "$SCRIPT" < /dev/null)"
+EXIT_CODE=$?
+set -e
+assert_empty "$OUT" "docs/sessions/不在でもクラッシュしない"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: docs/sessions/配下に「結果」欄が未記入のまま残る空テンプレを、SessionStart hookで検知・警告する
- リスク: 低
- 変更領域: ロジック（Stop hook本体は`~/`配下のためこのリポジトリの対象外。今回追加したのはリポジトリ内の検知hookのみ）
- 証拠状態: 実測4件（テストスクリプト全シナリオ実行）・npm test/hooks-test全件実測
- 影響範囲: `.claude/settings.json`のSessionStartフック一覧・`scripts/check-empty-session-report.sh`（新規）
- ロールバック可能性: 高（.claude/settings.jsonから1エントリ削除するだけで無効化可能）

レビューしてほしい点:
1. 「## 結果」セクション3項目が全て空の場合のみ警告する判定（1項目でも記入済みなら沈黙）が妥当か
2. コミット済みファイルを検知対象外にした設計（うっかりgit addされた空テンプレは目視依存になる）が許容範囲か

## 00 目的・影響範囲・対象外
- 目的: issue #673「セッションレポートhookが空テンプレのdocs/sessions/*.mdを生成し続けるバグを根治する」の残タスク（検知手段の追加）
- 変更範囲: `.claude/settings.json`（SessionStartフック追加）、`scripts/check-empty-session-report.sh`（新規）、`scripts/check-empty-session-report.test.sh`（新規）
- 対象外（今回あえて触らない）: 生成元スクリプト自体（`~/aidd_session_report.sh`・`~/write_aidd_stats.sh`）はこのリポジトリ外にあるため、PR対象外。今回のセッションで別途、(a)feature未記録/phase未実行時にレポート生成をスキップするガード、(b)24時間以上更新の無いstatsファイルを前セッションの放置物とみなし破棄する処理、の2点を直接編集済み（リポジトリ管理外のためこのPRには含まれない）
- 作業中に見つけた別件: 特になし

## 01 画面がどう変わったか（UI証拠）
対象外（hookのsystemMessage出力のみ、UIコンポーネント変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- `scripts/check-empty-session-report.sh`: `git status --porcelain -- docs/sessions/`で未コミットの.mdファイルを列挙し、各ファイルの「## 結果」セクション以下、うまくいったこと/問題・気になった点/次の課題の3項目が全て空（コロン直後に内容なし）ならSessionStart時にsystemMessageで警告する
- jq/git不在環境はfail-open（警告が出ないだけ、block不可）
- `.claude/settings.json`のSessionStartフック配列末尾に追加（[.claude/settings.json:199](.claude/settings.json)付近）

## 03 誰が操作できるか（RLS/権限証拠）
対象外（RLS・権限に関わる変更なし）

## 04 どう確認したか（テスト・検証）
- `scripts/check-empty-session-report.test.sh`（新規・6シナリオ、実測）:
  - docs/sessions/が空 → 沈黙
  - 結果欄が全空の未コミットファイル → 警告する
  - 結果欄が記入済みの未コミットファイル → 警告しない
  - 空テンプレがコミット済み → 対象外（警告しない）
  - 一部項目だけ記入済み → 警告しない（偽陽性回避）
  - docs/sessionsディレクトリ自体が無い → クラッシュせず沈黙
- `npm test`（vitest、実測）: Test Files 192 passed / Tests 1486 passed
- CI相当の`scripts/*.test.sh scripts/lib/*.test.sh`全件（ローカル実測、39+1本): 全件PASS
- verify-claimsでの追加検証は未実施（このPR自体の主張は上記テスト実行結果のみで、外部レビュー指摘の検証ではないため対象外と判断）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: SessionStart時のsystemMessage表示（docs/sessions/に未記入ファイルが残っていれば毎回表示される）
- 異常の判断基準: 空テンプレが解消されないまま何セッションも警告が出続ける場合、生成元スクリプト側のガード（リポジトリ外）が機能していない可能性
- ロールバック手順: `.claude/settings.json`のSessionStartフック配列から該当エントリを削除するだけ

## 後任AIへの注意
- この実装で壊してはいけない前提: 「## 結果」の見出し文言・3項目の文言（うまくいったこと/問題・気になった点/次の課題）に依存した部分文字列一致。文言を変更する場合は本スクリプトも追従させること
- 似ているが別物の用語: 本PRの「生成ガード」は`~/aidd_session_report.sh`（リポジトリ外・今回のセッションで別途修正済み）を指し、本PRの検知hookとは別物
- 勝手にリファクタしない場所: `git status --porcelain`のパース処理（`awk '{print $NF}'`）はファイル名にスペースを含むケースを想定していない簡易実装。既知の限界として許容している

🤖 Generated with [Claude Code](https://claude.com/claude-code)