### PR TITLE
tune: aidd-1-1-deep-taskのモデル階層をコスト最適化する

### DIFF
--- a/.claude/agents/contract-writer.md
+++ b/.claude/agents/contract-writer.md
@@ -2,7 +2,7 @@
 name: contract-writer
 description: 承認済みSPEC.mdのPart 2から型定義・APIインターフェースのみを先行確定させる。後続implementer（並列）が参照する「契約」を書く。
 tools: Read, Edit, Write, Bash
-model: sonnet
+model: haiku
 ---
 
 あなたはcontract-writer（契約定義担当）です。

--- a/.claude/workflows/aidd-1-1-deep-task.js
+++ b/.claude/workflows/aidd-1-1-deep-task.js
@@ -539,7 +539,7 @@ phase('Synthesize')
 
 const synthesis = await agent(
   `以下の全検証結果を統合して、仕様書ドラフトへの具体的な修正提案を出力せよ。\n\n## 元の仕様書ドラフト\n${draftSpec?.detail}\n\n## 生存した問題点 (${survived.length}件)\n${survived.map(f => `- [${f.severity}][${f.category}] ${f.title}: ${f.description}`).join('\n')}\n\n## ギャップ (${gaps.length}件)\n${gaps.map(g => `- [${g.area}] ${g.description} → 提案: ${g.suggestion}`).join('\n')}\n\n## Judge Panel結果\n### 採用推奨案: ${winner?.proposal?.name} (スコア: ${Math.round(winner?.avgScore ?? 0)})\n${winner?.proposal?.description}\n主要判断: ${winner?.proposal?.keyDecisions?.join(' / ')}\n\n### 他案のグラフト候補\n${runnerUps.map(r => `- ${r.proposal?.name}: ${r.proposal?.keyDecisions?.join(' / ')}`).join('\n')}\n\n## 出力形式\n1. **必須修正** (critical/important の問題点)\n2. **推奨修正** (minor・ギャップ)\n3. **設計判断** (採用推奨アプローチとその理由)\n4. **未解決事項** (人間が判断すべきポイント)\n\n## status/detail\n上記の統合提案本文は detail に格納し、status も返すこと。\n- pass: 統合提案を生成できた\n- fail: 生成されたが必須修正等のセクションが欠落するなど明らかに不完全\n- blocked: survived/gaps/winnerのいずれかが揃わず統合に着手できなかった`,
-  { label: 'synthesize', phase: 'Synthesize', model: 'opus', effort: 'high', schema: AGENT_RESULT_SCHEMA_PFB }
+  { label: 'synthesize', phase: 'Synthesize', model: 'sonnet', effort: 'high', schema: AGENT_RESULT_SCHEMA_PFB }
 )
 
 return {


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: 質の低下リスクがほぼ無い2箇所のモデル階層を下げ、クレジット単価を削減
- リスク: 低（出力の性質上、下位モデルでも十分な精度が見込める作業のみを選定）
- 変更領域: ロジック（AIDDワークフロー設定のみ、プロダクトコード無変更）
- 証拠状態: 実測（npm test全件・関連syncテスト個別実行）
- 影響範囲: `.claude/workflows/aidd-1-1-deep-task.js`・`.claude/agents/contract-writer.md`の2ファイル、各1行
- ロールバック可能性: 高（1コミット2行、`git revert`で即座に戻せる）

レビューしてほしい点:
1. `synthesize`をOpus→Sonnetに下げて品質が体感できるほど落ちないか（構造化済みの調査結果を統合するだけの作業のため、質の低下リスクは低いと判断）
2. `contract-writer`をSonnet→Haikuに下げて型抽出の粗さが増えないか（後続のtypecheck/implementerで機械的に検出される設計のため許容範囲と判断）

## 00 目的・影響範囲・対象外
- 目的: Claude Codeの利用クレジットが逼迫気味という会話上のきっかけから、AIDDワークフローのモデル階層を見直し。質へのリスクがほぼゼロな箇所のみをコスト最適化する
- 変更範囲: `aidd-1-1-deep-task.js`の`synthesize`ステージ（opus→sonnet）、`contract-writer`サブエージェント（sonnet→haiku）
- 対象外（今回あえて触らない）:
  - Sweep系エージェント（既にhaiku、実害報告も無いため現状維持）
  - Adversarial Verify（opus、偽陽性を消す最後の砦のため質のリスクが高く見送り）
  - S/M/Lルーティング閾値の厳格化（router-risk.jsに明記された「false negativeは許容しない」という設計方針そのものに反するため見送り）
  - Judge Panelの提案数・採点lens数の削減（実測で全体の約5%削減効果しかなく、設計案比較の多様性という質のトレードオフに見合わないと判断し見送り）
- 作業中に見つけた別件: 特になし

## 01 画面がどう変わったか（UI証拠）
対象外（ワークフロー内部の設定変更のみ、UI変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- `.claude/workflows/aidd-1-1-deep-task.js`: `synthesize`ステージの`model: 'opus'` → `model: 'sonnet'`（effortは`high`のまま維持、スキーマ・プロンプトは無変更）
- `.claude/agents/contract-writer.md`: frontmatterの`model: sonnet` → `model: haiku`（tools・プロンプト本文は無変更）

## 03 誰が操作できるか（RLS/権限証拠）
対象外（RLS・権限に関わる変更なし）

## 04 どう確認したか（テスト・検証）
- `npm test`（vitest全体）: Test Files 192 passed / Tests 1487 passed（実測）
- 関連するsync/expectationテスト（`find-av-precision.test.js`・`find-av-precision-sync.test.js`・`budget-guard-sync.test.js`・`sweep-prompt-sync.test.js`・`agent-progress-expectation.test.js`・`loop-observability-expectation.test.js`・`workflow-prompt-sync.test.js`）を個別実行し全PASS確認（実測）
- 実際のワークフロー実行による品質比較（Opus版とSonnet版のsynthesize出力比較等）は未実施。判断根拠は「素材が揃った状態での統合・転記作業であり新規発想を要さない」という定性的な見立てであり、定量評価はしていない旨を明記する
- `npm run eval:workflows`は未実施（プロンプト文言は無変更でmodelフィールドのみの変更のため、`.claude/rules/workflow-eval-requirement.md`の対象外と判断）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 特になし。実際にaidd-1-1-deep-taskやaidd-phase2を回した際の`synthesize`/`contract-writer`の出力品質を体感で確認する
- 異常の判断基準: SPEC統合結果が薄い・型定義に明らかな誤りが増えたと感じたら見直し対象
- ロールバック手順: 該当1行を元の値（opus/sonnet）に戻すだけ

## 後任AIへの注意
- この実装で壊してはいけない前提: 特になし（設定値のみの変更）
- 似ているが別物の用語: 「モデル階層(tier)」はこのPRの主題（synthesize/contract-writerのopus/sonnet/haiku指定）であり、TRI/RISK判定の「高リスク/低リスク」とは無関係の軸
- 勝手にリファクタしない場所: 今回意図的に見送った箇所（Sweep系・Adversarial Verify・S/M/Lルーティング閾値・Judge Panel提案数）は、質へのリスクとコスト効果を天秤にかけた上での判断のため、同じ理由で今後も安易に下げないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)