### PR TITLE
ci: npm install を npm ci にし、hook の TS 実行を npx tsx から Node 標準の型除去に変える

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci   # ロックファイルどおりに展開（依存解決を省く。node-check.yml のコメント参照）
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci   # ロックファイルどおりに展開（依存解決を省く。node-check.yml のコメント参照）
 
       - uses: supabase/setup-cli@v3
         with:

--- a/.github/workflows/node-check.yml
+++ b/.github/workflows/node-check.yml
@@ -25,8 +25,11 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+      # WHY: npm install はロックファイルがあっても依存解決のためレジストリへ問い合わせに行き、
+      #      レジストリが遅い日は 15 秒 → 300 秒になった（2026-09-04 実測、キャッシュは命中していた）。
+      #      npm ci はロックファイルどおりに展開するだけで解決を行わず、不整合なら失敗して知らせる。
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run npm run ${{ inputs.run-script }}
         env:
           RUN_SCRIPT: ${{ inputs.run-script }}

--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -135,6 +135,26 @@ RLSポリシーの棚卸し（`pg_policies`を見る、または`CREATE POLICY`�
 
 ## エージェント/hook運用層
 
+### CI・hook が npm レジストリに毎回依存する（`npm install` / `npx -y tsx`）
+
+**チェック内容:** `.github/workflows/*.yml` の install ステップは `npm ci`（`npm install` は使わない）。
+hook スクリプト（`scripts/*.sh`）から TypeScript / ESM を実行するときは `npx` を使わず
+`node --experimental-strip-types`（.ts）/ `node --experimental-detect-module`（.js）で直接実行し、
+その import 連鎖の相対 import には拡張子（`.ts` / `.js`）を付ける。
+`scripts/check-no-registry-fetch.test.sh`（CI `hooks-test`）が 3 点とも機械検査する。
+
+**なぜ再発したか（2026-09-04）:** CI が平常時の 4〜8 倍かかった。ジョブ内訳を取ると本体の
+実行時間は不変で、(1) `npm install` が 15 秒 → 300 秒（キャッシュ命中でもロックがあっても
+依存解決でレジストリへ行く）、(2) hooks-test の月次チェック回帰が 51 秒 → 425 秒（`npx -y tsx`
+が tsx を毎回ダウンロード。tsx は devDependencies に無く、hooks-test は node_modules 無しで走る）。
+レジストリが遅い日にだけ露出するため、コード変更と無関係に「CI が急に遅い」として現れる。
+同じ `npx -y tsx` は 6 本の hook スクリプトに散在していた（1 本直しても残りで再発する）。
+
+**副次的に見つかったこと:** `npm ci` に切り替えた初回 CI で「ロックファイルに
+`@emnapi/runtime` / `@emnapi/core` が無い」と失敗した。`npm install` はこの不整合を黙って補って
+いたため、それまで検知されなかった。`npm ci` の失敗は正しい検知なので、`npm install` に戻さず
+ロックを直す（`npm install --package-lock-only`。CI と同じ npm の版で行う）。
+
 ### hookから`claude -p`を起動する際のsettings.json/hooks継承漏れ
 
 **チェック内容:** Stop/PreToolUse等のhookスクリプトが検証・裏取り目的で`claude -p`

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -456,7 +455,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -505,9 +503,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -517,6 +537,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1492,7 +1513,6 @@
       "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.62.1"
       },
@@ -1900,7 +1920,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
       "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.108.2",
         "@supabase/functions-js": "2.108.2",
@@ -2144,6 +2163,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2264,6 +2304,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2362,7 +2403,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2409,7 +2451,6 @@
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2420,7 +2461,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2431,7 +2471,6 @@
       "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2481,7 +2520,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -3224,7 +3262,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3265,6 +3302,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3598,7 +3636,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3965,6 +4002,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3997,7 +4035,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4289,7 +4328,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4475,7 +4513,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6240,6 +6277,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6812,7 +6850,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6878,6 +6915,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6893,6 +6931,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6905,7 +6944,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6955,7 +6995,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6965,7 +7004,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7787,7 +7825,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8006,7 +8043,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8160,7 +8196,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8252,7 +8287,6 @@
       "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.11",
         "@vitest/mocker": "4.1.11",
@@ -8573,7 +8607,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/check-agent-progress-gap.sh
+++ b/scripts/check-agent-progress-gap.sh
@@ -36,4 +36,6 @@ fi
 
 ACTUAL_COUNT=$(( AFTER_COUNT - BEFORE_COUNT ))
 
-npx -y tsx "$SCRIPT_DIR/../.claude/workflows/lib/agent-progress-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"
+# WHY: npx tsx はレジストリ依存で遅い日に数分かかる（harvest-journal-events.sh のコメント参照）。
+#      実体は .js（ESM）なので node で直接実行する（"type":"module" 無しの .js のため構文検出フラグを付ける）
+node --experimental-detect-module --no-warnings "$SCRIPT_DIR/../.claude/workflows/lib/agent-progress-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"

--- a/scripts/check-loop-observability-gap.sh
+++ b/scripts/check-loop-observability-gap.sh
@@ -36,4 +36,6 @@ fi
 
 ACTUAL_COUNT=$(( AFTER_COUNT - BEFORE_COUNT ))
 
-npx -y tsx "$SCRIPT_DIR/../.claude/workflows/lib/loop-observability-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"
+# WHY: npx tsx はレジストリ依存で遅い日に数分かかる（harvest-journal-events.sh のコメント参照）。
+#      実体は .js（ESM）なので node で直接実行する
+node --experimental-detect-module --no-warnings "$SCRIPT_DIR/../.claude/workflows/lib/loop-observability-gap.js" --actual "$ACTUAL_COUNT" --expected "$EXPECTED_COUNT"

--- a/scripts/check-no-registry-fetch.test.sh
+++ b/scripts/check-no-registry-fetch.test.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# WHY: 2026-09-04 に CI が平常時の 4〜8 倍かかった。原因は npm レジストリへの通信に依存する 2 箇所
+#      （ワークフローの `npm install` による依存解決、hook スクリプトの `npx -y tsx` による毎回の
+#      ダウンロード）で、レジストリが遅い日にだけ露出した。修正後に同じ書き方が戻らないよう、
+#      「ワークフローに npm install が無い」「hook スクリプトが npx を実行しない」を構造テストで
+#      固定する（docs/agents/known-failure-patterns.md「CI・hook が npm レジストリに毎回依存する」）。
+#
+# 検査:
+#   1. .github/workflows/*.yml の run: に `npm install` が無い（`npm ci` を使う）
+#   2. scripts/*.sh・scripts/lib/*.sh（*.test.sh を除く）にコマンドとしての `npx` が無い
+#      （コメント行と、文字列内の `npx[` のような正規表現片は除く）
+#   3. hook から Node 標準の型除去で直接実行される scripts/lib/*.ts の相対 import に拡張子がある
+#      （拡張子が無いと node が ERR_MODULE_NOT_FOUND で落ち、hook は fail-open で沈黙する）
+#
+# 実行: bash scripts/check-no-registry-fetch.test.sh
+# 環境変数（テスト用注入ポイント）:
+#   NRF_WORKFLOWS_DIR   検査するワークフローディレクトリ（既定 .github/workflows）
+#   NRF_SCRIPTS_DIR     検査するスクリプトディレクトリ（既定 scripts）
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail=0
+assert_ok() { echo "  OK: $1"; }
+assert_fail() {
+  echo "  NG: $1"
+  [ -n "${2:-}" ] && echo "      $2"
+  fail=1
+}
+
+# 検査本体。$1=workflows dir $2=scripts dir。違反行を出し、末尾に violations=N
+check() {
+  local wf="$1" sc="$2" violations=0 f hits
+
+  # 1. workflows: run 行の npm install
+  for f in "$wf"/*.yml; do
+    [ -f "$f" ] || continue
+    hits="$(grep -nE '^[[:space:]]*(- )?run:.*\bnpm install\b' "$f" || true)"
+    if [ -n "$hits" ]; then
+      printf '%s\n' "$hits" | sed "s#^#    npm-install: $(basename "$f"):#"
+      violations=$((violations + $(printf '%s\n' "$hits" | grep -c .)))
+    fi
+  done
+
+  # 2. hook scripts: コマンドとしての npx（行頭・;・&&・|・$(・` の直後）。コメント行は除く
+  for f in "$sc"/*.sh "$sc"/lib/*.sh; do
+    [ -f "$f" ] || continue
+    case "$f" in *.test.sh) continue ;; esac
+    hits="$(grep -nE '(^|[;&|(`])[[:space:]]*npx[[:space:]]' "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+    if [ -n "$hits" ]; then
+      printf '%s\n' "$hits" | sed "s#^#    npx: $(basename "$f"):#"
+      violations=$((violations + $(printf '%s\n' "$hits" | grep -c .)))
+    fi
+  done
+
+  # 3. node --experimental-strip-types で実行される .ts は、その import 連鎖の相対 import に拡張子が要る
+  local ts entry queue seen="" spec target
+  queue="$(grep -hoE 'node [^"]*--experimental-strip-types[^"]*"[^"]+\.ts"' "$sc"/*.sh 2>/dev/null | grep -oE '"[^"]+\.ts"' | tr -d '"' | sed "s#\$SCRIPT_DIR#$sc#" | sort -u || true)"
+  while [ -n "$queue" ]; do
+    entry="$(printf '%s\n' "$queue" | head -n1)"
+    queue="$(printf '%s\n' "$queue" | tail -n +2)"
+    ts="$entry"
+    [ -f "$ts" ] || ts="$REPO_ROOT/$entry"
+    [ -f "$ts" ] || continue
+    printf '%s\n' "$seen" | grep -qx "$ts" && continue
+    seen="$(printf '%s\n%s' "$seen" "$ts")"
+    for spec in $(grep -oE "from '\.\.?/[^']+'" "$ts" | sed "s/from '//; s/'\$//"); do
+      case "$spec" in
+        *.ts|*.js|*.mjs|*.json) target="$(dirname "$ts")/$spec"; queue="$(printf '%s\n%s' "$queue" "$target")" ;;
+        *)
+          echo "    ts-import: $(basename "$ts") の相対 import に拡張子が無い: $spec（node 直接実行で解決できない）"
+          violations=$((violations+1))
+          ;;
+      esac
+    done
+  done
+
+  echo "violations=$violations"
+}
+
+echo "=== scenario 1: 実態のワークフロー・スクリプトに違反が無い ==="
+RESULT="$(check "${NRF_WORKFLOWS_DIR:-$REPO_ROOT/.github/workflows}" "${NRF_SCRIPTS_DIR:-$REPO_ROOT/scripts}")"
+printf '%s\n' "$RESULT" | grep -v '^violations=' || true
+if [ "$(printf '%s\n' "$RESULT" | tail -n1)" = "violations=0" ]; then
+  assert_ok "違反なし"
+else
+  assert_fail "違反あり" "$(printf '%s\n' "$RESULT" | tail -n1)"
+fi
+
+echo "=== scenario 2: fixture で違反を検知できる（RED 方向の自己検証） ==="
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+mkdir -p "$WORK_DIR/wf" "$WORK_DIR/sc/lib"
+cat > "$WORK_DIR/wf/bad.yml" <<'EOF'
+jobs:
+  x:
+    steps:
+      - run: npm install
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+EOF
+cat > "$WORK_DIR/sc/bad-hook.sh" <<'EOF'
+#!/bin/bash
+# npx tsx をコメントで書いても違反ではない
+PATTERN='^(npx[[:space:]]+)?supabase'
+npx -y tsx "$SCRIPT_DIR/lib/thing.ts"
+OUT="$(npx something)"
+node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/entry.ts"
+EOF
+cat > "$WORK_DIR/sc/bad-hook.test.sh" <<'EOF'
+npx -y tsx should-be-ignored-in-tests
+EOF
+printf "import { a } from './dep.ts'\nimport { b } from './noext'\n" > "$WORK_DIR/sc/lib/entry.ts"
+printf "export const a = 1\n" > "$WORK_DIR/sc/lib/dep.ts"
+RESULT="$(check "$WORK_DIR/wf" "$WORK_DIR/sc")"
+# 期待: npm install 1 + npx 2（npx -y tsx、$(npx something)）+ 拡張子なし import 1 = 4
+if [ "$(printf '%s\n' "$RESULT" | tail -n1)" = "violations=4" ]; then
+  assert_ok "違反 4 件をちょうど検知"
+else
+  assert_fail "違反件数が期待（4）と異なる" "$RESULT"
+fi
+for needle in 'npm-install: bad.yml' 'npx: bad-hook.sh:4' 'npx: bad-hook.sh:5' "ts-import: entry.ts"; do
+  if printf '%s\n' "$RESULT" | grep -qF "$needle"; then assert_ok "検知: $needle"; else assert_fail "検知できない: $needle"; fi
+done
+for needle in 'npm ci' 'playwright' 'bad-hook.test.sh' 'PATTERN'; do
+  if printf '%s\n' "$RESULT" | grep -qF "$needle"; then assert_fail "誤検知: $needle"; else assert_ok "誤検知しない: $needle"; fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/harvest-journal-events.sh
+++ b/scripts/harvest-journal-events.sh
@@ -53,6 +53,10 @@ if [[ ${#PROJECT_DIRS[@]} -eq 0 ]]; then
   exit 1
 fi
 
+# WHY: 以前は `npx -y tsx` で実行していたが、tsx は devDependencies に無く npx が毎回 npm レジストリへ
+#      取りに行く。CI の hooks-test（node_modules 無し）ではレジストリが遅い日に 1 回 7 分かかった
+#      （2026-09-04 実測。平常時 51 秒 → 425 秒）。Node 22.6+ / 24 標準の型除去で直接実行し、
+#      ネットワーク依存を無くす。ランナー既定の Node 22 では警告が出るため --no-warnings を付ける。
 for project_dir in "${PROJECT_DIRS[@]}"; do
-  npx -y tsx "$SCRIPT_DIR/lib/harvest-journal-events.ts" --output "$OUTPUT_FILE" --project-dir "$project_dir"
+  node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/harvest-journal-events.ts" --output "$OUTPUT_FILE" --project-dir "$project_dir"
 done

--- a/scripts/lib/aggregate-loop-observability-usage.ts
+++ b/scripts/lib/aggregate-loop-observability-usage.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { getPricing } from './model-pricing'
+import { getPricing } from './model-pricing.ts'
 
 export interface LoopObservabilityEntry {
   timestamp: string

--- a/scripts/lib/canonical-event.ts
+++ b/scripts/lib/canonical-event.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { loadJournalResults, pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability'
+import { loadJournalResults, pairAgentFiles, parseAgentTranscriptLines } from './reconstruct-loop-observability.ts'
 
 export type EventSource = 'subagent-skeleton' | 'journal' | 'agent-progress' | 'loop-observability'
 export type EventStatus = 'pass' | 'fail' | 'blocked' | 'done' | 'failed' | 'running' | 'starting' | 'waiting'

--- a/scripts/lib/gate-effectiveness-summary.ts
+++ b/scripts/lib/gate-effectiveness-summary.ts
@@ -1,7 +1,8 @@
 import { realpathSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
-import { journalAdapter, type CanonicalEvent } from './canonical-event'
-import { loadHarvestedEvents } from './harvest-journal-events'
+// 拡張子付き import: Node 標準の型除去で直接実行するため（harvest-journal-events.ts のコメント参照）
+import { journalAdapter, type CanonicalEvent } from './canonical-event.ts'
+import { loadHarvestedEvents } from './harvest-journal-events.ts'
 
 // WHY: issue #569の残タスクのうち「サマリー・復旧処理をcanonical event Module経由に寄せる」を
 // 部分的に実装する。summarize-loop-observability.sh（logs/loop-observability.jsonlのみ参照）は

--- a/scripts/lib/harvest-journal-events.ts
+++ b/scripts/lib/harvest-journal-events.ts
@@ -1,7 +1,9 @@
 import { appendFileSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { journalAdapter, type CanonicalEvent } from './canonical-event'
+// 拡張子付き import: npx tsx ではなく Node 標準の型除去（--experimental-strip-types）で直接実行するため
+// （Node の ESM 解決は拡張子を補完しない。tsconfig の allowImportingTsExtensions で型検査も通す）
+import { journalAdapter, type CanonicalEvent } from './canonical-event.ts'
 
 // WHY: issue #642。journalAdapterが読むwf_*ディレクトリ(~/.claude/projects/配下)は
 // transcript cleanupで消えるため(実測: 2026-08-22時点で3ディレクトリしか残存せず)、

--- a/scripts/lib/reconstruct-loop-observability.ts
+++ b/scripts/lib/reconstruct-loop-observability.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { getPricing } from './model-pricing'
+import { getPricing } from './model-pricing.ts'
 
 // WHY: reviewer/judge-panelはscripts/log-loop-observability.shを`--loop developer`明示で呼ぶ設計、
 //      implementer等それ以外はスクリプトのデフォルト値`agentic`に依存する設計だった（docs/agents/*.md参照）。

--- a/scripts/lib/verify-agent-progress-transcript.ts
+++ b/scripts/lib/verify-agent-progress-transcript.ts
@@ -1,4 +1,4 @@
-import { loadAllEvents, correlateEvents, type CanonicalEvent, type CorrelatedExecution } from './canonical-event'
+import { loadAllEvents, correlateEvents, type CanonicalEvent, type CorrelatedExecution } from './canonical-event.ts'
 
 export type StatusComparison = 'match' | 'mismatch' | 'unknown'
 

--- a/scripts/summarize-gate-passfail.sh
+++ b/scripts/summarize-gate-passfail.sh
@@ -24,4 +24,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-npx -y tsx "$SCRIPT_DIR/lib/gate-effectiveness-summary.ts" --harvest-file "$HARVEST_FILE" ${JSON_FLAG[@]+"${JSON_FLAG[@]}"}
+# WHY: npx tsx はレジストリ依存で CI が遅い日に数分かかる（harvest-journal-events.sh のコメント参照）。
+#      Node 標準の型除去で直接実行する
+node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/gate-effectiveness-summary.ts" --harvest-file "$HARVEST_FILE" ${JSON_FLAG[@]+"${JSON_FLAG[@]}"}

--- a/scripts/update-loop-observability-usage.sh
+++ b/scripts/update-loop-observability-usage.sh
@@ -7,4 +7,6 @@ source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
 LOG_FILE="${1:-$(resolve_log_dir)/loop-observability.jsonl}"
 PROJECTS_ROOT="${2:-$HOME/.claude/projects}"
 
-npx -y tsx "$SCRIPT_DIR/lib/aggregate-loop-observability-usage.ts" "$LOG_FILE" "$PROJECTS_ROOT"
+# WHY: npx tsx はレジストリ依存で遅い日に数分かかる（harvest-journal-events.sh のコメント参照）。
+#      Node 標準の型除去で直接実行する
+node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/aggregate-loop-observability-usage.ts" "$LOG_FILE" "$PROJECTS_ROOT"

--- a/scripts/verify-agent-progress-transcript.sh
+++ b/scripts/verify-agent-progress-transcript.sh
@@ -31,4 +31,6 @@ if [[ "$LOG_FILE_GIVEN" -eq 0 ]]; then
   ARGS=(--log-file "$(resolve_log_dir)/agent-progress.jsonl" "${ARGS[@]}")
 fi
 
-npx -y tsx "$SCRIPT_DIR/lib/verify-agent-progress-transcript.ts" "${ARGS[@]}"
+# WHY: npx tsx はレジストリ依存で遅い日に数分かかる（harvest-journal-events.sh のコメント参照）。
+#      Node 標準の型除去で直接実行する
+node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/verify-agent-progress-transcript.ts" "${ARGS[@]}"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: CI の所要時間が平常時の 4〜8 倍になった原因 2 点（`npm install` の依存解決、`npx -y tsx` の毎回ダウンロード）を、`npm ci` と Node 標準の型除去実行に置き換えて潰す
- リスク: 低〜中。プロダクトコードには触れない。CI yml 3 本と hook 2 本、hook が読む TS 4 本の import 拡張子、tsconfig 1 行
- 変更領域: CI / hook
- 証拠状態: 実測 6 件（hook 回帰 46 本・vitest 1487・typecheck・lint・`npm ci --dry-run`・月次チェック回帰 0.36 秒）/ CI 待ち 1 件（この PR 自身の CI 所要時間）
- 影響範囲: 全 PR の CI、Stop hook（月次サマリの収穫・集計）
- ロールバック可能性: 高（revert 1 コミット）

レビューしてほしい点:
1. `npm ci` への変更で dependabot PR が落ちるようになった場合、それはロックファイル不整合の正しい検知なので、`npm install` に戻さずロックを直す運用でよいか
2. `--experimental-strip-types` はランナー既定の Node 22.23 でも動く（22.6+）。`--no-warnings` で ExperimentalWarning を消す判断

## 00 目的・影響範囲・対象外
- 目的: 2026-09-04 に CI が 2 分 → 5〜8 分になった。ジョブ内訳を取ると本体（test / lint / build / typecheck の実行）は変わらず、`npm install` が 15〜19 秒 → 120〜300 秒（キャッシュは命中）、hooks-test の `gate-effectiveness-monthly-check.test.sh` scenario 6 が 51 秒 → 425 秒だった。どちらも npm レジストリへの通信に依存する箇所で、レジストリが遅い日に露出する。露出自体を無くす
- 変更範囲: `.github/workflows/node-check.yml` / `integration-gate.yml` / `e2e.yml`（`npm install` → `npm ci`）、`scripts/harvest-journal-events.sh` / `scripts/summarize-gate-passfail.sh`（`npx -y tsx` → `node --experimental-strip-types --no-warnings`）、`scripts/lib/{harvest-journal-events,gate-effectiveness-summary,canonical-event,reconstruct-loop-observability}.ts`（実行時 import に `.ts` 拡張子）、`tsconfig.json`（`allowImportingTsExtensions: true`）
- 対象外（今回あえて触らない）: hooks-test ジョブへの `setup-node` + `npm ci` 追加（node_modules 無しで動く現状を維持したかった）。npm レジストリ側の遅延そのもの
- 作業中に見つけた別件: derive が hook 回帰のコマンドとして `bash scripts/harvest-journal-events.test.sh` を出すが、このファイルは存在しない（回帰は `scripts/lib/*.test.ts` の vitest 側にある）。ルール表が「`<name>.sh` → `<name>.test.sh`」を機械的に組み立てているため。存在確認を入れるか、vitest 側を名指しするかは PR③ 後続の改善候補

## 01 画面がどう変わったか（UI証拠）
- 対象外（UI 変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- `npm ci`: ロックファイルどおりに展開するだけで依存解決を行わない。不整合なら失敗して知らせる（`npm install` は黙ってロックを書き換える）。ローカルで `npm ci --dry-run` を実行し 467 パッケージがロックどおりに展開できることを確認
- Node 標準の型除去: `node --experimental-strip-types` は Node 22.6+ で利用可（ランナー既定 22.23.2、ローカル 24.11）。型除去は import の拡張子を補完しないため、実行時に辿る 4 ファイルの相対 import に `.ts` を付けた。`tsconfig.json` は `noEmit` なので `allowImportingTsExtensions` を有効化でき、`tsc --noEmit` が通る。vitest 側（拡張子なしで import しているテスト）も `moduleResolution: bundler` で両方を解決する
- `--no-warnings`: Node 22 では型除去が ExperimentalWarning を stderr に出す。hook は stderr を捨てているが、手動実行時のノイズを避けるため付けた

## 03 誰が操作できるか（RLS/権限証拠）
- RLS・権限の変更点: なし
- 他テナントの ID でアクセスし、弾かれることを確認したか: 対象外（認可に触れていない。`integration-gate.yml` の変更は install ステップのみで、テストの内容は変わらない）
- 該当する約束（promise-catalog.md）: なし

## 04 どう確認したか（テスト・検証）
以下は `bash scripts/derive-test-selection.sh origin/main --format table` の出力を貼り、実施結果で ⬜ を書き換えたもの。

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ✅ 実施 | (自動テスト: パス) `npm run typecheck`（`.ts` 拡張子 import + `allowImportingTsExtensions`） |
| lint | ✅ 実施 | (自動テスト: パス) `npm run lint` warning 0 |
| unit（UI・データ層・API Route） | ✅ 実施 | (自動テスト: パス) `npm test` 192 files / 1487 tests |
| build | ➖ 今回不要 | `src/` に差分なし。CI `build` ジョブが回す（このジョブ自身が `npm ci` の検証になる） |
| migration 静的テスト | ✅ 実施 | (自動テスト: パス) `npm test` に含まれる |
| DB 制約 ratchet | ✅ 実施 | (自動テスト: パス) `npm test` に含まれる |
| ワークフロー同期テスト | ✅ 実施 | (自動テスト: パス) `npm test` に含まれる |
| hook 回帰 | ✅ 実施 | (自動テスト: パス) CI と同じループで 46 本 failed=0。`gate-effectiveness-monthly-check.test.sh`（scenario 6 を含む）は 0.36 秒。derive が名指しした `harvest-journal-events.test.sh` / `summarize-gate-passfail.test.sh` は存在しない（別件参照）。回帰は `scripts/lib/harvest-journal-events.test.ts` / `gate-effectiveness-summary.test.ts`（vitest、122 件 pass） |
| 認証ファイル漏洩チェック | ➖ 今回不要 | `e2e/.auth` に触れていない。CI `hooks-test` ジョブが回す |
| RLS/IDOR 統合（実 DB） | ✅ 実施 | (自動テスト: パス) CI `integration-gate` の integration ジョブ 2m48s pass（`npm ci` 経由）。ローカル Supabase は未起動のためローカル実行はしていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに差分なし。CI `integration-gate` 内のステップが回す |
| hook 実機発火 | 🟡 一部 | `harvest-journal-events.sh` はこのセッションの Stop hook（月次チェック）から毎回呼ばれる。このブランチでの Stop 時に `logs/journal-harvest.jsonl` が更新されることで観測する。Codex 側 hook は変更なし |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に関わるパスに触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | `.claude/agents`・`.claude/workflows` に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | `.claude/workflows` に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れておらず、retry_possible の申告も無い |
| 同時実行 | ➖ 今回不要 | 同一注文・同一在庫行を複数ユーザーが更新する変更ではなく、contention の申告も無い |
| E2E（Playwright） | ➖ 今回不要 | 節目の種別。`e2e.yml` の変更は install ステップのみで、main マージ後の自動実行で `npm ci` を検証する |
| スキーマドリフト検知 | ➖ 今回不要 | 節目の種別（日次 cron） |
| fault injection 訓練（ゲート） | ➖ 今回不要 | 節目の種別 |
| 障害注入（外部依存停止） | ➖ 今回不要 | 節目の種別 |
| 復旧手順（ランブック） | ➖ 今回不要 | 節目の種別 |

- この変更に直接対応するテスト: `scripts/gate-effectiveness-monthly-check.test.sh` scenario 6（収穫・集計を実際に走らせる）、`scripts/lib/harvest-journal-events.test.ts`、`scripts/lib/gate-effectiveness-summary.test.ts`
- 全体テストの実行結果: 実測。`npm test` 1487 passed（2026-09-04 09:45 ローカル）、hook 回帰 46 本 failed=0、`npm run lint` warning 0、`npm run typecheck` pass、`npm ci --dry-run` 467 packages、`git diff --check` 差分なし。CI 所要時間の比較（前回 run 33822231661 → 本 PR run 33823950229）: hooks-test 7m56s → 54s、test 6m50s → 2m11s、build 5m28s → 34s、lint 3m20s → 39s、typecheck 2m22s → 33s、integration 3m40s → 2m48s。全ジョブ pass: https://github.com/huuriekaiseki-sketch/medical-inventory-vkumai/actions/runs/33823950229
- 初回 CI（run 33823238436）は `npm ci` がロック不整合（`@emnapi/runtime` / `@emnapi/core` 欠落）で失敗。CI と同じ npm 11.17 で `--package-lock-only` 再生成し、2 コミット目で解消。ロック差分は欠落項目の追加と peer フラグの正規化のみで、依存の版は変わっていない
- 再発防止: `scripts/check-no-registry-fetch.test.sh`（hooks-test）が「ワークフローに npm install が無い」「hook が npx を実行しない」「node 直接実行する .ts の相対 import に拡張子がある」を機械検査（fixture 4 件で RED 方向を固定）。残り 4 本の hook（agent-progress-gap / loop-observability-gap / update-loop-observability-usage / verify-agent-progress-transcript）の `npx -y tsx` も同時に除去。`docs/agents/known-failure-patterns.md` に記録
- fault injection: 未実施（既存の scenario 5 が「収穫・集計スクリプト不在でも fail-open」を、scenario 6 が「実体が動く」を固定しており、今回の置き換えで両方が引き続き pass することを確認した）
- 上記はすべて実測。verify-claims は未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: CI 各ジョブの Install dependencies ステップと hooks-test の所要時間。Stop hook の月次サマリに「取得できませんでした」が出ないこと
- 異常の判断基準: `npm ci` がロック不整合で失敗する（→ ロックを直す。`npm install` へ戻さない）。ランナーの Node が 22.6 未満に変わり `--experimental-strip-types` が未知フラグになる（→ hook は fail-open で沈黙するので、月次サマリの断り書きで気づく）
- ロールバック手順: このコミットを revert

## 後任AIへの注意
- この実装で壊してはいけない前提: `scripts/lib/` の 4 ファイルは hook から Node 標準で直接実行される。相対 import に `.ts` 拡張子が必要で、`enum` / `namespace` / parameter properties 等の型除去できない構文を足すと hook が動かなくなる（vitest は通るので気づきにくい）
- 似ているが別物の用語: 「型検査（tsc）」と「型除去（strip-types）」。前者は型を見る、後者は型を消して実行するだけで検査しない
- 勝手にリファクタしない場所: `.github/workflows/*.yml` の `npm ci`。`npm install` へ戻すと依存解決が復活し、レジストリが遅い日に再発する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
