### PR TITLE
feat: PRを一度も作らず放置されたローカルブランチの検知をSessionStart hookに追加する(issue #708)

### DIFF
--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -36,7 +36,7 @@
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
 | SessionStart | `check-claude-md-size.sh` | warning-only | CLAUDE.md/docs/agents/common.mdの行数肥大化を警告（トークン効率化。common.mdは機械検知ルール集のため「短ければ良い」わけではなく、削除判断は人間に委ねる） |
-| SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）を警告。削除は不可逆に近い操作のため意図的にwarning-only |
+| SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）・PRを一度も作らず一定日数放置されたブランチ数（閾値超過時、issue #708）を警告。削除は不可逆に近い操作のため意図的にwarning-only |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |
 | Stop | `check-domain-decisions-suggest.sh` | warning-only | 高リスクドメイン変更時のドキュメント反映漏れ提案。**issue #685でagent型からcommand型へ置き換えた**（agent版は抑止条件に該当する場面でも毎ターンサブエージェントを起動し、「何も返さない」指示に反して判定理由を返し続けていた）。重複抑止はマーカーファイルで決定的に行い、「設計判断かどうか」の判断だけをメインループへ委ねる。**これによりagent型hookは0本になった** |
 | Stop | `ai-check-suggest.sh` | warning-only | `npm run ai:check`実行有無の警告 |

--- a/scripts/check-stale-worktrees.sh
+++ b/scripts/check-stale-worktrees.sh
@@ -29,11 +29,20 @@ command -v gh >/dev/null 2>&1 || exit 0
 # - 全経路 exit 0（blockしない）。是正（worktree削除・ブランチ削除）の実行は完全に人間の
 #   裁量に委ねる（worktree/ブランチの削除は不可逆に近い操作のため機械強制しない）
 #
+# WHY: issue #708。2026-09-05の棚卸しで、worktreeに紐づいてすらいない・PRを一度も
+# 作らずに放置されたローカルブランチが32本見つかった。上記1・2はworktree保有ブランチと
+# goneブランチしか見ておらず、この種の「そもそもPRを作らず古いまま放置」は検知対象外
+# だった。判定はupstream未設定（未push）かつ最終コミットが一定日数より古いブランチに絞り、
+# gh pr listを1回だけ呼んで（ブランチ数ぶんAPIを叩かない）該当ブランチのPRが一度も
+# 存在しないことを確認する。
+#
 # 環境変数（テスト用の注入ポイント）:
 #   STALE_WORKTREES_SESSION_ID     hook stdinのsession_idの代替
 #   STALE_WORKTREES_MARKER_FILE    警告済みマーカー（既定 .aidd/check-stale-worktrees-warning-shown.json）
 #   STALE_WORKTREES_MAX_CHECK      PR状態を確認するworktree数の上限（既定10、API呼び出し抑制）
 #   STALE_WORKTREES_GONE_THRESHOLD goneブランチ数の警告閾値（既定10）
+#   STALE_BRANCHES_AGE_DAYS        放置ブランチ判定の経過日数閾値（既定21）
+#   STALE_BRANCHES_ORPHAN_THRESHOLD 放置ブランチ数の警告閾値（既定5）
 
 cd "$(dirname "$0")/.."
 
@@ -98,8 +107,50 @@ GONE_COUNT="$(git branch -vv 2>/dev/null | grep -c ': gone\]')"
 set -e
 [ -z "$GONE_COUNT" ] && GONE_COUNT=0
 
-# どちらも該当なしなら何も出さず終了
-if [ "$STALE_WORKTREE_COUNT" -eq 0 ] 2>/dev/null && [ "$GONE_COUNT" -lt "$GONE_THRESHOLD" ] 2>/dev/null; then
+# 3. upstream未設定（未push）かつ最終コミットが一定日数より古い、PRを一度も作っていない
+#    放置ブランチの数（issue #708）。
+#    - worktreeでチェックアウト中のブランチは対象外（作業中の可能性があるため）
+#    - gh pr listは1回だけ呼び、ローカルで突き合わせる（ブランチ数ぶんAPIを叩かない）
+AGE_DAYS="${STALE_BRANCHES_AGE_DAYS:-21}"
+ORPHAN_THRESHOLD="${STALE_BRANCHES_ORPHAN_THRESHOLD:-5}"
+NOW_EPOCH="$(date +%s)"
+AGE_CUTOFF=$((NOW_EPOCH - AGE_DAYS * 86400))
+
+CHECKED_OUT_BRANCHES="$(printf '%s\n' "$WORKTREE_LIST" | sed -n 's/^branch refs\/heads\///p')"
+
+set +e
+ALL_PRS_JSON="$(gh pr list --state all --limit 300 --json headRefName 2>/dev/null)"
+set -e
+[ -z "$ALL_PRS_JSON" ] && ALL_PRS_JSON='[]'
+
+ORPHAN_BRANCH_COUNT=0
+set +e
+BRANCH_REFS="$(git for-each-ref --format='%(refname:short)|%(upstream)|%(committerdate:unix)' refs/heads/ 2>/dev/null)"
+set -e
+while IFS='|' read -r BNAME BUPSTREAM BCTIME; do
+  [ -z "$BNAME" ] && continue
+  [ "$BNAME" = "main" ] && continue
+  [ "$BNAME" = "master" ] && continue
+  [ -n "$BUPSTREAM" ] && continue
+  if printf '%s\n' "$CHECKED_OUT_BRANCHES" | grep -qxF "$BNAME"; then
+    continue
+  fi
+  [ -z "$BCTIME" ] && continue
+  if [ "$BCTIME" -ge "$AGE_CUTOFF" ] 2>/dev/null; then
+    continue
+  fi
+  HAS_PR="$(printf '%s' "$ALL_PRS_JSON" | jq --arg b "$BNAME" '[.[] | select(.headRefName == $b)] | length' 2>/dev/null)"
+  if [ -z "$HAS_PR" ] || [ "$HAS_PR" = "0" ]; then
+    ORPHAN_BRANCH_COUNT=$((ORPHAN_BRANCH_COUNT + 1))
+  fi
+done <<EOF
+$BRANCH_REFS
+EOF
+
+# いずれも該当なしなら何も出さず終了
+if [ "$STALE_WORKTREE_COUNT" -eq 0 ] 2>/dev/null \
+  && [ "$GONE_COUNT" -lt "$GONE_THRESHOLD" ] 2>/dev/null \
+  && [ "$ORPHAN_BRANCH_COUNT" -lt "$ORPHAN_THRESHOLD" ] 2>/dev/null; then
   exit 0
 fi
 
@@ -124,6 +175,10 @@ if [ "$STALE_WORKTREE_COUNT" -gt 0 ] 2>/dev/null; then
 fi
 if [ "$GONE_COUNT" -ge "$GONE_THRESHOLD" ] 2>/dev/null; then
   LINES="${LINES}- リモート追跡先が削除済み（gone）のローカルブランチが${GONE_COUNT}件あります。\`git branch -vv | grep gone\`で確認し、不要なら\`git branch -D\`で削除してください。
+"
+fi
+if [ "$ORPHAN_BRANCH_COUNT" -ge "$ORPHAN_THRESHOLD" ] 2>/dev/null; then
+  LINES="${LINES}- PRを一度も作らず${AGE_DAYS}日以上放置されているローカルブランチ（未push）が${ORPHAN_BRANCH_COUNT}件あります。不要なら\`git branch -D\`で削除してください（issue #708）。
 "
 fi
 

--- a/scripts/check-stale-worktrees.test.sh
+++ b/scripts/check-stale-worktrees.test.sh
@@ -45,10 +45,11 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$FAKE_BIN" "$WORK_DIR"' EXIT
 BASH_BIN="$(command -v bash)"
 
-# git worktree list --porcelain / git branch -vv の両方をフェイクgitで切り替える。
-# gh pr list --state all --json state --limit 5 の応答は $1 の内容次第で固定JSONを返す。
+# git worktree list --porcelain / git branch -vv / git for-each-ref をフェイクgitで切り替える。
+# gh pr list は --head の有無で「worktreeごとのPR確認」（gh_json）と
+# 「放置ブランチ検知用の全件取得」（all_prs_json、既定は空配列）を切り替えて返す。
 setup_fakes() {
-  local worktree_porcelain="$1" branch_vv="$2" gh_json="$3"
+  local worktree_porcelain="$1" branch_vv="$2" gh_json="$3" branch_refs="${4:-}" all_prs_json="${5:-[]}"
 
   cat > "$FAKE_BIN/git" <<EOF
 #!/bin/bash
@@ -64,13 +65,25 @@ $branch_vv
 BR_EOF
   exit 0
 fi
+if [ "\$1" = "for-each-ref" ]; then
+  cat <<'FER_EOF'
+$branch_refs
+FER_EOF
+  exit 0
+fi
 exit 0
 EOF
   chmod +x "$FAKE_BIN/git"
 
   cat > "$FAKE_BIN/gh" <<EOF
 #!/bin/bash
-echo '$gh_json'
+for arg in "\$@"; do
+  if [ "\$arg" = "--head" ]; then
+    echo '$gh_json'
+    exit 0
+  fi
+done
+echo '$all_prs_json'
 EOF
   chmod +x "$FAKE_BIN/gh"
 }
@@ -81,6 +94,7 @@ run_hook() {
   OUT="$(cd "$WORK_DIR" && STALE_WORKTREES_SESSION_ID="$session_id" \
     STALE_WORKTREES_MARKER_FILE="$WORK_DIR/.aidd/marker.json" \
     STALE_WORKTREES_MAX_CHECK=10 STALE_WORKTREES_GONE_THRESHOLD=10 \
+    STALE_BRANCHES_AGE_DAYS=21 STALE_BRANCHES_ORPHAN_THRESHOLD=5 \
     PATH="$FAKE_BIN:$PATH" "$BASH_BIN" "$SCRIPT" < /dev/null)"
   EXIT_CODE=$?
   set -e
@@ -177,6 +191,65 @@ EXIT_CODE=$?
 set -e
 assert_eq "$EXIT_CODE" "0" "exit 0"
 assert_empty "$OUT" "出力が空である"
+
+OLD_TIME=$(( $(date +%s) - 30 * 86400 ))
+NEW_TIME=$(( $(date +%s) - 1 * 86400 ))
+ORPHAN_REFS_5="orphan1||${OLD_TIME}
+orphan2||${OLD_TIME}
+orphan3||${OLD_TIME}
+orphan4||${OLD_TIME}
+orphan5||${OLD_TIME}"
+ORPHAN_REFS_2="orphan1||${OLD_TIME}
+orphan2||${OLD_TIME}"
+
+echo "=== scenario 7: PR未作成・upstream未設定・古いブランチが閾値以上 → 警告を出す ==="
+setup_fakes "$WT_NONE" "$BR_NONE" '[]' "$ORPHAN_REFS_5" '[]'
+run_hook "session-8"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "issue #708" "issue番号が含まれる"
+assert_contains "$OUT" "5件" "放置ブランチ件数が含まれる"
+
+echo "=== scenario 8: 該当ブランチが閾値未満 → 警告を出さない ==="
+setup_fakes "$WT_NONE" "$BR_NONE" '[]' "$ORPHAN_REFS_2" '[]'
+run_hook "session-9"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 9: 同名ブランチのPRが実在する → 放置扱いしない ==="
+setup_fakes "$WT_NONE" "$BR_NONE" '[]' "$ORPHAN_REFS_5" '[{"headRefName":"orphan1"},{"headRefName":"orphan2"},{"headRefName":"orphan3"},{"headRefName":"orphan4"},{"headRefName":"orphan5"}]'
+run_hook "session-10"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 10: 最終コミットが閾値日数より新しい → 放置扱いしない ==="
+NEW_REFS_5="new1||${NEW_TIME}
+new2||${NEW_TIME}
+new3||${NEW_TIME}
+new4||${NEW_TIME}
+new5||${NEW_TIME}"
+setup_fakes "$WT_NONE" "$BR_NONE" '[]' "$NEW_REFS_5" '[]'
+run_hook "session-11"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 11: worktreeでチェックアウト中のブランチは対象外 ==="
+WT_WITH_ORPHAN="worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/.claude/worktrees/orphan1
+HEAD def456
+branch refs/heads/orphan1"
+ORPHAN_REFS_WITH_CHECKOUT="orphan1||${OLD_TIME}
+orphan2||${OLD_TIME}
+orphan3||${OLD_TIME}
+orphan4||${OLD_TIME}
+orphan5||${OLD_TIME}
+orphan6||${OLD_TIME}"
+setup_fakes "$WT_WITH_ORPHAN" "$BR_NONE" '[]' "$ORPHAN_REFS_WITH_CHECKOUT" '[]'
+run_hook "session-12"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "5件" "チェックアウト中のorphan1を除いた5件が警告される"
 
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: `check-stale-worktrees.sh`に、PRを一度も作らず21日超放置されたローカルブランチ（upstream未設定）を検知する第3の警告項目を追加
- リスク: 低（warning-onlyのSessionStart hookのみ。プロダクトコード・DB・RLSには一切触れない）
- 変更領域: ロジック（hookスクリプト）のみ
- 証拠状態: 実測11ケース（既存5＋新規6、すべてローカルで実行しPASS確認）
- 影響範囲: SessionStart hook実行時の警告文言追加のみ。既存の検知（worktree/gone）の挙動は不変
- ロールバック可能性: 高（このコミットをrevertするだけで元の2項目検知に戻る）

## 00 目的・影響範囲・対象外
- 目的: 2026-09-05の手動棚卸しで、PRを一度も作らず古いまま放置されたローカルブランチが32本見つかった。既存hookは「worktree保有ブランチのPR状態」と「goneブランチ数」しか見ておらず、この種の残骸は検知対象外だったため、同じ枠組みで機械検知できるようにする
- 変更範囲: `scripts/check-stale-worktrees.sh`（検知ロジック追加）、`scripts/check-stale-worktrees.test.sh`（回帰テスト追加）、`docs/agents/actuator-inventory.md`（棚卸し表の更新）
- 対象外（今回あえて触らない）: 検知した残骸ブランチの自動削除（既存2項目と同様、削除は不可逆に近い操作のため人間の裁量に委ねる方針を踏襲）
- 作業中に見つけた別件: なし

## 01 画面がどう変わったか（UI証拠）
対象外（UIの変更はなし。SessionStart hookの警告メッセージのみ）

## 02 内部でどう守っているか（ロジック証拠）
- 判定条件: upstream未設定（未push）かつ最終コミットが`STALE_BRANCHES_AGE_DAYS`（既定21日）より古い、かつ`gh pr list --state all`の結果に一度もPRが存在しないブランチ
- worktreeでチェックアウト中のブランチは対象外（作業中の可能性があるため）
- API呼び出しはブランチ数によらず1回（`gh pr list --state all --limit 300 --json headRefName`を1回だけ呼び、ローカルでjq突合）
- 既存2項目と同じくfail-open（git/gh/jq不在時は無音でexit 0）・セッション1回のみ警告

## 03 誰が操作できるか（RLS/権限証拠）
対象外（認可・RLSに関わる変更なし）

## 04 どう確認したか（テスト・検証）
- `bash scripts/check-stale-worktrees.test.sh`: 既存5シナリオ＋新規6シナリオ（閾値超過で警告／閾値未満で沈黙／PR実在ブランチは除外／新しいブランチは除外／worktreeチェックアウト中は除外）全11件PASS
- 実リポジトリに対して手動実行し、今回の棚卸し後（残骸ゼロの状態）で警告が出ないことを確認済み
- `npm run ai:check`: 未実行（bashスクリプトのみの変更で対象コードなし、既存の`hooks-test`CIジョブでカバーされる想定）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 特になし（SessionStart時のsystemMessageのみ、永続ログは残らない）
- 異常の判断基準: 警告が誤検知（PRが実在するのに放置扱いされる等）で頻発する場合は閾値・判定条件を見直す
- ロールバック手順: このコミットをrevertすれば元の2項目検知（worktree・gone）のみに戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)