### PR TITLE
test: SKILL.md本文がcompaction再注入上限を超えないことを文字数で構造テストする(issue #716)

### DIFF
--- a/docs/agents/decisions/aidd-pipeline.md
+++ b/docs/agents/decisions/aidd-pipeline.md
@@ -595,3 +595,25 @@ lint scriptの`--max-warnings=0`追加のみをまとめて行った。
 **How to apply:** 新しいWorkflowスクリプトに反復構造（ループ・リトライ）や台数可変の
 フェーズを追加する際は、`isDefaultCapExceeded`をインライン複製し（`budget-guard-sync.test.js`の
 `WORKFLOW_FILES`にも追加）、workflow固有の`DEFAULT_TOKEN_CAP`を根拠コメント付きで定める。
+
+## なぜスキル本文（SKILL.md）のサイズをトークンではなく「文字数5,000」で構造テストするか（issue #716）
+
+Claude Code は compaction 後に起動済みスキル本文を再注入するが、1スキル 5,000 トークン・合計
+25,000 トークンで打ち切る（先頭を残し末尾を捨てる）。`handoff-format` のように作業終盤で使う
+スキルは compaction 後に呼ばれやすく、末尾の 4 値規約や必須見出しが切れると Stop hook
+（`check-handoff-format.sh`）の警告を誘発する。
+
+2026-09-05 の実測では、バイト数（6.7KB）を見て「上限付近」と誤認していたが、文字数は 3,248 で
+最悪ケース（1文字=1トークン）でも上限の 65% だった。日本語は 1 文字 3 バイトのため、バイト数は
+トークンの指標にならない。API の count_tokens はセッション環境から使えない（API キー参照が
+auto mode classifier に拒否される）ため、tokenizer に依存しない「文字数 ≤ 5,000」を上限に置いた。
+実トークンは日本語 1〜2 文字/トークン・ASCII 3〜4 文字/トークンなので、この閾値は安全側に倒れる。
+
+正本は `scripts/check-skill-size.test.sh`（CI `hooks-test`）。対象は `.claude/skills/` と Codex 側
+ミラー `.agents/skills/` の両方。文字数は `jq -Rs 'length'`（コードポイント数）で数える
+（`wc -m` はロケールが C だとバイト数を返す環境があるため使わない）。
+
+**How to apply:** テストが RED になったスキルは、Stop hook が検知する見出しや 4 値規約などの
+最重要指示を SKILL.md の冒頭へ寄せ、事例・経緯は `references/` へ分離する（agentskills.io の
+progressive disclosure: name+description → 本文 → 参照ファイルの 3 層）。閾値を上げる場合は
+公式 compaction 仕様の変更を確認してからにする。

--- a/scripts/check-skill-size.test.sh
+++ b/scripts/check-skill-size.test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# WHY: Claude Code は compaction 後に「起動済みスキル本文」を再注入するが、1スキルあたり
+#      5,000 トークンで打ち切る（先頭を残して末尾を捨てる。公式 context-window ドキュメント
+#      「What survives compaction」）。handoff-format のように作業終盤（= compaction 後に
+#      なりやすい）で使うスキルの末尾が切れると、Stop hook（check-handoff-format.sh）が
+#      検知する必須見出しや 4 値規約が消え、警告ループの原因になる。
+#
+#      トークン数は環境によって API を叩けないため、「1文字=1トークン」の最悪ケースで
+#      文字数を上限とみなす（issue #716 の実測: 日本語 1〜2 文字/トークン、ASCII 3〜4 文字/
+#      トークンなので、5,000 文字未満なら tokenizer によらず上限内）。バイト数は日本語で
+#      1 文字 3 バイトになりトークンの指標にならないので使わない。
+#
+#      対象は Claude 側 .claude/skills/ と Codex 側ミラー .agents/skills/ の両方
+#      （scripts/lib/claude-codex-skills-parity.test.ts が「同じスキル群」と定義している）。
+#
+# 見つけられること: SKILL.md 本文が最悪ケース換算で再注入上限を超えたこと
+# 見つけられないこと: 上限内でも重要指示が末尾に偏っていて要約で薄れるケース（内容の問題）
+#
+# 実行: bash scripts/check-skill-size.test.sh
+# 環境変数（テスト用注入ポイント）:
+#   SKILL_DIRS        スキルディレクトリ（スペース区切り。既定 .claude/skills .agents/skills）
+#   SKILL_CHAR_LIMIT  文字数上限（既定 5000）
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIMIT="${SKILL_CHAR_LIMIT:-5000}"
+DIRS="${SKILL_DIRS:-$REPO_ROOT/.claude/skills $REPO_ROOT/.agents/skills}"
+
+command -v jq >/dev/null 2>&1 || { echo "jq が必要です"; exit 1; }
+
+fail=0
+checked=0
+
+# 文字数（Unicode コードポイント数）。wc -m はロケール依存で、C ロケールだとバイト数を返す
+# 環境があるため、jq の string length（コードポイント数）を使う。
+count_chars() {
+  jq -Rs 'length' "$1"
+}
+
+for dir in $DIRS; do
+  [ -d "$dir" ] || { echo "  SKIP: $dir が無い"; continue; }
+  for skill in "$dir"/*/SKILL.md; do
+    [ -f "$skill" ] || continue
+    checked=$((checked + 1))
+    chars="$(count_chars "$skill")"
+    rel="${skill#"$REPO_ROOT"/}"
+    if [ "$chars" -gt "$LIMIT" ]; then
+      echo "  NG: $rel は ${chars} 文字（上限 ${LIMIT}）。compaction 再注入で末尾が切れる恐れがあります。最重要の指示を冒頭に寄せ、事例・経緯は references/ へ分離してください（issue #716）"
+      fail=1
+    else
+      echo "  OK: $rel ${chars} 文字（上限 ${LIMIT}）"
+    fi
+  done
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "  NG: 検査対象の SKILL.md が 1 つも見つかりませんでした（SKILL_DIRS=$DIRS）"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #716

## 30秒サマリー
- 変更概要: SKILL.md 本文が compaction 再注入上限（5,000 トークン）を超えないことを文字数で固定する構造テストを追加（実測で余裕があったため本文の並べ替えは不要と判断）
- リスク: 低
- 変更領域: テスト（hook 回帰）・docs
- 証拠状態: 実測 4 件（文字数計測 / GREEN 実行 / RED 実行 3 通り / test-matrix 整合テスト）、サンプル・未検証 0 件
- 影響範囲: `scripts/check-skill-size.test.sh`（新規、CI `hooks-test` で自動実行）、`docs/agents/decisions/aidd-pipeline.md`（追記）
- ロールバック可能性: ファイル削除で完全に戻る（プロダクトコード・設定に影響なし）

レビューしてほしい点:
1. 「トークン数を測れないので、1文字=1トークンの最悪ケースで文字数 5,000 を上限にする」という置き換えが妥当か（issue #716 のコメントに内訳表あり）
2. Codex 側ミラー `.agents/skills/` も検査対象に含めてよいか（同じスキル群という parity テストの定義に合わせた）

## 00 目的・影響範囲・対象外
- 目的: issue #716。作業終盤で使う `handoff-format` の末尾（4 値規約・必須見出し）が compaction 再注入で切れ、Stop hook の警告ループを招くのを予防する
- 変更範囲: 構造テスト 1 本の追加と decisions への設計判断追記
- 対象外（今回あえて触らない）: SKILL.md 本文の冒頭移動・`references/` 分離。実測で上限の 65% 以下だったため、テストが RED になってから行う
- 作業中に見つけた別件: `.agents/skills/handoff-format/SKILL.md`（Codex 側ミラー）が Claude 側より古く「依存の変更」「promise-catalog」「04 表の4値規約」が欠けている。parity テストはファイル一覧しか見ていないため未検知だった。別 issue として起票済み（Stop hook 経由。番号は起票後に追記）
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外（UI 変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- `scripts/check-skill-size.test.sh`: `.claude/skills/*/SKILL.md` と `.agents/skills/*/SKILL.md` を `jq -Rs 'length'`（Unicode コードポイント数）で数え、`SKILL_CHAR_LIMIT`（既定 5,000）超で FAILED。対象ゼロでも FAILED（fail-open 防止）。`wc -m` はロケールが C だとバイト数を返すため使わない
- 実測（2026-09-05、文字数 / 非ASCII / ASCII / バイト）:
  - handoff-format: 3,248 / 1,758 / 1,490 / 6,760（最悪ケース使用率 65%）
  - feature-spec: 2,910 / 1,797 / 1,113 / 6,502（58%）
  - e2e-runner: 1,481 / 551 / 930 / 2,581（30%）
  - structured-review: 183 / 90 / 93 / 363（4%）
- API の count_tokens は環境から使えなかった（API キー参照が auto mode classifier に拒否）。日本語 1〜2 文字/トークン・ASCII 3〜4 文字/トークンのため、文字数上限は安全側

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外（auth / RLS / facility 境界に触れていない）
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
`bash scripts/derive-test-selection.sh --files scripts/check-skill-size.test.sh,docs/agents/decisions/aidd-pipeline.md --format table` の出力（route: light）を基に更新:

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行（ローカル未実施。TS に触れていない） |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行（ローカル未実施。TS に触れていない） |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行（ローカル未実施。src/ に触れていない） |
| build | ⬜ 未実施 | CI `build` ジョブで実行（ローカル未実施） |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行（workflows に触れていない） |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-skill-size.test.sh` GREEN（8 ファイル OK）。RED 方向 3 通り: 6,022 文字の fixture で FAILED / `SKILL_CHAR_LIMIT=3000` で handoff-format が FAILED / `SKILL_DIRS=/nonexistent` で「対象ゼロ」FAILED。`bash scripts/check-test-matrix.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行（依存に触れていない） |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行（依存に触れていない） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に関わるパスに触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook スクリプト・settings に触れていない（テストのみ追加） |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- 「⬜ 未実施」の行はいずれも CI が全 PR で回す種別で、この PR の変更（shell テスト 1 本 + docs）が触れていない層。CI 結果は PR 作成後にこの表へ URL を追記する
- `npm run ai:check` は未実行（src/ に変更なし、CI に委ねる）
- verify-claims: 未実施（数値は上記コマンドの生出力からの転記）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: CI `hooks-test` ジョブの `scripts/check-skill-size.test.sh` グループ
- 異常の判断基準: スキル追記の PR で FAILED が出たら、閾値を上げるのではなく本文の冒頭寄せ・`references/` 分離で対応する
- ロールバック手順: `scripts/check-skill-size.test.sh` を削除し、decisions の該当節を削除

## 後任AIへの注意
- この実装で壊してはいけない前提: 閾値 5,000 は「最悪ケース 1文字=1トークン」の換算。公式の compaction 仕様（1スキル 5,000 トークン）が変わらない限り上げない
- 似ているが別物の用語: バイト数（`wc -c`）とトークン数は別物。日本語は 1 文字 3 バイトなので、バイト数で上限を判断すると 2〜3 倍過大に見積もる（今回の issue 起票時の誤認）
- 勝手にリファクタしない場所: `.agents/skills/` は Codex 側ミラーで、feature-spec の差分は意図的。別 issue（ミラー陳腐化）で扱う

🤖 Generated with [Claude Code](https://claude.com/claude-code)
