### PR TITLE
feat: compaction時はAIDD実行状態の再注入だけを行い、警告系SessionStart hookはcompact以外に限定する(issue #712)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -146,6 +146,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear|fork",
         "hooks": [
           {
             "type": "command",
@@ -205,6 +206,16 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-empty-session-report.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/reinject-aidd-run-state.sh",
             "timeout": 10
           }
         ]

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -27,6 +27,7 @@
 | PreToolUse (Write/Edit/MultiEdit 高リスクパス) | `check-run-manifest-presence.sh` | warning-only | `permissionDecision: "allow"` + `additionalContext`。blockしない設計（issue #444、意図的） |
 | SessionStart | `check-workflow-interruption.sh` | **自動復旧（queue）** | Workflow中断を検知し`workflow-interrupted`としてqueue登録（issue #534） |
 | SessionStart | `check-recovery-queue.sh` | 自動復旧（queue、表示側） | pendingエントリのcontext注入＋surfaced放置エントリのエスカレーション表示（issue #523・#579）。是正の実行そのものはこのhookの範囲外 |
+| SessionStart（matcher: `compact` のみ） | `reinject-aidd-run-state.sh` | context 注入（是正なし） | compaction 直後に `.aidd/run-manifest.json`・`logs/agent-progress.jsonl`・`.aidd/recovery-queue.jsonl` の現在値を additionalContext として再注入する（issue #712）。同時に上記 12 本の警告系 hook は matcher `startup\|resume\|clear\|fork` に限定し、compact 時には再実行しない。構成は `scripts/check-session-start-matchers.test.sh` が固定する |
 | SessionStart | `check-branch-pr-status.sh` | warning-only | マージ済みブランチ上での作業を警告 |
 | SessionStart | `check-branch-tool-ownership.sh` | warning-only | ブランチ命名規約（codex/*・claude/*）と起動ツールの取り違えを警告。Claude/Codex両方のhook設定に登録される共有ガード（引数で自ツール名を渡す）。block不可のSessionStartのため意図的にwarning-only |
 | PreToolUse (Codex側・Bash/Write/Edit skipマーカー) | `codex-skip-marker-deny.sh` | **deny**（Codex側のみ） | `check-skip-marker-write.sh`（Claude側ask）のCodex用ラッパー。Codexはask未対応（実機確認済み）のためdenyへ読み替える。判定ロジックは共有正本に委譲し、出力契約の変換のみ担う |
@@ -61,6 +62,7 @@
 - 自動復旧（queue、うち登録側）: 2件（`check-workflow-interruption.sh`・`check-gap-check-state.sh`）
 - 自動復旧（queue、表示側）: 1件（`check-recovery-queue.sh`）
 - warning-only: 17件
+- context 注入（是正なし、compact 時のみ）: 1件（`reinject-aidd-run-state.sh`、issue #712）
 
 約23件の検知hookのうち、機械的に実行を止める・確認を強制する（block/ask）のは3件。
 recovery-queue接続によって「次回セッション冒頭で機械的に目の前に出る」までは自動化されている

--- a/docs/agents/decisions/aidd-pipeline.md
+++ b/docs/agents/decisions/aidd-pipeline.md
@@ -617,3 +617,42 @@ auto mode classifier に拒否される）ため、tokenizer に依存しない�
 最重要指示を SKILL.md の冒頭へ寄せ、事例・経緯は `references/` へ分離する（agentskills.io の
 progressive disclosure: name+description → 本文 → 参照ファイルの 3 層）。閾値を上げる場合は
 公式 compaction 仕様の変更を確認してからにする。
+
+## なぜ SessionStart hook を「compact 以外」と「compact のみ」の2群に分け、compact 時は AIDD 実行状態の再注入だけにしたか（issue #712）
+
+**結論: 警告系 12 本は matcher `startup|resume|clear|fork` に限定し、compact 時は
+`scripts/reinject-aidd-run-state.sh` 1 本だけが run-manifest / 進捗 / 復旧キューの現在値を
+additionalContext として再注入する。**
+
+公式の compaction 仕様（context-window ドキュメント「What survives compaction」）では、
+プロジェクトルート CLAUDE.md・unscoped rules・auto memory はディスクから再注入されるが、
+**hook が以前に注入したコンテキストは会話と一緒に要約されて薄れる**。一方 SessionStart hook は
+matcher 無しだと startup / resume / clear / compact / fork のすべてで再実行される。従来の
+設定は 12 本すべてが matcher 無しで、長時間の AIDD 自律実行中に compaction が起きると、
+ブランチ鮮度・worktree 残骸・OTel 状態などの警告 12 本（この時点では何も変わっていない）が
+毎回再注入される一方、本当に必要な「どの run-manifest で・どのエージェントがどこまで進み・
+未対応の復旧タスクは何か」は薄れていた。センサーの本数は多いが、compaction という
+「コンテキストが失われる瞬間」に何を守るかが設計されていなかった。
+
+**警告系を `startup` のみでなく `startup|resume|clear|fork` にした理由:** issue 本文は
+「startup 限定」としていたが、resume は数時間〜数日後の再開でありブランチ鮮度・main 遅れ・
+worktree 残骸の警告は改めて有用。clear / fork はコンテキストが空になるので同様。除外すべきは
+「環境は何も変わっていないのにコンテキストだけ縮んだ」compact だけ、と整理した。
+将来 source の値が増えた場合はこの matcher に足さないと警告が出なくなる（構造テストが
+startup / resume / clear / fork の 4 値については固定する）。
+
+**再注入の内容を状態ファイル由来に限定した理由:** CLAUDE.md の「絶対ルール」
+「サーキットブレーカー」等は compaction 後に CLAUDE.md 自体が再注入されるので重複させない
+（ポインタのみ）。/goal の条件は会話内にしか無く外部から読めない（issue #441）ため、
+「設定していたなら従い続けること」という注意喚起に留める。
+
+**既知の限界:** matcher が実際に compact 時だけ発火するか・additionalContext が compaction 後の
+context に入るかは、Claude Code 本体の挙動であり shell テストでは証明できない
+（`docs/agents/test-matrix.md`「hook 実機発火」）。スクリプト単体の入出力と settings.json の
+構造は `scripts/reinject-aidd-run-state.test.sh`・`scripts/check-session-start-matchers.test.sh`
+で固定した。実機確認は AIDD 実行中のセッションで `/compact` を手動実行し、直後の応答に
+「compaction 後に AIDD 実行状態を再注入しました」の systemMessage が出ることで行う。
+
+**How to apply:** SessionStart hook を新設するときは必ず matcher を付ける（構造テストが
+無指定を拒否する）。compact 時に必要なものは reinject スクリプトのセクションとして足し、
+別 hook を compact に登録しない。

--- a/scripts/check-session-start-matchers.test.sh
+++ b/scripts/check-session-start-matchers.test.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# WHY: issue #712 の構造テスト。.claude/settings.json の SessionStart hook が「compact 時には
+#      AIDD 実行状態の再注入だけを行い、警告系 hook は再実行しない」構成を保っていることを
+#      settings.json を直接読んで検査する。
+#
+#      背景: SessionStart hook は matcher 無しだと startup / resume / clear / compact / fork の
+#      すべてで再実行される。長時間の AIDD 自律実行中の compaction で、ブランチ鮮度・worktree
+#      残骸などの警告 12 本が毎回再注入される一方、本当に必要な run-manifest / 進捗 / 復旧キューは
+#      要約で薄れていた。この構成が「matcher を足し忘れた新 hook」で静かに崩れるのを止める。
+#
+# 不変条件:
+#   1. SessionStart の全エントリが matcher を持つ（無指定 = 全 source で実行、を禁止）
+#   2. source "compact" にマッチするエントリは、hooks が reinject-aidd-run-state.sh のみ
+#   3. startup / resume / clear / fork の各 source には、reinject 以外のエントリが少なくとも 1 つ
+#      マッチし、reinject を含むエントリはマッチしない
+#   4. reinject-aidd-run-state.sh は SessionStart のどこかに必ず登録されている
+#
+# 実行: bash scripts/check-session-start-matchers.test.sh
+# 環境変数（テスト用注入ポイント）: CLAUDE_SETTINGS_PATH（既定 .claude/settings.json）
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETTINGS="${CLAUDE_SETTINGS_PATH:-$REPO_ROOT/.claude/settings.json}"
+REINJECT="reinject-aidd-run-state.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "jq が必要です"; exit 1; }
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+
+# 検査本体。$1=settings.json。違反を行で出し、末尾に violations=N
+check() {
+  local settings="$1" violations=0
+  local n i matcher cmds has_reinject
+  n="$(jq '.hooks.SessionStart | length' "$settings")"
+  if [ "$n" -eq 0 ]; then
+    echo "    empty: SessionStart エントリが 0 件"
+    echo "violations=1"
+    return
+  fi
+
+  local reinject_registered=0
+  local -a startup_ok=(0 0 0 0)
+  local sources=(startup resume clear fork)
+
+  for ((i = 0; i < n; i++)); do
+    matcher="$(jq -r ".hooks.SessionStart[$i].matcher // \"\"" "$settings")"
+    cmds="$(jq -r ".hooks.SessionStart[$i].hooks[].command" "$settings")"
+    has_reinject=0
+    if printf '%s\n' "$cmds" | grep -qF "$REINJECT"; then has_reinject=1; reinject_registered=1; fi
+
+    if [ -z "$matcher" ] || [ "$matcher" = "*" ]; then
+      echo "    no-matcher: エントリ $i（$(printf '%s' "$cmds" | head -n1 | xargs basename) …）が全 source で実行される"
+      violations=$((violations + 1))
+      continue
+    fi
+
+    # compact にマッチするか
+    if [[ "compact" =~ ^($matcher)$ ]]; then
+      if [ "$has_reinject" -ne 1 ] || [ "$(printf '%s\n' "$cmds" | grep -c .)" -ne 1 ]; then
+        echo "    compact-noise: エントリ $i（matcher=$matcher）が compact 時に reinject 以外を実行する"
+        violations=$((violations + 1))
+      fi
+    fi
+
+    for si in "${!sources[@]}"; do
+      if [[ "${sources[$si]}" =~ ^($matcher)$ ]]; then
+        if [ "$has_reinject" -eq 1 ]; then
+          echo "    reinject-on-${sources[$si]}: エントリ $i（matcher=$matcher）が ${sources[$si]} で reinject を実行する"
+          violations=$((violations + 1))
+        else
+          startup_ok[$si]=1
+        fi
+      fi
+    done
+  done
+
+  for si in "${!sources[@]}"; do
+    if [ "${startup_ok[$si]}" -ne 1 ]; then
+      echo "    missing-${sources[$si]}: ${sources[$si]} で実行される警告系エントリが無い"
+      violations=$((violations + 1))
+    fi
+  done
+  if [ "$reinject_registered" -ne 1 ]; then
+    echo "    missing-reinject: $REINJECT が SessionStart に登録されていない"
+    violations=$((violations + 1))
+  fi
+  echo "violations=$violations"
+}
+
+echo "=== scenario 1: 実態の settings.json が不変条件を満たす ==="
+RESULT="$(check "$SETTINGS")"
+printf '%s\n' "$RESULT" | grep -v '^violations=' || true
+if [ "$(printf '%s\n' "$RESULT" | tail -n1)" = "violations=0" ]; then
+  ok "違反なし（SessionStart $(jq '.hooks.SessionStart | length' "$SETTINGS") エントリ）"
+else
+  ng "違反あり" "$(printf '%s\n' "$RESULT" | tail -n1)"
+fi
+
+echo "=== scenario 2: fixture で違反を検知できる（RED 方向の自己検証） ==="
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+# 違反 4 種: matcher 無し / compact で警告も実行 / startup で reinject 実行 / reinject の警告系エントリしか無い fork
+cat > "$WORK/bad.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/check-a.sh" } ] },
+      { "matcher": "startup|resume|clear|compact", "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/check-b.sh" },
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/reinject-aidd-run-state.sh" }
+      ] }
+    ]
+  }
+}
+EOF
+RESULT="$(check "$WORK/bad.json")"
+for needle in 'no-matcher:' 'compact-noise:' 'reinject-on-startup:' 'missing-fork:'; do
+  if printf '%s\n' "$RESULT" | grep -qF "$needle"; then ok "検知: $needle"; else ng "検知できない: $needle" "$RESULT"; fi
+done
+
+cat > "$WORK/good.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "startup|resume|clear|fork", "hooks": [ { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/check-a.sh" } ] },
+      { "matcher": "compact", "hooks": [ { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/reinject-aidd-run-state.sh" } ] }
+    ]
+  }
+}
+EOF
+RESULT="$(check "$WORK/good.json")"
+if [ "$(printf '%s\n' "$RESULT" | tail -n1)" = "violations=0" ]; then ok "正しい構成は誤検知しない"; else ng "正しい構成を誤検知" "$RESULT"; fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/reinject-aidd-run-state.sh
+++ b/scripts/reinject-aidd-run-state.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: issue #712。SessionStart hook（matcher: compact）から呼ばれ、context compaction の直後に
+#      「今の AIDD 実行状態」だけを additionalContext として再注入する。
+#
+#      Claude Code の compaction 仕様（公式 context-window ドキュメント「What survives compaction」）:
+#        - プロジェクトルート CLAUDE.md・unscoped rules・auto memory はディスクから再注入される
+#        - hook が以前に注入したコンテキストは会話と一緒に要約されて薄れる
+#        - source: "compact" にマッチする SessionStart hook だけが compaction 後に再実行される
+#      従来は SessionStart hook 12 本すべてが matcher 無しで、compact 時にもブランチ鮮度・
+#      worktree 残骸などの警告 12 本が再実行される一方、長時間の AIDD 自律実行で本当に必要な
+#      「どの run-manifest で・どのエージェントがどこまで進み・未対応の復旧タスクは何か」は
+#      要約で薄れていた。本スクリプトはその逆転を直す。
+#
+# 出力するもの（存在するものだけ。全部無ければ何も出力しない）:
+#   1. .aidd/run-manifest.json の要約（specPath / specHash / baseCommit / approval / changedFiles 件数）
+#   2. logs/agent-progress.jsonl の最新状態（scripts/show-agent-status.sh の出力、先頭 20 行）
+#   3. .aidd/recovery-queue.jsonl の未解決エントリ数（pending + surfaced）
+#   4. CLAUDE.md の再注入済みルールへのポインタ（本文は重複させない）
+#
+# ガード: stdin の hook 入力 JSON に source があり "compact" 以外なら何もしない（matcher の
+#         設定ミスで startup 等にも登録された場合の二重注入防止）。REINJECT_FORCE=1 で無効化。
+# 全経路 exit 0（block 不可の SessionStart のため）。jq 不在なら静かに終了（fail-open。他の
+# SessionStart hook と同じ方針、issue #636）。
+#
+# 環境変数（テスト用の注入ポイント）:
+#   AIDD_MANIFEST_PATH   run-manifest のパス（既定 .aidd/run-manifest.json）
+#   RECOVERY_QUEUE_FILE  復旧キューのパス（既定 .aidd/recovery-queue.jsonl）
+#   AGENT_PROGRESS_LOG   進捗ログのパス（既定 scripts/lib/resolve-log-dir.sh が解決する logs/agent-progress.jsonl）
+#   REINJECT_FORCE       1 なら source ガードを無効化
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+INPUT="$(cat 2>/dev/null || true)"
+if [ "${REINJECT_FORCE:-0}" != "1" ] && [ -n "$INPUT" ]; then
+  SOURCE="$(printf '%s' "$INPUT" | jq -r '.source // empty' 2>/dev/null || true)"
+  if [ -n "$SOURCE" ] && [ "$SOURCE" != "compact" ]; then
+    exit 0
+  fi
+fi
+
+MANIFEST="${AIDD_MANIFEST_PATH:-.aidd/run-manifest.json}"
+QUEUE_FILE="${RECOVERY_QUEUE_FILE:-.aidd/recovery-queue.jsonl}"
+if [ -n "${AGENT_PROGRESS_LOG:-}" ]; then
+  PROGRESS_LOG="$AGENT_PROGRESS_LOG"
+else
+  # shellcheck source=lib/resolve-log-dir.sh
+  source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+  PROGRESS_LOG="$(resolve_log_dir)/agent-progress.jsonl"
+fi
+
+SECTIONS=""
+
+if [ -f "$MANIFEST" ]; then
+  MANIFEST_SUMMARY="$(jq -r '
+    "- specPath: \(.specPath // "（未設定）")",
+    "- specHash: \((.specHash // "（未設定）") | .[0:12])",
+    "- baseCommit: \((.baseCommit // "（未設定）") | .[0:12])",
+    "- 停止①承認: \(if .approval and .approval.approvedBy then "\(.approval.approvedBy) @ \(.approval.approvedAt // "?")" else "未承認（Phase 3 以降へ進めない）" end)",
+    "- changedFiles: \((.changedFiles // []) | length) 件"
+  ' "$MANIFEST" 2>/dev/null || echo "- （run-manifest.json の解析に失敗。Read ツールで直接確認すること）")"
+  SECTIONS="${SECTIONS}
+## AIDD Run Manifest（${MANIFEST}）
+${MANIFEST_SUMMARY}"
+fi
+
+if [ -f "$PROGRESS_LOG" ] && [ -x "$SCRIPT_DIR/show-agent-status.sh" ]; then
+  PROGRESS="$(bash "$SCRIPT_DIR/show-agent-status.sh" --log-file "$PROGRESS_LOG" 2>/dev/null | head -n 20 || true)"
+  if [ -n "$PROGRESS" ]; then
+    SECTIONS="${SECTIONS}
+
+## サブエージェント進捗（${PROGRESS_LOG}、最新 20 行）
+${PROGRESS}"
+  fi
+fi
+
+if [ -f "$QUEUE_FILE" ]; then
+  UNRESOLVED="$(jq -R -r 'fromjson? | select(.status == "pending" or .status == "surfaced") | "- [\(.type)] id=\(.id) status=\(.status)"' "$QUEUE_FILE" 2>/dev/null || true)"
+  if [ -n "$UNRESOLVED" ]; then
+    SECTIONS="${SECTIONS}
+
+## 未解決の復旧タスク（${QUEUE_FILE}）
+${UNRESOLVED}
+対応後は scripts/resolve-recovery-task.sh --id <ID> で解決済みにする"
+  fi
+fi
+
+if [ -z "$SECTIONS" ]; then
+  exit 0
+fi
+
+CONTEXT="context compaction 後の AIDD 実行状態の再注入（scripts/reinject-aidd-run-state.sh、issue #712）。
+以下はディスク上の状態ファイルから読み直した現在値であり、要約前の会話より新しい。
+${SECTIONS}
+
+## ルールの所在
+- 「絶対ルール」「サーキットブレーカー」「AIDD stats 書き出しルール」「gap check state 記録ルール」は、compaction 後に再注入された CLAUDE.md を参照する（ここには重複させない）
+- /goal の停止条件は会話内にしか無い。フロー開始時に設定していたなら、その条件（ターン数上限を含む）に引き続き従うこと"
+
+jq -n --arg ctx "$CONTEXT" '{
+  systemMessage: "compaction 後に AIDD 実行状態（run-manifest / 進捗 / 復旧キュー）を再注入しました（issue #712）",
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'

--- a/scripts/reinject-aidd-run-state.test.sh
+++ b/scripts/reinject-aidd-run-state.test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# WHY: scripts/reinject-aidd-run-state.sh（SessionStart hook、matcher: compact、issue #712）の回帰テスト。
+#      状態ファイルが無ければ沈黙し、あれば run-manifest / 進捗 / 復旧キューの要約を
+#      additionalContext に出すこと、source が compact 以外なら何もしないことを確認する。
+#      本物の .aidd/ や logs/ は環境変数で差し替え、書き換えない。
+#
+# 実行: bash scripts/reinject-aidd-run-state.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/reinject-aidd-run-state.sh"
+
+fail=0
+assert_empty() {
+  if [ -z "$1" ]; then echo "  OK: $2"; else echo "  NG: $2 (actual=$1)"; fail=1; fi
+}
+assert_contains() {
+  if printf '%s' "$1" | grep -qF -- "$2"; then echo "  OK: $3"; else echo "  NG: $3"; echo "      expected: $2"; echo "      actual: $1"; fail=1; fi
+}
+assert_not_contains() {
+  if printf '%s' "$1" | grep -qF -- "$2"; then echo "  NG: $3 (unexpected: $2)"; fail=1; else echo "  OK: $3"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+EMPTY_MANIFEST="$WORK/no-manifest.json"
+EMPTY_QUEUE="$WORK/no-queue.jsonl"
+EMPTY_LOG="$WORK/no-log.jsonl"
+
+run() {
+  # $1=source $2=manifest $3=queue $4=log
+  printf '{"session_id":"t","hook_event_name":"SessionStart","source":"%s"}' "$1" \
+    | AIDD_MANIFEST_PATH="$2" RECOVERY_QUEUE_FILE="$3" AGENT_PROGRESS_LOG="$4" bash "$SCRIPT"
+}
+
+echo "=== scenario 1: 状態ファイルが何も無い → 何も出力しない ==="
+OUT="$(run compact "$EMPTY_MANIFEST" "$EMPTY_QUEUE" "$EMPTY_LOG")"
+assert_empty "$OUT" "状態が無ければ沈黙する"
+
+echo "=== scenario 2: run-manifest がある → 要約を additionalContext に出す ==="
+cat > "$WORK/run-manifest.json" <<'EOF'
+{
+  "specPath": "docs/superpowers/specs/2026-07-10-example-feature-design.md",
+  "specHash": "3b1c9d5f2a6e4d0c8b7a1f9e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6b7a8f9e0d1c",
+  "baseCommit": "d1a7dbdb1c4e2f6a9b0c3d4e5f6a7b8c9d0e1f2a",
+  "changedFiles": ["src/app/x.tsx", "src/lib/supabase/x.ts"],
+  "approval": { "approvedBy": "reviewer@example.com", "approvedAt": "2026-07-10T05:00:00+09:00" }
+}
+EOF
+OUT="$(run compact "$WORK/run-manifest.json" "$EMPTY_QUEUE" "$EMPTY_LOG")"
+assert_contains "$OUT" '"hookEventName": "SessionStart"' "hookSpecificOutput が SessionStart"
+assert_contains "$OUT" "additionalContext" "additionalContext を返す"
+assert_contains "$OUT" "2026-07-10-example-feature-design.md" "specPath が入る"
+assert_contains "$OUT" "specHash: 3b1c9d5f2a6e" "specHash は先頭 12 桁"
+assert_contains "$OUT" "reviewer@example.com" "承認者が入る"
+assert_contains "$OUT" "changedFiles: 2 件" "changedFiles 件数"
+assert_contains "$OUT" "/goal" "/goal 条件へのポインタ"
+assert_contains "$OUT" "CLAUDE.md" "CLAUDE.md 再注入へのポインタ"
+
+echo "=== scenario 3: 承認前の manifest → 未承認と明示する ==="
+jq 'del(.approval)' "$WORK/run-manifest.json" > "$WORK/run-manifest-unapproved.json"
+OUT="$(run compact "$WORK/run-manifest-unapproved.json" "$EMPTY_QUEUE" "$EMPTY_LOG")"
+assert_contains "$OUT" "未承認" "approval 欠如を未承認として出す"
+
+echo "=== scenario 4: 復旧キューの未解決エントリ → 件数と id を出す。resolved は出さない ==="
+cat > "$WORK/queue.jsonl" <<'EOF'
+{"id":"r1","timestamp":"2026-09-01T00:00:00Z","type":"workflow-interrupted","detail":"x","status":"pending"}
+{"id":"r2","timestamp":"2026-09-01T00:00:00Z","type":"gap-check-followup","detail":"y","status":"surfaced","surfacedAt":"2026-09-02T00:00:00Z"}
+{"id":"r3","timestamp":"2026-09-01T00:00:00Z","type":"gap-check-followup","detail":"z","status":"resolved","resolvedAt":"2026-09-03T00:00:00Z"}
+EOF
+OUT="$(run compact "$EMPTY_MANIFEST" "$WORK/queue.jsonl" "$EMPTY_LOG")"
+assert_contains "$OUT" "id=r1 status=pending" "pending を出す"
+assert_contains "$OUT" "id=r2 status=surfaced" "surfaced を出す"
+assert_not_contains "$OUT" "id=r3" "resolved は出さない"
+assert_contains "$OUT" "resolve-recovery-task.sh" "解決手順へのポインタ"
+
+echo "=== scenario 5: 進捗ログがある → show-agent-status.sh の出力を含める ==="
+cat > "$WORK/progress.jsonl" <<'EOF'
+{"timestamp":"2026-09-05T00:00:00Z","agent":"implementer-ui","feature":"example","status":"running","note":"UI実装中"}
+EOF
+OUT="$(run compact "$EMPTY_MANIFEST" "$EMPTY_QUEUE" "$WORK/progress.jsonl")"
+assert_contains "$OUT" "implementer-ui" "エージェント名が入る"
+assert_contains "$OUT" "サブエージェント進捗" "進捗セクションの見出し"
+
+echo "=== scenario 6: source が compact 以外 → 状態があっても何も出力しない（二重注入防止） ==="
+OUT="$(run startup "$WORK/run-manifest.json" "$WORK/queue.jsonl" "$WORK/progress.jsonl")"
+assert_empty "$OUT" "startup では沈黙する"
+OUT="$(run resume "$WORK/run-manifest.json" "$EMPTY_QUEUE" "$EMPTY_LOG")"
+assert_empty "$OUT" "resume でも沈黙する"
+
+echo "=== scenario 7: REINJECT_FORCE=1 なら source ガードを無効化できる（手動検証用） ==="
+OUT="$(printf '{"source":"startup"}' | REINJECT_FORCE=1 AIDD_MANIFEST_PATH="$WORK/run-manifest.json" RECOVERY_QUEUE_FILE="$EMPTY_QUEUE" AGENT_PROGRESS_LOG="$EMPTY_LOG" bash "$SCRIPT")"
+assert_contains "$OUT" "additionalContext" "FORCE で出力される"
+
+echo "=== scenario 8: stdin が空でも壊れない（手動実行） ==="
+OUT="$(AIDD_MANIFEST_PATH="$WORK/run-manifest.json" RECOVERY_QUEUE_FILE="$EMPTY_QUEUE" AGENT_PROGRESS_LOG="$EMPTY_LOG" bash "$SCRIPT" < /dev/null)"
+assert_contains "$OUT" "additionalContext" "stdin 空でも出力される"
+
+echo "=== scenario 9: 出力は妥当な JSON ==="
+if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext | length > 0' >/dev/null; then
+  echo "  OK: jq でパースできる"
+else
+  echo "  NG: JSON として不正"; fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Refs #712（実機での `/compact` 発火確認が未実施のため、確認後に close する）

## 30秒サマリー
- 変更概要: SessionStart hook を「compact 以外（警告系 12 本）」と「compact のみ（AIDD 実行状態の再注入 1 本）」の 2 群に分けた
- リスク: 中（`.claude/settings.json` の hook 構成変更。matcher の解釈は Claude Code 本体依存で、誤っていると警告系が一切出なくなる）
- 変更領域: hook 設定 / hook スクリプト / テスト / docs
- 証拠状態: 実測 4 件（スクリプト単体テスト 9 シナリオ / 構造テスト GREEN+RED / settings.json の jq パース / docs 整合性）、サンプル・未検証 1 件（Claude Code 本体が matcher `compact` で本当にこの hook だけを起動し additionalContext を再注入するか）
- 影響範囲: `.claude/settings.json`（SessionStart 節）、`scripts/reinject-aidd-run-state.sh`（新規）、`scripts/reinject-aidd-run-state.test.sh`・`scripts/check-session-start-matchers.test.sh`（新規、CI hooks-test）、`docs/agents/actuator-inventory.md`・`docs/agents/decisions/aidd-pipeline.md`
- ロールバック可能性: settings.json の matcher 2 行と compact エントリを外せば従来構成に戻る（スクリプト・テストは残っても無害）

レビューしてほしい点:
1. 警告系を issue 本文の「startup 限定」ではなく `startup|resume|clear|fork`（= compact 以外）にした判断（resume は数日後の再開でブランチ警告が有用。decisions に理由）
2. matcher の正規表現 `startup|resume|clear|fork` が Claude Code の SessionStart matcher で期待通り解釈されるか。PreToolUse の `Bash|Write|Edit` と同じ書式だが、SessionStart での実機確認はまだ

## 00 目的・影響範囲・対象外
- 目的: issue #712。長時間 AIDD 自律実行中の compaction で「本当に必要な状態」が薄れ、「不要な警告 12 本」が再注入される逆転を直す
- 変更範囲: SessionStart hook の matcher 分割と、compact 専用の再注入スクリプト
- 対象外（今回あえて触らない）: 各警告 hook のセッション内 dedup 実装の見直し。PreCompact hook での状態保存（今回は既にディスクにある状態ファイルを読むだけで足りる）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外（UI 変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- `.claude/settings.json`: SessionStart が 2 エントリになった（`jq -r '.hooks.SessionStart[].matcher'` → `startup|resume|clear|fork` / `compact`）
- `scripts/reinject-aidd-run-state.sh`: 存在する状態ファイルだけを要約して additionalContext に出す。run-manifest（specPath / specHash 先頭 12 桁 / baseCommit / 停止①承認の有無 / changedFiles 件数）、`show-agent-status.sh` の出力先頭 20 行、復旧キューの pending + surfaced。全部無ければ沈黙。stdin の `source` が compact 以外なら何もしない（matcher 設定ミス時の二重注入防止）。CLAUDE.md のルールは再注入済みなのでポインタのみ、/goal 条件は会話内にしか無いので注意喚起のみ
- `scripts/check-session-start-matchers.test.sh`: settings.json を直接読み、(1) 全エントリに matcher がある (2) compact にマッチするエントリは reinject 1 本だけ (3) startup / resume / clear / fork の各 source に警告系が届き reinject は届かない (4) reinject が登録されている、を固定。bash の `=~` で matcher 正規表現を実際に評価している

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外（auth / RLS / facility 境界に触れていない。derive が `docs/agents/actuator-inventory.md` を高リスク判定したのは、ファイル名の "inventory" が router-risk のドメイン語に文字列一致した既知の誤一致）
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
`bash scripts/derive-test-selection.sh --files <変更 6 ファイル> --format table` の出力（route: deep。理由は上記の誤一致）を基に更新:

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行（TS に触れていない） |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行（TS に触れていない） |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行（src/ に触れていない） |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行（workflows に触れていない） |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/reinject-aidd-run-state.test.sh` ALL PASSED（9 シナリオ）。`bash scripts/check-session-start-matchers.test.sh` ALL PASSED（実態 2 エントリ違反なし / fixture で no-matcher・compact-noise・reinject-on-startup・missing-fork の 4 種を検知 / 正しい構成は誤検知なし）。`bash scripts/codex-config-separation.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行（依存に触れていない） |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行（依存に触れていない） |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED（checked=35 violations=0） |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | derive の高リスク判定は `actuator-inventory.md` のファイル名 "inventory" の誤一致。DB・RLS・データ層に触れていない |
| 生成型の鮮度 | ➖ 今回不要 | 同上（DB スキーマに触れていない） |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上（auth / 認可 / RLS に触れていない） |
| hook 実機発火 | 🟡 一部 | スクリプト単体は `source: compact` の stdin を与えて実測済み。**Claude Code 本体が compaction 時に matcher `compact` のエントリだけを起動し、警告系を起動しないこと**は未確認。確認手順: AIDD 実行中（`.aidd/run-manifest.json` がある状態）のセッションで `/compact` を実行し、直後に「compaction 後に AIDD 実行状態（…）を再注入しました（issue #712）」の systemMessage が出て、ブランチ鮮度等の警告が**出ない**ことを見る。確認後に issue #712 を close |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- 「⬜ 未実施」はいずれも CI が全 PR で回す種別で、この PR が触れていない層
- verify-claims: 未実施（数値は上記コマンドの生出力からの転記）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 新規セッション開始時に従来の警告（ブランチ鮮度等）が引き続き出ること（出なければ matcher の解釈が想定と違う）。`/compact` 後の systemMessage
- 異常の判断基準: 新規セッションで警告系が 1 本も出ない → matcher 正規表現が SessionStart で効いていない。ロールバックする
- ロールバック手順: `.claude/settings.json` の 2 つの `"matcher"` 行と compact エントリを削除（従来の matcher 無し 12 本構成に戻る）。構造テストは RED になるので同時に削除するか、fixture のみに戻す

## 後任AIへの注意
- この実装で壊してはいけない前提: SessionStart hook を新設するときは必ず matcher を付ける（構造テストが無指定を拒否する）。compact 時に必要なものは reinject スクリプトのセクションとして足し、別 hook を compact に登録しない
- 似ているが別物の用語: `systemMessage`（ユーザーに見える）と `additionalContext`（Claude のコンテキストに入る）。再注入の本体は後者
- 勝手にリファクタしない場所: reinject スクリプトの `source` ガード。外すと matcher 設定ミス時に startup でも二重注入される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
