### PR TITLE
feat: 常時ロードされる指示ファイルの合計文字数をSessionStart hookで計測し閾値超過を警告する(issue #711)

### DIFF
--- a/docs/agents/decisions/aidd-pipeline.md
+++ b/docs/agents/decisions/aidd-pipeline.md
@@ -656,3 +656,37 @@ context に入るかは、Claude Code 本体の挙動であり shell テスト�
 **How to apply:** SessionStart hook を新設するときは必ず matcher を付ける（構造テストが
 無指定を拒否する）。compact 時に必要なものは reinject スクリプトのセクションとして足し、
 別 hook を compact に登録しない。
+
+## なぜ常時ロード量の閾値を行数ではなく「CLAUDE.md + @import + unscoped rules の合計文字数」にし、既定を実測 +10% のラチェットにしたか（issue #711）
+
+**結論: `scripts/check-claude-md-size.sh` は行数（従来）に加え、起動時に全量ロードされる
+指示ファイル群の合計文字数を計測し、既定 24,000 文字（2026-09-05 実測 21,790 の約 +10%）
+超過で警告する。**
+
+公式ドキュメント（memory / context-window）の要点は 3 つ。CLAUDE.md は 1 ファイル 200 行以下、
+`@import` は整理には効くがコンテキストは減らない、paths 無しの `.claude/rules/` も毎セッション
+ロードされる。従来の hook は CLAUDE.md と common.md の**行数**しか見ておらず、import 先や
+rules へ移した分が計測から漏れる構造だった。
+
+**実測（2026-09-05）:** プロジェクト CLAUDE.md 3,694 文字 + common.md 18,097 文字 = 21,790 文字、
+概算 11,400 トークン（非ASCII 1 文字≈1、ASCII 4 文字≈1 の近似）。公式の可視化例
+（CLAUDE.md ≈ 1,800 トークン）の約 6 倍で、8 割が common.md。ユーザー CLAUDE.md・MEMORY.md・
+hook 出力を足すと約 18,400 トークン。詳細表は issue #711 のコメント。
+
+**文字数にした理由:** バイト数は日本語 1 文字 3 バイトでトークンの指標にならず（issue #716 で
+誤認した実例）、API の count_tokens は hook 環境から使えない。文字数なら tokenizer に依存せず、
+概算トークンは近似係数で添えられる。
+
+**閾値をラチェットにした理由:** 「何トークンまでなら adherence が保てるか」の実測データは無く、
+先に目標値を決めると根拠の無い数字になる。実測 +10% に置けば、次に誰かが common.md を
+1 節増やした瞬間に鳴り、「増やすなら何かを切り出す」判断を強制できる。減らす方向の候補
+（AIDD stats ルールのスキル化、依存変更ルールの paths 付き rules 化、重要ファイル表の
+ai-config-map への寄せ）は issue #711 のコメントに列挙し、1 件ずつ別 PR にする。
+
+**対象外にしたもの:** MEMORY.md（$HOME 配下の個人ファイルで、プロジェクト hook が読むべきで
+ない）と SessionStart hook 自身の出力（自己再帰になる）。どちらも issue コメントの手動実測で代替。
+
+**How to apply:** 常時ロード量の警告が出たら閾値を上げるのではなく、切り出し候補から 1 つを
+skill / paths 付き rules / 参照ドキュメントへ移す。切り出した節は compaction 後に再注入
+されなくなるので、フロー実行に必須のものは `scripts/reinject-aidd-run-state.sh`（issue #712）の
+ポインタに載せる。

--- a/scripts/check-claude-md-size.sh
+++ b/scripts/check-claude-md-size.sh
@@ -8,15 +8,33 @@ set -euo pipefail
 # 機械検知ルール集であり、「短ければ良い」わけではない（削除の判断は人間に委ねる）。
 # block（session開始そのものの停止）はできない前提のためwarningのみ。
 #
-# 閾値は環境変数で上書き可能（デフォルトはCLAUDE.md=200行、common.md=300行。
-# common.mdは@importで別ファイルとして分離されている実態を踏まえ、CLAUDE.md本体より
-# 緩めの閾値にした）。
+# 2つの検査を行う:
+#  (a) 行数（従来）: CLAUDE.md=200行、common.md=300行が既定。公式推奨「1ファイル200行以下」に
+#      対し、common.mdは@importで別ファイルに分離されている実態を踏まえ緩めにしている
+#  (b) 常時ロード総量（issue #711）: 公式仕様では @import 先は起動時に全量ロードされ
+#      「分割してもコンテキストは減らない」。また .claude/rules/ のうち paths: frontmatter の
+#      無いルールも毎セッションロードされる。行数だけ見ていると、@import先やrulesに
+#      移した分が計測から漏れるため、CLAUDE.md + @import（4段まで再帰）+ unscoped rules の
+#      合計**文字数**で閾値判定する。バイト数は日本語1文字3バイトでトークンの指標に
+#      ならないため使わない（issue #716と同じ理由）。トークン概算は
+#      「非ASCII 1文字≈1トークン、ASCII 4文字≈1トークン」で出す（実測に基づく近似。
+#      2026-09-05: 本体21,791文字≈9,200トークン。根拠は docs/agents/decisions/aidd-pipeline.md）。
+#      閾値の既定 24,000 文字は 2026-09-05 実測値の約 +10%（「増えたら気づく」ラチェット）。
+#      MEMORY.md（auto memory、先頭200行/25KB）と SessionStart hook の出力は、hook自身から
+#      安全に測れない（前者は $HOME 配下の個人ファイル、後者は自己再帰）ため対象外。
+#      それらを含めた実測値は issue #711 のコメントを参照。
+#
+# 閾値は環境変数で上書き可能:
+#   CLAUDE_MD_LINE_LIMIT（既定200）/ COMMON_MD_LINE_LIMIT（既定300）
+#   STARTUP_CONTEXT_CHAR_LIMIT（既定24000）
+#   CLAUDE_PROJECT_DIR（既定 pwd。テスト用差し替え）
 
 command -v wc >/dev/null 2>&1 || exit 0
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 CLAUDE_MD_LIMIT="${CLAUDE_MD_LINE_LIMIT:-200}"
 COMMON_MD_LIMIT="${COMMON_MD_LINE_LIMIT:-300}"
+CHAR_LIMIT="${STARTUP_CONTEXT_CHAR_LIMIT:-24000}"
 
 CLAUDE_MD_PATH="$PROJECT_DIR/CLAUDE.md"
 COMMON_MD_PATH="$PROJECT_DIR/docs/agents/common.md"
@@ -34,6 +52,66 @@ if [ -f "$COMMON_MD_PATH" ]; then
   LINES=$(wc -l < "$COMMON_MD_PATH" | tr -d ' ')
   if [ "$LINES" -gt "$COMMON_MD_LIMIT" ]; then
     WARNINGS+=("docs/agents/common.mdが${LINES}行（閾値${COMMON_MD_LIMIT}行）を超えています。CLAUDE.mdへの@importで全メッセージにプリロードされるため、既存ルールの棚卸しファイルへの分離（issue #486と同様の対応）を検討してください。")
+  fi
+fi
+
+# ---- (b) 常時ロード総量（jq が無ければこの検査だけ省略） ----
+if command -v jq >/dev/null 2>&1 && [ -f "$CLAUDE_MD_PATH" ]; then
+  # @import を再帰的に解決して対象ファイル一覧を作る（公式仕様: 相対パスは import 元ファイル基準、
+  # 最大4段、コードスパン・フェンス内の @ は無視、~/ は $HOME 展開）
+  declare -a FILES=()
+  declare -a SEEN=()
+  collect() {
+    local file="$1" depth="$2" line target abs
+    for s in "${SEEN[@]:-}"; do [ "$s" = "$file" ] && return 0; done
+    SEEN+=("$file")
+    FILES+=("$file")
+    [ "$depth" -ge 4 ] && return 0
+    local in_fence=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in '```'*|'~~~'*) in_fence=$((1 - in_fence)); continue ;; esac
+      [ "$in_fence" -eq 1 ] && continue
+      # コードスパンを潰してから @path を拾う
+      line="$(printf '%s' "$line" | sed -E 's/`[^`]*`//g')"
+      for target in $(printf '%s' "$line" | grep -oE '(^|[[:space:]])@[^[:space:]]+' | sed -E 's/^[[:space:]]*@//'); do
+        case "$target" in
+          '~/'*) abs="$HOME/${target#\~/}" ;;
+          /*) abs="$target" ;;
+          *) abs="$(dirname "$file")/$target" ;;
+        esac
+        if [ -f "$abs" ]; then collect "$abs" $((depth + 1)); fi
+      done
+    done < "$file"
+    # 最後の [ -f ] が偽だと関数の戻り値が非0になり set -e で落ちるため明示的に 0 を返す
+    return 0
+  }
+  collect "$CLAUDE_MD_PATH" 0 || true
+  # paths: frontmatter の無い rules も起動時ロード
+  if [ -d "$PROJECT_DIR/.claude/rules" ]; then
+    while IFS= read -r rule; do
+      [ -z "$rule" ] && continue
+      if ! awk 'NR==1 && $0 != "---" {exit 1} /^---$/ && NR>1 {exit 0} /^paths:/ {found=1} END {exit found ? 0 : 1}' "$rule" 2>/dev/null; then
+        FILES+=("$rule")
+      fi
+    done < <(find "$PROJECT_DIR/.claude/rules" -name '*.md' -type f 2>/dev/null | sort)
+  fi
+
+  TOTAL_CHARS=0
+  TOTAL_NONASCII=0
+  BREAKDOWN=""
+  for f in "${FILES[@]}"; do
+    chars="$(jq -Rs 'length' "$f")"
+    nonascii="$(jq -Rs '[explode[] | select(. > 127)] | length' "$f")"
+    TOTAL_CHARS=$((TOTAL_CHARS + chars))
+    TOTAL_NONASCII=$((TOTAL_NONASCII + nonascii))
+    BREAKDOWN="${BREAKDOWN}
+  - ${f#"$PROJECT_DIR"/}: ${chars}文字"
+  done
+  ASCII=$((TOTAL_CHARS - TOTAL_NONASCII))
+  EST_TOKENS=$((TOTAL_NONASCII + ASCII / 4))
+
+  if [ "$TOTAL_CHARS" -gt "$CHAR_LIMIT" ]; then
+    WARNINGS+=("常時ロードされる指示ファイルの合計が${TOTAL_CHARS}文字（閾値${CHAR_LIMIT}文字、概算${EST_TOKENS}トークン）を超えています（issue #711）。@importで分割してもコンテキストは減りません。フロー実行時にしか要らない手順はskill化、特定パスでしか要らない規則はpaths付きrulesへ移すことを検討してください。内訳:${BREAKDOWN}")
   fi
 fi
 

--- a/scripts/check-claude-md-size.test.sh
+++ b/scripts/check-claude-md-size.test.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # WHY: scripts/check-claude-md-size.sh(SessionStart hook)の回帰テスト。
-# CLAUDE.md / docs/agents/common.mdの行数が閾値を超えたら警告し、超えなければ
-# 何も出力しないことを確認する。CLAUDE_PROJECT_DIR/CLAUDE_MD_LINE_LIMIT/
-# COMMON_MD_LINE_LIMITでテスト用に差し替える（本物のCLAUDE.mdを書き換えないため）。
+# (a) CLAUDE.md / docs/agents/common.mdの行数が閾値を超えたら警告し、超えなければ
+#     何も出力しないこと
+# (b) CLAUDE.md + @import先（再帰）+ paths無しrulesの合計文字数が閾値を超えたら警告し、
+#     paths付きrules・コードスパン内の@・存在しないimportは数えないこと（issue #711）
+# を確認する。CLAUDE_PROJECT_DIR/CLAUDE_MD_LINE_LIMIT/COMMON_MD_LINE_LIMIT/
+# STARTUP_CONTEXT_CHAR_LIMITでテスト用に差し替える（本物のCLAUDE.mdを書き換えないため）。
 #
 # 実行: bash scripts/check-claude-md-size.test.sh
 set -euo pipefail
@@ -29,6 +32,15 @@ assert_contains() {
     echo "      expected to find: $needle"
     echo "      actual: $haystack"
     fail=1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  NG: $label (unexpected: $needle)"
+    fail=1
+  else
+    echo "  OK: $label"
   fi
 }
 
@@ -67,6 +79,35 @@ EMPTY_DIR="$(mktemp -d)"
 OUT="$(CLAUDE_PROJECT_DIR="$EMPTY_DIR" bash "$SCRIPT")"
 assert_empty "$OUT" "ファイル不在でもクラッシュしない"
 rm -rf "$EMPTY_DIR"
+
+echo "=== scenario 6: 常時ロード総量 = CLAUDE.md + @import（再帰）+ paths無しrules（issue #711） ==="
+W="$(mktemp -d)"
+mkdir -p "$W/docs/agents" "$W/.claude/rules" "$W/sub"
+# CLAUDE.md 10文字 + common.md 20文字（@import）+ sub/deep.md 30文字（common.md からの相対 import）
+# + rules/unscoped.md 40文字。paths 付き rules（50文字）・コードスパン内の @（`@docs/x.md`）・
+# 存在しない @docs/none.md は数えない。合計 100 文字ちょうど
+printf '@docs/agents/common.md\n' > "$W/CLAUDE.md"                    # 23文字だが本文は @行のみ
+printf 'あいうえおかきくけこ' > "$W/sub/deep.md"                          # 10 非ASCII
+printf '@../../sub/deep.md `@docs/x.md` @docs/none.md\n' > "$W/docs/agents/common.md"
+printf 'unscoped rule body here!' > "$W/.claude/rules/unscoped.md"     # 24 ASCII
+printf -- '---\npaths:\n  - "src/**"\n---\nscoped rule body\n' > "$W/.claude/rules/scoped.md"
+CLAUDE_CHARS="$(jq -Rs 'length' "$W/CLAUDE.md")"
+COMMON_CHARS="$(jq -Rs 'length' "$W/docs/agents/common.md")"
+EXPECTED=$((CLAUDE_CHARS + COMMON_CHARS + 10 + 24))
+OUT="$(CLAUDE_PROJECT_DIR="$W" STARTUP_CONTEXT_CHAR_LIMIT=$((EXPECTED - 1)) bash "$SCRIPT")"
+assert_contains "$OUT" "合計が${EXPECTED}文字" "合計文字数が期待どおり（import再帰・unscoped rules込み）"
+assert_contains "$OUT" "sub/deep.md" "import元相対で解決した深い import が内訳に出る"
+assert_contains "$OUT" ".claude/rules/unscoped.md" "paths無しrulesが内訳に出る"
+assert_not_contains "$OUT" "rules/scoped.md" "paths付きrulesは数えない"
+assert_not_contains "$OUT" "docs/x.md" "コードスパン内の@は数えない"
+OUT="$(CLAUDE_PROJECT_DIR="$W" STARTUP_CONTEXT_CHAR_LIMIT=$EXPECTED bash "$SCRIPT")"
+assert_empty "$OUT" "閾値ちょうどなら警告なし"
+rm -rf "$W"
+
+echo "=== scenario 7: 実態のリポジトリで既定閾値を超えていない（超えたら分離を検討する合図） ==="
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT="$(CLAUDE_PROJECT_DIR="$REPO_ROOT" bash "$SCRIPT")"
+assert_not_contains "$OUT" "常時ロードされる指示ファイルの合計" "実態が STARTUP_CONTEXT_CHAR_LIMIT 以内"
 
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"


### PR DESCRIPTION
Closes #711

## 30秒サマリー
- 変更概要: SessionStart hook `check-claude-md-size.sh` を拡張し、行数に加えて「起動時に全量ロードされる指示ファイル群（CLAUDE.md + @import 先 + paths 無し rules）の合計文字数」を計測・閾値判定する。実測は issue #711 コメントに記録
- リスク: 低（warning-only hook の拡張。閾値超過でも block しない）
- 変更領域: hook スクリプト / テスト / docs
- 証拠状態: 実測 4 件（常時ロード各ファイルの文字数表 / hook 12 本の注入量 / テスト 7 シナリオ GREEN+RED / 実態が閾値以内）、サンプル・未検証 1 件（トークン概算の係数は tokenizer 実測ではない近似）
- 影響範囲: `scripts/check-claude-md-size.sh`、`scripts/check-claude-md-size.test.sh`、`docs/agents/decisions/aidd-pipeline.md`
- ロールバック可能性: スクリプトの (b) 節を削除すれば従来の行数検査のみに戻る

レビューしてほしい点:
1. 閾値の既定 24,000 文字を「実測 21,790 の約 +10% のラチェット」にした判断（減らす目標値ではなく、増えたら鳴らす）
2. 切り出し候補 4 件（issue コメント）の優先順。特に `common.md`「重要ファイルへのパス」表（全体の 1/4）を `docs/ai-config-map.md` へ寄せる案

## 00 目的・影響範囲・対象外
- 目的: issue #711。行数だけの検査では @import 先・rules へ移した分が漏れ、常時ロード量の実態が誰にも見えていなかった
- 変更範囲: 計測と警告の追加のみ
- 対象外（今回あえて触らない）: `common.md` の切り出し（候補は issue コメントに列挙、1 件ずつ別 PR）。MEMORY.md と hook 出力の hook 内計測（$HOME 配下 / 自己再帰のため手動実測で代替）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外（UI 変更なし）

## 02 内部でどう守っているか（ロジック証拠）
- 実測（2026-09-05、文字数 / 概算トークン）: プロジェクト CLAUDE.md 3,694 / 約 2,200、`common.md` 18,097 / 約 9,200、unscoped rules 0、ユーザー CLAUDE.md 3,597 / 約 2,200、MEMORY.md 8,200 / 約 4,200、hook 出力 967 / 約 600。合計約 34,600 文字 / 約 18,400 トークン
- `check-claude-md-size.sh` (b) 節: `@path` を import 元ファイル相対で解決（`~/` は $HOME、絶対パスはそのまま）、4 段まで再帰、フェンス・コードスパン内は無視、存在しない import は無視。`.claude/rules/*.md` は frontmatter に `paths:` が無いものだけ加算。文字数は `jq -Rs 'length'`、概算トークンは非ASCII + ASCII/4
- 初回実装のバグ: import 先不在で `[ -f ] && collect` が偽になり関数の戻り値が非 0 → `set -e` で hook ごと落ちていた。fixture（scenario 6）で発見し `return 0` を明示

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
`bash scripts/derive-test-selection.sh --files scripts/check-claude-md-size.sh,scripts/check-claude-md-size.test.sh,docs/agents/decisions/aidd-pipeline.md --format table` の出力（route: light）を基に更新:

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行（TS に触れていない） |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行（TS に触れていない） |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行（src/ に触れていない） |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行（migrations に触れていない） |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行（workflows に触れていない） |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-claude-md-size.test.sh` ALL PASSED（7 シナリオ。scenario 6 は import 再帰・unscoped/scoped rules・コードスパン・不在 import の fixture で合計 103 文字ちょうどを検知、閾値ちょうどでは沈黙。scenario 7 は実態が既定閾値以内） |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行（依存に触れていない） |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行（依存に触れていない） |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| hook 実機発火 | 🟡 一部 | `CLAUDE_PROJECT_DIR=<repo> STARTUP_CONTEXT_CHAR_LIMIT=1` で強制発火させ、実態の内訳（CLAUDE.md 3,694 / common.md 18,096、概算 11,381 トークン）が systemMessage に出ることを確認。既定閾値では鳴らないため、新規セッションで「鳴らないこと」の確認は次セッション開始時に行う |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- 「⬜ 未実施」はいずれも CI が全 PR で回す種別で、この PR が触れていない層
- 未検証: トークン概算の係数（非ASCII 1 文字≈1、ASCII 4 文字≈1）。tokenizer 実測ではなく、桁の目安として使う
- verify-claims: 未実施（数値は上記コマンドの生出力からの転記）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 新規セッション開始時の警告（既定閾値 24,000 では今は鳴らない。common.md に約 2,200 文字以上足すと鳴る）
- 異常の判断基準: 警告が出たら閾値を上げず、issue #711 コメントの切り出し候補から 1 つを移す
- ロールバック手順: `check-claude-md-size.sh` の「(b) 常時ロード総量」節と test の scenario 6・7 を削除

## 後任AIへの注意
- この実装で壊してはいけない前提: 閾値はラチェット。上げるときは decisions に「なぜ増やしてよいか」を書く
- 似ているが別物の用語: バイト数（日本語 1 文字 3 バイト）と文字数とトークン数。閾値と内訳は文字数、概算トークンは近似
- 勝手にリファクタしない場所: `collect` 関数の `return 0`（無いと import 先不在で hook が `set -e` で落ちる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
