### PR TITLE
test: AGENTS.md/common.mdのTRI/RISK基準がrouter-risk.jsの正本と同期していることをnpm testで固定する(issue #715)

### DIFF
--- a/.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js
+++ b/.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const LIB_FILE = path.resolve(__dirname, '../router-risk.js')
+const DOC_FILES = ['AGENTS.md', 'docs/agents/common.md']
+const SECTION_HEADING = '## TRI/RISK 機械判定基準'
+
+// WHY: TRI/RISK 機械判定基準（高リスクパス・ドメイン語）は、Claude Code が読む
+// docs/agents/common.md（CLAUDE.md から @import）と Codex が読む AGENTS.md の両方に本文として
+// 存在する。Claude/Codex 共存設計（docs/agents/parallel-agent-work.md）は「2つのコピーが
+// 食い違ったとき必ずバグになるもの」の共有を認めており、TRI/RISK 基準はまさにそれに当たるが、
+// これまで同期テストが無く、issue #681（proxy.ts 追加）のような基準変更で片方だけ更新される
+// 事故が構造的に起こりえた（issue #715）。
+//
+// 正本は .claude/workflows/lib/router-risk.js（RISK_PATH_PREFIXES / RISK_DOMAIN_KEYWORDS /
+// isHighRiskPath 内の middleware.ts・proxy.ts 判定）。本テストは
+//   1. 両 doc の TRI/RISK 節に、正本の全パス接頭辞・middleware.ts・proxy.ts・全ドメイン語が
+//      含まれること（正本 → doc の片方向）
+//   2. 両 doc の TRI/RISK 節の「基準本体」（箇条書き〜「迷ったら高リスク側に倒す」まで）が
+//      一字一句一致すること（doc 同士のドリフト検知）
+// を検証する。AGENTS.md をポインタ化して重複を無くす案（issue #715 案A）は、Codex が起動時に
+// 読む本文から常時ルールが消えるため採らなかった（docs/agents/decisions.md）。
+
+function extractSection(markdown, heading) {
+  const lines = markdown.split('\n')
+  const start = lines.findIndex(l => l.startsWith(heading))
+  if (start < 0) return null
+  let end = lines.length
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) { end = i; break }
+  }
+  return lines.slice(start, end).join('\n')
+}
+
+// 基準本体: 「変更が以下の」で始まる段落から「迷ったら高リスク側に倒す」を含む行まで
+function extractRuleCore(section) {
+  const lines = section.split('\n')
+  const start = lines.findIndex(l => l.startsWith('変更が以下の'))
+  const end = lines.findIndex(l => l.includes('迷ったら高リスク側に倒す'))
+  if (start < 0 || end < 0 || end < start) return null
+  return lines.slice(start, end + 1).join('\n')
+}
+
+function stringLiterals(declSource) {
+  return [...declSource.matchAll(/'([^']+)'/g)].map(m => m[1])
+}
+
+describe('TRI/RISK 機械判定基準の AGENTS.md / common.md と router-risk.js の同期（issue #715）', () => {
+  const libSource = readFileSync(LIB_FILE, 'utf-8')
+  const pathPrefixes = stringLiterals(extractDeclaration(libSource, 'RISK_PATH_PREFIXES'))
+  const domainKeywords = stringLiterals(extractDeclaration(libSource, 'RISK_DOMAIN_KEYWORDS'))
+  const fileNameRules = ['middleware.ts', 'proxy.ts']
+
+  it('正本から接頭辞・ドメイン語を取り出せる（テスト自身の前提）', () => {
+    expect(pathPrefixes.length).toBeGreaterThan(0)
+    expect(domainKeywords.length).toBeGreaterThan(0)
+    const isHighRiskPath = extractDeclaration(libSource, 'isHighRiskPath')
+    for (const f of fileNameRules) expect(isHighRiskPath).toContain(f)
+  })
+
+  const sections = {}
+  for (const rel of DOC_FILES) {
+    const section = extractSection(readFileSync(path.join(REPO_ROOT, rel), 'utf-8'), SECTION_HEADING)
+    sections[rel] = section
+
+    it(`${rel} に「${SECTION_HEADING}」節がある`, () => {
+      expect(section).not.toBeNull()
+    })
+
+    for (const prefix of pathPrefixes) {
+      it(`${rel} の TRI/RISK 節に高リスクパス接頭辞 ${prefix} がある`, () => {
+        expect(section).toContain(prefix)
+      })
+    }
+    for (const f of fileNameRules) {
+      it(`${rel} の TRI/RISK 節にファイル名規則 ${f} がある`, () => {
+        expect(section).toContain(f)
+      })
+    }
+    for (const kw of domainKeywords) {
+      it(`${rel} の TRI/RISK 節にドメイン語 ${kw} がある（大文字小文字不問）`, () => {
+        expect(section.toLowerCase()).toContain(kw.toLowerCase())
+      })
+    }
+  }
+
+  it('AGENTS.md と common.md の基準本体（箇条書き〜「迷ったら高リスク側に倒す」）が一字一句一致する', () => {
+    const cores = DOC_FILES.map(rel => extractRuleCore(sections[rel]))
+    for (const core of cores) expect(core).not.toBeNull()
+    expect(cores[0]).toBe(cores[1])
+  })
+
+  it('RED 方向: 片方の節から proxy.ts を消すと不一致を検知する（テスト自身の自己検証）', () => {
+    const tampered = sections['AGENTS.md'].replaceAll('proxy.ts', 'prox_y.ts')
+    expect(extractRuleCore(tampered)).not.toBe(extractRuleCore(sections['docs/agents/common.md']))
+    expect(tampered).not.toContain('proxy.ts')
+  })
+})

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -317,3 +317,33 @@ workflow）を docs 側の paths で起動し、コード側の変更で回る h
 違反にしない」という規則は**リポジトリの `.gitignore`** にしか依存できないので、
 `.claude/settings.local.json` を `.gitignore` に明示した。ローカル green・CI red の典型で、
 グローバル ignore に頼ったパスは他にも同じ形で壊れうる。
+
+## なぜ TRI/RISK 基準の AGENTS.md / common.md 重複を残し、router-risk.js を正本にした同期テストで固定したか（issue #715）
+
+**結論: AGENTS.md（Codex が読む）と docs/agents/common.md（Claude Code が CLAUDE.md から
+@import で読む）の「TRI/RISK 機械判定基準」節は両方に本文として残す。正本は
+`.claude/workflows/lib/router-risk.js` とし、`.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js`
+が「正本の全パス接頭辞・middleware.ts・proxy.ts・全ドメイン語が両節に含まれる」ことと
+「両節の基準本体が一字一句一致する」ことを `npm test` で検査する。**
+
+3 案を比較した。
+
+- **案A（AGENTS.md をポインタ化）:** 重複は消えるが、Codex は起動時に AGENTS.md しか読まない
+  ため、常時効かせたい高リスク判定が「必要なら common.md を読め」という間接参照になる。
+  [`parallel-agent-work.md`](./parallel-agent-work.md) の「2つのコピーが食い違ったとき必ずバグに
+  なるものだけを共有する」原則は、まさにこの基準を**両方に本文として持ち、機械で同期する**
+  ことを想定している。共存テンプレートの原則 10（並行作業禁止を AGENTS.md / CLAUDE.md の
+  両方に明文化）と同じ扱いにするのが筋。却下。
+- **案B（重複を残し同期テスト）:** 採用。既存の prompt-sync / router-risk-sync と同型で、
+  基準を変える PR は正本・両 doc の 3 箇所を同時に直さないと RED になる。
+- **案C（CLAUDE.md に @AGENTS.md）:** 公式推奨だが、常時ロード量が約 3,600 文字増え
+  （issue #711 の実測で既に公式例の約 6 倍）、かつ AGENTS.md には Codex 固有の節
+  （`.codex/` 設定・ask 未対応のラッパー）があり Claude に読ませる意味が無い。却下。
+
+**Codex 実機確認を省いた理由:** AGENTS.md の本文を変えていないため、Codex 側の読み込み結果は
+変わらない。案A を採る場合にのみ `codex --ask-for-approval never "Summarize current instructions."`
+での確認が必要だった。
+
+**How to apply:** TRI/RISK 基準（高リスクパス・ドメイン語・ファイル名規則）を変えるときは
+`router-risk.js` → `AGENTS.md` → `common.md` の順に 3 箇所を同時に直す。テストが RED に
+なったら「片方だけ直した」合図。基準本体の文言を整えるときも両 doc を同じ文字列に揃える。


### PR DESCRIPTION
Closes #715

## 30秒サマリー
- 変更概要: AGENTS.md（Codex）と docs/agents/common.md（Claude）に重複する TRI/RISK 機械判定基準を、`router-risk.js` を正本とする同期テストで固定（案B）。本文は変更しない
- リスク: 低（テストと決定記録の追加のみ）
- 変更領域: テスト / docs
- 証拠状態: 実測 3 件（vitest 27 件 GREEN / RED 自己検証 / docs 整合性）、サンプル・未検証 0 件
- 影響範囲: `.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js`（新規、`npm test`）、`docs/agents/decisions.md`（追記）
- ロールバック可能性: テスト削除で完全に戻る

レビューしてほしい点:
1. 案A（AGENTS.md をポインタ化）ではなく案B（重複を残して機械同期）を選んだ判断。根拠は `parallel-agent-work.md` の「2つのコピーが食い違ったとき必ずバグになるものだけを共有する」原則
2. 「基準本体が一字一句一致」の範囲（箇条書き〜「迷ったら高リスク側に倒す」まで）。common.md 側の後続段落（issue #444 の注記等）は Claude 固有で対象外にしている

## 00 目的・影響範囲・対象外
- 目的: issue #715。基準変更時に片方だけ更新される事故を `npm test` で止める
- 変更範囲: テスト追加と decisions 追記
- 対象外（今回あえて触らない）: AGENTS.md / common.md の本文（案A・C は却下）。Codex 実機確認（本文が変わらないため不要）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- `tri-risk-docs-sync.test.js`: `extractDeclaration` で `router-risk.js` の `RISK_PATH_PREFIXES` / `RISK_DOMAIN_KEYWORDS` を取り出し、`isHighRiskPath` に `middleware.ts` / `proxy.ts` があることを前提確認。両 doc の「## TRI/RISK 機械判定基準」節（次の `## ` まで）に全接頭辞・両ファイル名・全ドメイン語（大文字小文字不問）が含まれること、両節の基準本体が完全一致することを検証。RED 自己検証として AGENTS.md 側の `proxy.ts` を全置換した文字列で不一致と欠落を検知
- 現状は両節の基準本体が既に一字一句同一だったため、本文修正は不要だった

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
`bash scripts/derive-test-selection.sh --files .claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js,docs/agents/decisions.md --format table` の出力（route: meta）を基に更新:

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行（TS に触れていない） |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行（src/ に触れていない） |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ✅ 実施 (自動テスト: パス) | `npx vitest run .claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js` 27 passed（うち RED 自己検証 1 件）。修正前は `replace` が最初の 1 箇所しか置換せず自己検証が失敗し、`replaceAll` に直して通した |
| hook 回帰 | ⬜ 未実施 | CI `hooks-test` ジョブで実行（hook スクリプトに触れていない） |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| agents baseline 鮮度 | ➖ 今回不要 | `.claude/workflows/lib/__tests__/` にテストを足しただけで model / effort・プロンプトに触れていない（derive は paths だけで判定するため required に出る） |
| ワークフロープロンプト eval | ➖ 今回不要 | 同上（プロンプト文言を変えていない） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook スクリプト・settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- 「⬜ 未実施」はいずれも CI が全 PR で回す種別で、この PR が触れていない層
- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: TRI/RISK 基準を変える PR で `npm test` が RED になること（3 箇所同時修正の合図）
- 異常の判断基準: 両 doc の文言を意図的に変えたい場合は、同じ文字列に揃えてからテストを通す
- ロールバック手順: テストファイルを削除

## 後任AIへの注意
- この実装で壊してはいけない前提: 正本は `router-risk.js`。doc 側だけ直してテストを緩めない
- 似ているが別物の用語: 「基準本体」（両 doc で一致させる範囲）と、common.md にだけある後続段落（issue #444・#457 の注記。Claude 固有で一致対象外）
- 勝手にリファクタしない場所: `extractRuleCore` の開始・終了行の目印（「変更が以下の」「迷ったら高リスク側に倒す」）。文言を変えるならテストも同時に

🤖 Generated with [Claude Code](https://claude.com/claude-code)
