### PR TITLE
feat: 「保留・未対応」文脈で参照しているissueがCLOSEDならwarningを出すdocs検査を追加する(issue #714)

### DIFF
--- a/.github/workflows/docs-integrity-check.yml
+++ b/.github/workflows/docs-integrity-check.yml
@@ -3,7 +3,8 @@
 # paths-ignore しており、docs だけを変えた PR では hooks-test（scripts/*.test.sh 一括実行）が
 # 回らないため、docs 側の変更を起点にする軽量な単独 workflow を置く（eval-runs-freshness-check.yml
 # と同型）。コード側の変更で回る hooks-test と合わせて、実質すべての PR で検査される。
-# 意味的な陳腐化（LLM 判定）やクローズ済み issue への言及は対象外（issue #714 の 3 番、未実装）。
+# 意味的な陳腐化（LLM 判定）は対象外。クローズ済み issue への言及は「保留・未対応」文脈のものだけを
+# warning-only で扱う（scripts/lib/check-docs-issue-refs.mjs）。
 
 name: Docs Integrity Check
 
@@ -24,6 +25,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 concurrency:
   group: docs-integrity-${{ github.workflow }}-${{ github.ref }}
@@ -40,3 +42,10 @@ jobs:
       # （issue #710）。docs のみの PR で手編集された場合も止める
       - name: Check AIDD graph renderings are up to date
         run: bash scripts/check-aidd-graph-rendered.test.sh
+      # WHY: 「保留・未対応」の文脈で参照している issue が CLOSED なら warning（issue #714 の残項目）。
+      # gh 依存のため hooks-test では回さず、ここで warning-only（continue-on-error）にする
+      - name: Warn on closed issues referenced as pending
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/lib/check-docs-issue-refs.mjs

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -270,9 +270,9 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | `scripts/check-aidd-phase-stats-recorded.sh` | Stop hookによるAIDD stats phase1/phase2呼び忘れの機械検知（issue #524） |
 | `scripts/check-handoff-format.sh` | Stop hookによるPR本文の引き継ぎフォーマット必須見出し欠如の機械検知（issue #524） |
 | `scripts/check-find-av-precision-recorded.sh` | Stop hookによるfind-av-precisionログ記録漏れの機械検知（issue #522） |
-| [`docs/agents/recovery-queue.md`](./recovery-queue.md) | 検知後の自動復旧閉ループの設計・スコープ・既知の未対応（issue #523） |
+| [`docs/agents/recovery-queue.md`](./recovery-queue.md) | 検知後の自動復旧閉ループの設計・スコープ・既知の限界（issue #523） |
 | `scripts/queue-recovery-task.sh` | 検知hookから呼ばれ`.aidd/recovery-queue.jsonl`へ復旧タスクを登録する（issue #523） |
-| `scripts/check-recovery-queue.sh` | SessionStart hookによる未対応の復旧タスクのcontext注入・surfaced放置エントリのエスカレーション（issue #523・#579） |
+| `scripts/check-recovery-queue.sh` | SessionStart hookによる未解決の復旧タスクのcontext注入・surfaced放置エントリのエスカレーション（issue #523・#579） |
 | `scripts/resolve-recovery-task.sh` | 復旧タスク対応後に`status`を`"resolved"`へ書き換える（issue #579） |
 | `scripts/check-workflow-interruption.sh` | SessionStart hookによるWorkflow中断検知(`wf_*.json`のstatus/staleness判定)とrecovery-queueへの登録（issue #534） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -290,7 +290,7 @@ OpenAI の Harness engineering 事例（2026-02）は、AGENTS.md を「地図�
 
 **検査を3種に限定した理由:** 意味的な陳腐化（「issue #NNN で対応済み」の状態変化など）は LLM か
 `gh` が必要で、CI の hooks-test（checkout のみ・認証なし）では回せない。まず機械的に判定できる
-ものだけを CI に載せ、クローズ済み issue の言及は未実装のまま issue #714 に残した。
+ものだけを CI に載せた。クローズ済み issue の言及は、その後「保留・未対応の文脈で参照している issue が CLOSED」の場合だけを `scripts/lib/check-docs-issue-refs.mjs` が warning-only で出す（docs-integrity-check.yml、gh 依存。全参照を見ると数百件の履歴記述が鳴るため文脈で絞った）。
 
 **削除済みパスに歴史的マーカーを要求する理由:** decisions や observability-internals は「かつて
 あった `scripts/x.sh`（削除済み）を置き換えた」という経緯を書く場所であり、言及そのものは正当。しかし

--- a/scripts/check-docs-issue-refs.test.sh
+++ b/scripts/check-docs-issue-refs.test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# WHY: scripts/lib/check-docs-issue-refs.mjs（issue #714 残項目: 「保留・未対応」文脈で参照している issue が
+#      CLOSED なら warning）の回帰テスト。gh を呼ばず --states で状態を注入する。
+#      候補の抽出条件（同じ行に保留系マーカーがある参照だけ）・CLOSED だけ警告・OPEN/不明は警告しない・
+#      フェンス内は無視・--strict の exit code を確認する。
+#
+# 実行: bash scripts/check-docs-issue-refs.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/lib/check-docs-issue-refs.mjs"
+
+command -v node >/dev/null 2>&1 || { echo "node が必要です"; exit 1; }
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+contains() { if printf '%s\n' "$1" | grep -qF -- "$2"; then ok "$3"; else ng "$3" "expected: $2 / actual: $1"; fi; }
+not_contains() { if printf '%s\n' "$1" | grep -qF -- "$2"; then ng "$3" "unexpected: $2"; else ok "$3"; fi; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/docs/agents"
+cat > "$WORK/docs/agents/x.md" <<'EOF'
+# x
+
+- 歴史: issue #10 で導入した（マーカー無し → 候補にしない）
+- 保留: issue #11 の対応待ち（CLOSED → 警告）
+- 保留: issue #12 は着手時期未定（OPEN → 警告しない）
+- 未実装: issue #13 を待つ（状態不明 → 警告しない）
+- 同じ行に2つ: issue #11 と issue #12 は検討中
+
+```bash
+# フェンス内: issue #11 は保留（無視）
+```
+EOF
+cat > "$WORK/states.json" <<'EOF'
+{ "11": "CLOSED", "12": "OPEN" }
+EOF
+
+echo "=== scenario 1: --list は保留系マーカーのある行の参照だけを候補にする ==="
+OUT="$(node "$CHECKER" --root "$WORK" --files docs/agents/x.md --list)"
+contains "$OUT" "candidates=5" "候補 5 件（#11×2, #12×2, #13）"
+not_contains "$OUT" "issue #10" "マーカー無しの履歴参照は候補にしない"
+
+echo "=== scenario 2: CLOSED だけ警告し、OPEN・不明は警告しない ==="
+OUT="$(node "$CHECKER" --root "$WORK" --files docs/agents/x.md --states "$WORK/states.json")"
+contains "$OUT" "warnings=2" "警告 2 件（#11 の 2 行）"
+contains "$OUT" "issue #11" "CLOSED の #11 を警告"
+not_contains "$OUT" "WARN: docs/agents/x.md:5" "OPEN の #12 だけの行は警告しない"
+contains "$OUT" "unresolved=1" "状態不明 1 件（#13）を報告"
+
+echo "=== scenario 3: 既定は warning-only（exit 0）、--strict なら exit 1 ==="
+if node "$CHECKER" --root "$WORK" --files docs/agents/x.md --states "$WORK/states.json" >/dev/null; then ok "既定は exit 0"; else ng "既定で exit 非 0"; fi
+if node "$CHECKER" --root "$WORK" --files docs/agents/x.md --states "$WORK/states.json" --strict >/dev/null; then ng "--strict で exit 0"; else ok "--strict で exit 1"; fi
+
+echo "=== scenario 4: フェンス内の参照は無視する ==="
+OUT="$(node "$CHECKER" --root "$WORK" --files docs/agents/x.md --list)"
+not_contains "$OUT" "x.md:10" "フェンス内（10 行目）は候補にしない"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/lib/check-docs-issue-refs.mjs
+++ b/scripts/lib/check-docs-issue-refs.mjs
@@ -1,0 +1,105 @@
+// docs 内の「保留・未実装・予定」文脈で参照している issue が実はクローズ済み、を warning で知らせる
+// （issue #714 の残項目）。
+//
+// WHY: docs/agents/ には「issue #NNN で対応予定」「#NNN 待ち」のような記述が多く、issue が閉じても
+//      文面が残る。ただし docs 内の issue 参照は数百件あり、その大半は「issue #NNN で導入した」という
+//      履歴の記述で、閉じているのが当然。全参照を警告すると無意味になるため、同じ行に
+//      「保留 / 未実装 / 未着手 / 未対応 / 待ち / 検討中 / 着手時期未定」のいずれかが
+//      ある行だけを候補にし、その issue が CLOSED なら警告する。
+//
+// 状態の取得は `gh issue view` に依存する（ネットワーク・認証が要る）ため、CI では
+// docs-integrity-check.yml の warning-only ステップ（continue-on-error）で回し、hooks-test では
+// 回さない。テストは `--states <json>` で状態を注入し gh を呼ばない。
+//
+// 使い方:
+//   node scripts/lib/check-docs-issue-refs.mjs --list            # 候補行だけ列挙（gh を呼ばない）
+//   node scripts/lib/check-docs-issue-refs.mjs                   # gh で状態を引き、CLOSED を警告。常に exit 0
+//   node scripts/lib/check-docs-issue-refs.mjs --strict          # 警告があれば exit 1（ローカル確認用）
+//   node scripts/lib/check-docs-issue-refs.mjs --states s.json   # {"123":"CLOSED",...} を注入（テスト用）
+//   node scripts/lib/check-docs-issue-refs.mjs --root <dir> --files a.md,b.md
+
+import { readFileSync, existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defaultTargets, stripFences } from './check-docs-integrity.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DEFAULT_ROOT = path.resolve(__dirname, '../..')
+
+// 「予定」（「変更予定ファイル」等）と「blocked」（このリポジトリでは AgentResult の status 値として頻出）は
+// 誤検知源だったため外している（2026-09-05 の初回実行で候補 27 件中 15 件がこの 2 語由来）
+export const PENDING_MARKERS = /保留|未実装|未着手|未対応|待ち|検討中|着手時期未定/
+
+export function parseArgs(argv) {
+  const opts = { root: DEFAULT_ROOT, files: null, list: false, strict: false, states: null }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--root') opts.root = path.resolve(argv[++i])
+    else if (a === '--files') opts.files = (argv[++i] ?? '').split(',').map(s => s.trim()).filter(Boolean)
+    else if (a === '--list') opts.list = true
+    else if (a === '--strict') opts.strict = true
+    else if (a === '--states') opts.states = path.resolve(argv[++i])
+    else throw new Error(`unknown argument: ${a}`)
+  }
+  return opts
+}
+
+export function findCandidates(root, files) {
+  const out = []
+  for (const abs of files) {
+    if (!existsSync(abs)) continue
+    const rel = path.relative(root, abs)
+    const lines = stripFences(readFileSync(abs, 'utf8')).split('\n')
+    lines.forEach((line, idx) => {
+      // Markdown リンクの飛び先（アンカー slug に「保留」等の語が入りうる）はマーカー判定から除外する
+      const plain = line.replace(/\]\([^)]*\)/g, ']')
+      if (!PENDING_MARKERS.test(plain)) return
+      for (const m of plain.matchAll(/issue #(\d+)/g)) {
+        out.push({ file: rel, line: idx + 1, issue: Number(m[1]), text: line.trim() })
+      }
+    })
+  }
+  return out
+}
+
+function ghState(number) {
+  const r = spawnSync('gh', ['issue', 'view', String(number), '--json', 'state'], { encoding: 'utf8' })
+  if (r.status !== 0) return null
+  try { return JSON.parse(r.stdout).state ?? null } catch { return null }
+}
+
+export function resolveStates(numbers, injected) {
+  const states = {}
+  for (const n of numbers) {
+    if (injected) states[n] = injected[String(n)] ?? null
+    else states[n] = ghState(n)
+  }
+  return states
+}
+
+export function run(opts) {
+  const files = opts.files ? opts.files.map(f => path.resolve(opts.root, f)) : defaultTargets(opts.root)
+  const candidates = findCandidates(opts.root, files)
+  if (opts.list) return { candidates, warnings: [], unresolved: [] }
+  const injected = opts.states ? JSON.parse(readFileSync(opts.states, 'utf8')) : null
+  const states = resolveStates([...new Set(candidates.map(c => c.issue))], injected)
+  const warnings = candidates.filter(c => states[c.issue] === 'CLOSED')
+  const unresolved = [...new Set(candidates.filter(c => states[c.issue] === null).map(c => c.issue))]
+  return { candidates, warnings, unresolved }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  const opts = parseArgs(process.argv.slice(2))
+  const { candidates, warnings, unresolved } = run(opts)
+  if (opts.list) {
+    for (const c of candidates) console.log(`  ${c.file}:${c.line} issue #${c.issue}: ${c.text.slice(0, 100)}`)
+    console.log(`candidates=${candidates.length}`)
+  } else {
+    for (const w of warnings) console.log(`  WARN: ${w.file}:${w.line} は「保留・未対応」の文脈で issue #${w.issue} を参照していますが、その issue は CLOSED です。文面を更新するか、歴史的記述なら文脈を直してください: ${w.text.slice(0, 100)}`)
+    if (unresolved.length) console.log(`  (状態を取得できなかった issue: ${unresolved.map(n => '#' + n).join(', ')}。gh 未認証・ネットワーク不可の場合は判定をスキップします)`)
+    console.log(`candidates=${candidates.length} warnings=${warnings.length} unresolved=${unresolved.length}`)
+    if (opts.strict && warnings.length > 0) process.exit(1)
+  }
+}


### PR DESCRIPTION
Closes #714

## 30秒サマリー
- 変更概要: issue #714 の残項目。「保留・未対応」の文脈で参照している issue が CLOSED なら warning を出す docs 検査を、docs-integrity-check.yml の warning-only ステップとして追加
- リスク: 低（warning-only。マージを止めない）
- 変更領域: docs 検査スクリプト / テスト / CI / docs 文言
- 証拠状態: 実測 4 件（テスト 4 シナリオ GREEN / 実リポジトリで gh を使った初回実行 27 候補→絞り込み後 5 候補・警告 0 / docs 整合性 / 常時ロード量）、サンプル・未検証 1 件（CI 上で `github.token` による `gh issue view` が通ること）
- 影響範囲: `scripts/lib/check-docs-issue-refs.mjs`・`scripts/check-docs-issue-refs.test.sh`（新規）、`.github/workflows/docs-integrity-check.yml`（ステップ追加・`issues: read`）、`docs/agents/common.md`（2 行の文言）、`docs/agents/decisions.md`（#714 エントリ更新）
- ロールバック可能性: ステップとファイルを削除するだけ

レビューしてほしい点:
1. マーカー語（保留 / 未実装 / 未着手 / 未対応 / 待ち / 検討中 / 着手時期未定）の選定。「予定」「blocked」は誤検知源として外した。初回実行では候補 27 件→絞り込み後 5 件、うち実際に CLOSED を「未対応」文脈で参照していたのは common.md の 2 行だけだった

## 00 目的・影響範囲・対象外
- 目的: 「issue #NNN で対応予定」と書いたまま issue が閉じて文面が残る腐敗を機械で拾う
- 変更範囲: 上記
- 対象外（今回あえて触らない）: 文脈マーカー無しの参照（履歴記述）。意味的な陳腐化
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- `check-docs-issue-refs.mjs`: `check-docs-integrity.mjs` と同じ走査対象。フェンス内無視、Markdown リンクの飛び先を除いた本文にマーカーがある行の `issue #N` を候補にし、`gh issue view N --json state` で CLOSED なら warning。状態を引けない場合は unresolved として報告し警告しない（gh 未認証・オフラインで fail-open）。既定 exit 0、`--strict` で exit 1
- 初回実行（gh あり）: 候補 27 → マーカーから「予定」「blocked」を外して 9 → リンク飛び先除外で 5。警告 3 件のうち common.md の 2 行は文言修正（「既知の未対応」→「既知の限界」、「未対応の復旧タスク」→「未解決の復旧タスク」）、1 件はアンカー slug 内の「保留」による誤検知でリンク飛び先除外で消えた。修正後の再実行は warnings=0

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-issue-refs.test.sh` ALL PASSED（候補抽出 / CLOSED のみ警告 / exit code / フェンス無視）。`bash scripts/check-claude-md-size.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED。`node scripts/lib/check-docs-issue-refs.mjs`（gh あり）candidates=5 warnings=0 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook スクリプト・settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- 未検証: CI 上で `GH_TOKEN: ${{ github.token }}` により `gh issue view` が通るか（この PR 自身の `docs-integrity` ジョブのログで確認する。通らなければ unresolved として報告され、警告は出ない＝fail-open）
- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: docs-integrity ジョブの「Warn on closed issues referenced as pending」ステップ出力
- 異常の判断基準: 履歴記述が大量に鳴る → マーカー語を見直す。`unresolved` が常に全件 → token 権限（`issues: read`）を確認
- ロールバック手順: ステップと 2 ファイルを削除

## 後任AIへの注意
- この実装で壊してはいけない前提: warning-only（`continue-on-error: true`）。block にすると履歴記述の書き換えを強いる
- 似ているが別物の用語: 「候補」（マーカー付き参照）と「警告」（候補のうち CLOSED）
- 勝手にリファクタしない場所: マーカー語の一覧。足す前に `--list` で候補数を見る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
