### PR TITLE
fix: show-agent-status.sh に最終報告の上限日数(--max-age-seconds、既定7日)を追加し、過去フローの残骸を表示から落とす

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -149,7 +149,7 @@ scripts/log-agent-progress.sh --agent "<自分のagent名>" --feature "<feature�
 `--status` は `starting|running|waiting|done|failed` のいずれか。`feature`名が
 呼び出し元から与えられていない場合は `unknown` を使う。
 
-現在の状態は `scripts/show-agent-status.sh` で一覧できる（`--stale-seconds`未満は既定180秒＝3分。`running`/`waiting`のまま既定180秒以上更新がないエージェントは「止まってる？」として表示される）。
+現在の状態は `scripts/show-agent-status.sh` で一覧できる（`--stale-seconds`未満は既定180秒＝3分。`running`/`waiting`のまま既定180秒以上更新がないエージェントは「止まってる？」として表示される）。最終報告が`--max-age-seconds`（既定604800秒＝7日）より古いエージェントは過去フローの残骸として表示せず、末尾に非表示件数だけ出す（`0`で全件表示。ログは追記のみで消えないため、数週間前の`running`が「止まってる？（数百万秒応答なし）」としてcompaction後の再注入（issue #712）に毎回混ざっていた対策）。
 
 記録漏れ検知の手順はloop-observabilityと共通のgap check state方式（上記[「loop-observabilityログの記録漏れ検知」](#loop-observabilityログの記録漏れ検知)参照。フロー完了後に `scripts/record-gap-check-state.sh expected --agent-progress <値>` を呼ぶ）。記録内容の正しさは `scripts/verify-agent-progress-transcript.sh` が自己申告とtranscriptを機械比較する。両者の判定ロジック・既知の限界（agent-progress.jsonlの構造的限界、mismatches/lowOverlapDetailsの仕組み等）は [`observability-internals.md`](./observability-internals.md#agent-progress記録の構造的限界記録内容検証の詳細) を参照。
 

--- a/scripts/show-agent-status.sh
+++ b/scripts/show-agent-status.sh
@@ -6,12 +6,19 @@ source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
 
 LOG_FILE="$(resolve_log_dir)/agent-progress.jsonl"
 STALE_SECONDS=180
+# WHY: agent-progress.jsonl は追記のみで消えないため、数週間前のフローで running のまま終わった
+#      エージェントが「止まってる？（3,460,274秒応答なし）」として永久に表示され続けていた
+#      （2026-09-05、compaction 後の再注入（issue #712）で 40 日前の 3 件が毎回混ざるのを確認）。
+#      一定期間より古い最終報告は「今のフローの状態」ではないので表示から落とす。
+#      過去フローの done/failed も同様に落とす（表示を「現在進行中のフロー」に絞る）。
+MAX_AGE_SECONDS=604800
 NOW_EPOCH=""
 
 usage() {
-  echo "Usage: $0 [--log-file PATH] [--stale-seconds N] [--now-epoch N]" >&2
-  echo "  --stale-seconds N  この秒数を超えて更新がないrunning/waiting/starting中のエージェントを「止まってる？」と表示する（既定: 180）" >&2
-  echo "  --now-epoch N      現在時刻をUNIX epoch秒で上書きする（主にテスト用）" >&2
+  echo "Usage: $0 [--log-file PATH] [--stale-seconds N] [--max-age-seconds N] [--now-epoch N]" >&2
+  echo "  --stale-seconds N    この秒数を超えて更新がないrunning/waiting/starting中のエージェントを「止まってる？」と表示する（既定: 180）" >&2
+  echo "  --max-age-seconds N  最終報告がこの秒数より古いエージェントは表示しない（既定: 604800＝7日。0 で無制限）" >&2
+  echo "  --now-epoch N        現在時刻をUNIX epoch秒で上書きする（主にテスト用）" >&2
   exit 1
 }
 
@@ -19,6 +26,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --log-file) LOG_FILE="$2"; shift 2 ;;
     --stale-seconds) STALE_SECONDS="$2"; shift 2 ;;
+    --max-age-seconds) MAX_AGE_SECONDS="$2"; shift 2 ;;
     --now-epoch) NOW_EPOCH="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; usage ;;
   esac
@@ -33,19 +41,26 @@ if [[ ! -f "$LOG_FILE" ]]; then
   exit 0
 fi
 
-jq -s -r --argjson now "$NOW_EPOCH" --argjson stale "$STALE_SECONDS" '
+jq -s -r --argjson now "$NOW_EPOCH" --argjson stale "$STALE_SECONDS" --argjson maxAge "$MAX_AGE_SECONDS" '
   def epoch: (. | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime);
+  def render:
+    . as $e
+    | ($e.timestamp | epoch) as $t
+    | ($now - $t) as $ageSec
+    | if ($e.status != "done" and $e.status != "failed" and $ageSec > $stale)
+      then "\($e.agent)：止まってる？（\($ageSec)秒応答なし）"
+      elif $e.status == "done" then "\($e.agent)：\($e.note) ✓"
+      elif $e.status == "failed" then "\($e.agent)：\($e.note) ✗"
+      else "\($e.agent)：\($e.note)"
+      end;
   group_by(.agent)
   | map(sort_by(.timestamp) | .[-1])
   | sort_by(.agent)
+  | map(select($maxAge == 0 or ($now - (.timestamp | epoch)) <= $maxAge)) as $recent
+  | (length - ($recent | length)) as $hidden
+  | ($recent | map(render))
+    + (if $hidden > 0
+       then ["（他 \($hidden) 件は最終報告が \($maxAge) 秒（\($maxAge / 86400 | floor) 日）より前のため非表示。--max-age-seconds 0 で全件表示）"]
+       else [] end)
   | .[]
-  | . as $e
-  | ($e.timestamp | epoch) as $t
-  | ($now - $t) as $ageSec
-  | if ($e.status != "done" and $e.status != "failed" and $ageSec > $stale)
-    then "\($e.agent)：止まってる？（\($ageSec)秒応答なし）"
-    elif $e.status == "done" then "\($e.agent)：\($e.note) ✓"
-    elif $e.status == "failed" then "\($e.agent)：\($e.note) ✗"
-    else "\($e.agent)：\($e.note)"
-    end
 ' "$LOG_FILE"

--- a/scripts/show-agent-status.test.sh
+++ b/scripts/show-agent-status.test.sh
@@ -82,6 +82,29 @@ echo "=== test: stale-seconds未満のrunningは「止まってる？」にな�
 assert_not_contains "$OUTPUT" "sweep-types：止まってる？" "sweep-typesは2分経過のみなので止まってる扱いにならない"
 assert_contains "$OUTPUT" "sweep-types：型調査中..." "sweep-typesは通常の進捗表示のまま"
 
+echo "=== test: max-age-seconds(既定7日)より古い最終報告は表示せず、非表示件数を末尾に出す ==="
+# WHY: 追記のみのログに残った数週間前の running が「止まってる？（数百万秒応答なし）」として
+#      再注入（issue #712）のたびに混ざっていた。過去フローの残骸は既定で落とす。
+OLD_LOG="$WORKDIR/agent-progress-old.jsonl"
+printf '{"timestamp":"%s","agent":"implementer-old","feature":"f0","status":"running","note":"40日前の残骸"}\n' "$(epoch_to_iso $((BASE_EPOCH - 3456000)))" >> "$OLD_LOG"
+printf '{"timestamp":"%s","agent":"reviewer-old","feature":"f0","status":"done","note":"40日前の完了"}\n' "$(epoch_to_iso $((BASE_EPOCH - 3456000)))" >> "$OLD_LOG"
+printf '{"timestamp":"%s","agent":"sweep-6days","feature":"f1","status":"done","note":"6日前の完了"}\n' "$(epoch_to_iso $((BASE_EPOCH - 518400)))" >> "$OLD_LOG"
+printf '{"timestamp":"%s","agent":"sweep-now","feature":"f1","status":"running","note":"進行中"}\n' "$(epoch_to_iso $((BASE_EPOCH - 60)))" >> "$OLD_LOG"
+OLD_OUTPUT="$(bash "$SHOW_AGENT_STATUS" --log-file "$OLD_LOG" --now-epoch "$BASE_EPOCH")"
+assert_not_contains "$OLD_OUTPUT" "implementer-old" "40日前のrunningは表示しない（止まってる？にもならない）"
+assert_not_contains "$OLD_OUTPUT" "reviewer-old" "40日前のdoneも表示しない"
+assert_contains "$OLD_OUTPUT" "sweep-6days：6日前の完了 ✓" "7日未満のdoneは表示する"
+assert_contains "$OLD_OUTPUT" "sweep-now：進行中" "現在進行中は表示する"
+assert_contains "$OLD_OUTPUT" "（他 2 件は最終報告が 604800 秒（7 日）より前のため非表示" "非表示件数を末尾に出す"
+
+echo "=== test: --max-age-seconds 0 なら全件表示する（従来挙動） ==="
+ALL_OUTPUT="$(bash "$SHOW_AGENT_STATUS" --log-file "$OLD_LOG" --now-epoch "$BASE_EPOCH" --max-age-seconds 0)"
+assert_contains "$ALL_OUTPUT" "implementer-old：止まってる？（3456000秒応答なし）" "0指定で古いrunningも止まってる？として出る"
+assert_not_contains "$ALL_OUTPUT" "非表示" "0指定では非表示の案内を出さない"
+
+echo "=== test: 非表示が0件なら末尾の案内を出さない ==="
+assert_not_contains "$OUTPUT" "非表示" "全件が新しい場合は案内なし"
+
 echo "=== test: ログファイルが存在しない場合はエラーにならず案内文を返す ==="
 NO_LOG_OUTPUT="$(bash "$SHOW_AGENT_STATUS" --log-file "$WORKDIR/no-such-file.jsonl")"
 assert_contains "$NO_LOG_OUTPUT" "進捗ログがありません" "ログ未生成時は案内文を返す"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: `scripts/show-agent-status.sh` に最終報告の上限日数 `--max-age-seconds`（既定 7 日）を追加し、過去フローの残骸（40 日前の「止まってる？（3,460,274秒応答なし）」等）を表示から落とす。compaction 後の再注入（issue #712）に毎回混ざっていたノイズの対策
- リスク: 低（表示のみ。ログの記録・削除には触れない。`--max-age-seconds 0` で従来挙動）
- 変更領域: 観測スクリプト / 構造テスト / docs
- 証拠状態: 実測 3 件（構造テスト GREEN・実ログで 50→15 件・再注入テスト GREEN）
- 影響範囲: `scripts/show-agent-status.sh`、`scripts/show-agent-status.test.sh`、`docs/agents/common.md`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 既定 7 日が妥当か。AIDD フロー 1 本が 7 日を跨ぐことは実績上ないが、跨いだ場合は末尾の案内行で気づける設計にした

## 00 目的・影響範囲・対象外
- 目的: 「現在進行中のフロー」だけを表示し、compaction 後の再注入コンテキストからノイズを消す
- 変更範囲: 上記 3 ファイル
- 対象外（今回あえて触らない）: agent-progress.jsonl 自体のローテーション・削除（他ハーベスト処理が読むため別件）。reinject 側の行数上限（20 行）はそのまま
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外（CLI 出力のみ）。実ログでの before/after:
  - before: 50 行、うち「止まってる？（3,4xx,xxx秒応答なし）」3 行
  - after: 15 行 + 末尾「（他 35 件は最終報告が 604800 秒（7 日）より前のため非表示。--max-age-seconds 0 で全件表示）」

## 02 内部でどう守っているか（ロジック証拠）
- agent ごとに最新 1 件へ集約したあと、`now - timestamp > maxAge` の行を status を問わず落とす。落とした件数が 1 以上のときだけ案内行を出す
- `--max-age-seconds 0` は無制限（従来挙動）。テストで固定

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/show-agent-status.test.sh` ALL PASSED（新規 5 シナリオ含む）。`bash scripts/reinject-aidd-run-state.test.sh` ALL PASSED。`bash scripts/check-readonly-bash.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED。`bash scripts/check-claude-md-size.sh` 上限内 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook 本体（reinject）は無変更。呼び出し先スクリプトの出力変更のみで、reinject テストで取り込みを確認済み |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 次回 compaction 後の再注入ブロックに「止まってる？（数百万秒）」が出ないこと
- 異常の判断基準: 進行中フローのエージェントが表示から消えた → 7 日を跨いだフロー。`--max-age-seconds 0` で確認
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 既定は「現在のフロー」に絞る。ログのローテーションで代替しないこと（harvest 系が過去行を読む）
- 似ているが別物の用語: `--stale-seconds`（応答なし判定、既定 3 分）と `--max-age-seconds`（表示対象の上限、既定 7 日）
- 勝手にリファクタしない場所: jq の集約順（agent ごとの最新 1 件 → 年齢フィルタ）。順を逆にすると古い報告で最新が隠れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
