### PR TITLE
fix: Stop hook 3本がtranscript先頭行のtimestamp決め打ちでbridge-sessionセッションでは無音で死んでいた問題を修正する(issue #495 #522 #524)

### DIFF
--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -248,6 +248,30 @@ issue化を検討）。
 
 詳細: [`tooling-decisions.md`](./tooling-decisions.md#subagent-frontmatterのskillsプリロードpermissionmode-planは見送りmaxturnsは延期issue-652)
 
+### fail-open の warning-only hook が、入力形式の変化で無音のまま死ぬ（2026-09-05）
+
+**チェック内容:** 「判定材料が取れなければ沈黙する（fail-open）」設計の hook を書く・触るときは、
+沈黙の入口ごとに「その材料が取れなくなる現実的な形式変化」を 1 つ挙げ、**その形式のfixtureで
+警告が出る RED テスト**を持っているか確認する。特に Claude Code 本体が生成するファイル
+（transcript `*.jsonl`・`wf_*.json`・`agent-*.meta.json`）の「先頭行」「特定キー」を決め打ちで
+読んでいる箇所は、本体更新で形式が変わっても hook 側にエラーが出ない。
+
+**なぜ再発したか:** `check-find-av-precision-recorded.sh`（issue #522）・`check-aidd-stats-recorded.sh`
+（#495）・`check-aidd-phase-stats-recorded.sh`（#524）の 3 本は、セッション開始時刻を
+transcript の **1 行目**の `timestamp` から取っていた。Remote Control 連携で始まるセッションの
+transcript は `{"type":"bridge-session",...}`（timestamp 無し）で始まるため、3 本とも「開始時刻
+不明 → 沈黙」で無音のまま死んでいた。2026-08-28 に deep-task が `verifiedCount=61` で完走した
+セッションでも警告は出ず、`logs/find-av-precision.jsonl` は 0 件のまま、誰も気づかなかった。
+既存テストには「先頭行に timestamp が無い → 沈黙」というシナリオまであり、**バグの挙動を
+仕様として固定していた**。warning-only かつ fail-open の hook は「壊れても何も起きない」ので、
+壊れたことに気づく手段が hook 自身には無い。
+
+**機械検知:** 3 本とも「先頭 50 行のうち最初に timestamp を持つ行」を採用するよう修正し、
+各 `*.test.sh` に「1 行目が bridge-session でも警告する」RED シナリオを追加した。ただし
+「次に来る未知の形式変化」は同じ手段では検知できない。fail-open hook が本当に生きているかは、
+`logs/*.jsonl` の**最終更新日が伸びているか**（記録が止まっていたら hook か記録経路が死んでいる）
+を節目で見るしかない（本件は `docs/agents/eval-runs.jsonl` の記録停止を追った副産物として発覚）。
+
 ## RLS/テナント分離層
 
 ### 「動いたからOK」でfacility_idフィルタ漏れ・RLS未設定を見逃す（issue #24再発防止）

--- a/scripts/check-aidd-phase-stats-recorded.sh
+++ b/scripts/check-aidd-phase-stats-recorded.sh
@@ -120,7 +120,10 @@ fi
 # check-aidd-stats-recorded.shと同一パターン）
 SESSION_START_EPOCH=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+  # WHY: transcript の 1 行目は timestamp を持たない {"type":"bridge-session"} レコードで始まる
+  #      ことがある（Remote Control 連携時。2026-09-05 実測）。先頭行決め打ちだと開始時刻が取れず
+  #      fail-open で沈黙するため、先頭 50 行のうち最初に timestamp を持つ行を採用する
+  FIRST_TS="$(head -n 50 "$TRANSCRIPT_PATH" 2>/dev/null | jq -R -r 'fromjson? | .timestamp // empty' 2>/dev/null | head -n 1 || true)"
   case "$FIRST_TS" in
     *Z)
       SESSION_START_EPOCH="$(python3 -c "

--- a/scripts/check-aidd-phase-stats-recorded.test.sh
+++ b/scripts/check-aidd-phase-stats-recorded.test.sh
@@ -183,6 +183,16 @@ run_hook
 assert_eq "$EXIT_CODE" "0" "exit 0"
 assert_empty "$OUT" "UTC(Z)以外の形式は信頼せず沈黙する"
 
+echo "=== scenario 13b: transcript先頭行がtimestamp無しのbridge-sessionレコード → 2行目の時刻で判定し警告する ==="
+# WHY: Remote Control 連携セッションの transcript は timestamp 無しの bridge-session 行で始まる（2026-09-05 実測）。
+#      1 行目決め打ちだと開始時刻が取れず、この hook が無音で死ぬ
+reset_env
+write_wf_result "wf_a.json" "phase1"
+printf '{"type":"bridge-session","sessionId":"%s"}\n{"type":"user","timestamp":"%s"}\n' "$SESSION" "$SESSION_START_ISO" > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "bridge-session行を読み飛ばして警告する"
+
 echo "=== scenario 14: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
 reset_env
 write_wf_result "wf_a.json" "phase1"

--- a/scripts/check-aidd-stats-recorded.sh
+++ b/scripts/check-aidd-stats-recorded.sh
@@ -110,7 +110,10 @@ fi
 # UTCとしてパースするとサイレントにズレたepochになるため、想定外形式は沈黙に倒す
 # （レビューminor指摘の反映）
 [ -f "$TRANSCRIPT_PATH" ] || exit 0
-FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+# WHY: transcript の 1 行目は timestamp を持たない {"type":"bridge-session"} レコードで始まる
+#      ことがある（Remote Control 連携時。2026-09-05 実測）。先頭行決め打ちだと開始時刻が取れず
+#      fail-open で沈黙するため、先頭 50 行のうち最初に timestamp を持つ行を採用する
+FIRST_TS="$(head -n 50 "$TRANSCRIPT_PATH" 2>/dev/null | jq -R -r 'fromjson? | .timestamp // empty' 2>/dev/null | head -n 1 || true)"
 [ -n "$FIRST_TS" ] || exit 0
 case "$FIRST_TS" in
   *Z) : ;;

--- a/scripts/check-aidd-stats-recorded.test.sh
+++ b/scripts/check-aidd-stats-recorded.test.sh
@@ -172,6 +172,16 @@ run_hook
 assert_eq "$EXIT_CODE" "0" "exit 0"
 assert_empty "$OUT" "timestamp欠損時は沈黙する"
 
+echo "=== scenario 11b: transcript先頭行がtimestamp無しのbridge-sessionレコード → 2行目の時刻で判定し警告する ==="
+# WHY: Remote Control 連携セッションの transcript は timestamp 無しの bridge-session 行で始まる（2026-09-05 実測）。
+#      1 行目決め打ちだと開始時刻が取れず、この hook が無音で死ぬ
+reset_env
+wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"
+printf '{"type":"bridge-session","sessionId":"%s"}\n{"type":"user","timestamp":"%s"}\n' "$SESSION" "$SESSION_START_ISO" > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "bridge-session行を読み飛ばして警告する"
+
 echo "=== scenario 12: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
 reset_env
 wf_event "$SESSION_START_ISO" "$SESSION" > "$SKELETON"

--- a/scripts/check-find-av-precision-recorded.sh
+++ b/scripts/check-find-av-precision-recorded.sh
@@ -95,7 +95,11 @@ shopt -u nullglob
 # 2. セッション開始時刻（transcript先頭行timestamp。末尾ZのUTC表記のみ信頼する）
 SESSION_START_EPOCH=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  FIRST_TS="$(head -1 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null || true)"
+  # WHY: transcript の 1 行目は timestamp を持たない {"type":"bridge-session"} レコードで始まる
+  #      ことがある（Remote Control 連携時。2026-09-05 に 8/28 の deep-task セッションで実測）。
+  #      先頭行決め打ちだと開始時刻が取れず fail-open で沈黙するため、先頭 50 行のうち最初に
+  #      timestamp を持つ行を採用する。check-aidd-stats-recorded.sh / check-aidd-phase-stats-recorded.sh も同型
+  FIRST_TS="$(head -n 50 "$TRANSCRIPT_PATH" 2>/dev/null | jq -R -r 'fromjson? | .timestamp // empty' 2>/dev/null | head -n 1 || true)"
   case "$FIRST_TS" in
     *Z)
       SESSION_START_EPOCH="$(python3 -c "

--- a/scripts/check-find-av-precision-recorded.test.sh
+++ b/scripts/check-find-av-precision-recorded.test.sh
@@ -143,6 +143,23 @@ run_hook
 assert_eq "$EXIT_CODE" "0" "exit 0"
 assert_empty "$OUT" "判定不能時は沈黙する"
 
+echo "=== scenario 8b: transcript先頭行がtimestamp無しのbridge-sessionレコード → 2行目の時刻で判定し警告する ==="
+# WHY: 8/28 の deep-task セッション（verifiedCount=61）で警告が出なかった実原因。1 行目決め打ちだと沈黙する
+reset_env
+write_wf_with_precision "wf_a.json" 3
+printf '{"type":"bridge-session","sessionId":"%s"}\n{"type":"user","timestamp":"%s"}\n' "$SESSION" "$SESSION_START_ISO" > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "systemMessage" "bridge-session行を読み飛ばして警告する"
+
+echo "=== scenario 8c: transcriptのどの行にもtimestampが無い → 沈黙（fail-open） ==="
+reset_env
+write_wf_with_precision "wf_a.json" 3
+printf '{"type":"bridge-session","sessionId":"%s"}\n' "$SESSION" > "$TRANSCRIPT"
+run_hook
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_empty "$OUT" "開始時刻が取れなければ沈黙する"
+
 echo "=== scenario 9: マーカーが書き込めない環境 → クラッシュせず警告は出す（exit 0） ==="
 reset_env
 write_wf_with_precision "wf_a.json" 3


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: Stop hook 3 本（AIDD stats start 呼び忘れ #495 / phase 呼び忘れ #524 / find-av-precision 記録漏れ #522）が、transcript 1 行目の `timestamp` 決め打ちのため Remote Control 連携セッション（1 行目が `bridge-session`）では無音で死んでいた。先頭 50 行のうち最初に timestamp を持つ行を使うよう修正
- リスク: 低（warning-only hook の判定入力の取り方のみ。全経路 exit 0 は不変）
- 変更領域: hook スクリプト 3 本 / 構造テスト 3 本 / known-failure-patterns
- 証拠状態: 実測 3 件（構造テスト GREEN・8/28 実セッション記録での再現 RED→GREEN・docs 整合性）、未検証 1 件（Claude Code の Stop イベント経由での発火。配線は無変更）
- 影響範囲: `scripts/check-find-av-precision-recorded.sh`、`scripts/check-aidd-stats-recorded.sh`、`scripts/check-aidd-phase-stats-recorded.sh` と各 `.test.sh`、`docs/agents/known-failure-patterns.md`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 既存テスト「先頭行に timestamp が無い → 沈黙」（check-aidd-stats-recorded.test.sh scenario 11）はバグ挙動を仕様として固定していたが、1 行しか無い fixture なので修正後も沈黙で通る。残置してよいか（「どの行にも無ければ沈黙」の意味に読み替えられる）
2. 「先頭 50 行」の上限。bridge-session 行は 1 行目にしか観測していないが、余裕を持たせた

## 00 目的・影響範囲・対象外
- 目的: `docs/agents/eval-runs.jsonl` の記録停止を追った副産物。`logs/find-av-precision.jsonl` が 0 件のままだった直接原因（hook の無音死）を潰す
- 変更範囲: 上記
- 対象外（今回あえて触らない）: eval-runs 側（CI warning が見えない問題）は別 PR で fail 化する。8/28 分のデータは `scripts/log-find-av-precision.sh` で手動復旧済み（`backfilledFrom` 付き、git 管理外の `logs/`）
- 作業中に見つけた別件: eval-runs freshness の warning が 3 PR（#627 #679 #693）で無視されていた → 次 PR
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- 変更は 1 行: `head -1 | jq '.timestamp'` → `head -n 50 | jq -R 'fromjson? | .timestamp // empty' | head -n 1`。壊れた行は `fromjson?` で読み飛ばす
- 再現（RED→GREEN）: 8/28 の実 transcript と `wf_b14041be` を env 注入で hook に食わせると、修正前は出力なし、修正後は `systemMessage`（issue #522 の警告文）が出る

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-find-av-precision-recorded.test.sh`（11 シナリオ、8b/8c 新規）、`bash scripts/check-aidd-stats-recorded.test.sh`（16 シナリオ、11b 新規）、`bash scripts/check-aidd-phase-stats-recorded.test.sh`（15 シナリオ、13b 新規）すべて ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| hook 実機発火 | 🟡 一部 | 8/28 の実セッション（session 2266ba71）の transcript と wf_*.json を env 注入で食わせ、修正後に警告が出ることを確認。Claude Code の Stop イベント経由（settings.json の配線）は無変更のため未再確認。次に bridge-session で始まるセッションで AIDD を回したとき、Stop 時に警告が出れば完了 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: `logs/find-av-precision.jsonl` の最終更新日が deep-task 実行に追随すること。`~/.aidd-stats` の start/phase 記録漏れ警告が bridge セッションでも出ること
- 異常の判断基準: deep-task 完走後の Stop で警告も記録も無い → transcript 形式が再度変わった可能性。`head -n 5 <transcript>` で timestamp の位置を確認
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 全経路 exit 0（block しない）。timestamp が `Z` 終端でなければ沈黙、はそのまま
- 似ているが別物の用語: 「沈黙（fail-open、判定材料なし）」と「記録済みで沈黙（正常）」。テストの assert_empty はどちらも同じに見える
- 勝手にリファクタしない場所: 3 本で同じ 1 行を複製している。共通化すると各 hook の env 注入テストが崩れるので、今は複製のまま（known-failure-patterns にも記録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
