### PR TITLE
chore: eval再実行結果(2026-09-05)をeval-runs.jsonlに記録する

### DIFF
--- a/docs/agents/eval-runs.jsonl
+++ b/docs/agents/eval-runs.jsonl
@@ -5,3 +5,9 @@
 {"timestamp":"2026-07-23T03:37:40Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
 {"timestamp":"2026-07-23T10:55:19Z","script":"eval-workflow-prompts","fixtureSet":"spec-check","pass":0,"total":1}
 {"timestamp":"2026-07-23T10:56:35Z","script":"eval-workflow-prompts","fixtureSet":"spec-check","pass":1,"total":1}
+{"timestamp":"2026-09-05T04:33:11Z","script":"eval-sweep-recall","fixtureSet":"sweep-ui","pass":2,"total":2}
+{"timestamp":"2026-09-05T04:37:05Z","script":"eval-sweep-recall","fixtureSet":"sweep-data","pass":0,"total":1}
+{"timestamp":"2026-09-05T04:40:31Z","script":"eval-sweep-recall","fixtureSet":"sweep-db","pass":1,"total":1}
+{"timestamp":"2026-09-05T04:43:46Z","script":"eval-sweep-recall","fixtureSet":"sweep-types","pass":0,"total":1}
+{"timestamp":"2026-09-05T04:48:22Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
+{"timestamp":"2026-09-05T04:48:38Z","script":"eval-workflow-prompts","fixtureSet":"spec-check","pass":1,"total":1}


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: eval-runs.jsonlの鮮度切れ（2026-07-23で停止）を解消するため、sweep-ui/data/db/types・db-impl・spec-checkの6件を再実行し記録を追記
- リスク: 低
- 変更領域: ドキュメント・観測ログのみ（docs/agents/eval-runs.jsonl、1ファイル）
- 証拠状態: 実測6件（本PR作成セッションで実行）
- 影響範囲: eval鮮度チェック（issue #496）のみ。プロダクトコードへの影響なし
- ロールバック可能性: 高（git revertで即座に戻せる）

レビューしてほしい点:
1. sweep-data・sweep-typesがMISSになっている点（下記参照。issue化が必要か判断してほしい）

## 00 目的・影響範囲・対象外
- 目的: issue #496のeval鮮度チェック警告がPR #627 #679 #693で無視され、記録が2026-07-23で止まっていた問題の解消。PR #729でwarningから失敗判定へ変更されたため、このPRで記録を最新化する
- 変更範囲: docs/agents/eval-runs.jsonl への追記のみ
- 対象外（今回あえて触らない）: sweep-data/sweep-typesのMISS原因調査・修正（今回はeval再実行と記録更新のみが依頼内容）
- 作業中に見つけた別件: sweep-data（case-1-missing-auth-check）とsweep-types（case-1-missing-mapper-field）がMISSした。フィクスチャの陳腐化かSweepプロンプト側の回帰かは未調査。issue化を検討してほしい
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
対象外（UI変更なし）

## 02 内部でどう守っているか（ロジック証拠）
対象外（ロジック変更なし。ログファイルへの追記のみ）

## 03 誰が操作できるか（RLS/権限証拠）
対象外（RLS/権限変更なし）

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 / lint / unit / build（毎回、CI） | ⬜ 未実施 | CIで実行予定。ローカル未実施 |
| docs 整合性 | ✅ 実施(手動) | `node scripts/lib/check-docs-integrity.mjs` → checked=36 violations=0 |
| hook 回帰（毎回、CI hooks-test） | ⬜ 未実施 | CIで実行予定。ローカル未実施 |
| RLS/IDOR 統合 | ➖ 今回不要 | supabase/migrations・src/lib/supabase・proxy.ts に触れていない |
| 直接攻撃の実測 | ➖ 今回不要 | auth/認可/RLSに関わる変更なし |
| E2E | ➖ 今回不要 | 節目の種別。今回のPR段階では対象外 |
| 冪等性 / 同時実行 / 障害注入 | ➖ 今回不要 | 該当する変更なし |

- eval実行結果そのもの（本PRの本体）:
  - sweep-ui: 2/2 pass
  - sweep-data: 0/1（MISS: case-1-missing-auth-check）
  - sweep-db: 1/1 pass
  - sweep-types: 0/1（MISS: case-1-missing-mapper-field）
  - db-impl: 4/4 pass
  - spec-check: 1/1 pass
- 上記は本セッションで実際に`bash scripts/eval-sweep-recall.sh <fixtureSet>`・`npm run eval:workflows <fixtureSet>`を実行した実測値（サンプル・推測ではない）

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 次回以降のセッションでdocs/agents/eval-runs.jsonlの鮮度チェック（issue #496、PR #729でfail化）が通ること
- 異常の判断基準: 鮮度チェックが再び失敗する、またはsweep-data/sweep-typesのMISSが継続悪化する
- ロールバック手順: `git revert <このコミットのSHA>`

## 後任AIへの注意
- この実装で壊してはいけない前提: eval-runs.jsonlは1行1JSONの追記専用ログ。既存行を書き換えない
- 似ているが別物の用語: sweep-recall eval（Sweepエージェントの発見率検証）とworkflow-prompts eval（ゲート判定プロンプトの期待値検証）は別基盤・別スクリプト
- 勝手にリファクタしない場所: sweep-data/sweep-typesのMISSは今回未調査。原因を決めつけて直接fixtureやプロンプトを書き換えないこと（issue化して切り分けてから対応する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
