### PR TITLE
fix: sweep recall fixtureの自己申告コメントを外しNOTES.mdへ移す。ハーネスは非JSON応答・層をまたぐ欠陥の別ファイル指摘も正しく判定する(issue #731)

### DIFF
--- a/docs/agents/eval-runs.jsonl
+++ b/docs/agents/eval-runs.jsonl
@@ -11,3 +11,8 @@
 {"timestamp":"2026-09-05T04:43:46Z","script":"eval-sweep-recall","fixtureSet":"sweep-types","pass":0,"total":1}
 {"timestamp":"2026-09-05T04:48:22Z","script":"eval-workflow-prompts","fixtureSet":"db-impl","pass":4,"total":4}
 {"timestamp":"2026-09-05T04:48:38Z","script":"eval-workflow-prompts","fixtureSet":"spec-check","pass":1,"total":1}
+{"timestamp":"2026-09-05T04:54:58Z","script":"eval-sweep-recall","fixtureSet":"sweep-types","pass":1,"total":1}
+{"timestamp":"2026-09-05T04:55:38Z","script":"eval-sweep-recall","fixtureSet":"sweep-data","pass":0,"total":1}
+{"timestamp":"2026-09-05T05:01:19Z","script":"eval-sweep-recall","fixtureSet":"sweep-data","pass":1,"total":1}
+{"timestamp":"2026-09-05T05:06:47Z","script":"eval-sweep-recall","fixtureSet":"sweep-types","pass":0,"total":1}
+{"timestamp":"2026-09-05T05:10:41Z","script":"eval-sweep-recall","fixtureSet":"sweep-types","pass":0,"total":1}

--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -272,6 +272,42 @@ transcript は `{"type":"bridge-session",...}`（timestamp 無し）で始まる
 `logs/*.jsonl` の**最終更新日が伸びているか**（記録が止まっていたら hook か記録経路が死んでいる）
 を節目で見るしかない（本件は `docs/agents/eval-runs.jsonl` の記録停止を追った副産物として発覚）。
 
+### eval fixture がコード内コメントで自分の正体を明かし、エージェントが指摘から外す（issue #731）
+
+**チェック内容:** 検出力（recall）を測る fixture のコード（`scripts/eval-fixtures/*/case-*/files/` 配下）に、
+「ベンチマーク用 fixture」「○○を意図的に再現」「issue #431」のような、読む側に「これは評価用の
+仕込みで本物の欠陥ではない」と教える語を書いていないか確認する。fixture の設計意図は case
+ディレクトリ直下の `NOTES.md`（clone 先へコピーされない）に書く。
+
+**なぜ再発したか:** 2026-09-05、7/17 以来初めて sweep recall ベンチマーク（issue #431）を再実行したところ
+sweep-data が 0/1 になった。生出力は `{"detail":"指摘なし"}`、別の実行では「すべての API ルート
+（**eval-fixture-recall を除く**）に requireAuth が実装されている」と書いており、エージェントは
+欠陥に**気づいた上で**、fixture 先頭の「issue #431 の recall ベンチマーク用 fixture。認可チェック欠落を
+意図的に再現」というコメントを読んで「意図的なもの」として指摘から外していた。7/17 時点のエージェント
+定義でも同じ挙動で、コメントを外すと同じ定義・同じモデル（haiku）で 1/1 に戻った。
+6 fixture すべてが同じ形の自己申告コメントを持っており、sweep-types も同日に 0/1 と 1/1 の両方を
+出していた（1/1 の回も出力は「既知の意図的不一致」と格下げ）。7/17 の 1/1 は偶然通っていただけで、
+ベンチマークは「欠陥を見つけるか」ではなく「コメントを無視するか」を測っていた。
+
+**機械検知:** `scripts/check-eval-fixtures-neutral.test.sh`（CI `hooks-test`）が `files/` 配下に
+自己申告語（fixture / ベンチマーク / 意図的 / recall / issue #431 / 再現 等）が無いこと、各 case に
+`NOTES.md` があることを検査する。ファイル名の `eval-fixture-recall` は識別子として本文に必ず現れるため
+対象外（実測ではファイル名だけなら HIT した）。
+
+**同時に見つかった 2 つ目の穴（ハーネス側）:** 中立化した fixture で sweep-types を再実行すると、
+エージェントは欠陥を見つけて報告しているのに 0/1 になった。`--json-schema` を渡しても haiku が
+Markdown の素テキストで返すことがあり、`jq -r '.detail'` が失敗して判定対象が空文字になっていた。
+`scripts/eval-sweep-recall.sh` は JSON として読めなければ生出力全体を判定対象にする fallback を
+持ち、`scripts/eval-sweep-recall.test.sh`（モック応答、実課金なし）が JSON / 素テキスト / 素テキストで
+未検出の 3 シナリオで固定する。**recall が落ちたとき「エージェントが見落とした」と結論する前に、
+生出力（`EVAL_SWEEP_RECALL_DEBUG_DIR`）を必ず読む。** 本件では 2 件の MISS の原因が fixture 側と
+ハーネス側で別々だった。さらにその後の再実行では、エージェントが層をまたぐ欠陥を**型定義側の
+ファイル**（fixture 内の `types/eval-fixture-recall.ts`）を指して正しく報告したのに、期待パスが
+`repository.ts` 固定だったため 3 度目の MISS になった。判定器は `expectedFilePathContains` の
+配列（いずれか一致）を受け付けるようにし、2 ファイルにまたがる fixture は両方を書く。
+**「MISS = 見落とし」ではない。判定器・fixture・エージェントの 3 者のどれが原因かを生出力で
+毎回切り分ける。**
+
 ## RLS/テナント分離層
 
 ### 「動いたからOK」でfacility_idフィルタ漏れ・RLS未設定を見逃す（issue #24再発防止）

--- a/scripts/check-eval-fixtures-neutral.test.sh
+++ b/scripts/check-eval-fixtures-neutral.test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# WHY: issue #731。sweep recall ベンチマーク（issue #431）の fixture コードに
+#      「issue #431 の recall ベンチマーク用 fixture。○○を意図的に再現」という自己申告コメントが
+#      あると、sweep エージェントが欠陥に気づいた上で「意図的な fixture」と判断して指摘から外し、
+#      MISS になる（2026-09-05 実測: コメント有り 0/1 → 同じ定義・同じモデルでコメント無し 1/1）。
+#      fixture の説明は各 case の NOTES.md（clone 先へコピーされない）に置き、`files/` 配下のコードには
+#      正体を明かす語を書かないことを機械検査する。
+#
+# 実行: bash scripts/check-eval-fixtures-neutral.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_ROOT="${EVAL_FIXTURES_NEUTRAL_ROOT:-$SCRIPT_DIR/eval-fixtures}"
+
+# clone 先へコピーされる files/ 配下に現れてはいけない語。
+# 「fixture」「ベンチマーク」「意図的」「recall」「issue #431」「再現」は、コードを読む側に
+# 「これは評価用の仕込みで、本物の欠陥ではない」と教えてしまう
+FORBIDDEN_PATTERN='fixture|ベンチマーク|benchmark|意図的|recall|issue #431|再現|eval-runs|known-failure-patterns'
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+
+scan() {
+  # $1: fixtures root。files/ 配下のソースだけを見る（NOTES.md・expected.json・manifest.json は対象外）。
+  # ファイル名（eval-fixture-recall 等）は対象外: import パスや識別子として本文に必ず現れるため
+  find "$1" -path '*/files/*' -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.sql' -o -name '*.js' \) -print0 \
+    | xargs -0 grep -n -E -i "$FORBIDDEN_PATTERN" 2>/dev/null \
+    | grep -v -E 'eval[-_]fixture[-_]recall' || true
+}
+
+echo "=== scenario 1: 実態の fixture コードに自己申告語が無い ==="
+HITS="$(scan "$FIXTURES_ROOT")"
+if [ -z "$HITS" ]; then
+  ok "files/ 配下に自己申告語なし（$FIXTURES_ROOT）"
+else
+  ng "files/ 配下に自己申告語がある。説明は case ディレクトリの NOTES.md へ移すこと" "$HITS"
+fi
+
+echo "=== scenario 2: 各 case に NOTES.md がある（説明の置き場所を固定） ==="
+for case_dir in "$FIXTURES_ROOT"/sweep-*/case-*/; do
+  [ -d "$case_dir" ] || continue
+  if [ -f "$case_dir/NOTES.md" ]; then
+    ok "NOTES.md あり: $(basename "$(dirname "$case_dir")")/$(basename "$case_dir")"
+  else
+    ng "NOTES.md が無い: $case_dir"
+  fi
+done
+
+echo "=== scenario 3: 自己申告コメントを仕込むと検知する（RED 方向の自己検証） ==="
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/sweep-x/case-1/files/src"
+printf '// issue #431のrecallベンチマーク用fixture。認可チェック欠落を意図的に再現\nexport const x = 1\n' > "$WORK/sweep-x/case-1/files/src/a.ts"
+RED_HITS="$(scan "$WORK")"
+if [ -n "$RED_HITS" ]; then
+  ok "仕込んだ自己申告コメントを検知"
+else
+  ng "自己申告コメントを検知できない（検査が空振り）"
+fi
+
+echo "=== scenario 4: ファイル名・import パス由来の eval-fixture-recall は誤検知しない ==="
+mkdir -p "$WORK/sweep-y/case-1/files/src"
+printf "import type { Item } from '@/types/eval-fixture-recall'\nexport const y = 1\n" > "$WORK/sweep-y/case-1/files/src/b.ts"
+GREEN_HITS="$(scan "$WORK/sweep-y")"
+if [ -z "$GREEN_HITS" ]; then
+  ok "識別子・パスとしての eval-fixture-recall は許容"
+else
+  ng "識別子・パスを誤検知" "$GREEN_HITS"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/NOTES.md
+++ b/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/NOTES.md
@@ -1,0 +1,10 @@
+# case-1-missing-auth-check（sweep-data）
+
+埋め込んでいる欠陥: `docs/agents/known-failure-patterns.md`「動いたからOKでfacility_idフィルタ漏れ・RLS未設定を見逃す」（issue #24再発防止）の再現。`requireAuth` / `requireFacilityAccess` による認可チェックが一切無いまま、パスパラメータの `id` をそのまま DB クエリに渡している。
+
+**この説明を `files/` 配下のコードにコメントとして書かないこと。** 2026-09-05 の切り分け（issue #731）で、
+コード先頭に「issue #431 の recall ベンチマーク用 fixture。○○を意図的に再現」と書いてあると、
+sweep エージェントが欠陥に気づいた上で「意図的な fixture」と判断して指摘から外し（生出力に
+「すべての API ルート（eval-fixture-recall を除く）に requireAuth が実装されている」と書いた）、
+MISS になることを実測した。コメントを外すと同じ定義・同じモデルで HIT した。
+`scripts/check-eval-fixtures-neutral.test.sh` が `files/` 配下に自己申告語が無いことを機械検査する。

--- a/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/files/src/app/api/eval-fixture-recall/[id]/route.ts
+++ b/scripts/eval-fixtures/sweep-data/case-1-missing-auth-check/files/src/app/api/eval-fixture-recall/[id]/route.ts
@@ -1,8 +1,3 @@
-// issue #431のrecallベンチマーク用fixture。既知の失敗パターン
-// （docs/agents/known-failure-patterns.md「動いたからOKでfacility_idフィルタ漏れ・
-// RLS未設定を見逃す」issue #24再発防止）を意図的に再現している:
-// requireAuth/requireFacilityAccessによる認可チェックが一切無いまま、
-// パスパラメータのidをそのままDBクエリに渡している。
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerSupabase } from '@/lib/supabase/server'
 

--- a/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/NOTES.md
+++ b/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/NOTES.md
@@ -1,0 +1,11 @@
+# case-1-security-definer-bypass（sweep-db）
+
+埋め込んでいる欠陥: `docs/agents/known-failure-patterns.md`「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」の再現。
+`SECURITY DEFINER` 関数が `is_facility_member` / `is_admin` による明示的な認可チェックを一切行わないまま、
+施設に紐づく機微データ（`internal_note`）を返し、`GRANT EXECUTE` で `anon` にも実行権限を与えている。
+
+テーブル自体は意図する欠陥（認可チェック欠落）とは無関係だが、参照先テーブルも定義している
+（「テーブル未定義」という別の欠陥に注目が逸れないようにするため）。
+
+**この説明を `files/` 配下のコードにコメントとして書かないこと**（issue #731。
+`../../sweep-data/case-1-missing-auth-check/NOTES.md` 参照）。

--- a/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/files/supabase/migrations/20260716999999_eval_fixture_recall.sql
+++ b/scripts/eval-fixtures/sweep-db/case-1-security-definer-bypass/files/supabase/migrations/20260716999999_eval_fixture_recall.sql
@@ -1,11 +1,3 @@
--- issue #431のrecallベンチマーク用fixture。既知の失敗パターン
--- （docs/agents/known-failure-patterns.md「SECURITY DEFINER + GRANT EXECUTEの認可バイパス」）を
--- 意図的に再現している: SECURITY DEFINER関数がis_facility_member/is_adminによる
--- 明示的な認可チェックを一切行わないまま、施設に紐づく機微データを返し、
--- GRANT EXECUTEでanonにも実行権限を与えている。
--- テーブル自体は本fixtureが意図する欠陥（認可チェック欠落）とは無関係のため、
--- 参照先テーブルも定義しておく（テーブル未定義という別の欠陥に注目が逸れないようにするため）。
-
 CREATE TABLE IF NOT EXISTS eval_fixture_recall_items (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   facility_id UUID NOT NULL,

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/NOTES.md
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/NOTES.md
@@ -1,0 +1,16 @@
+# case-1-missing-mapper-field（sweep-types）
+
+埋め込んでいる欠陥: 層をまたぐ型不一致。`src/types/eval-fixture-recall.ts` の `EvalFixtureRecallItem` は
+`internalNote` を宣言していないが、`src/lib/eval-fixture-recall/repository.ts` の `mapRow()` は
+`internalNote` を含むオブジェクトを返している（DB 列は存在するが型定義に欠落）。TypeScript の
+余剰プロパティチェックで型エラーになる箇所を `@ts-expect-error` で抑制している。
+
+**この説明を `files/` 配下のコードにコメントとして書かないこと**（理由は
+`../../sweep-data/case-1-missing-auth-check/NOTES.md` と同じ。issue #731）。2026-09-05 の実走では
+自己申告コメント付きのまま HIT したが、出力は「既知の意図的不一致（ベンチマーク用 fixture）」と
+格下げされており、同日の別実行では MISS だった。
+
+期待パスは 2 つ（`eval-fixture-recall/repository.ts` と `types/eval-fixture-recall.ts`）のいずれか。
+層をまたぐ欠陥なので、エージェントが型定義側を指して「internalNote が型定義に無い」と報告しても
+正しい検出。2026-09-05 の再実行で型定義側だけを指した報告が repository.ts 固定の期待パスに
+一致せず MISS になったため、判定器を配列対応にした（`scripts/lib/judge-sweep-recall.py`）。

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/expected.json
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/expected.json
@@ -1,4 +1,4 @@
 {
-  "expectedFilePathContains": "eval-fixture-recall/repository.ts",
+  "expectedFilePathContains": ["eval-fixture-recall/repository.ts", "types/eval-fixture-recall.ts"],
   "expectedKeywords": ["internalNote", "internal_note", "EvalFixtureRecallItem"]
 }

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/lib/eval-fixture-recall/repository.ts
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/lib/eval-fixture-recall/repository.ts
@@ -1,8 +1,3 @@
-// issue #431のrecallベンチマーク用fixture。src/types/eval-fixture-recall.tsの
-// EvalFixtureRecallItem型は`internalNote`を宣言していないが、このmapRow()は
-// 宣言済みの戻り値型を偽って`internalNote`を含むオブジェクトを返している
-// （型定義とmapperの層間不一致。実際にはTypeScriptの余剰プロパティチェックに
-// より型エラーになる箇所だが、意図的に@ts-expect-errorで抑制している）。
 import type { EvalFixtureRecallItem } from '@/types/eval-fixture-recall'
 
 type EvalFixtureRecallRow = {
@@ -12,8 +7,7 @@ type EvalFixtureRecallRow = {
 }
 
 export function mapRow(row: EvalFixtureRecallRow): EvalFixtureRecallItem {
-  // @ts-expect-error internalNoteはEvalFixtureRecallItem型に宣言されていないが、
-  // 呼び出し元は実際にこのフィールドに依存している（issue #431のrecallベンチマーク用fixture）
+  // @ts-expect-error 呼び出し元が依存しているフィールドを含めて返す
   return {
     id: row.id,
     name: row.name,

--- a/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/types/eval-fixture-recall.ts
+++ b/scripts/eval-fixtures/sweep-types/case-1-missing-mapper-field/files/src/types/eval-fixture-recall.ts
@@ -1,6 +1,3 @@
-// issue #431のrecallベンチマーク用fixture。層をまたぐ型不一致を意図的に再現している。
-// このEvalFixtureRecallItem型は、対応するrepository.tsのmapRow()が実際に返す
-// internalNoteフィールドを宣言していない（DB列は存在するが型定義に欠落）。
 export type EvalFixtureRecallItem = {
   id: string
   name: string

--- a/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/NOTES.md
+++ b/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/NOTES.md
@@ -1,0 +1,8 @@
+# case-1-missing-suspense（sweep-ui）
+
+埋め込んでいる欠陥: `docs/agents/known-failure-patterns.md`「Suspenseフォールバック未設定」の再現。
+`useSearchParams()` を使うクライアントコンポーネントが `<Suspense fallback={...}>` でラップされずに
+export されている。
+
+**この説明を `files/` 配下のコードにコメントとして書かないこと**（issue #731。
+`../../sweep-data/case-1-missing-auth-check/NOTES.md` 参照）。

--- a/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/files/src/app/(pages)/eval-fixture-recall/page.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-1-missing-suspense/files/src/app/(pages)/eval-fixture-recall/page.tsx
@@ -1,7 +1,3 @@
-// issue #431のrecallベンチマーク用fixture。既知の失敗パターン
-// （docs/agents/known-failure-patterns.md「Suspenseフォールバック未設定」）を意図的に
-// 再現している: useSearchParams()を使うクライアントコンポーネントが、
-// Suspenseでラップされずにexportされている。
 'use client'
 
 import { useSearchParams } from 'next/navigation'

--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/NOTES.md
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/NOTES.md
@@ -1,0 +1,18 @@
+# case-2-late-suspense-after-decoy（sweep-ui）
+
+2 ファイル構成。狙いは「最初の指摘を見つけた時点で探索を打ち切る」sweep を囮で止まらせ、
+辞書順で後に来る本命を検出できるか（「除外後の一覧を最後まで確認する」手順が効いているか）を測ること。
+
+- `alert-banner.tsx`（囮・辞書順で前）: sweep-ui の調査観点「null 非安全・undefined 参照の可能性」に該当。
+  `items` が空配列のとき `items[0].label` が実行時エラーになり、空配列時のフォールバック表示も無い。
+  `expected.json` の期待ファイルではないため、ここだけを報告しても MISS になる
+- `search-filter-panel.tsx`（本命・辞書順で後）: `docs/agents/known-failure-patterns.md`
+  「Suspenseフォールバック未設定」の再現。`useSearchParams()` をトップレベルで呼ぶクライアント
+  コンポーネントが `<Suspense fallback={...}>` でラップされずに export されている
+
+注意: eslint（`--max-warnings=0`）を通す必要があるため、lint が機械的に検知できる欠陥（key の欠落・
+暗黙の any・useEffect 内の setState 等）は意図的に使っていない。ここで狙っているのは「lint では
+拾えないが sweep なら拾える」種類の指摘である。
+
+**この説明を `files/` 配下のコードにコメントとして書かないこと**（issue #731。
+`../../sweep-data/case-1-missing-auth-check/NOTES.md` 参照）。

--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/alert-banner.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/alert-banner.tsx
@@ -1,14 +1,3 @@
-// issue #431のrecallベンチマーク用fixture（case-2の「囮」側）。
-// このファイルは意図的に、sweep-uiの調査観点「null非安全・undefined参照の可能性」に
-// 該当する指摘を含んでいる: itemsが空配列のとき items[0].label が実行時エラーになり、
-// 空配列時のフォールバック表示も無い。
-// 狙いは「最初の指摘を見つけた時点で探索を打ち切る」sweepを、ここで止まらせること。
-// 本命の欠陥は同じディレクトリの search-filter-panel.tsx にあり、辞書順で後に来る。
-// このファイルは expected.json の期待ファイルではないため、ここだけを報告してもMISSになる。
-//
-// 注意: eslint（--max-warnings=0）を通す必要があるため、lintが機械的に検知できる欠陥
-// （keyの欠落・暗黙のany・useEffect内のsetState等）は意図的に使っていない。ここで狙って
-// いるのは「lintでは拾えないがsweepなら拾える」種類の指摘である。
 'use client'
 
 type AlertBannerProps = {

--- a/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/search-filter-panel.tsx
+++ b/scripts/eval-fixtures/sweep-ui/case-2-late-suspense-after-decoy/files/src/components/eval-fixture-recall-b/search-filter-panel.tsx
@@ -1,9 +1,3 @@
-// issue #431のrecallベンチマーク用fixture（case-2の「本命」側）。
-// docs/agents/known-failure-patterns.md「Suspenseフォールバック未設定」を再現している:
-// useSearchParams()をトップレベルで呼ぶクライアントコンポーネントが、
-// <Suspense fallback={...}> でラップされずにexportされている。
-// 同ディレクトリの alert-banner.tsx（辞書順で前）に別種の囮を置いてあるため、
-// このファイルを検出するには「除外後の一覧を最後まで確認する」必要がある。
 'use client'
 
 import { useSearchParams } from 'next/navigation'

--- a/scripts/eval-sweep-recall.sh
+++ b/scripts/eval-sweep-recall.sh
@@ -173,7 +173,15 @@ for case_dir in "$FIXTURE_SET_DIR"/case-*/; do
   fi
 
   DETAIL_FILE="$(mktemp)"
-  printf '%s' "$AGENT_OUTPUT" | jq -r '.detail // ""' > "$DETAIL_FILE" 2>/dev/null || echo -n "" > "$DETAIL_FILE"
+  # WHY(issue #731): --json-schema を渡しても、モデル（特に haiku）が JSON でなく素のテキストで返す
+  #      ことがある。その場合 jq が失敗して detail が空になり、エージェントが欠陥を正しく報告して
+  #      いても MISS になっていた（2026-09-05 実測: 生出力に期待パスとキーワードの両方があるのに 0/1）。
+  #      JSON として読めなければ生出力全体を判定対象にする（判定は部分文字列一致なので過検出は
+  #      増えない。status の取得は諦める）
+  if ! printf '%s' "$AGENT_OUTPUT" | jq -r '.detail // ""' > "$DETAIL_FILE" 2>/dev/null; then
+    printf '%s' "$AGENT_OUTPUT" > "$DETAIL_FILE"
+    echo "[$case_name] 注意: エージェント出力が JSON ではないため生出力全体を判定対象にしました" >&2
+  fi
   IS_HIT="$(EXPECTED_FILE="$expected_file" DETAIL_FILE="$DETAIL_FILE" python3 "$SCRIPT_DIR/lib/judge-sweep-recall.py")"
   rm -f "$DETAIL_FILE"
 

--- a/scripts/eval-sweep-recall.test.sh
+++ b/scripts/eval-sweep-recall.test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# WHY: eval-sweep-recall.sh は claude -p のサブプロセス実行を含み実課金が発生するため、
+# EVAL_SWEEP_RECALL_AGENT_CMD でモックに差し替えて判定ロジックを実課金なしで回帰テストする
+# （eval-workflow-prompts.test.sh と同型）。issue #731 で、モデルが --json-schema を無視して素の
+# テキストで返すと detail が空になり、欠陥を正しく報告していても MISS になる欠陥が見つかったため、
+# その fallback（JSON でなければ生出力全体を判定対象にする）を RED/GREEN 両方向で固定する。
+#
+# 実行: bash scripts/eval-sweep-recall.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/eval-sweep-recall.sh"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- clone 元となるダミー repo（buildSweepPrompt を含む） ---
+DUMMY_REPO="$WORKDIR/dummy-repo"
+mkdir -p "$DUMMY_REPO/.claude/workflows/lib/prompts" "$DUMMY_REPO/.claude/agents" "$DUMMY_REPO/docs/agents"
+(
+  cd "$DUMMY_REPO"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  echo "export function buildSweepPrompt(task, scope = 'full') { return 'task:' + task + ' scope:' + scope }" > .claude/workflows/lib/prompts/sweep.js
+  printf -- '---\nname: sweep-x\ndescription: test\n---\nbody\n' > .claude/agents/sweep-x.md
+  git add -A
+  git commit -q -m "init"
+)
+
+# --- 最小 fixture セット ---
+FIXTURES_DIR="$WORKDIR/fixtures"
+mkdir -p "$FIXTURES_DIR/sweep-x/case-1/files/src/lib/probe"
+echo '{ "agentType": "sweep-x", "model": "haiku" }' > "$FIXTURES_DIR/sweep-x/manifest.json"
+echo "export const probe = 1" > "$FIXTURES_DIR/sweep-x/case-1/files/src/lib/probe/repository.ts"
+echo '{ "expectedFilePathContains": "probe/repository.ts", "expectedKeywords": ["internalNote", "型不一致"] }' > "$FIXTURES_DIR/sweep-x/case-1/expected.json"
+
+MOCK_AGENT="$WORKDIR/mock-agent.sh"
+MOCK_RESPONSE_FILE="$WORKDIR/mock-response.txt"
+cat > "$MOCK_AGENT" <<'MOCK_EOF'
+#!/usr/bin/env bash
+cat /dev/stdin > /dev/null
+cat "$MOCK_RESPONSE_FILE"
+MOCK_EOF
+chmod +x "$MOCK_AGENT"
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+assert_contains() { if printf '%s' "$1" | grep -qF -- "$2"; then ok "$3"; else ng "$3" "expected: $2 / actual: $1"; fi; }
+
+run_eval() {
+  set +e
+  OUT="$(
+    EVAL_SWEEP_RECALL_REPO_DIR="$DUMMY_REPO" \
+    EVAL_SWEEP_RECALL_FIXTURES_DIR="$FIXTURES_DIR" \
+    EVAL_SWEEP_RECALL_LOCK_DIR="$WORKDIR/lock" \
+    EVAL_SWEEP_RECALL_AGENT_CMD="MOCK_RESPONSE_FILE='$MOCK_RESPONSE_FILE' '$MOCK_AGENT'" \
+    bash "$SCRIPT" sweep-x 2>&1
+  )"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: JSON 応答の detail に期待パスとキーワード → HIT ==="
+printf '{"status":"pass","detail":"src/lib/probe/repository.ts:5 — internalNote が型定義に無い"}' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_contains "$OUT" "recall: 1 / 1" "JSON 応答で HIT"
+[ "$EXIT_CODE" -eq 0 ] && ok "exit 0" || ng "exit $EXIT_CODE"
+
+echo "=== scenario 2: 素のテキスト応答（--json-schema 無視）でも本文に期待パスとキーワードがあれば HIT（issue #731） ==="
+# WHY: 2026-09-05 実測。haiku が Markdown の素テキストで返し、jq が失敗して detail 空 → MISS になっていた
+printf '## 調査結果\n\n3. **EvalFixtureRecallItem** - src/lib/probe/repository.ts\n   - mapper が internalNote を追加返却\n' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_contains "$OUT" "recall: 1 / 1" "素テキスト応答で HIT（生出力 fallback）"
+assert_contains "$OUT" "JSON ではないため生出力全体を判定対象" "fallback したことを標準エラーに出す"
+
+echo "=== scenario 3: 素のテキスト応答で期待パスが無ければ MISS（fallback が過検出を生まない） ==="
+printf '## 調査結果\n\n指摘なし。internalNote について特記事項なし\n' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_contains "$OUT" "recall: 0 / 1" "パス無しは MISS のまま"
+[ "$EXIT_CODE" -eq 1 ] && ok "MISS で exit 1" || ng "MISS なのに exit $EXIT_CODE"
+
+echo "=== scenario 4: expectedFilePathContains が配列なら、いずれか 1 つのパスで HIT（層をまたぐ欠陥、issue #731） ==="
+# WHY: 型定義と mapper の不一致のように 2 ファイルにまたがる欠陥は、エージェントがどちら側を指しても正しい検出
+echo '{ "expectedFilePathContains": ["probe/repository.ts", "types/probe.ts"], "expectedKeywords": ["internalNote"] }' > "$FIXTURES_DIR/sweep-x/case-1/expected.json"
+printf '{"status":"pass","detail":"src/types/probe.ts — internalNote が型定義に無い（repository が返している）"}' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_contains "$OUT" "recall: 1 / 1" "配列の 2 つ目のパスで HIT"
+printf '{"status":"pass","detail":"src/lib/other.ts — internalNote について"}' > "$MOCK_RESPONSE_FILE"
+run_eval
+assert_contains "$OUT" "recall: 0 / 1" "配列のどれにも一致しなければ MISS"
+
+echo "=== scenario 5: 実行痕跡が REPO_DIR の docs/agents/eval-runs.jsonl に追記される ==="
+RUNS="$(cat "$DUMMY_REPO/docs/agents/eval-runs.jsonl")"
+assert_contains "$RUNS" '"fixtureSet":"sweep-x"' "fixtureSet を記録"
+LINES="$(wc -l < "$DUMMY_REPO/docs/agents/eval-runs.jsonl" | tr -d ' ')"
+[ "$LINES" -eq 5 ] && ok "5 回の実行で 5 行" || ng "行数が $LINES（期待 5）"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"

--- a/scripts/lib/judge-sweep-recall.py
+++ b/scripts/lib/judge-sweep-recall.py
@@ -4,6 +4,12 @@
 # を読み、期待ファイルパスの部分文字列と期待キーワードのいずれか1つが両方detail内に
 # 含まれていれば"true"を出力する。ファイル経由にしているのは、detail文字列がシェル引用符・
 # バッククォート等を含んでも安全に受け渡すため。
+#
+# expectedFilePathContains は文字列または文字列の配列(issue #731)。配列なら「いずれか1つ」が
+# 含まれていればパス一致とする。層をまたぐ欠陥（型定義とmapperの不一致等）は、エージェントが
+# どちら側のファイルを指しても正しい検出であり、片側だけを正解にすると検出しているのに
+# MISS になる（2026-09-05 実測: sweep-types が型定義側 src/types/eval-fixture-recall.ts を
+# 指して報告したが、期待パスが repository.ts 固定だったため 0/1）。
 import json
 import os
 
@@ -15,7 +21,11 @@ with open(expected_path) as f:
 with open(detail_path) as f:
     detail = f.read().lower()
 
-path_hit = expected["expectedFilePathContains"].lower() in detail
+paths = expected["expectedFilePathContains"]
+if isinstance(paths, str):
+    paths = [paths]
+
+path_hit = any(p.lower() in detail for p in paths)
 keyword_hit = any(k.lower() in detail for k in expected["expectedKeywords"])
 
 print("true" if (path_hit and keyword_hit) else "false")


### PR DESCRIPTION
Closes #731

## 30秒サマリー
- 変更概要: sweep recall ベンチマークの 2 層 MISS を切り分けた結果、原因は「エージェントの見落とし」ではなく (1) fixture がコード内コメントで自分を「ベンチマーク用・意図的な再現」と明かしていた、(2) ハーネスが非 JSON 応答を空として判定していた、(3) 判定器が層をまたぐ欠陥の片側ファイルしか正解にしていなかった、の 3 つ。すべて直し、再発防止テストを付けた
- リスク: 低（eval 用 fixture・ハーネス・判定器のみ。製品コード・hook・settings は無変更）
- 変更領域: eval fixture / eval ハーネス / 構造テスト / docs
- 証拠状態: 実測 6 run（haiku、生出力保存）で原因を分離。構造テスト 2 本 GREEN（RED 自己検証付き）。docs 整合性 GREEN
- 影響範囲: `scripts/eval-fixtures/**`（7 ソース + NOTES.md 5 件 + expected.json 1 件）、`scripts/eval-sweep-recall.sh`、`scripts/lib/judge-sweep-recall.py`、`scripts/eval-sweep-recall.test.sh`（新規）、`scripts/check-eval-fixtures-neutral.test.sh`（新規）、`docs/agents/eval-runs.jsonl`、`docs/agents/known-failure-patterns.md`
- ロールバック可能性: revert のみ（fixture の中身は元のコメント付きに戻るだけ）

レビューしてほしい点:
1. 7/17 の「4 層 1/1」は偶然通っていただけで、ベンチマークは「欠陥を見つけるか」ではなく「コメントを無視するか」を測っていた。issue #528（閾値確定）の前提データとして 7/17 の値は使わない、でよいか
2. 判定器の配列対応（`expectedFilePathContains: [...]`）で緩めすぎていないか。2 ファイルにまたがる sweep-types のみ配列にし、他は文字列のまま

## 00 目的・影響範囲・対象外
- 目的: issue #731。recall ベンチマークが本当に検出力を測れる状態にする
- 変更範囲: 上記
- 対象外（今回あえて触らない）: fixture のファイル名 `eval-fixture-recall`（識別子として本文に必ず現れる。実測ではファイル名だけなら HIT した）。4 層全部の再ベースライン取得（コスト。次に `.claude/agents/sweep-*` を触るときに回す）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
切り分けの実測（すべて haiku・`EVAL_SWEEP_RECALL_DEBUG_DIR` で生出力保存）:

| # | 定義 | fixture | 結果 | 生出力の要点 |
|---|---|---|---|---|
| 1 | 現行 | 元（コメント付き） | sweep-data 0/1 | `{"detail":"指摘なし"}` |
| 2 | 7/17 (dbe2fba) | 元 | sweep-data 0/1 | 「すべての API ルート（**eval-fixture-recall を除く**）に requireAuth が実装」＝気づいた上で除外 |
| 3 | 現行 | コメント無し | sweep-data **1/1** | 「🔴 重大: 認証チェック漏れ … eval-fixture-recall/[id]/route.ts:4-10」 |
| 4 | 現行 | 元 | sweep-types 1/1 | 「既知の意図的不一致（ベンチマーク用 fixture）」と格下げしつつ報告 |
| 5 | 現行 | コメント無し | sweep-types 0/1 | 欠陥を報告しているが**素のテキスト**で返り、`jq -r '.detail'` が失敗 → 判定対象が空 |
| 6 | 現行 + fallback | コメント無し | sweep-types 0/1 | 「EvalFixtureRecallItem / **src/types/**eval-fixture-recall.ts — internalNote」と型定義側を指して報告。期待パスが repository.ts 固定で不一致。新判定器（配列）でオフライン判定すると **true** |

- fixture: 自己申告コメントを削除。説明は case 直下の `NOTES.md`（`files/` 外なので clone 先へコピーされない）へ
- ハーネス: JSON として読めなければ生出力全体を判定対象に（stderr に注意書き）
- 判定器: `expectedFilePathContains` に配列を許容（いずれか一致）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外（fixture の route.ts は「認可チェックが無い」ことを検出させるための仕込みで、製品コードではない。使い捨て clone にのみ配置され、本体の `src/` には存在しない）
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | 🟡 一部 | `npx eslint --max-warnings=0 scripts/eval-fixtures` パス。`npm run lint` 全体はローカルで `src/app/login/page.tsx`（未変更）のルール定義不在エラーが出るため CI `lint` ジョブで確定する（main の CI lint は本日緑） |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/eval-sweep-recall.test.sh` ALL PASSED（JSON / 素テキスト / 素テキスト未検出 / 配列パス / 記録追記）。`bash scripts/check-eval-fixtures-neutral.test.sh` ALL PASSED（実態 / NOTES.md / RED 自己検証 / 識別子は許容） |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | derive はパスの `auth` で高リスク判定したが、対象は eval fixture（使い捨て clone にのみ置かれる仕込みコード）で製品の `src/` には存在しない。RLS / API に変更なし |
| 生成型の鮮度 | ➖ 今回不要 | 同上。DB スキーマに触れていない（fixture の SQL も clone 先のみ） |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上。製品の auth / 認可 / RLS に触れていない |
| hook 実機発火 | ➖ 今回不要 | derive が `scripts/eval-sweep-recall.sh` を hook 扱いしたが、これは手動起動の eval ハーネスで hook / settings.json には未登録。実機発火に相当する確認は上表 #5→#6 の実 run（haiku）で実施済み |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない（eval-runs.jsonl は切り分け run の記録として更新） |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 次回の `eval-sweep-recall.sh` 4 層。sweep-data / sweep-types が 1/1 に戻ること。MISS が出たら必ず `EVAL_SWEEP_RECALL_DEBUG_DIR` の生出力を読んでから結論する
- 異常の判断基準: 生出力に期待パスと期待キーワードがあるのに MISS → 判定器側。「〜を除く」「意図的」の語で除外されている → fixture 側。どちらも無い → 初めてエージェントの見落とし
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: `files/` 配下のコードに fixture の正体を書かない。説明は NOTES.md へ。構造テストが止める
- 似ているが別物の用語: 「MISS」（判定器の結果）と「見落とし」（エージェントの挙動）。本 PR の 3 件の MISS はすべて見落としではなかった
- 勝手にリファクタしない場所: 判定器の部分文字列一致。LLM judge にしない（issue #431 の設計判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
