### PR TITLE
docs: 多リポジトリ展開の棚卸し表に 2026-09-01〜05 の追加分（#710〜#731）と現時点の所見を反映する(issue #535)

### DIFF
--- a/docs/agents/portability-inventory.md
+++ b/docs/agents/portability-inventory.md
@@ -28,6 +28,12 @@ issue本文の進め方は変えていない。本ファイルはその判断材
 | 引き継ぎメモ 04 の4値検知（Stop hook の行名指し警告） | `scripts/check-handoff-format.sh` | 「どう確認したか」節の表行の状態列を見るだけで、種別名には依存しない |
 | 約束カタログの形式（9 列・`P-`3 桁・番号帯）と双方向の構造テスト | `docs/agents/promise-catalog.md`の列構成、`scripts/check-promise-catalog.test.sh` | 「ID が守るテストのファイル内に実在」「孤児 ID 禁止」の検査は言語・フレームワークに依存しない（検索対象の拡張子だけ差し替える） |
 | グラフマニフェストのスキーマ（nodes / edges / humanGates / budgets、blocked エッジは returnsTo 必須）と同期テスト・生成図の仕組み | `.claude/workflows/graph/aidd-graph.mjs`、`.claude/workflows/lib/__tests__/graph-manifest-sync.test.js`、`scripts/lib/render-aidd-graph.mjs` | issue #710。スキーマと「JS から静的抽出して突合する」方式は汎用。nodes / edges の中身（sweep 4 軸・Review 4 観点・予算値）はリポジトリ固有 |
+| 常時ロード量の予算（CLAUDE.md + `@import` 連鎖 + 非スコープ rules の文字数上限）とスキル本文の文字数上限 | `scripts/check-claude-md-size.sh`、`scripts/check-skill-size.test.sh` | issue #711・#716。「起動時に必ず読まれる文字数を測って上限で止める」方式は汎用。上限値（24,000 / 5,000 文字）は各リポジトリの実測で決め直す |
+| compaction 後の状態再注入（SessionStart `compact` matcher で実行状態だけを再注入し、警告系 hook は startup に限定） | `scripts/reinject-aidd-run-state.sh`、`.claude/settings.json` の SessionStart 2 エントリ、`scripts/check-session-start-matchers.test.sh` | issue #712。「要約で消える状態をディスクから読み直す」設計は汎用。再注入する内容（run-manifest / agent-progress / recovery-queue）はこのリポジトリの観測ファイルに依存 |
+| 読み取り専用ロールの Bash ガード（settings.json の PreToolUse で `agent_type` を見て書き込み系コマンドを deny） | `scripts/check-readonly-bash.sh`、`READONLY_AGENT_TYPES` | issue #713。「ロール名の集合 × コマンド分類」で deny する方式は汎用。ロール名一覧（sweep-* / reviewer 等）はエージェント構成に依存 |
+| docs 整合性検査（相対リンク・見出しアンカー・パス言及の実在、歴史的マーカー付きは免除） | `scripts/lib/check-docs-integrity.mjs`、`.github/workflows/docs-integrity-check.yml` | issue #714。検査の 3 種と GitHub の slug 規則は汎用。`PATH_MENTION_PREFIXES`（`scripts/` `supabase/` 等）と歴史的マーカー語（削除済み・廃止済み等）はリポジトリ固有 |
+| eval fixture の中立性検査（fixture コードに「ベンチマーク用・意図的」等の自己申告語を書かせない）と、recall 判定器の「非 JSON 応答は生出力で判定」「期待パスの配列（いずれか一致）」 | `scripts/check-eval-fixtures-neutral.test.sh`、`scripts/eval-sweep-recall.sh`、`scripts/lib/judge-sweep-recall.py` | issue #731。「評価対象に正解を教えない」「MISS = 見落としではない、判定器・fixture・エージェントを生出力で切り分ける」という原則は LLM 評価一般に通用する。禁止語の一覧は日本語運用固有 |
+| 実行痕跡の鮮度チェックを warning でなく失敗にし、免除は PR 本文の申告（`eval-skip: <理由>`）に限定する運用 | `scripts/check-eval-runs-freshness.sh`、`.github/workflows/eval-runs-freshness-check.yml` | issue #496。「`::warning::` は run を開かないと見えず 3 PR で無視された」という教訓と、本文申告による免除の形は汎用 |
 
 ## このリポジトリ・スタック固有と考えられる部分
 
@@ -43,6 +49,8 @@ issue本文の進め方は変えていない。本ファイルはその判断材
 | テスト一覧の行（種別・トリガー・証跡・コマンド） | `docs/agents/test-matrix.md`の各行 | RLS/IDOR 統合・スキーマドリフト等は Supabase 前提。kojigyo（RAG）には golden set・資料鮮度など vkumai に無い行があり、それらは vkumai を経由せず RAG 系の派生先へ持っていく |
 | derive のルール表（derive キー・trigger・not_required の理由・コマンド） | `scripts/lib/derive-test-selection.rules.mjs` | 一覧の行と 1:1。高リスク判定は `router-risk.js` を参照するため、そちらの語彙にも依存する |
 | 約束カタログの行（施設境界・AAL2・admin 境界の各約束） | `docs/agents/promise-catalog.md`の各行 | facility / is_facility_member / has_aal2 等はこのリポジトリの認可設計に固有。kojigyo（corpus の閲覧区分）とは中身が全く違う |
+| Claude / Codex の二重管理（`.claude/skills` と `.agents/skills` のミラー、parity テストのスキルごとの同期単位、AGENTS.md / common.md の TRI/RISK 節の同期テスト） | `scripts/lib/claude-codex-skills-parity.test.ts`、`.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js` | issue #715・#719。Codex を併用しないリポジトリには不要。併用する場合も「どのスキルを完全一致にするか」は運用判断 |
+| Stop hook が transcript から「セッション開始時刻」を取る方法（先頭 50 行のうち最初に `timestamp` を持つ行。`bridge-session` 行を読み飛ばす） | `scripts/check-aidd-stats-recorded.sh`、`scripts/check-aidd-phase-stats-recorded.sh`、`scripts/check-find-av-precision-recorded.sh` | Claude Code 本体の transcript 形式（`*.jsonl`、Remote Control 時の先頭行）に依存。本体更新で無音死しうるため、fail-open hook の生存確認（`logs/*.jsonl` の最終更新日）を節目で見る運用とセット |
 
 ## 判断が難しい・要検証の部分
 
@@ -53,9 +61,23 @@ issue本文の進め方は変えていない。本ファイルはその判断材
 | `~/write_aidd_stats.sh`・`~/.claude/pending_issues.jsonl`等、リポジトリ外（ホームディレクトリ）に置かれた個人スクリプト・設定 | ルート`CLAUDE.md`「AIDD stats 書き出しルール」等 | リポジトリに含まれないため「移植」の対象なのかどうか自体が論点（ユーザー個人の運用習慣なのか、フレームワークの一部なのか） |
 | sweep-db/sweep-ui/sweep-types/sweep-dataという4軸分類 | `.claude/agents/sweep-*.md` | 「UI/データ/DB/型」という軸自体はNext.js+Supabase構成に最適化されており、他スタック（例: モバイルアプリ、バッチ処理基盤）でも同じ4軸が意味を持つかは未検証 |
 
+## 2026-09-05 時点の所見（issue #535 のレビュー用）
+
+- 起票時の前提「移植先候補は未定」は変わった。riff-gear（EC）・cardiosearch（Codex 版）へ移植済みで、
+  派生側からの逆輸入（hooks-test CI、マイグレーション番号衝突検知、`-- ROLLBACK:` 規約）も始まっている
+  （issue #535 コメント 2026-08-24）。論点は「汎用化する価値があるか」から「本家⇔派生の双方向同期を
+  どう設計するか（Plugin 化 #420 を含む）」へ移っている
+- 2026-09-01〜05 に入った仕組み（上表の #710〜#731）は、いずれも「構造・検査方式は汎用、しきい値・
+  語彙・ロール名は固有」という同じ切り口に収まった。分離の粒度は「エンジン（共通）とルール表（固有）」
+  （derive の設計）で統一できる見込み
+- 派生側で判明した差分（ドメインキーワード・コマンド・スタック依存部分）の反映は、riff-gear /
+  cardiosearch がこの Mac のホーム直下に無いため未着手。両リポジトリの場所が分かり次第、上表の
+  「固有」列を派生側の実値と突き合わせる
+
 ## 次にやること
 
 - 通常のAIDD作業（Phase 1-5・issue対応）を進める中で、新しく追加/変更したファイルがどの区分に
   当たるかをこの3表に追記していく
-- 1週間分たまったら、issue #535のレビュー基準（汎用プラグイン化に着手する価値があるか、移植先候補
-  リポジトリの目星がついたか）に沿って判断する
+- riff-gear / cardiosearch の実移植で判明した差分で「固有」列を更新する（場所の特定が先）
+- issue #420（Plugin 化）に着手する際、上表の「汎用」列をそのままプラグイン本体、「固有」列を
+  リポジトリ側設定として切り出す


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: issue #535 の棚卸し表（`docs/agents/portability-inventory.md`）に、2026-09-01〜05 で入った仕組み（#710〜#731）の区分を追記し、レビュー用の所見を追加。docs のみ
- リスク: なし（docs のみ）
- 変更領域: docs
- 証拠状態: docs 整合性 GREEN
- 影響範囲: `docs/agents/portability-inventory.md` のみ
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 所見「論点は汎用化の是非から本家⇔派生の双方向同期の設計へ移った」の認識が合っているか
2. riff-gear / cardiosearch の派生側実値との突合は、両リポジトリの場所が分かってから（この Mac のホーム直下に無い）

## 00 目的・影響範囲・対象外
- 目的: #535 の「1 週間後にレビュー」期限（2026-08-26 起票）超過分を埋め、レビューできる状態にする
- 変更範囲: 棚卸し表 3 表への行追加と所見節の追加
- 対象外（今回あえて触らない）: 派生側実値との突合、Plugin 化（#420）の着手
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- 対象外（docs のみ）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ➖ 今回不要 | docs のみ（ci.yml の paths-ignore 対象） |
| lint | ➖ 今回不要 | docs のみ |
| unit（UI・データ層・API Route） | ➖ 今回不要 | docs のみ |
| build | ➖ 今回不要 | docs のみ |
| migration 静的テスト | ➖ 今回不要 | docs のみ |
| DB 制約 ratchet | ➖ 今回不要 | docs のみ |
| ワークフロー同期テスト | ➖ 今回不要 | docs のみ |
| hook 回帰 | ➖ 今回不要 | docs のみ |
| 認証ファイル漏洩チェック | ➖ 今回不要 | docs のみ |
| 依存監査（既知脆弱性） | ➖ 今回不要 | docs のみ |
| ロックファイルの出所 | ➖ 今回不要 | docs のみ |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED。CI `docs-integrity` でも実行 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | docs/agents のみのメタ改修（derive: route meta）。高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook / settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: なし
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 3 表の列構成（項目 / 所在 / 備考・論点）。構造テストは無いが派生先と持ち回る形式
- 似ているが別物の用語: 「汎用（構造・検査方式）」と「固有（しきい値・語彙・ロール名）」。同じ仕組みが両表に分かれて載る
- 勝手にリファクタしない場所: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
