### PR TITLE
fix: handoff形式検知Stop hookがマージ後にmainへ戻った運用ではPRを見つけられず無音だった問題を、transcriptからPR番号を取る形で修正する(issue #524)

### DIFF
--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -272,6 +272,15 @@ transcript は `{"type":"bridge-session",...}`（timestamp 無し）で始まる
 `logs/*.jsonl` の**最終更新日が伸びているか**（記録が止まっていたら hook か記録経路が死んでいる）
 を節目で見るしかない（本件は `docs/agents/eval-runs.jsonl` の記録停止を追った副産物として発覚）。
 
+**再発（同日、`check-handoff-format.sh`）:** 同じ日に全 Stop hook を本セッションの実データで
+実走したところ、handoff 形式検知が「Stop 時点の現在ブランチ」で `gh pr list --head` を引いていた。
+PR を作って CI を待ち、マージして main へ戻ってから Stop する運用ではブランチが main になり、
+PR が見つからず沈黙する。1 セッションで 14 本の PR を作ったのに 1 本も評価されていなかった。
+修正は transcript の `gh pr create` の tool_result（PR URL）と `gh pr edit N` から PR 番号を取る形
+（`scripts/lib/pr-numbers-from-transcript.jq`）。**「入力形式の変化」だけでなく「運用手順の変化
+（マージ後に main へ戻る）」でも fail-open hook は無音死する。** 検知 hook を書くときは、
+判定材料が「いつ・どこにある」前提かを 1 行書き、その前提が崩れる運用を 1 つ挙げて RED を持つ。
+
 ### eval fixture がコード内コメントで自分の正体を明かし、エージェントが指摘から外す（issue #731）
 
 **チェック内容:** 検出力（recall）を測る fixture のコード（`scripts/eval-fixtures/*/case-*/files/` 配下）に、

--- a/scripts/check-handoff-format.sh
+++ b/scripts/check-handoff-format.sh
@@ -20,8 +20,14 @@ command -v jq >/dev/null 2>&1 || exit 0
 # 1. transcript_pathを軽くgrepし、このセッションで`gh pr create`/`gh pr edit`が呼ばれた
 #    形跡があるかを確認する。無ければ「PR操作なしセッション」として沈黙する
 #    （最頻経路。gh呼び出し自体を避けてコストを抑える）
-# 2. 形跡があれば、現在のブランチに紐づく直近のPR（`gh pr list --head <branch>`）を取得する
-# 3. PR本文に「30秒サマリー」「どう確認したか」の2見出しが含まれるかを確認する
+# 2. 形跡があれば、対象 PR 番号を transcript から特定する
+#    （`gh pr create` の tool_result に残る PR URL の /pull/N と、`gh pr edit N` のコマンド文字列。
+#    scripts/lib/pr-numbers-from-transcript.jq）。1 件も取れなければ従来どおり現在ブランチの
+#    直近 PR（`gh pr list --head <branch>`）にフォールバックする
+#    WHY(2026-09-05): 以前は現在ブランチだけを見ていたが、PR を作って CI を待ち、マージして main へ
+#    戻った後の Stop ではブランチが main になり PR が見つからず沈黙していた。1 セッションで 14 本の
+#    PR を作ったのに 1 本も評価されなかったことを実データで確認した（fail-open の無音死）
+# 3. 各 PR の本文に「30秒サマリー」「どう確認したか」の2見出しが含まれるかを確認する
 #    （issue #666でフォーマットを00〜05構成に刷新した際、最も本質的な2つに絞った近似判定。
 #    厳密なMarkdown見出しレベル一致ではなく部分文字列一致で緩く判定する。
 #    誤検知よりも取りこぼしを許容する）
@@ -30,7 +36,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 # 設計方針:
 # - fail-open: 判定材料が取れないケース（gh/jq不在・git repo外・ネットワーク不通・
 #   PR未検出等）はすべて沈黙する
-# - 警告は同一セッション・同一PR番号につき1回のみ
+# - 警告は同一セッション・同一PR番号につき1回のみ（マーカーは keys 配列で複数 PR を保持）
 # - 全経路 exit 0（blockしない）
 #
 # 5. （PR②、docs/superpowers/specs/2026-09-04-derive-test-selection-design.md）見出しが揃って
@@ -51,6 +57,8 @@ command -v jq >/dev/null 2>&1 || exit 0
 #   見る近似。表を使わず箇条書きで書いた04（バグ修正時の代替形式）は検査しない
 # - 見出し文言の部分文字列一致のため、別の文脈で偶然「30秒サマリー」「どう確認したか」という語が
 #   PR本文に含まれていれば見出しが無くても素通りしうる（fail-openの範囲内として許容）
+# - transcript からの PR 番号抽出は `gh pr create` の tool_result に PR URL が出ることに依存する
+#   （gh の出力仕様）。URL が出ない場合はブランチのフォールバックに落ちる
 #
 # 環境変数（テスト用の注入ポイント）:
 #   HANDOFF_CHECK_SESSION_ID       hook stdinのsession_idの代替
@@ -61,6 +69,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 
 cd "$(dirname "$0")/.."
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MARKER_FILE="${HANDOFF_CHECK_MARKER_FILE:-.aidd/handoff-format-warning-shown.json}"
 GH_CMD="${HANDOFF_CHECK_GH_CMD:-gh}"
 
@@ -83,73 +92,109 @@ if ! grep -qF -e '"command":"gh pr create' -e '"command":"gh pr edit' "$TRANSCRI
   exit 0
 fi
 
-# 2. 現在のブランチに紐づく直近PRを取得
-BRANCH="${HANDOFF_CHECK_GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)}"
-[ -n "$BRANCH" ] || exit 0
+# 2. 対象 PR 番号の特定。transcript 由来を優先し、取れなければ現在ブランチにフォールバック
+PR_NUMBERS="$(jq -s -r -f "$SCRIPT_DIR/lib/pr-numbers-from-transcript.jq" "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+if [ -z "$PR_NUMBERS" ]; then
+  BRANCH="${HANDOFF_CHECK_GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)}"
+  [ -n "$BRANCH" ] || exit 0
+  PR_JSON="$("$GH_CMD" pr list --head "$BRANCH" --state all --json number,body --limit 1 2>/dev/null || true)"
+  [ -n "$PR_JSON" ] || exit 0
+  PR_NUMBERS="$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)"
+fi
+[ -n "$PR_NUMBERS" ] || exit 0
 
-PR_JSON="$("$GH_CMD" pr list --head "$BRANCH" --state all --json number,body --limit 1 2>/dev/null || true)"
-[ -n "$PR_JSON" ] || exit 0
-
-PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)"
-PR_BODY="$(printf '%s' "$PR_JSON" | jq -r '.[0].body // empty' 2>/dev/null || true)"
-[ -n "$PR_NUMBER" ] || exit 0
-
-# 警告済みマーカー: 同一セッション・同一PR番号では2回目以降沈黙
+# 警告済みマーカー（同一セッション・同一PR番号では2回目以降沈黙）。
+# 旧形式 {key: "..."} と新形式 {keys: ["...", ...]} の両方を読む
+WARNED_KEYS=""
 if [ -f "$MARKER_FILE" ]; then
-  WARNED_KEY="$(jq -r '.key // empty' "$MARKER_FILE" 2>/dev/null || true)"
-  if [ "$WARNED_KEY" = "${SESSION_ID}:${PR_NUMBER}" ]; then
-    exit 0
+  WARNED_KEYS="$(jq -r '((.keys // []) + [.key // empty]) | .[]' "$MARKER_FILE" 2>/dev/null || true)"
+fi
+
+# 1 PR 分の判定。警告文を stdout に出す（問題なければ何も出さない）
+check_pr() {
+  local pr_number="$1"
+  local pr_body has_summary has_verified four_state_issues dep_issue pr_files
+  pr_body="$("$GH_CMD" pr view "$pr_number" --json body --jq '.body' 2>/dev/null || true)"
+
+  has_summary=0
+  if printf '%s' "$pr_body" | grep -qF '30秒サマリー'; then
+    has_summary=1
   fi
-fi
-
-HAS_SUMMARY=0
-if printf '%s' "$PR_BODY" | grep -qF '30秒サマリー'; then
-  HAS_SUMMARY=1
-fi
-HAS_VERIFIED=0
-if printf '%s' "$PR_BODY" | grep -qF 'どう確認したか'; then
-  HAS_VERIFIED=1
-fi
-
-# 04 表の4値検知。「どう確認したか」節の表行（見出し行・区切り行を除く）ごとに
-# 状態列（2列目）が4値のいずれかで始まるか、➖ / ⬜ の行に3列目（理由）があるかを見る。
-# 外れた行の種別名を FOUR_STATE_ISSUES に溜める（空なら問題なし）
-FOUR_STATE_ISSUES=""
-if [ "$HAS_VERIFIED" -eq 1 ]; then
-  FOUR_STATE_ISSUES="$(printf '%s\n' "$PR_BODY" | awk -F'|' '
-    /^#+ .*どう確認したか/ {f=1; next}
-    /^## / {f=0}
-    f && /^\| / {
-      kind=$2; gsub(/^ +| +$/,"",kind)
-      if (kind=="" || kind ~ /^-+$/ || kind ~ /^種別/) next
-      status=$3; gsub(/^ +| +$/,"",status)
-      reason=$4; gsub(/^ +| +$/,"",reason)
-      if (status !~ /^(✅|➖|🟡|⬜)/) { printf "%s（状態 \"%s\" が4値でない）; ", kind, status; next }
-      # substr は Linux の awk（C ロケール）だとバイト単位で絵文字を切るため使わない
-      if (status ~ /^(➖|⬜)/ && (reason=="" || reason=="—")) { mark = (status ~ /^➖/) ? "➖" : "⬜"; printf "%s（%s なのに理由が無い）; ", kind, mark }
-    }' 2>/dev/null || true)"
-fi
-
-# 依存の変更（package.json / package-lock.json を触った PR に「依存の変更」の記述があるか）。
-# 変更ファイル一覧が取れない場合は判定しない（fail-open）
-DEP_ISSUE=""
-PR_FILES="$("$GH_CMD" pr view "$PR_NUMBER" --json files --jq '.files[].path' 2>/dev/null || true)"
-if printf '%s\n' "$PR_FILES" | grep -qxE '(.*/)?package(-lock)?\.json'; then
-  if ! printf '%s' "$PR_BODY" | grep -qF '依存の変更'; then
-    DEP_ISSUE="$(printf '%s\n' "$PR_FILES" | grep -E '(.*/)?package(-lock)?\.json' | tr '\n' ' ')"
+  has_verified=0
+  if printf '%s' "$pr_body" | grep -qF 'どう確認したか'; then
+    has_verified=1
   fi
-fi
 
-if [ "$HAS_SUMMARY" -eq 1 ] && [ "$HAS_VERIFIED" -eq 1 ] && [ -z "$FOUR_STATE_ISSUES" ] && [ -z "$DEP_ISSUE" ]; then
-  exit 0
-fi
+  # 04 表の4値検知。「どう確認したか」節の表行（見出し行・区切り行を除く）ごとに
+  # 状態列（2列目）が4値のいずれかで始まるか、➖ / ⬜ の行に3列目（理由）があるかを見る。
+  # 外れた行の種別名を four_state_issues に溜める（空なら問題なし）
+  four_state_issues=""
+  if [ "$has_verified" -eq 1 ]; then
+    four_state_issues="$(printf '%s\n' "$pr_body" | awk -F'|' '
+      /^#+ .*どう確認したか/ {f=1; next}
+      /^## / {f=0}
+      f && /^\| / {
+        kind=$2; gsub(/^ +| +$/,"",kind)
+        if (kind=="" || kind ~ /^-+$/ || kind ~ /^種別/) next
+        status=$3; gsub(/^ +| +$/,"",status)
+        reason=$4; gsub(/^ +| +$/,"",reason)
+        if (status !~ /^(✅|➖|🟡|⬜)/) { printf "%s（状態 \"%s\" が4値でない）; ", kind, status; next }
+        # substr は Linux の awk（C ロケール）だとバイト単位で絵文字を切るため使わない
+        if (status ~ /^(➖|⬜)/ && (reason=="" || reason=="—")) { mark = (status ~ /^➖/) ? "➖" : "⬜"; printf "%s（%s なのに理由が無い）; ", kind, mark }
+      }' 2>/dev/null || true)"
+  fi
 
+  # 依存の変更（package.json / package-lock.json を触った PR に「依存の変更」の記述があるか）。
+  # 変更ファイル一覧が取れない場合は判定しない（fail-open）
+  dep_issue=""
+  pr_files="$("$GH_CMD" pr view "$pr_number" --json files --jq '.files[].path' 2>/dev/null || true)"
+  if printf '%s\n' "$pr_files" | grep -qxE '(.*/)?package(-lock)?\.json'; then
+    if ! printf '%s' "$pr_body" | grep -qF '依存の変更'; then
+      dep_issue="$(printf '%s\n' "$pr_files" | grep -E '(.*/)?package(-lock)?\.json' | tr '\n' ' ')"
+    fi
+  fi
+
+  if [ "$has_summary" -eq 1 ] && [ "$has_verified" -eq 1 ] && [ -z "$four_state_issues" ] && [ -z "$dep_issue" ]; then
+    return 0
+  fi
+
+  if [ "$has_summary" -eq 1 ] && [ "$has_verified" -eq 1 ] && [ -z "$four_state_issues" ]; then
+    printf '%s' "PR #${pr_number} は依存関係ファイル（${dep_issue}）を変更していますが、本文に「依存の変更」の記述がありません。追加・更新・削除したパッケージごとに、用途 / 代替案 / 権限・環境変数・DB への影響 / 固定した版と出所 / npm ci と npm audit --omit=dev --audit-level=high の結果 / ロールバック方法を 00 欄「依存の変更」に書いてください（依存追加は第三者コードを増やす設計判断。docs/agents/known-failure-patterns.md「依存関係層」。この警告はこのPRにつき1回のみ表示されます）。"
+  elif [ "$has_summary" -eq 1 ] && [ "$has_verified" -eq 1 ]; then
+    printf '%s' "PR #${pr_number} の「04 どう確認したか」に、4値（✅ 実施 / ➖ 今回不要 / 🟡 一部 / ⬜ 未実施）に収まらない行があります: ${four_state_issues}。フォーマットに収まらない行は「書き方の問題」か「一覧（docs/agents/test-matrix.md）に無い種類の確認が出てきた」かのどちらかです。前者なら bash scripts/derive-test-selection.sh origin/main --format table の出力に揃え、後者なら一覧と derive ルールへの追加を検討してください（この警告はこのPRにつき1回のみ表示されます）。"
+  else
+    printf '%s' "PR #${pr_number} の本文に、docs/agents/common.md「引き継ぎフォーマット」の必須見出し（30秒サマリー / どう確認したか）が見当たりません。作業完了報告には引き継ぎフォーマット（30秒サマリー・00〜05の証拠・後任AIへの注意）を含めてください（この警告はこのPRにつき1回のみ表示されます）。"
+  fi
+}
+
+MESSAGES=""
+NEW_KEYS=""
+while IFS= read -r pr_number; do
+  [ -n "$pr_number" ] || continue
+  key="${SESSION_ID}:${pr_number}"
+  if printf '%s\n' "$WARNED_KEYS" | grep -qxF "$key"; then
+    continue
+  fi
+  msg="$(check_pr "$pr_number")"
+  [ -n "$msg" ] || continue
+  MESSAGES="${MESSAGES:+$MESSAGES
+
+}$msg"
+  NEW_KEYS="${NEW_KEYS:+$NEW_KEYS
+}$key"
+done <<< "$PR_NUMBERS"
+
+[ -n "$MESSAGES" ] || exit 0
+
+# 警告した PR のキーをマーカーへ追記（atomic）。書けなくてもクラッシュせず警告は出す
 write_marker() {
   local dir tmp
   dir="$(dirname "$MARKER_FILE")"
   mkdir -p "$dir" 2>/dev/null || return 1
   tmp="$(mktemp "$dir/.handoff-format-warning.XXXXXX" 2>/dev/null)" || return 1
-  jq -n --arg key "${SESSION_ID}:${PR_NUMBER}" '{key: $key}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  printf '%s\n%s\n' "$WARNED_KEYS" "$NEW_KEYS" \
+    | jq -R -s 'split("\n") | map(select(length > 0)) | unique | {keys: .}' > "$tmp" 2>/dev/null \
+    || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$MARKER_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
   return 0
 }
@@ -157,13 +202,6 @@ set +e
 write_marker
 set -e
 
-if [ "$HAS_SUMMARY" -eq 1 ] && [ "$HAS_VERIFIED" -eq 1 ] && [ -z "$FOUR_STATE_ISSUES" ]; then
-  MSG="PR #${PR_NUMBER} は依存関係ファイル（${DEP_ISSUE}）を変更していますが、本文に「依存の変更」の記述がありません。追加・更新・削除したパッケージごとに、用途 / 代替案 / 権限・環境変数・DB への影響 / 固定した版と出所 / npm ci と npm audit --omit=dev --audit-level=high の結果 / ロールバック方法を 00 欄「依存の変更」に書いてください（依存追加は第三者コードを増やす設計判断。docs/agents/known-failure-patterns.md「依存関係層」。この警告はこのPRにつき1回のみ表示されます）。"
-elif [ "$HAS_SUMMARY" -eq 1 ] && [ "$HAS_VERIFIED" -eq 1 ]; then
-  MSG="PR #${PR_NUMBER} の「04 どう確認したか」に、4値（✅ 実施 / ➖ 今回不要 / 🟡 一部 / ⬜ 未実施）に収まらない行があります: ${FOUR_STATE_ISSUES}。フォーマットに収まらない行は「書き方の問題」か「一覧（docs/agents/test-matrix.md）に無い種類の確認が出てきた」かのどちらかです。前者なら bash scripts/derive-test-selection.sh origin/main --format table の出力に揃え、後者なら一覧と derive ルールへの追加を検討してください（この警告はこのPRにつき1回のみ表示されます）。"
-else
-  MSG="PR #${PR_NUMBER} の本文に、docs/agents/common.md「引き継ぎフォーマット」の必須見出し（30秒サマリー / どう確認したか）が見当たりません。作業完了報告には引き継ぎフォーマット（30秒サマリー・00〜05の証拠・後任AIへの注意）を含めてください（この警告はこのPRにつき1回のみ表示されます）。"
-fi
-jq -n --arg msg "$MSG" '{systemMessage: $msg}'
+jq -n --arg msg "$MESSAGES" '{systemMessage: $msg}'
 
 exit 0

--- a/scripts/check-handoff-format.test.sh
+++ b/scripts/check-handoff-format.test.sh
@@ -65,10 +65,17 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   fi
   exit 0
 fi
-# `gh pr view N --json files --jq '.files[].path'` の模擬: 1行1パスのファイルをそのまま返す
+# `gh pr view N --json files --jq '.files[].path'` の模擬: 1行1パスのファイルをそのまま返す。
+# `gh pr view N --json body --jq .body` の模擬: $PR_RESPONSE_FILE（配列）から number==N の body を返す
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-  if [ -f "$PR_FILES_FILE" ]; then
-    cat "$PR_FILES_FILE"
+  if [ "$4" = "--json" ] && [ "$5" = "files" ]; then
+    if [ -f "$PR_FILES_FILE" ]; then
+      cat "$PR_FILES_FILE"
+    fi
+    exit 0
+  fi
+  if [ -f "$PR_RESPONSE_FILE" ]; then
+    jq -r --argjson n "$3" '.[] | select(.number == $n) | .body // ""' "$PR_RESPONSE_FILE"
   fi
   exit 0
 fi
@@ -89,6 +96,23 @@ no_pr_command_transcript() {
 set_pr_response() {
   # $1: PR番号, $2: PR本文
   jq -n --argjson num "$1" --arg body "$2" '[{number: $num, body: $body}]' > "$PR_RESPONSE_FILE"
+}
+add_pr_response() {
+  # 既存の配列に $1: PR番号, $2: PR本文 を追加する（複数 PR のシナリオ用）
+  jq --argjson num "$1" --arg body "$2" '. + [{number: $num, body: $body}]' "$PR_RESPONSE_FILE" > "$PR_RESPONSE_FILE.tmp"
+  mv "$PR_RESPONSE_FILE.tmp" "$PR_RESPONSE_FILE"
+}
+# 実 transcript と同じ形: gh pr create の tool_use（id 付き）と、それに対応する tool_result（PR URL を含む）。
+# 引数: PR番号…（複数可）。gh pr create → マージ → main へ戻る運用を模し、ブランチ側の pr list は空にする
+pr_create_with_result_transcript() {
+  : > "$TRANSCRIPT"
+  local n i=0
+  for n in "$@"; do
+    i=$((i + 1))
+    printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_%s","name":"Bash","input":{"command":"gh pr create --title x --body-file y"}}]}}\n' "$i" >> "$TRANSCRIPT"
+    printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_%s","content":"https://github.com/o/r/pull/%s\\n"}]}}\n' "$i" "$n" >> "$TRANSCRIPT"
+    printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_m%s","name":"Bash","input":{"command":"gh pr merge %s --squash --delete-branch"}}]}}\n' "$i" "$n" >> "$TRANSCRIPT"
+  done
 }
 
 run_hook() {
@@ -218,6 +242,54 @@ set_pr_response 109 $'## 30秒サマリー\n内容\n\n## 04 どう確認した�
 set_pr_files "src/app/page.tsx" "docs/packages.md"
 run_hook
 assert_empty "$OUT" "依存ファイルに触れていなければ沈黙する"
+
+echo "=== scenario 15: PR を作ってマージし main へ戻った後の Stop（ブランチに PR 無し）でも transcript の tool_result から PR を特定して警告する ==="
+# WHY(2026-09-05): 従来は現在ブランチの pr list だけを見ていたため、この運用では 1 本も評価されず無音だった
+reset_env
+pr_create_with_result_transcript 201
+set_pr_response 201 'Summary only'
+rm -f "$PR_RESPONSE_FILE.branch"
+BRANCH="main"
+run_hook
+BRANCH="feature/test-branch"
+assert_eq "$EXIT_CODE" "0" "exit 0"
+assert_contains "$OUT" "PR #201" "ブランチに依存せず transcript 由来の PR 番号で警告する"
+
+echo "=== scenario 16: 同一セッションで複数 PR を作った → 問題のある PR をすべて名指しし、マーカーは全件保持 ==="
+reset_env
+pr_create_with_result_transcript 202 203 204
+set_pr_response 202 'no headings'
+add_pr_response 203 $'## 30秒サマリー\n内容\n\n## 04 どう確認したか\n| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |\n| --- | --- | --- |\n| 型検査 | ✅ 実施 | パス |\n\n## 05\n内容'
+add_pr_response 204 'no headings either'
+run_hook
+assert_contains "$OUT" "PR #202" "1 本目の問題 PR を名指し"
+assert_contains "$OUT" "PR #204" "3 本目の問題 PR を名指し"
+if printf '%s' "$OUT" | grep -qF 'PR #203'; then
+  echo "  NG: 正常な PR #203 が名指しされている"; fail=1
+else
+  echo "  OK: 正常な PR #203 は名指しされない"
+fi
+MARKER_KEYS="$(jq -r '.keys | length' "$MARKER")"
+assert_eq "$MARKER_KEYS" "2" "マーカーに警告済み 2 件を保持"
+run_hook
+assert_empty "$OUT" "2 回目は両方とも抑止される"
+
+echo "=== scenario 17: gh pr edit N の形跡 → N を対象にする（tool_result 無しでも番号はコマンドから取れる） ==="
+reset_env
+printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_e","name":"Bash","input":{"command":"gh pr edit 205 --body-file x"}}]}}\n' > "$TRANSCRIPT"
+set_pr_response 205 'Summary only'
+BRANCH="main"
+run_hook
+BRANCH="feature/test-branch"
+assert_contains "$OUT" "PR #205" "gh pr edit の番号で警告する"
+
+echo "=== scenario 18: 旧形式マーカー {key: ...} でも抑止が効く（後方互換） ==="
+reset_env
+pr_create_with_result_transcript 206
+set_pr_response 206 'Summary only'
+jq -n --arg key "${SESSION}:206" '{key: $key}' > "$MARKER"
+run_hook
+assert_empty "$OUT" "旧形式マーカーの key でも沈黙する"
 
 echo "=== scenario 8: transcriptが読めない → 沈黙（fail-open） ==="
 reset_env

--- a/scripts/lib/pr-numbers-from-transcript.jq
+++ b/scripts/lib/pr-numbers-from-transcript.jq
@@ -1,0 +1,25 @@
+# scripts/check-handoff-format.sh から `jq -s -r -f` で呼ばれる。
+# transcript（JSONL を -s で配列化）から、このセッションで作成・編集した PR 番号を列挙する。
+#
+# WHY(2026-09-05): 以前は「Stop 時点の現在ブランチ」で `gh pr list --head` を引いていたが、
+#   PR を作って CI を待ち、マージして main へ戻った後の Stop ではブランチが main になり PR が
+#   見つからず沈黙していた（1 セッションで 14 本の PR を作ったのに 1 本も評価されなかった実測）。
+#   PR 番号は transcript に残る `gh pr create` の tool_result（作成された PR の URL）と
+#   `gh pr edit N` のコマンド文字列から取る。ブランチには依存しない。
+#
+# 出力: PR 番号を 1 行 1 つ（重複除去・昇順）。該当が無ければ何も出さない。
+[ .[] | .message?.content? // empty | .[]? ] as $blocks
+| ($blocks
+   | map(select(.type == "tool_use" and .name == "Bash" and ((.input.command // "") | test("^gh pr create"))))
+   | map(.id)) as $create_ids
+| (
+    [ $blocks[]
+      | select(.type == "tool_result" and (.tool_use_id as $id | $create_ids | index($id)))
+      | (.content | if type == "string" then . elif type == "array" then (map(.text? // "") | join("\n")) else "" end)
+      | capture("/pull/(?<n>[0-9]+)") | .n ]
+    + [ $blocks[]
+        | select(.type == "tool_use" and .name == "Bash")
+        | (.input.command // "")
+        | capture("^gh pr edit (?<n>[0-9]+)") | .n ]
+  )
+| map(tonumber) | unique | .[]


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: handoff 形式検知の Stop hook（issue #524）が「Stop 時点の現在ブランチ」で PR を探していたため、PR を作ってマージし main へ戻る運用では 1 本も評価されず無音だった。transcript の `gh pr create` の tool_result（PR URL）と `gh pr edit N` から PR 番号を取る形に変更し、複数 PR を全件判定する
- リスク: 低（warning-only hook。全経路 exit 0 は不変。判定材料の取り方だけが変わる）
- 変更領域: Stop hook / 構造テスト / docs
- 証拠状態: 実測 2 件（本セッションの実 transcript で修正前は PR 番号を特定できず判定に到達せず、修正後は 14 本を特定して全件適合で沈黙。構造テスト 19 シナリオ GREEN）
- 影響範囲: `scripts/check-handoff-format.sh`、`scripts/lib/pr-numbers-from-transcript.jq`（新規）、`scripts/check-handoff-format.test.sh`、`docs/agents/known-failure-patterns.md`
- ロールバック可能性: revert のみ（マーカーは旧形式も読むため互換）

レビューしてほしい点:
1. 複数 PR の警告を 1 つの systemMessage に連結する方式（Stop hook の出力は 1 JSON のため）
2. 抽出は `gh pr create` の tool_result に PR URL が出る gh の出力仕様に依存。URL が出なければ従来のブランチ方式にフォールバックする

## 00 目的・影響範囲・対象外
- 目的: v1 前の「眠っている仕組みを全部一度動かす」方針で全 Stop hook を実データ実走した際に見つかった無音死を潰す
- 変更範囲: 上記
- 対象外（今回あえて触らない）: `ai-check-suggest.sh` / `gate-effectiveness-monthly-check.sh` が返す `{"systemMessage": ""}`（空メッセージ。害は未確認）、`harvest-journal-events.sh` が全 project dir（43 件）ごとに 1 行ずつ出力するノイズ。いずれも正しさには影響しないため別途
- 作業中に見つけた別件: `check-workflow-interruption.sh` は killed 記録から復旧キューへ正しく登録することを実データで確認（バグではない）
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- PR 番号の特定: `jq -s` で transcript を読み、`gh pr create` の tool_use id と対になる tool_result から `/pull/N` を、`gh pr edit N` はコマンド文字列から取る。14MB の transcript で 0.1 秒
- 修正前の実走: `gh pr list --head main` → `[]` → 沈黙（bash -x で確認）。修正後: 14 本を列挙し各 PR の本文を `gh pr view N --json body` で取得
- マーカー: `{keys: [...]}` に警告済み `<session>:<pr>` を全件保持。旧形式 `{key}` も読む（テスト 18）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-handoff-format.test.sh` ALL PASSED（既存 15 + 新規 4: マージ後 main で Stop / 複数 PR / gh pr edit N / 旧形式マーカー） |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| hook 実機発火 | ✅ 実施 (手動: パス) | 本セッションの実 hook 入力（session_id / transcript_path）を stdin に流して実走。修正前: `gh pr list --head main` が空で沈黙。修正後: 14 本の PR を特定し、全件フォーマット適合のため沈黙（マーカーは scratchpad に隔離） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: PR を作ってマージした後の Stop で、フォーマット不備の PR があれば警告が出ること（この PR 自身の Stop が最初の実機確認になる）
- 異常の判断基準: gh の出力仕様が変わり tool_result に URL が出なくなった場合は、ブランチのフォールバックに落ちて従来の無音に戻る。`jq -s -r -f scripts/lib/pr-numbers-from-transcript.jq <transcript>` で番号が出るか確認する
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 全経路 exit 0。警告は PR ごと 1 回（マーカーの keys）
- 似ているが別物の用語: 「PR 未検出（fail-open で沈黙）」と「全 PR 適合（正常で沈黙）」。実走で区別するには bash -x で PR_NUMBERS を見る
- 勝手にリファクタしない場所: `jq -s` を streaming に変えない（tool_use と tool_result の突合に全体が要る。0.1 秒なので問題ない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
