### PR TITLE
test: hook の警告文が指す docs の節が実在することを機械検査し、autoMode 警告の移動済み参照を直す

### DIFF
--- a/scripts/check-automode-config.sh
+++ b/scripts/check-automode-config.sh
@@ -33,7 +33,7 @@ if [ "$HAS_HARD_DENY" = "true" ]; then
   exit 0
 fi
 
-MSG="autoMode(hard_deny)による医療データ外部送信・RLS無効化の無条件ブロックが、個人設定(${SETTINGS_PATH})に見当たりません。プロジェクト側の設定ファイルでは強制できない仕様のため、有効化したい場合は docs/agents/common.md の推奨autoMode設定を各自の ~/.claude/settings.json に追加してください（任意、issue #439）。"
+MSG="autoMode(hard_deny)による医療データ外部送信・RLS無効化の無条件ブロックが、個人設定(${SETTINGS_PATH})に見当たりません。プロジェクト側の設定ファイルでは強制できない仕様のため、有効化したい場合は docs/agents/tooling-decisions.md「autoMode(hard_deny)は個人設定のみ有効・設定し忘れ検知はSessionStart hookで」の推奨設定を各自の ~/.claude/settings.json に追加してください（任意、issue #439。以前は common.md を指していたが issue #486 の圧縮で節が移動した）。"
 
 jq -n --arg msg "$MSG" '{
   systemMessage: $msg,

--- a/scripts/check-hook-doc-pointers.test.sh
+++ b/scripts/check-hook-doc-pointers.test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# WHY(2026-09-05): hook の警告文は「docs/agents/common.md「ブランチ運用ルール」を参照」のように docs の
+#      節を指す。docs 側は圧縮・分割（issue #486 で common.md → tooling-decisions.md 等）で節が移動する
+#      が、hook 文言は追従せず、古い場所を指したままになる（check-automode-config.sh が「common.md の
+#      推奨 autoMode 設定」を指していたが、その節は tooling-decisions.md に移動済みだった実例）。
+#      docs 間のリンクは check-docs-integrity.mjs が検査するが、hook 文言（bash 文字列）は対象外だった。
+#      scripts/*.sh（テスト以外）から `docs/agents/<file>.md「<節名>」` を抽出し、ファイルの実在と
+#      「節名を含む見出し行」の実在を検査する。
+#
+# 実行: bash scripts/check-hook-doc-pointers.test.sh
+set -euo pipefail
+
+# WHY: BSD grep（macOS の /usr/bin/grep）はロケール未指定だと `[^」]` のようなマルチバイトの否定文字
+#      クラスを正しく扱えず、4 件中 2 件しか抽出しなかった（2026-09-05 実測。その状態では「壊れた参照
+#      なし」が空振りで通ってしまう）。C.UTF-8 は macOS・Ubuntu の両方にある
+export LC_ALL=C.UTF-8
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${HOOK_DOC_POINTERS_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+
+# $1: root。テスト以外の scripts/*.sh から参照を抽出し、壊れているものを "file:line<TAB>pointer<TAB>reason" で出す
+scan() {
+  local root="$1" script pointer file heading line
+  for script in "$root"/scripts/*.sh; do
+    case "$script" in *.test.sh) continue ;; esac
+    [ -f "$script" ] || continue
+    grep -n -o 'docs/agents/[A-Za-z0-9_./-]*\.md「[^」]*」' "$script" 2>/dev/null | while IFS= read -r hit; do
+      line="${hit%%:*}"
+      pointer="${hit#*:}"
+      file="${pointer%%「*}"
+      heading="${pointer#*「}"
+      heading="${heading%」}"
+      if [ ! -f "$root/$file" ]; then
+        printf '%s:%s\t%s\tファイルが無い\n' "$(basename "$script")" "$line" "$pointer"
+        continue
+      fi
+      # 見出し行（# で始まる行）に節名が部分一致すれば OK。「## 次回実施予定日」のように節名が # を含む場合は剥がす
+      heading="${heading#\#\#\# }"; heading="${heading#\#\# }"; heading="${heading#\# }"
+      if ! grep -E '^#{1,6} ' "$root/$file" | grep -qF -- "$heading"; then
+        printf '%s:%s\t%s\t見出しが無い\n' "$(basename "$script")" "$line" "$pointer"
+      fi
+    done || true
+  done
+  # WHY: 最後のスクリプトに参照が無いと grep の exit 1 が関数の戻り値になり、set -e で呼び出し元が
+  #      無言で落ちる（scenario 2 で実際に起きた）。抽出結果は stdout で返すので戻り値は常に 0
+  return 0
+}
+
+echo "=== scenario 1: 実態の hook 文言が指す docs の節がすべて実在する ==="
+BROKEN="$(scan "$ROOT")"
+if [ -z "$BROKEN" ]; then
+  ok "壊れた参照なし"
+else
+  ng "hook 文言が指す docs の節が見つからない（節の移動・改名に hook 文言が追従していない）" "$BROKEN"
+fi
+
+echo "=== scenario 2: 壊れた参照を仕込むと検知する（RED 方向の自己検証） ==="
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/scripts" "$WORK/docs/agents"
+printf '# doc\n\n## 実在する節\n本文\n' > "$WORK/docs/agents/x.md"
+printf 'MSG="docs/agents/x.md「実在する節」を参照"\n' > "$WORK/scripts/good.sh"
+printf 'MSG="docs/agents/x.md「消えた節」と docs/agents/gone.md「節」を参照"\n' > "$WORK/scripts/bad.sh"
+printf 'MSG="docs/agents/x.md「消えた節」"\n' > "$WORK/scripts/bad.test.sh"
+RED="$(scan "$WORK")"
+if printf '%s' "$RED" | grep -qF 'bad.sh:1'; then ok "消えた節を検知"; else ng "消えた節を検知できない" "$RED"; fi
+if printf '%s' "$RED" | grep -qF 'gone.md'; then ok "無いファイルを検知"; else ng "無いファイルを検知できない" "$RED"; fi
+if printf '%s' "$RED" | grep -qF 'good.sh'; then ng "実在する参照を誤検知" "$RED"; else ok "実在する参照は誤検知しない"; fi
+if printf '%s' "$RED" | grep -qF 'bad.test.sh'; then ng "テストファイルまで対象にしている"; else ok "テストファイルは対象外"; fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: hook の警告文が指す docs の節（`docs/agents/<file>.md「<節名>」`）が実在することを CI で機械検査する構造テストを追加し、移動済みの節を指していた autoMode 警告の参照を直す
- リスク: 低（テスト追加と警告文の文言修正のみ。hook の判定は不変）
- 変更領域: 構造テスト / SessionStart hook の文言
- 証拠状態: 実測 2 件（実態の参照 22 件が全件実在・RED 自己検証 GREEN）、実測で見つけたテスト自身の穴 1 件（BSD grep のロケール）を修正済み
- 影響範囲: `scripts/check-hook-doc-pointers.test.sh`（新規）、`scripts/check-automode-config.sh`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 「」形式（`docs/agents/x.md「節名」`）だけを検査対象にした。「x.md の◯◯」のような自由形式は検査できないので、hook 文言で docs の節を指すときは「」形式で書く、を暗黙の規約にする（今回 autoMode をその形に揃えた）
2. 見出し一致は「節名を含む見出し行がある」の部分一致。見出しが改名されても語が残れば通る緩さ

## 00 目的・影響範囲・対象外
- 目的: v1 前の「眠っている仕組みを全部一度動かす」方針で SessionStart hook を実データ実走した際に、警告文が #486 で移動済みの節を指していたのを見つけた。docs 間リンクは docs-integrity が守るが bash 文字列内の参照は誰も見ていなかった
- 変更範囲: 上記
- 対象外（今回あえて触らない）: `.claude/agents/*.md`・`.claude/skills/**` 内の docs 参照（別の形式で書かれており、必要なら同型の検査を足す）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- 抽出: テスト以外の `scripts/*.sh` から `grep -o` で参照を取り、ファイル実在と `^#{1,6} ` 行への部分一致を検査。壊れていれば `script:line<TAB>pointer<TAB>理由` で列挙
- テスト自身の穴: BSD grep はロケール未指定だと `[^」]` を扱えず 4 件中 2 件しか抽出せず、「壊れた参照なし」が空振りで通った（bash -x で発見）。`LC_ALL=C.UTF-8` を固定し、`scan` の戻り値を常に 0 にして `set -e` の無言終了も防いだ

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-hook-doc-pointers.test.sh` ALL PASSED（実態 22 件実在 / 消えた節・無いファイルを検知 / 実在は誤検知しない / テストは対象外）。`bash scripts/check-automode-config.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ➖ 今回不要 | docs を変更していない |
| hook 実機発火 | 🟡 一部 | `check-automode-config.sh` を本セッションの hook 入力で実走し、修正後の文言（tooling-decisions.md の節）が出ることを確認。判定ロジックは無変更 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: docs の節を改名・移動した PR で hooks-test が赤になること
- 異常の判断基準: CI（Ubuntu）で `C.UTF-8` が無い場合は抽出ゼロで空振りする。scenario 2（RED）が同時に落ちるので気づける
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: scenario 2 の RED 自己検証。これが無いと抽出ゼロの空振りに気づけない
- 似ているが別物の用語: 「参照が壊れている」（節が無い）と「参照が検査対象外」（「」形式でない）
- 勝手にリファクタしない場所: `export LC_ALL=C.UTF-8`。外すと macOS で抽出が半分になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
