### PR TITLE
docs: 全hookを現在セッションの実データで実走するランブック(hook-live-drill.md)を追加し、2026-09-05の初回結果を記録する

### DIFF
--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -276,6 +276,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | `scripts/resolve-recovery-task.sh` | 復旧タスク対応後に`status`を`"resolved"`へ書き換える（issue #579） |
 | `scripts/check-workflow-interruption.sh` | SessionStart hookによるWorkflow中断検知(`wf_*.json`のstatus/staleness判定)とrecovery-queueへの登録（issue #534） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
+| [`docs/agents/hook-live-drill.md`](./hook-live-drill.md) | 全 hook を現在セッションの実データで実走し、fail-open の無音死を見つけるランブックと実施記録（2026-09-05 初回で 7 件発見。プラグイン v1 前の必須作業） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |
 | `.claude/workflows/lib/prompts/` | ワークフロー内プロンプト文字列の正本（Workflow DSL側へはインライン複製、sync testで乖離検知） |

--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -1,0 +1,114 @@
+# hook 実走ドリル（眠っている検知の生存確認）
+
+`.claude/settings.json` に登録された hook は、ほぼすべてが **fail-open**（判定材料が取れなければ沈黙）
+かつ **warning-only** で設計されている。この組み合わせは「壊れても何も起きない」ため、hook 自身には
+壊れたことに気づく手段が無い。構造テスト（`scripts/*.test.sh`）はスクリプトの判定ロジックを固定するが、
+「本物の入力が想定した形で来ているか」「前提にした運用がまだ続いているか」までは検証できない。
+
+このランブックは、**現在のセッションの実データを各 hook に食わせ、判定経路に到達しているかを確認する**
+手順と、実施結果の記録場所を定める。プラグイン v1 として切り出す前に、眠っている仕組みを一度全部
+動かして潰す方針（`docs/agents/decisions.md` 参照、issue #420）の中核作業。
+
+## 2026-09-05 の実施結果（初回）
+
+7 月以来一度も実走していなかった仕組みを動かしたところ、1 日で **7 件の無音死・空振り**が見つかった。
+いずれも構造テストは GREEN のままだった。
+
+| 発見 | 種別 | 症状 | 修正 |
+|---|---|---|---|
+| Stop hook 3 本（#495 #522 #524）が transcript 1 行目の `timestamp` 決め打ち | 入力形式の変化 | Remote Control 連携セッションの transcript は timestamp 無しの `bridge-session` 行で始まり、開始時刻が取れず沈黙。deep-task が 61 件検証しても記録漏れ警告が出なかった | PR #728。先頭 50 行のうち最初に timestamp を持つ行を採用 |
+| eval-runs 鮮度チェックの `::warning::` | 届かない警告 | 3 PR で正しく出ていたが run を開かないと見えず、全件無視されて記録が 7/23 で停止 | PR #729。失敗（exit 1）化、免除は本文の `eval-skip:` |
+| sweep recall fixture が「ベンチマーク用・意図的に再現」と自己申告 | fixture の欠陥 | エージェントが欠陥に気づいた上で「意図的」として指摘から外し MISS | PR #732。コメント削除、NOTES.md へ分離、中立性テスト |
+| recall ハーネスが非 JSON 応答を空として判定 | ハーネスの欠陥 | 欠陥を報告しているのに MISS | PR #732。生出力 fallback |
+| recall 判定器が層をまたぐ欠陥の片側ファイルしか正解にしない | 判定器の欠陥 | 型定義側を指した正しい報告が MISS | PR #732。期待パスの配列 |
+| handoff 形式検知が「Stop 時点の現在ブランチ」で PR を探す | 運用手順の変化 | PR を作ってマージし main へ戻る運用では 14 本作っても 1 本も評価されず沈黙 | PR #734。transcript の tool_result から PR 番号を取る |
+| autoMode 警告文が #486 で移動済みの節を指す | docs 参照の腐敗 | 「common.md の推奨設定」が存在しない | PR #735。参照修正＋hook 文言の docs 参照検査テスト |
+
+副産物として、`show-agent-status.sh` が 40 日前の残骸を毎回再注入していた件（PR #727）、
+`check-hook-doc-pointers.test.sh` 自身が BSD grep のロケール問題で空振りしていた件（同 PR 内で修正）も
+同じ「動かして初めて分かる」型だった。
+
+## 手順
+
+### 1. 現在セッションの hook 入力を作る
+
+hook は stdin で JSON を受け取る。`session_id` と `transcript_path` があれば大半の hook は動く。
+transcript のパスは `~/.claude/projects/<cwd を - に置換した名前>/<session_id>.jsonl`。
+
+```json
+{"session_id":"<session_id>","transcript_path":"/Users/<you>/.claude/projects/<project-dir>/<session_id>.jsonl","cwd":"<worktree の絶対パス>","hook_event_name":"Stop","source":"startup"}
+```
+
+これを scratchpad に `hook-input.json` として置く（リポジトリ内には置かない）。
+
+### 2. 各 hook を単体実行し、沈黙なら `bash -x` で判定経路を見る
+
+```bash
+bash scripts/<hook>.sh < hook-input.json
+bash -x scripts/<hook>.sh < hook-input.json
+```
+
+**沈黙は 2 種類ある。** 「判定材料を集めた上で報告事項なし」（正常）と「判定材料が取れず早期 exit」
+（fail-open の無音死）。`bash -x` で最後に通った分岐を見て区別する。判定材料に到達しているなら
+正常。`[ -n "$X" ] || exit 0` の類で抜けているなら、その X が「今の実データで取れない」理由を追う。
+
+副作用があるもの（マーカー・seen ファイル・キュー）は環境変数で scratchpad に逃がす。
+各 hook の先頭コメントに「テスト用の注入ポイント」として一覧がある。
+
+### 3. RED 方向（本来止める・警告すべき入力）も 1 つ与える
+
+PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `tool_input`）を作って流す。
+実際のツールは実行しない（`supabase db push` を本当に打たない）。Stop / SessionStart の警告系は、
+過去の実データ（killed な `wf_*.json`、verifiedCount>0 の run など）を `*_PROJECT_ROOT` /
+`*_WORKFLOWS_DIR` の注入ポイントで指して、警告が出ることを見る。
+
+### 4. 記録
+
+結果は本ファイルの「実施結果」に追記し、見つかった型は `docs/agents/known-failure-patterns.md`
+「fail-open の warning-only hook が、入力形式の変化で無音のまま死ぬ」に足す。
+
+## hook 一覧と 2026-09-05 の判定
+
+| イベント | hook | 判定 | 備考 |
+|---|---|---|---|
+| SessionStart | check-branch-pr-status | 正常（判定到達・報告なし） | `gh pr list --head <branch> --state merged` |
+| SessionStart | check-branch-tool-ownership | 起動時に発火確認 | |
+| SessionStart | check-local-main-freshness | 正常（FETCH_HEAD 0h・behind 0） | |
+| SessionStart | check-otel-collector-status | 正常（opt-in 未設定で早期 exit は設計どおり） | |
+| SessionStart | check-automode-config | 警告あり。**文言の参照先が移動済み** → 修正 | |
+| SessionStart | check-blocked-issues-staleness | 正常（blocked 1 件、90 日未満） | |
+| SessionStart | check-fault-injection-drill-staleness | 正常（次回予定日前） | |
+| SessionStart | check-workflow-interruption | 正常。killed 記録を注入すると復旧キューへ登録 | 表示は recovery-queue 側 |
+| SessionStart | check-recovery-queue | 正常（キュー無し） | |
+| SessionStart | check-claude-md-size | 起動時に発火確認（上限内） | |
+| SessionStart | check-stale-worktrees | 警告あり（残骸 2 件、正しい） | |
+| SessionStart | check-empty-session-report | 正常（未コミットの sessions 無し） | |
+| SessionStart(compact) | reinject-aidd-run-state | 実 compaction で発火確認（#712） | 40 日前の残骸混入 → PR #727 |
+| PreToolUse | check-skip-marker-write | RED: Write / cwd 相対 touch とも ask | |
+| PreToolUse | check-dependency-change | 実機で ask 確認（`npm install foo`、別セッション） | |
+| PreToolUse | check-run-manifest-presence | 高リスクパス編集で警告発火を確認（fixture 編集時） | |
+| PreToolUse | check-direct-ddl-execution | RED: 素の `db push` / MCP execute_sql は deny、`--local` は通過 | |
+| PreToolUse | check-readonly-bash | 実機 deny 確認済み（#713） | |
+| SubagentStart/Stop | log-subagent-hook-skeleton | 記録あり。**app 内部の subagent（agentType 空）も記録される** | 集計側は wf_ パスで絞るため影響なし |
+| Stop | check-domain-decisions-suggest | 空 systemMessage | 害は未確認（下記） |
+| Stop | ai-check-suggest | 空 systemMessage | 同上 |
+| Stop | verify-claims | 観測ログが当日更新 → 生存 | 実走は課金のため省略 |
+| Stop | gate-effectiveness-monthly-check | 空 systemMessage（30 日未経過） | |
+| Stop | check-gap-check-state | 正常（state 無し） | |
+| Stop | check-aidd-stats-recorded | **bridge-session で無音死** → PR #728 | |
+| Stop | check-aidd-phase-stats-recorded | 同上 → PR #728 | |
+| Stop | check-handoff-format | **マージ後 main で無音死** → PR #734 | |
+| Stop | check-find-av-precision-recorded | **bridge-session で無音死** → PR #728 | |
+| Stop | harvest-journal-events | 正常。ただし project dir 43 件を毎回走査（2.8 秒・node 43 起動） | 改善候補 |
+
+未解決の観察（バグかどうか未確定）:
+- 3 つの Stop hook が `{"systemMessage": ""}` を返す。Claude Code が空文字をどう扱うか未確認。
+  害が無ければ現状維持、あれば「何も出力しない」に揃える
+- `harvest-journal-events.sh` は全 worktree の project dir を毎 Stop で走査する。mtime で絞れば
+  短縮できるが、正しさの問題ではない
+
+## 次回実施の目安
+
+- `.claude/settings.json` の hooks を追加・変更したとき（その hook のみ）
+- Claude Code 本体のメジャー更新後（transcript / `wf_*.json` の形式が変わりうる）
+- プラグイン v1 の切り出し前と、各バージョンのリリース前（全件）


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: 全 hook（29 本）を現在セッションの実データで実走し fail-open の無音死を見つけるランブック `docs/agents/hook-live-drill.md` を追加し、2026-09-05 の初回結果（7 件発見、すべて修正済み）と hook ごとの判定を記録。docs のみ
- リスク: なし（docs のみ）
- 変更領域: docs
- 証拠状態: 記録している 7 件はすべて本日の PR（#727 #728 #729 #732 #734 #735）で実測・修正済み
- 影響範囲: `docs/agents/hook-live-drill.md`（新規）、`docs/agents/common.md`（重要ファイル表 1 行）
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 「次回実施の目安」（hooks 変更時・Claude Code メジャー更新後・v1 切り出し前と各バージョン前）。fault-injection-drill のように「次回実施予定日」＋SessionStart 鮮度 hook を付けるかは、v1 のリリース手順が固まってから決めたい
2. 未解決の観察 2 件（空 `systemMessage` の扱い、journal 収穫の 43 dir 走査）を issue にするか

## 00 目的・影響範囲・対象外
- 目的: プラグイン v1 前の「眠っている仕組みを一度全部動かして潰す」作業を、次回も同じ手順で回せる形にする（v1 の各バージョンで残す「vkumai での実証結果」の置き場）
- 変更範囲: 上記
- 対象外（今回あえて触らない）: 未解決の観察 2 件の修正。ドリルの自動化（実データを食わせる性質上、人がセッション内で回す）
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- 対象外（docs のみ）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ➖ 今回不要 | docs のみ（ci.yml の paths-ignore 対象） |
| lint | ➖ 今回不要 | docs のみ |
| unit（UI・データ層・API Route） | ➖ 今回不要 | docs のみ |
| build | ➖ 今回不要 | docs のみ |
| migration 静的テスト | ➖ 今回不要 | docs のみ |
| DB 制約 ratchet | ➖ 今回不要 | docs のみ |
| ワークフロー同期テスト | ➖ 今回不要 | docs のみ |
| hook 回帰 | ➖ 今回不要 | docs のみ |
| 認証ファイル漏洩チェック | ➖ 今回不要 | docs のみ |
| 依存監査（既知脆弱性） | ➖ 今回不要 | docs のみ |
| ロックファイルの出所 | ➖ 今回不要 | docs のみ |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED（checked=37）。`bash scripts/check-claude-md-size.sh` 上限内 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | docs/agents のみのメタ改修 |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook / settings に触れていない（ランブック自体が実機発火の記録） |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: なし
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 「沈黙は 2 種類ある」の区別（報告なし vs 早期 exit）。ドリルの価値はここにある
- 似ているが別物の用語: `fault-injection-drill.md`（Workflow のゲートが blocked を返すかの訓練）と本ファイル（hook が判定に到達するかの訓練）
- 勝手にリファクタしない場所: 実施結果の表。追記のみ（履歴として残す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
