### PR TITLE
fix: Stop hook 3本の空systemMessageを無出力に揃え、journal収穫を前回以降に更新のあるproject dirだけ走査する(issue #737 #738)

### DIFF
--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -101,11 +101,12 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 | Stop | check-find-av-precision-recorded | **bridge-session で無音死** → PR #728 | |
 | Stop | harvest-journal-events | 正常。ただし project dir 43 件を毎回走査（2.8 秒・node 43 起動） | 改善候補 |
 
-未解決の観察（バグかどうか未確定）:
-- 3 つの Stop hook が `{"systemMessage": ""}` を返す。Claude Code が空文字をどう扱うか未確認。
-  害が無ければ現状維持、あれば「何も出力しない」に揃える
-- `harvest-journal-events.sh` は全 worktree の project dir を毎 Stop で走査する。mtime で絞れば
-  短縮できるが、正しさの問題ではない
+同日中に対応した観察（issue #737 / #738）:
+- 3 つの Stop hook が `{"systemMessage": ""}` を返していた。公式仕様は「表示しないなら systemMessage を
+  省略する」で、空文字の扱いは未定義だったため、報告事項なしは無出力に揃えた（他の Stop hook と同じ）
+- `harvest-journal-events.sh` は全 worktree の project dir（43 件）を毎 Stop で走査していた。前回収穫
+  （state ファイルの mtime）より新しいファイルを `wf_*` 配下に持つ dir だけ node を起動する形にし、
+  収穫 0 件の dir は出力しない
 
 ## 次回実施の目安
 

--- a/scripts/ai-check-suggest.sh
+++ b/scripts/ai-check-suggest.sh
@@ -28,18 +28,18 @@ if [ -f "$STATE_FILE" ]; then
 fi
 
 if [ "$CURRENT_HASH" = "$PREV_HASH" ]; then
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 fi
 
 # ソースコード変更（ドキュメント・設定のみの変更は対象外）がなければチェック不要
 if ! printf '%s' "$CHANGED_FILES" | grep -qE '\.(ts|tsx|sql)$'; then
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 fi
 
 if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 fi
 
@@ -55,7 +55,7 @@ if printf '%s' "$EXECUTED_COMMANDS" | grep -qE 'npm run (ai:check|typecheck|lint
   # 未実行のまま書き込むと、同一diff状態での再Stopが30行目の早期returnで
   # 無条件にスキップされ、警告が最大1回しか出なくなってしまう。
   echo "$CURRENT_HASH" > "$STATE_FILE"
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
 else
   MSG="ソースコード変更（.ts/.tsx/.sql）があるにもかかわらず、このセッションで npm run ai:check 相当のコマンド（typecheck/lint/test）が実行された痕跡が見当たりません。実行を検討してください。"
   jq -n --arg msg "$MSG" '{systemMessage: $msg}'

--- a/scripts/ai-check-suggest.test.sh
+++ b/scripts/ai-check-suggest.test.sh
@@ -96,7 +96,8 @@ cat > "$TRANSCRIPT3" <<'EOF'
 {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"npm run test"}}]}}
 EOF
 OUT="$(run_hook "$SANDBOX3" "session-executed" "$TRANSCRIPT3")"
-assert_contains "$OUT" '"systemMessage": ""' "空文字列である(実行済みのため警告なし)"
+# WHY(issue #737): 報告事項なしは無出力（公式仕様では表示しないなら systemMessage を省略する）。以前は空文字を出していた
+if [ -z "$OUT" ]; then echo "  OK: 無出力である(実行済みのため警告なし)"; else echo "  NG: 無出力でない(actual=$OUT)"; fail=1; fi
 
 echo "=== scenario 4: 未実行のまま同一sessionで再Stop → 状態ハッシュが書かれていないため再度警告が出る(issue #635) ==="
 SANDBOX4="$WORKDIR/sandbox4"

--- a/scripts/check-domain-decisions-suggest.sh
+++ b/scripts/check-domain-decisions-suggest.sh
@@ -29,7 +29,7 @@ INPUT="$(cat)"
 SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')"
 
 silent() {
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 }
 

--- a/scripts/check-domain-decisions-suggest.test.sh
+++ b/scripts/check-domain-decisions-suggest.test.sh
@@ -30,8 +30,9 @@ assert_contains() {
 }
 assert_silent() {
   local actual="$1" label="$2"
-  # 沈黙は systemMessage が空文字であること（Stop hookの出力契約）
-  if [ "$(printf '%s' "$actual" | tr -d '[:space:]')" = '{"systemMessage":""}' ]; then
+  # 沈黙は無出力であること（issue #737。公式仕様では表示しないなら systemMessage を省略する。
+  # 以前は空文字の systemMessage を出力契約としていた）
+  if [ -z "$(printf '%s' "$actual" | tr -d '[:space:]')" ]; then
     echo "  OK: $label"
   else
     echo "  NG: $label (actual=$actual)"

--- a/scripts/gate-effectiveness-monthly-check.sh
+++ b/scripts/gate-effectiveness-monthly-check.sh
@@ -32,7 +32,7 @@ bash "$SCRIPT_DIR/harvest-journal-events.sh" >/dev/null 2>&1 || true
 
 LOG_FILE="$(resolve_log_dir)/loop-observability.jsonl"
 if [ ! -f "$LOG_FILE" ]; then
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 fi
 
@@ -46,7 +46,7 @@ if [ -f "$STATE_FILE" ]; then
   # find -mtime +N は「N日より古い」判定。該当すればstdoutに1行出る
   STALE="$(find "$STATE_FILE" -mtime "+${INTERVAL_DAYS}" 2>/dev/null || true)"
   if [ -z "$STALE" ]; then
-    echo '{"systemMessage": ""}'
+    :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
     exit 0
   fi
 fi
@@ -56,7 +56,7 @@ PASSFAIL_SUMMARY="$(bash "$SCRIPT_DIR/summarize-gate-passfail.sh" 2>/dev/null ||
 touch "$STATE_FILE"
 
 if [ -z "$SUMMARY" ] && [ -z "$PASSFAIL_SUMMARY" ]; then
-  echo '{"systemMessage": ""}'
+  :  # 報告事項なし。公式仕様では表示しないなら systemMessage を省略する（issue #737。以前は空文字を出していた）
   exit 0
 fi
 

--- a/scripts/gate-effectiveness-monthly-check.test.sh
+++ b/scripts/gate-effectiveness-monthly-check.test.sh
@@ -22,9 +22,9 @@ assert_contains() {
 }
 assert_empty_system_message() {
   local actual="$1" label="$2"
-  local msg
-  msg="$(printf '%s' "$actual" | jq -r '.systemMessage')"
-  if [ -z "$msg" ]; then
+  # WHY(issue #737): 報告事項なしは無出力（公式仕様では表示しないなら systemMessage を省略する）。
+  #      以前は空文字の systemMessage を出していたため、無出力のみを沈黙として認める
+  if [ -z "$(printf '%s' "$actual" | tr -d '[:space:]')" ]; then
     echo "  OK: $label"
   else
     echo "  NG: $label (systemMessage=$msg)"

--- a/scripts/harvest-journal-events.sh
+++ b/scripts/harvest-journal-events.sh
@@ -12,19 +12,34 @@ set -euo pipefail
 # リポジトリのメインworktreeパスをsanitizeしたprefixに前方一致する全projectディレクトリを
 # 走査して1つずつ収穫する(重複はTS側のsource+agentIdキーで排除される)。
 #
-# 使い方: scripts/harvest-journal-events.sh [--project-dir PATH]
+# WHY(issue #738、2026-09-05): 上記の全走査は project dir が増えるほど重くなる（実測 43 dir、
+# 毎 Stop 2.8 秒・node 起動 43 回、追記 0 件）。前回収穫時刻（state ファイルの mtime）より新しい
+# ファイルを wf_* 配下に持つ dir だけ node を起動し、それ以外は読まずに飛ばす。収穫 0 件の dir は
+# 出力しない（以前は「0件追記」が dir 数ぶん stdout に並んでいた）。state ファイルは走査の最後に
+# touch する（途中で落ちても次回は前回時刻から再走査するので取りこぼさない）。
+#
+# 使い方: scripts/harvest-journal-events.sh [--project-dir PATH] [--force]
+#   --force  mtime による間引きをせず全 dir を走査する（手動の全量再収穫用）
+# 環境変数:
+#   AIDD_JOURNAL_PROJECT_DIR  テスト・手動検証での project dir 差し替え（resolve-log-dir.sh の AIDD_LOG_DIR と同じ流儀）
+#   HARVEST_STATE_FILE        前回収穫時刻の記録先（既定 <log dir>/.journal-harvest-last-run）
+#   HARVEST_VERBOSE=1         dir ごとの「走査 / スキップ」を stderr に出す（テスト・調査用）
 # fail-open: 収穫はあくまで観測のための副次処理なので、npx/tsx不在等で失敗しても
 # 呼び出し元(Stop hook)は落とさない。ただし単体実行時は失敗を見えるようにexit codeは返す。
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
 
-OUTPUT_FILE="$(resolve_log_dir)/journal-harvest.jsonl"
+LOG_DIR="$(resolve_log_dir)"
+OUTPUT_FILE="$LOG_DIR/journal-harvest.jsonl"
+STATE_FILE="${HARVEST_STATE_FILE:-$LOG_DIR/.journal-harvest-last-run}"
 
 CLI_PROJECT_DIR=""
+FORCE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project-dir) CLI_PROJECT_DIR="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -53,10 +68,50 @@ if [[ ${#PROJECT_DIRS[@]} -eq 0 ]]; then
   exit 1
 fi
 
+# dir に前回収穫より新しい wf_* 配下のファイルがあるか（state が無ければ全 dir 対象）
+has_new_files() {
+  local dir="$1"
+  if [[ "$FORCE" -eq 1 || ! -f "$STATE_FILE" ]]; then
+    return 0
+  fi
+  [[ -n "$(find "$dir" -path '*/wf_*' -type f -newer "$STATE_FILE" -print -quit 2>/dev/null)" ]]
+}
+
 # WHY: 以前は `npx -y tsx` で実行していたが、tsx は devDependencies に無く npx が毎回 npm レジストリへ
 #      取りに行く。CI の hooks-test（node_modules 無し）ではレジストリが遅い日に 1 回 7 分かかった
 #      （2026-09-04 実測。平常時 51 秒 → 425 秒）。Node 22.6+ / 24 標準の型除去で直接実行し、
 #      ネットワーク依存を無くす。ランナー既定の Node 22 では警告が出るため --no-warnings を付ける。
+# WHY: state に記録する時刻は「走査開始時刻」にする。走査終了時刻にすると、走査中に書かれた
+#      ファイルが state より古くなり、次回スキップされて取りこぼす。開始時刻なら走査中の書き込みは
+#      必ず state より新しく、次回もう一度拾われる（重複は TS 側の source+agentId で排除される）
+START_MARK="$(mktemp "${TMPDIR:-/tmp}/.journal-harvest-start.XXXXXX")"
+SCANNED=0
+SKIPPED=0
+TOTAL_APPENDED=0
 for project_dir in "${PROJECT_DIRS[@]}"; do
-  node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/harvest-journal-events.ts" --output "$OUTPUT_FILE" --project-dir "$project_dir"
+  if ! has_new_files "$project_dir"; then
+    SKIPPED=$((SKIPPED + 1))
+    [[ "${HARVEST_VERBOSE:-}" = "1" ]] && echo "journal harvest: スキップ（前回以降の更新なし） $project_dir" >&2
+    continue
+  fi
+  SCANNED=$((SCANNED + 1))
+  [[ "${HARVEST_VERBOSE:-}" = "1" ]] && echo "journal harvest: 走査 $project_dir" >&2
+  RESULT="$(node --experimental-strip-types --no-warnings "$SCRIPT_DIR/lib/harvest-journal-events.ts" --output "$OUTPUT_FILE" --project-dir "$project_dir")"
+  APPENDED="$(printf '%s' "$RESULT" | sed -n 's/^journal harvest: \([0-9][0-9]*\)件追記.*/\1/p')"
+  case "$APPENDED" in
+    ''|*[!0-9]*) APPENDED=0 ;;
+  esac
+  if [[ "$APPENDED" -gt 0 ]]; then
+    echo "$RESULT"
+    TOTAL_APPENDED=$((TOTAL_APPENDED + APPENDED))
+  fi
 done
+
+# 走査が最後まで通ったときだけ state を進める（途中で node が失敗すれば set -e で抜け、次回再走査）。
+# state の mtime は走査開始時刻（START_MARK の作成時刻）
+mkdir -p "$(dirname "$STATE_FILE")"
+mv "$START_MARK" "$STATE_FILE"
+
+if [[ "${HARVEST_VERBOSE:-}" = "1" ]]; then
+  echo "journal harvest: 走査 ${SCANNED} dir / スキップ ${SKIPPED} dir / 追記 ${TOTAL_APPENDED} 件" >&2
+fi

--- a/scripts/harvest-journal-events.test.sh
+++ b/scripts/harvest-journal-events.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# WHY(issue #738): scripts/harvest-journal-events.sh は Stop hook として毎ターン走り、以前は
+#      vkumai 由来の全 project dir（実測 43 件）で node を起動していた（2.8 秒/Stop、追記 0 件）。
+#      「前回収穫（state ファイルの mtime）より新しいファイルを wf_* 配下に持つ dir だけ走査する」
+#      間引きと、「収穫 0 件の dir は出力しない」を固定する。実環境の ~/.claude/projects/ は読まず、
+#      AIDD_JOURNAL_PROJECT_DIR / AIDD_LOG_DIR / HARVEST_STATE_FILE で一時ディレクトリへ差し替える。
+#
+# 実行: bash scripts/harvest-journal-events.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/harvest-journal-events.sh"
+
+command -v node >/dev/null 2>&1 || { echo "node が必要です"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PROJ="$WORK/proj"
+WF="$PROJ/sess-1/subagents/workflows/wf_abc"
+mkdir -p "$WF" "$WORK/logs"
+printf '{"agentType":"reviewer"}\n' > "$WF/agent-a1.meta.json"
+printf '{"type":"assistant","timestamp":"2026-09-05T00:00:00Z","message":{"content":[{"type":"text","text":"done"}]}}\n' > "$WF/agent-a1.jsonl"
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+contains() { if printf '%s\n' "$1" | grep -qF -- "$2"; then ok "$3"; else ng "$3" "expected: $2 / actual: $1"; fi; }
+
+run_harvest() {
+  # $@: 追加引数。stdout を OUT、stderr を ERR に入れる
+  set +e
+  OUT="$(AIDD_JOURNAL_PROJECT_DIR="$PROJ" AIDD_LOG_DIR="$WORK/logs" HARVEST_STATE_FILE="$WORK/state" HARVEST_VERBOSE=1 \
+    bash "$SCRIPT" "$@" 2> "$WORK/err.txt")"
+  EXIT_CODE=$?
+  set -e
+  ERR="$(cat "$WORK/err.txt")"
+}
+
+echo "=== scenario 1: state 無し（初回） → 全 dir を走査し、state を作る ==="
+run_harvest
+[ "$EXIT_CODE" -eq 0 ] && ok "exit 0" || ng "exit $EXIT_CODE" "$ERR"
+contains "$ERR" "走査 1 dir / スキップ 0 dir" "初回は走査する"
+[ -f "$WORK/state" ] && ok "state ファイルが作られる" || ng "state ファイルが無い"
+
+echo "=== scenario 2: 前回以降に更新が無い → node を起動せずスキップし、stdout は無出力 ==="
+sleep 1
+run_harvest
+contains "$ERR" "走査 0 dir / スキップ 1 dir" "更新が無ければスキップする"
+[ -z "$OUT" ] && ok "追記 0 件のときは stdout に何も出さない" || ng "stdout に出力がある" "$OUT"
+
+echo "=== scenario 3: wf_* 配下に新しいファイルが増えた → その dir だけ再走査する ==="
+sleep 1
+printf '{"agentType":"implementer"}\n' > "$WF/agent-a2.meta.json"
+printf '{"type":"assistant","timestamp":"2026-09-05T00:01:00Z","message":{"content":[{"type":"text","text":"done"}]}}\n' > "$WF/agent-a2.jsonl"
+run_harvest
+contains "$ERR" "走査 1 dir / スキップ 0 dir" "新しいファイルがあれば走査する"
+contains "$OUT" "件追記" "追記があれば stdout に結果を出す"
+
+echo "=== scenario 4: --force → 更新が無くても全 dir を走査する ==="
+sleep 1
+run_harvest --force
+contains "$ERR" "走査 1 dir / スキップ 0 dir" "--force で間引きを無効化"
+
+echo "=== scenario 5: wf_* 以外のファイル更新（transcript 本体など）では再走査しない ==="
+sleep 1
+printf '{"type":"user"}\n' > "$PROJ/sess-1.jsonl"
+run_harvest
+contains "$ERR" "走査 0 dir / スキップ 1 dir" "wf_* 配下でない更新は無視する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #737
Closes #738

## 30秒サマリー
- 変更概要: hook 実走ドリルの未解決 2 件。(1) Stop hook 3 本が報告事項なしのときに出していた `{"systemMessage": ""}` を無出力に揃える。(2) journal 収穫が毎 Stop で 43 の project dir に node を起動していたのを、前回収穫より新しいファイルを持つ dir だけに絞る（2.97 秒 → 0.155 秒）
- リスク: 低（(1) は表示の有無のみ。(2) は state ファイルが無い・古い場合は従来どおり全走査に戻る fail-safe）
- 変更領域: Stop hook 3 本 / 収穫スクリプト / 構造テスト 4 本（1 本新規）/ docs
- 証拠状態: 実測 2 件（実環境で 2 回目の Stop が 0.155 秒・構造テスト全 GREEN）、公式仕様の確認 1 件（hooks の JSON output は「表示しないなら systemMessage を省略」、空文字は未定義）
- 影響範囲: `scripts/ai-check-suggest.sh`、`scripts/check-domain-decisions-suggest.sh`、`scripts/gate-effectiveness-monthly-check.sh`、`scripts/harvest-journal-events.sh`、各 `.test.sh`、`scripts/harvest-journal-events.test.sh`（新規）、`docs/agents/hook-live-drill.md`
- ロールバック可能性: revert のみ（state ファイルは `logs/.journal-harvest-last-run`、消せば全走査に戻る）

レビューしてほしい点:
1. (2) の間引き条件は「`wf_*` 配下のファイルの mtime > state の mtime」。state の時刻は**走査開始時刻**（`mktemp` で作った印を走査後に state へ `mv`）にしてあり、走査中に書かれたファイルは必ず state より新しく次回もう一度拾われる（重複は TS 側で排除）。取りこぼす経路は残っていない認識だが、`find -newer` の秒未満の扱いだけは環境依存
2. (1) は既存テストが「沈黙 = 空文字の systemMessage」を出力契約として明文化していたため、契約の変更として扱った

## 00 目的・影響範囲・対象外
- 目的: 毎ターン走る Stop hook の無駄（空メッセージ・43 回の node 起動）を無くす
- 変更範囲: 上記
- 対象外（今回あえて触らない）: harvest の TS 側（`scripts/lib/harvest-journal-events.ts`）。間引きは bash 側で完結
- 作業中に見つけた別件: なし
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外（Stop 時の hook 出力）。before: 43 行の「0件追記」+ 空 systemMessage。after: 無出力

## 02 内部でどう守っているか（ロジック証拠）
- (2) `has_new_files`: `find "$dir" -path '*/wf_*' -type f -newer "$STATE_FILE" -print -quit`。state が無いか `--force` なら常に走査。state の touch は走査ループの後（途中で node が失敗すれば `set -e` で抜けて state が進まず、次回再走査）
- 実測: 初回（state 無し）2.97 秒 → 2 回目 0.155 秒

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/harvest-journal-events.test.sh`（新規 5 シナリオ）、`bash scripts/ai-check-suggest.test.sh`、`bash scripts/check-domain-decisions-suggest.test.sh`、`bash scripts/gate-effectiveness-monthly-check.test.sh`、`bash scripts/check-hook-doc-pointers.test.sh` すべて ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| hook 実機発火 | ✅ 実施 (手動: パス) | 実環境で `harvest-journal-events.sh` を 2 回実行し、初回 2.97 秒（全走査）→ 2 回目 0.155 秒（全スキップ・無出力）。Stop hook 3 本は本セッションの hook 入力で実走し無出力を確認 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: `logs/journal-harvest.jsonl` が AIDD 実行後に増えること（間引きで取りこぼしていない証拠）。増えなければ `bash scripts/harvest-journal-events.sh --force`
- 異常の判断基準: 上記
- ロールバック手順: revert、または `logs/.journal-harvest-last-run` を削除して全走査に戻す

## 後任AIへの注意
- この実装で壊してはいけない前提: state の mtime は走査**開始**時刻、state への反映は走査ループの**後**。前者を終了時刻にすると走査中の書き込みを取りこぼし、後者を前に動かすと途中失敗で取りこぼす
- 似ているが別物の用語: 「スキップ（更新なしで node を起動しない）」と「skipped（TS 側の重複排除で追記しなかった件数）」
- 勝手にリファクタしない場所: 「沈黙 = 無出力」に揃えたテスト。空文字の systemMessage に戻さない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
