### PR TITLE
chore(deps): dev 依存の high 脆弱性 3 件（brace-expansion / browserslist / js-yaml）を npm audit fix でパッチ更新する

### DIFF
--- a/docs/agents/known-failure-patterns.md
+++ b/docs/agents/known-failure-patterns.md
@@ -400,3 +400,10 @@ Node 24 最新（例: 24.20 の 11.19）は版が違い、新しい npm はロ�
 ローカルの 11.6 で `npm install next@… --package-lock-only` した際に、11.6 が `@emnapi/*` の項目を
 「不要」と判断して落とした。ローカルの `npm ci --dry-run` は 11.6 なので通り、CI の 11.19 だけが
 落ちる。**ローカルで通ったことは CI で通る証拠にならない**（版が違う）。
+
+**再発（3 回目、2026-09-05）:** `npm audit fix` でも同じ。ローカル 11.6 で実行すると脆弱性は直るが
+`@emnapi/*` 2 項目を落とし、差分が 147 行に膨らんだ。直後に `npx -y npm@11.19.0 install
+--package-lock-only` を掛けると項目が戻り差分は版更新のみ（66 行）になった。**`npm audit fix` /
+`npm update` / `npm install` のどれであれ、lock を書き換えた後は必ず CI と同じ版で
+`install --package-lock-only` を掛け直し、`npx -y npm@<CI 版> ci --dry-run` で確認する。**
+CI の版は Actions の setup-node ログ「Environment details」で確認する（2026-09-05 時点 11.19.0）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -2720,16 +2720,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3621,9 +3621,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3643,9 +3643,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3667,9 +3667,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -3687,11 +3687,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3761,9 +3761,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4104,9 +4104,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.375",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5834,9 +5834,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -6586,9 +6586,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8220,9 +8220,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: dev 依存の high 脆弱性 3 件（brace-expansion / browserslist / js-yaml）を `npm audit fix` でパッチ更新。package.json は無変更、package-lock.json のみ（9 パッケージ、版更新のみ）
- リスク: 低（推移的 dev 依存のパッチ。本番バンドルに含まれず、CI の `--omit=dev` 監査は元から緑）
- 変更領域: 依存（lock）/ docs
- 証拠状態: 実測 6 件（11.19 の `ci --dry-run`・lock 出所検査・`npm audit` 0 件・lint・test 1551 件・`npm ci`）
- 影響範囲: `package-lock.json`、`docs/agents/known-failure-patterns.md`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. ローカル npm 11.6 の `npm audit fix` が `@emnapi/*` を落として差分 147 行になり、CI と同じ 11.19 で再生成して 66 行に戻した。既知パターン 3 回目の再発として known-failure-patterns に追記した。ローカルの npm を CI に合わせる（`corepack` / `.nvmrc` + `npm i -g npm@11.19`）恒久策を入れるかは別判断

## 00 目的・影響範囲・対象外
- 目的: hook 実走ドリルと並行して見つけた dev 依存の high 3 件を潰す（急がない項目だが 1 PR で終わるため）
- 変更範囲: 上記
- 対象外（今回あえて触らない）: `jsdom@30.0.1` の engines 警告（Node 24.15 以上を要求。ローカル 24.11、CI 24.20。警告のみで動作に影響なし）。`unrs-resolver` / `fsevents` の install スクリプト警告（allowScripts 未設定、既存）
- 作業中に見つけた別件: なし
- **依存の変更**:
  | パッケージ | 変更 | 用途 / 経路 | 代替案 | 権限・環境変数・DB | 固定版と出所 |
  |---|---|---|---|---|---|
  | brace-expansion | 1.1.15 → 1.1.18、5.0.6 → 5.0.9 | minimatch 経由（eslint / typescript-eslint）。glob 展開の DoS（GHSA-3jxr-9vmj-r5cp 他） | 据え置き（dev 時のみ動作、攻撃者制御の glob を lint に渡す経路なし） | なし | registry.npmjs.org、sha512 |
  | browserslist（+ baseline-browser-mapping / caniuse-lite / electron-to-chromium / node-releases / update-browserslist-db） | 4.28.2 → 4.28.9 | babel 経由（next / jest-dom）。メモリ無制限成長・stats.json 経由の prototype 書き込み（GHSA-c83g-rgw3-j3cx 他） | 据え置き | なし | 同上 |
  | js-yaml | 4.2.0 → 4.3.2 | eslint 経由。YAML マージキーの CPU 二次的消費（GHSA-52cp-r559-cp3m 他） | 据え置き | なし | 同上 |
  - `npm ci`: 成功（ローカル 11.6.2、および `npx -y npm@11.19.0 ci --dry-run`）
  - `npm audit --omit=dev --audit-level=high`: 0 件（`npm audit` 全体も 0 件）
  - ロールバック: revert

## 01 画面がどう変わったか（UI証拠）
- 対象外

## 02 内部でどう守っているか（ロジック証拠）
- 対象外（依存の版のみ）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ✅ 実施 (手動: パス) | `npm run lint` エラー 0（node_modules を `npm ci` で揃えた状態） |
| unit（UI・データ層・API Route） | ✅ 実施 (手動: パス) | `npm test` 194 ファイル / 1551 件パス |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ✅ 実施 (手動: パス) | `npm test` に含まれる |
| DB 制約 ratchet | ✅ 実施 (手動: パス) | `npm test` に含まれる |
| ワークフロー同期テスト | ✅ 実施 (手動: パス) | `npm test` に含まれる |
| hook 回帰 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ✅ 実施 (手動: パス) | `npm audit --omit=dev --audit-level=high` 0 件、`npm audit` 0 件（更新前は high 3 件） |
| ロックファイルの出所 | ✅ 実施 (手動: パス) | `bash scripts/check-lockfile-integrity.test.sh` ALL PASSED（570 項目） |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED |
| 依存差分レビュー | ✅ 実施 (手動: パス) | 00 欄「依存の変更」のとおり。`git diff -U0 package-lock.json` で版更新 9 件のみ、新規パッケージなし |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook / settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: CI `dependency-audit` の `npm ci` が 11.19 で通ること（この PR の CI が最初の確認）
- 異常の判断基準: `npm ci` が lock の欠落項目で落ちたら、ローカルの npm 版ズレ。`npx -y npm@11.19.0 install --package-lock-only` で作り直す
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: lock は CI と同じ npm 版で作る。ローカルで `npm ci` が通ることは CI で通る証拠にならない
- 似ているが別物の用語: 「`npm audit fix` が直した脆弱性」（3 件）と「lock の差分」（npm 版の違いで増減する）
- 勝手にリファクタしない場所: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
