### PR TITLE
feat: 公式ドキュメント差分の定期確認をランブック化し、次回実施予定日の期限切れを SessionStart hook で警告する（2026-09-05 初回記録付き）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -207,6 +207,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-empty-session-report.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-upstream-docs-review-staleness.sh",
+            "timeout": 10
           }
         ]
       },

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -37,6 +37,7 @@
 | SessionStart | `check-automode-config.sh` | warning-only | autoMode(hard_deny)未設定の警告（個人設定のため機械強制不可） |
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
+| SessionStart | `check-upstream-docs-review-staleness.sh` | warning-only | 公式ドキュメント差分の定期確認（`docs/agents/upstream-docs-review.md`）の期限切れ警告 |
 | SessionStart | `check-claude-md-size.sh` | warning-only | CLAUDE.md/docs/agents/common.mdの行数肥大化を警告（トークン効率化。common.mdは機械検知ルール集のため「短ければ良い」わけではなく、削除判断は人間に委ねる） |
 | SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）・PRを一度も作らず一定日数放置されたブランチ数（閾値超過時、issue #708）を警告。削除は不可逆に近い操作のため意図的にwarning-only |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -277,6 +277,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | `scripts/check-workflow-interruption.sh` | SessionStart hookによるWorkflow中断検知(`wf_*.json`のstatus/staleness判定)とrecovery-queueへの登録（issue #534） |
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | [`docs/agents/hook-live-drill.md`](./hook-live-drill.md) | 全 hook を現在セッションの実データで実走し、fail-open の無音死を見つけるランブックと実施記録（2026-09-05 初回で 7 件発見。プラグイン v1 前の必須作業） |
+| [`docs/agents/upstream-docs-review.md`](./upstream-docs-review.md) | Claude Code / Anthropic / Codex の公式ドキュメント差分を月 1 で確認する手順・実施記録・「最後に確認した版」（v1 の対応バージョンの正本）。期限は `scripts/check-upstream-docs-review-staleness.sh` が SessionStart で警告 |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |
 | `.claude/workflows/lib/prompts/` | ワークフロー内プロンプト文字列の正本（Workflow DSL側へはインライン複製、sync testで乖離検知） |

--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -78,6 +78,7 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 | SessionStart | check-automode-config | 警告あり。**文言の参照先が移動済み** → 修正 | |
 | SessionStart | check-blocked-issues-staleness | 正常（blocked 1 件、90 日未満） | |
 | SessionStart | check-fault-injection-drill-staleness | 正常（次回予定日前） | |
+| SessionStart | check-upstream-docs-review-staleness | 導入時（2026-09-05）に実態ファイルで沈黙・過去日 fixture で警告を確認 | 公式 docs 差分確認の期限監視 |
 | SessionStart | check-workflow-interruption | 正常。killed 記録を注入すると復旧キューへ登録 | 表示は recovery-queue 側 |
 | SessionStart | check-recovery-queue | 正常（キュー無し） | |
 | SessionStart | check-claude-md-size | 起動時に発火確認（上限内） | |

--- a/docs/agents/upstream-docs-review.md
+++ b/docs/agents/upstream-docs-review.md
@@ -1,0 +1,69 @@
+# 公式ドキュメント差分の定期確認（upstream docs review）
+
+Claude Code・Anthropic・OpenAI/Codex の公式ドキュメントは数週間単位で更新される（2026-08〜09 の
+1 か月で Claude Code は約 20 版）。「業界推奨を網羅したか」は 1 回の調査で決まる状態ではなく、
+**定期的に差分を見て、この表と同じ形で判定し直す**作業として持つ。fault-injection 訓練
+（[`fault-injection-drill.md`](./fault-injection-drill.md)）と同じ型で、「次回実施予定日」を
+SessionStart hook（`scripts/check-upstream-docs-review-staleness.sh`）が監視する。
+
+プラグイン v1（issue #420）の各バージョンで残す「対応する Claude Code・Codex のバージョン」は、
+本ファイルの「最後に確認した版」を正本にする。
+
+## 次回実施予定日
+
+2026-10-05（月 1 の目安。Claude Code のマイナー版が 10 個以上進んだとき、または v1 の各バージョン前は
+予定日を待たず実施する。実施後に手動で書き換える）
+
+## 最後に確認した版
+
+| 対象 | 版 / 日付 | 確認日 |
+|---|---|---|
+| Claude Code | 2.1.261（changelog の先頭） | 2026-09-05 |
+| Codex CLI | 0.153.4（2026-09-04） | 2026-09-05 |
+| Anthropic engineering blog | 最新記事 2026-04-23 | 2026-09-05 |
+
+## 手順（1〜2 時間）
+
+1. **差分を取る**（WebFetch で要約。日付でフィルタさせると要約器が誤るので「先頭から N 版」で取る）
+   - Claude Code changelog: `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
+     （「最後に確認した版」より新しい版の項目を全部。hooks / subagent / compaction / plugin / workflow /
+     sandbox / permission / skill の語を含む項目は省略させない）
+   - Claude Code docs: `hooks`・`sub-agents`・`plugins-reference`・`memory`・`context-window`
+     （イベント一覧・frontmatter フィールド・プラグイン構成要素・読み込み仕様の**現行値**を取り、
+     前回の記録と突き合わせる）
+   - Anthropic engineering: `https://www.anthropic.com/engineering`（新記事の有無）
+   - Codex: `https://learn.chatgpt.com/docs/changelog`（旧 developers.openai.com/codex/changelog はリダイレクト）
+2. **判定する**: 各項目を「v1 設計に効く制約 / 取り込む価値あり / 対応不要」の 3 つに分け、
+   取り込むものは issue 化する（小粒なら #654 バックログへ束ねる）
+3. **記録する**: 下の実施記録に追記し、「最後に確認した版」と「次回実施予定日」を更新する
+4. **必要なら実走する**: hook のイベントや transcript 形式が変わっていたら
+   [`hook-live-drill.md`](./hook-live-drill.md) を回す（形式変化は fail-open hook を無音で殺す）
+
+## 実施記録
+
+### 2026-09-05（初回。issue #420 の v1 準備として）
+
+範囲: Claude Code 2.1.239〜2.1.261、Codex 0.150〜0.153、Anthropic engineering（新記事なし）。
+このセッションでの 7 案（グラフマニフェスト #710、常時ロード量 #711、compaction 再注入 #712、
+読み取り専用ガード #713、docs GC #714、TRI/RISK 同期 #715、スキル上限 #716）を実装した直後の確認。
+
+**v1 設計に効く制約（issue #420 にコメント済み）**
+- プラグインは `.claude/rules/` を同梱できない。CLAUDE.md も読まれない。path-scoped rules は導入先アダプター側に残す
+- プラグインの `settings.json` は `agent` / `subagentStatusLine` のみ。permissions・hooks は書けない。hook は `hooks/hooks.json` で同梱
+- プラグイン同梱の subagent では frontmatter の `hooks` / `permissionMode` / `mcpServers` が無視される（#713 の settings.json 方式が正解）
+- Workflows は `workflows/` で同梱可。`dependencies` に semver 制約付きで依存プラグインを書ける
+
+**取り込む価値あり（issue 化）**
+- `Setup` hook（`claude -p --maintenance`）を定期作業の入口にする → issue #741
+- `InstructionsLoaded` hook で常時ロード量を実測に置き換える → issue #742
+- `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` が AIDD のモデル階層を無効化するため検知する → issue #743
+- `/skill-doctor`（2.1.261）で未使用スキルと context コストを 1 回測る（手動）
+- `subagentPromptCacheTtl` / frontmatter `experimental.cacheTtl`（1h）は `/cost` の cache miss 原因を見てから判断
+
+**対応不要**
+- `PostCompact` hook: 案 3 は SessionStart(compact) で実装済みで実機動作を確認。移す必要なし
+- 2.1.260 の「Workflow subagent が長い compaction 中に stalled 扱いで再起動」修正: check-workflow-interruption の staleness 近似（4 時間）は安全側に動く
+- MEMORY.md の上限 200 行 / 25KB: 現状余裕あり
+- Codex 0.150 の Interrupt hook: Codex 実機待ちの issue #653 に束ねる
+
+**このセッションで先行して潰した無音死（差分確認と並行の実走ドリル）**: [`hook-live-drill.md`](./hook-live-drill.md) 参照

--- a/scripts/check-upstream-docs-review-staleness.sh
+++ b/scripts/check-upstream-docs-review-staleness.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY: 本スクリプトは警告専用（ブロックしない）hookである。jq未インストール環境では
+# jq呼び出しがexit 127でスクリプトごと死に、警告が出せなくなっていた（issue #636）。
+# ブロックしないスクリプトなので実害は無音のfail-open（警告が出ないだけ）であり、
+# エラーノイズだけを消す目的でjq不在時は静かにexit 0する。
+command -v jq >/dev/null 2>&1 || exit 0
+
+# SessionStart hookから呼ばれる。公式ドキュメント（Claude Code / Anthropic / Codex）の差分確認
+# （docs/agents/upstream-docs-review.md）は「1 回やって終わり」になりやすい第3層ルールのため、
+# fault-injection 訓練（scripts/check-fault-injection-drill-staleness.sh、issue #443）と同じ型で
+# 「## 次回実施予定日」を過ぎていたら警告する。2026-09-05 に、7 月に調べた推奨事項の再確認で
+# v1 プラグイン設計に効く制約 3 件と取り込む価値のある新機能 4 件が見つかった実績があり、
+# 差分確認自体を定期化する価値が実測で確認できたため導入した。
+#
+# 日付抽出はmacOS/Linuxのdate非互換を避けるため他のスクリプトと同様にpython3に委ねる。
+#
+# 環境変数（テスト用の注入ポイント）:
+#   UPSTREAM_DOCS_REVIEW_DOC  対象ドキュメント（既定 docs/agents/upstream-docs-review.md）
+
+REVIEW_DOC="${UPSTREAM_DOCS_REVIEW_DOC:-docs/agents/upstream-docs-review.md}"
+
+if [ ! -f "$REVIEW_DOC" ]; then
+  exit 0
+fi
+
+RESULT="$(python3 -c "
+import re, sys
+from datetime import date
+
+with open('$REVIEW_DOC', encoding='utf-8') as f:
+    text = f.read()
+
+m = re.search(r'## 次回実施予定日\s*\n+(\d{4}-\d{2}-\d{2})', text)
+if not m:
+    print('NO_DATE')
+    sys.exit(0)
+
+due = date.fromisoformat(m.group(1))
+today = date.today()
+if today >= due:
+    print(f'DUE {due.isoformat()} {(today - due).days}')
+else:
+    print('OK')
+" 2>/dev/null || echo 'OK')"
+
+if [ "$RESULT" = "OK" ]; then
+  exit 0
+fi
+
+if [ "$RESULT" = "NO_DATE" ]; then
+  MSG="${REVIEW_DOC}の「## 次回実施予定日」欄から日付を読み取れませんでした。書式が崩れていないか確認してください。"
+  jq -n --arg msg "$MSG" '{
+    systemMessage: $msg,
+    hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: $msg }
+  }'
+  exit 0
+fi
+
+DUE_DATE="$(printf '%s' "$RESULT" | cut -d' ' -f2)"
+DAYS_OVERDUE="$(printf '%s' "$RESULT" | cut -d' ' -f3)"
+
+MSG="公式ドキュメント差分の定期確認（${REVIEW_DOC}）の次回実施予定日（${DUE_DATE}）を${DAYS_OVERDUE}日過ぎています。同ファイルの手順で Claude Code changelog / docs・Anthropic engineering・Codex changelog の差分を確認し、実施記録・「最後に確認した版」・次回予定日を更新してください（docs/agents/upstream-docs-review.md「## 次回実施予定日」）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: $msg }
+}'

--- a/scripts/check-upstream-docs-review-staleness.test.sh
+++ b/scripts/check-upstream-docs-review-staleness.test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# WHY: scripts/check-upstream-docs-review-staleness.sh(SessionStart hook)の回帰テスト。
+# 実物のdocs/agents/upstream-docs-review.mdを書き換えず、テスト用の一時ファイルを
+# UPSTREAM_DOCS_REVIEW_DOC環境変数で差し替えて決定的に検証する
+# （check-fault-injection-drill-staleness.test.shと同型）。
+#
+# 実行: bash scripts/check-upstream-docs-review-staleness.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-upstream-docs-review-staleness.sh"
+
+fail=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+future_iso() {
+  python3 -c "
+from datetime import date, timedelta
+print((date.today() + timedelta(days=$1)).isoformat())
+"
+}
+past_iso() {
+  python3 -c "
+from datetime import date, timedelta
+print((date.today() - timedelta(days=$1)).isoformat())
+"
+}
+
+echo "=== scenario 1: 次回実施予定日が未来 → 何も出力しない ==="
+FUTURE="$(future_iso 30)"
+printf '## 次回実施予定日\n\n%s（月 1 の目安）\n' "$FUTURE" > "$TMPDIR_TEST/future.md"
+OUT="$(UPSTREAM_DOCS_REVIEW_DOC="$TMPDIR_TEST/future.md" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 2: 次回実施予定日が過去(期限切れ) → 警告する ==="
+PAST="$(past_iso 10)"
+printf '## 次回実施予定日\n\n%s（月 1 の目安）\n' "$PAST" > "$TMPDIR_TEST/past.md"
+OUT="$(UPSTREAM_DOCS_REVIEW_DOC="$TMPDIR_TEST/past.md" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessageフィールドがある"
+assert_contains "$OUT" "$PAST" "期限日が含まれる"
+assert_contains "$OUT" "10日過ぎています" "超過日数が含まれる"
+assert_contains "$OUT" "additionalContext" "additionalContextフィールドがある"
+
+echo "=== scenario 3: 次回実施予定日が今日ちょうど → 警告する(期限当日も対象) ==="
+TODAY="$(past_iso 0)"
+printf '## 次回実施予定日\n\n%s\n' "$TODAY" > "$TMPDIR_TEST/today.md"
+OUT="$(UPSTREAM_DOCS_REVIEW_DOC="$TMPDIR_TEST/today.md" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "当日も警告対象になる"
+
+echo "=== scenario 4: 見出し自体が無い/日付を抽出できない → 警告する(書式崩れの検知) ==="
+printf '## 別の見出し\n\n本文のみで日付が無い\n' > "$TMPDIR_TEST/broken.md"
+OUT="$(UPSTREAM_DOCS_REVIEW_DOC="$TMPDIR_TEST/broken.md" bash "$SCRIPT")"
+assert_contains "$OUT" "読み取れませんでした" "書式崩れの警告が出る"
+
+echo "=== scenario 5: ドキュメント自体が存在しない → 何も出力しない ==="
+OUT="$(UPSTREAM_DOCS_REVIEW_DOC="$TMPDIR_TEST/no-such-file.md" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空である"
+
+echo "=== scenario 6: 実態の docs/agents/upstream-docs-review.md から日付を読める（書式の回帰） ==="
+OUT="$(bash "$SCRIPT")"
+if printf '%s' "$OUT" | grep -qF "読み取れませんでした"; then
+  echo "  NG: 実態のファイルの「## 次回実施予定日」から日付を読み取れない"; fail=1
+else
+  echo "  OK: 実態のファイルの書式は読み取れる（期限前なら沈黙、期限後なら超過警告）"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー
- 変更概要: Claude Code / Anthropic / Codex の公式ドキュメント差分確認を「月 1 の定期作業」としてランブック化（`docs/agents/upstream-docs-review.md`）。fault-injection 訓練と同じ型で「次回実施予定日」を SessionStart hook が監視し、2026-09-05 の初回結果（v1 設計に効く制約 3 件、取り込む新機能で issue #741 #742 #743）を記録
- リスク: 低（warning-only の SessionStart hook 1 本追加と docs）
- 変更領域: docs / SessionStart hook / settings.json / 構造テスト
- 証拠状態: 実測 3 件（構造テスト 6 シナリオ GREEN・実態ファイルで実走し沈黙・SessionStart 登録の構造テスト GREEN）
- 影響範囲: `docs/agents/upstream-docs-review.md`（新規）、`scripts/check-upstream-docs-review-staleness.sh` と `.test.sh`（新規）、`.claude/settings.json`（startup 群 13 本目）、`docs/agents/common.md`・`actuator-inventory.md`・`hook-live-drill.md`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 頻度「月 1、または Claude Code のマイナー版 10 個進んだら、または v1 の各バージョン前」。多すぎれば予定日をずらすだけ
2. 「最後に確認した版」を v1 の「対応する Claude Code・Codex のバージョン」の正本にする位置づけ

## 00 目的・影響範囲・対象外
- 目的: 「網羅したか」を 1 回の判断で終わらせず、差分確認を回る仕組みにする
- 変更範囲: 上記
- 対象外（今回あえて触らない）: `Setup(maintenance)` hook からの一括起動（issue #741）、確認作業の自動化（要約の判定は人が読む）
- 作業中に見つけた別件: なし（差分確認の結果は issue #741 #742 #743 と #420 コメント）
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- 対象外。予定日超過時の SessionStart 警告: 「公式ドキュメント差分の定期確認（…）の次回実施予定日（YYYY-MM-DD）を N 日過ぎています。…」

## 02 内部でどう守っているか（ロジック証拠）
- `## 次回実施予定日` 直下の `YYYY-MM-DD` を python3 で読み、今日以降なら警告。見出しが無い・日付が読めない場合も警告（書式崩れの検知）。ファイル不在は沈黙（fail-open）
- 実態ファイル（2026-10-05）に対して実走 → 沈黙。過去日 fixture → 警告（テスト 2・3）

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/check-upstream-docs-review-staleness.test.sh` ALL PASSED（未来/過去/当日/書式崩れ/不在/実態）。`bash scripts/check-session-start-matchers.test.sh` ALL PASSED。`bash scripts/check-hook-doc-pointers.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED（checked=38）。`bash scripts/check-claude-md-size.sh` 上限内 |
| hook 実機発火 | 🟡 一部 | 本セッションの hook 入力で実走し沈黙（予定日前）。SessionStart 経由の発火は次の新規セッションで確認（同型の fault-injection hook が同じ登録方法で発火実績あり） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | derive は `docs/agents/actuator-inventory.md` のファイル名（`inventory`）で高リスク判定したが docs の一覧表への 1 行追加のみ（既知の語衝突）。製品コード・RLS・API に変更なし |
| 生成型の鮮度 | ➖ 今回不要 | 同上。DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上。auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 2026-10-05 以降の SessionStart で警告が出ること
- 異常の判断基準: 警告が鳴り続ける → 実施して予定日を更新する（鳴らないよう予定日だけ先送りするのは「網羅した」の根拠を失う）
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: `## 次回実施予定日` の直下に `YYYY-MM-DD` を置く書式（hook が読む）。テスト 6 が実態ファイルで検査
- 似ているが別物の用語: 「最後に確認した版」（差分確認の起点）と「対応するバージョン」（v1 が動作保証する版。前者を正本にして後者を決める）
- 勝手にリファクタしない場所: 実施記録は追記のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
