### PR TITLE
feat: Setup hook（claude -p --maintenance）で定期作業 3 つの期限を一括表示する maintenance-digest.sh を追加する(issue #741)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -144,6 +144,18 @@
     ]
   },
   "hooks": {
+    "Setup": [
+      {
+        "matcher": "maintenance",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/maintenance-digest.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|resume|clear|fork",

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -38,6 +38,7 @@
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
 | SessionStart | `check-upstream-docs-review-staleness.sh` | warning-only | 公式ドキュメント差分の定期確認（`docs/agents/upstream-docs-review.md`）の期限切れ警告 |
+| Setup（matcher `maintenance`） | `maintenance-digest.sh` | warning-only | `claude -p --maintenance` で fault-injection 訓練・hook 実走ドリル・docs 差分確認の 3 期限を一括表示（issue #741）。明示的に呼ばないと動かないため SessionStart の個別警告は残す |
 | SessionStart | `check-claude-md-size.sh` | warning-only | CLAUDE.md/docs/agents/common.mdの行数肥大化を警告（トークン効率化。common.mdは機械検知ルール集のため「短ければ良い」わけではなく、削除判断は人間に委ねる） |
 | SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）・PRを一度も作らず一定日数放置されたブランチ数（閾値超過時、issue #708）を警告。削除は不可逆に近い操作のため意図的にwarning-only |
 | Stop | `check-gap-check-state.sh` | **自動復旧（queue）** | gap check警告を`gap-check-followup`としてqueue登録（issue #488・#523） |

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -278,6 +278,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | [`docs/agents/fault-injection-drill.md`](./fault-injection-drill.md) | `aidd-phase2.js`のdeny-by-defaultゲート実測訓練のランブック（issue #395） |
 | [`docs/agents/hook-live-drill.md`](./hook-live-drill.md) | 全 hook を現在セッションの実データで実走し、fail-open の無音死を見つけるランブックと実施記録（2026-09-05 初回で 7 件発見。プラグイン v1 前の必須作業） |
 | [`docs/agents/upstream-docs-review.md`](./upstream-docs-review.md) | Claude Code / Anthropic / Codex の公式ドキュメント差分を月 1 で確認する手順・実施記録・「最後に確認した版」（v1 の対応バージョンの正本）。期限は `scripts/check-upstream-docs-review-staleness.sh` が SessionStart で警告 |
+| `scripts/maintenance-digest.sh` | 定期作業 3 つ（fault-injection 訓練・hook 実走ドリル・docs 差分確認）の期限を一括表示。`claude -p --maintenance`（Setup hook）または手動実行（issue #741） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |
 | `.claude/workflows/lib/prompts/` | ワークフロー内プロンプト文字列の正本（Workflow DSL側へはインライン複製、sync testで乖離検知） |

--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -85,6 +85,7 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 | SessionStart | check-stale-worktrees | 警告あり（残骸 2 件、正しい） | |
 | SessionStart | check-empty-session-report | 正常（未コミットの sessions 無し） | |
 | SessionStart(compact) | reinject-aidd-run-state | 実 compaction で発火確認（#712） | 40 日前の残骸混入 → PR #727 |
+| Setup(maintenance) | maintenance-digest | `claude -p --maintenance --debug` で発火確認（debug ログに `Hook Setup:maintenance (Setup) success` とダイジェスト本文。1 ターン約 $0.21） | 同時に個人プラグイン claude-mem 10.6.3 の Setup hook が `setup.sh: No such file` を出す（リポジトリ外） |
 | PreToolUse | check-skip-marker-write | RED: Write / cwd 相対 touch とも ask | |
 | PreToolUse | check-dependency-change | 実機で ask 確認（`npm install foo`、別セッション） | |
 | PreToolUse | check-run-manifest-presence | 高リスクパス編集で警告発火を確認（fixture 編集時） | |
@@ -114,3 +115,9 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 - `.claude/settings.json` の hooks を追加・変更したとき（その hook のみ）
 - Claude Code 本体のメジャー更新後（transcript / `wf_*.json` の形式が変わりうる）
 - プラグイン v1 の切り出し前と、各バージョンのリリース前（全件）
+
+## 次回実施予定日
+
+2026-12-05（四半期後の目安。v1 の切り出し前は予定日を待たず全件実施する。実施後に手動で書き換える。
+期限は `scripts/maintenance-digest.sh`（`claude -p --maintenance`、issue #741）が他の定期作業と
+まとめて表示する）

--- a/docs/agents/upstream-docs-review.md
+++ b/docs/agents/upstream-docs-review.md
@@ -12,7 +12,8 @@ SessionStart hook（`scripts/check-upstream-docs-review-staleness.sh`）が監�
 ## 次回実施予定日
 
 2026-10-05（月 1 の目安。Claude Code のマイナー版が 10 個以上進んだとき、または v1 の各バージョン前は
-予定日を待たず実施する。実施後に手動で書き換える）
+予定日を待たず実施する。実施後に手動で書き換える。期限は SessionStart の個別警告に加え、
+`claude -p --maintenance`（`scripts/maintenance-digest.sh`、issue #741）で他の定期作業とまとめて確認できる）
 
 ## 最後に確認した版
 

--- a/scripts/maintenance-digest.sh
+++ b/scripts/maintenance-digest.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WHY(issue #741): 期限付きの定期作業が 3 つあり（fault-injection 訓練、hook 実走ドリル、公式 docs
+# 差分確認）、それぞれ SessionStart hook が個別に期限切れを警告している。ただし SessionStart は
+# 「たまたま始めたセッション」でしか鳴らず、「いつやるか」は人の記憶に残っていた。Claude Code の
+# `Setup` hook（`claude -p --maintenance` で発火、matcher `maintenance`）を定期作業の入口にし、
+# 3 つの予定日と経過日数を 1 つのダイジェストで出す。手動実行（`bash scripts/maintenance-digest.sh`）
+# でも同じ出力が得られる。
+#
+# 判定は各ランブックの「## 次回実施予定日」直下の YYYY-MM-DD（既存の staleness hook と同じ書式）。
+# 出力: Setup hook の JSON（systemMessage）。期限超過が 1 つも無くても「次の期限」を一覧で出す
+# （ダイジェストの目的は「いつやるか」を見せることで、超過の警告だけではない）。
+#
+# 環境変数（テスト用の注入ポイント。各 staleness hook と同じ名前）:
+#   FAULT_INJECTION_DRILL_DOC   既定 docs/agents/fault-injection-drill.md
+#   HOOK_LIVE_DRILL_DOC         既定 docs/agents/hook-live-drill.md
+#   UPSTREAM_DOCS_REVIEW_DOC    既定 docs/agents/upstream-docs-review.md
+#   MAINTENANCE_DIGEST_PLAIN=1  JSON でなく人が読む素のテキストで出す（手動実行用）
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+cd "$(dirname "$0")/.."
+
+# stdin（hook 入力）は読み捨てる。setup_type は maintenance 前提（settings.json の matcher で絞る）
+cat >/dev/null 2>&1 || true
+
+# $1: ランブックのパス → "OK <due> <days_left>" / "DUE <due> <days_over>" / "NO_DATE" / "MISSING"
+judge() {
+  local doc="$1"
+  if [ ! -f "$doc" ]; then
+    echo "MISSING"
+    return 0
+  fi
+  python3 -c "
+import re, sys
+from datetime import date
+
+with open(sys.argv[1], encoding='utf-8') as f:
+    text = f.read()
+m = re.search(r'## 次回実施予定日\s*\n+(\d{4}-\d{2}-\d{2})', text)
+if not m:
+    print('NO_DATE')
+    sys.exit(0)
+due = date.fromisoformat(m.group(1))
+today = date.today()
+if today >= due:
+    print(f'DUE {due.isoformat()} {(today - due).days}')
+else:
+    print(f'OK {due.isoformat()} {(due - today).days}')
+" "$doc" 2>/dev/null || echo "NO_DATE"
+}
+
+# $1: 表示名, $2: ランブック, $3: 実施コマンド/参照
+line_for() {
+  local name="$1" doc="$2" howto="$3" result
+  result="$(judge "$doc")"
+  case "$result" in
+    MISSING) printf '%s: ランブックが見つかりません（%s）\n' "$name" "$doc" ;;
+    NO_DATE) printf '%s: 「## 次回実施予定日」から日付を読み取れません（%s）\n' "$name" "$doc" ;;
+    DUE*)
+      printf '%s: ⚠ 期限 %s を %s 日超過。%s\n' "$name" "$(cut -d' ' -f2 <<<"$result")" "$(cut -d' ' -f3 <<<"$result")" "$howto"
+      OVERDUE=$((OVERDUE + 1))
+      ;;
+    OK*)
+      printf '%s: 期限 %s（あと %s 日）\n' "$name" "$(cut -d' ' -f2 <<<"$result")" "$(cut -d' ' -f3 <<<"$result")"
+      ;;
+  esac
+}
+
+OVERDUE=0
+BODY="$(
+  line_for "fault injection 訓練" "${FAULT_INJECTION_DRILL_DOC:-docs/agents/fault-injection-drill.md}" "手順: docs/agents/fault-injection-drill.md「## 実行手順」"
+  line_for "hook 実走ドリル" "${HOOK_LIVE_DRILL_DOC:-docs/agents/hook-live-drill.md}" "手順: docs/agents/hook-live-drill.md「## 手順」"
+  line_for "公式 docs 差分確認" "${UPSTREAM_DOCS_REVIEW_DOC:-docs/agents/upstream-docs-review.md}" "手順: docs/agents/upstream-docs-review.md「## 手順（1〜2 時間）」"
+)"
+# サブシェル内の加算は親に戻らないため、本文の ⚠ を数え直す
+OVERDUE="$(printf '%s\n' "$BODY" | grep -c '⚠' || true)"
+
+HEADER="定期メンテナンスのダイジェスト（issue #741。claude -p --maintenance または bash scripts/maintenance-digest.sh）"
+if [ "$OVERDUE" -gt 0 ]; then
+  SUMMARY="期限超過 ${OVERDUE} 件。超過分を実施し、各ランブックの「## 次回実施予定日」と実施記録を更新してください。"
+else
+  SUMMARY="期限超過なし。次の期限は上の一覧のとおりです。"
+fi
+MSG="${HEADER}
+${BODY}
+${SUMMARY}"
+
+if [ "${MAINTENANCE_DIGEST_PLAIN:-}" = "1" ]; then
+  printf '%s\n' "$MSG"
+  exit 0
+fi
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: { hookEventName: "Setup", additionalContext: $msg }
+}'
+exit 0

--- a/scripts/maintenance-digest.test.sh
+++ b/scripts/maintenance-digest.test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# WHY: scripts/maintenance-digest.sh（Setup hook、matcher maintenance。issue #741）の回帰テスト。
+# 実物のランブック 3 本を書き換えず、環境変数で一時ファイルへ差し替えて決定的に検証する。
+# あわせて .claude/settings.json に Setup(maintenance) の登録があることを検査する
+# （settings 側の登録が落ちるとダイジェスト自体が呼ばれなくなるため）。
+#
+# 実行: bash scripts/maintenance-digest.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/maintenance-digest.sh"
+SETTINGS="$SCRIPT_DIR/../.claude/settings.json"
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+contains() { if printf '%s\n' "$1" | grep -qF -- "$2"; then ok "$3"; else ng "$3" "expected: $2 / actual: $1"; fi; }
+not_contains() { if printf '%s\n' "$1" | grep -qF -- "$2"; then ng "$3" "unexpected: $2"; else ok "$3"; fi; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+iso_offset() { python3 -c "from datetime import date, timedelta; print((date.today() + timedelta(days=$1)).isoformat())"; }
+write_doc() { printf '# x\n\n## 次回実施予定日\n\n%s（目安）\n' "$2" > "$1"; }
+
+run_digest() {
+  set +e
+  OUT="$(FAULT_INJECTION_DRILL_DOC="$WORK/fi.md" HOOK_LIVE_DRILL_DOC="$WORK/hl.md" UPSTREAM_DOCS_REVIEW_DOC="$WORK/ud.md" \
+    bash "$SCRIPT" < /dev/null 2>&1)"
+  EXIT_CODE=$?
+  set -e
+}
+
+echo "=== scenario 1: 3 本とも期限前 → 超過なしのダイジェスト（次の期限一覧） ==="
+write_doc "$WORK/fi.md" "$(iso_offset 30)"
+write_doc "$WORK/hl.md" "$(iso_offset 60)"
+write_doc "$WORK/ud.md" "$(iso_offset 10)"
+run_digest
+[ "$EXIT_CODE" -eq 0 ] && ok "exit 0" || ng "exit $EXIT_CODE"
+contains "$OUT" "systemMessage" "Setup hook の JSON を返す"
+contains "$OUT" '"hookEventName": "Setup"' "hookEventName が Setup"
+contains "$OUT" "期限超過なし" "超過なしの要約"
+contains "$OUT" "fault injection 訓練: 期限 $(iso_offset 30)" "各作業の次の期限を出す"
+contains "$OUT" "あと 10 日" "残り日数を出す"
+
+echo "=== scenario 2: 1 本が期限超過 → ⚠ と超過件数、手順への参照 ==="
+write_doc "$WORK/hl.md" "$(iso_offset -5)"
+run_digest
+contains "$OUT" "hook 実走ドリル: ⚠ 期限 $(iso_offset -5) を 5 日超過" "超過した作業を ⚠ 付きで出す"
+contains "$OUT" "期限超過 1 件" "超過件数を要約に出す"
+contains "$OUT" "hook-live-drill.md" "手順への参照を出す"
+not_contains "$OUT" "fault injection 訓練: ⚠" "期限前の作業には ⚠ を付けない"
+
+echo "=== scenario 3: 日付が読めないランブック → その旨を出し、他の判定は続ける ==="
+printf '# x\n\n本文のみ\n' > "$WORK/fi.md"
+run_digest
+contains "$OUT" "fault injection 訓練: 「## 次回実施予定日」から日付を読み取れません" "書式崩れを名指し"
+contains "$OUT" "公式 docs 差分確認: 期限" "他の作業の判定は続く"
+
+echo "=== scenario 4: ランブック不在 → その旨を出し、exit 0 ==="
+rm -f "$WORK/ud.md"
+run_digest
+contains "$OUT" "公式 docs 差分確認: ランブックが見つかりません" "不在を名指し"
+[ "$EXIT_CODE" -eq 0 ] && ok "exit 0（block しない）" || ng "exit $EXIT_CODE"
+
+echo "=== scenario 5: MAINTENANCE_DIGEST_PLAIN=1 → JSON でなく素のテキスト ==="
+PLAIN="$(FAULT_INJECTION_DRILL_DOC="$WORK/fi.md" HOOK_LIVE_DRILL_DOC="$WORK/hl.md" UPSTREAM_DOCS_REVIEW_DOC="$WORK/ud.md" MAINTENANCE_DIGEST_PLAIN=1 bash "$SCRIPT" < /dev/null)"
+not_contains "$PLAIN" "systemMessage" "素のテキストには JSON キーが無い"
+contains "$PLAIN" "定期メンテナンスのダイジェスト" "見出し行がある"
+
+echo "=== scenario 6: settings.json に Setup(maintenance) が登録されている ==="
+if [ -f "$SETTINGS" ]; then
+  REG="$(jq -r '.hooks.Setup[]? | select(.matcher == "maintenance") | .hooks[].command' "$SETTINGS")"
+  contains "$REG" "scripts/maintenance-digest.sh" "Setup(maintenance) から maintenance-digest.sh が呼ばれる"
+else
+  ng "settings.json が見つからない"
+fi
+
+echo "=== scenario 7: 実態のランブック 3 本すべてから日付を読める（書式の回帰） ==="
+REAL="$(MAINTENANCE_DIGEST_PLAIN=1 bash "$SCRIPT" < /dev/null)"
+not_contains "$REAL" "読み取れません" "実態の 3 本は日付を読める"
+not_contains "$REAL" "見つかりません" "実態の 3 本は存在する"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Closes #741

## 30秒サマリー
- 変更概要: Claude Code の `Setup` hook（`claude -p --maintenance`、matcher `maintenance`）を定期作業の入口にし、fault-injection 訓練・hook 実走ドリル・公式 docs 差分確認の 3 つの期限をダイジェスト 1 つで出す `scripts/maintenance-digest.sh` を追加。hook-live-drill.md に「次回実施予定日」を新設
- リスク: 低（warning-only の Setup hook 追加。SessionStart の個別警告は残す）
- 証拠状態: 実測 3 件（構造テスト 7 シナリオ GREEN・実態の 3 ランブックで手動実行・`claude -p --maintenance --debug` で Setup hook の発火を debug ログで確認）
- 影響範囲: `scripts/maintenance-digest.sh` と `.test.sh`（新規）、`.claude/settings.json`（Setup 登録）、`docs/agents/hook-live-drill.md`・`upstream-docs-review.md`・`common.md`・`actuator-inventory.md`
- ロールバック可能性: revert のみ

レビューしてほしい点:
1. 実機確認で、個人プラグイン claude-mem 10.6.3 の Setup hook が `setup.sh: No such file or directory` を出していた（リポジトリ外、`~/.claude/plugins/cache/...`）。害は無いがプラグイン更新で消えた可能性があるので、`/plugin` の Errors タブを一度見てもらえると確実
2. `-p --maintenance` は 1 ターン分の API 費用（今回 約 $0.21、Sonnet）がかかる。手動の `bash scripts/maintenance-digest.sh`（`MAINTENANCE_DIGEST_PLAIN=1`）なら無料なので、日常はこちらでもよい

## 00 目的・影響範囲・対象外
- 目的: 「いつやるか」を人の記憶でなく 1 コマンドに寄せる（issue #741）
- 変更範囲: 上記
- 対象外（今回あえて触らない）: OS の cron / launchd からの自動起動（issue #443 で見送り済みの判断を変えない）。ダイジェストに期限以外の項目（例: 未解決の recovery-queue）を載せること
- 作業中に見つけた別件: claude-mem の Setup hook エラー（上記）
- 依存の変更: なし

## 01 画面がどう変わったか（UI証拠）
- `MAINTENANCE_DIGEST_PLAIN=1 bash scripts/maintenance-digest.sh` の出力（2026-09-05）:
  ```
  定期メンテナンスのダイジェスト（issue #741。claude -p --maintenance または bash scripts/maintenance-digest.sh）
  fault injection 訓練: 期限 2026-10-16（あと 41 日）
  hook 実走ドリル: 期限 2026-12-05（あと 91 日）
  公式 docs 差分確認: 期限 2026-10-05（あと 30 日）
  期限超過なし。次の期限は上の一覧のとおりです。
  ```

## 02 内部でどう守っているか（ロジック証拠）
- 各ランブックの `## 次回実施予定日` 直下の `YYYY-MM-DD` を既存 staleness hook と同じ正規表現で読む。期限前は残り日数、超過は ⚠ と超過日数と手順への参照、書式崩れ・不在はその旨（他の判定は続行）。全経路 exit 0
- 実機: debug ログ `Hook Setup:maintenance (Setup) success:` にダイジェスト本文、`provided additionalContext (229 chars)`

## 03 誰が操作できるか（RLS/権限証拠）
- 対象外
- 該当する約束: なし

## 04 どう確認したか（テスト・検証）
| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ⬜ 未実施 | CI `typecheck` ジョブで実行 |
| lint | ⬜ 未実施 | CI `lint` ジョブで実行 |
| unit（UI・データ層・API Route） | ⬜ 未実施 | CI `test` ジョブで実行 |
| build | ⬜ 未実施 | CI `build` ジョブで実行 |
| migration 静的テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| DB 制約 ratchet | ⬜ 未実施 | CI `test` ジョブで実行 |
| ワークフロー同期テスト | ⬜ 未実施 | CI `test` ジョブで実行 |
| hook 回帰 | ✅ 実施 (手動: パス) | `bash scripts/maintenance-digest.test.sh` ALL PASSED（期限前 / 超過 / 書式崩れ / 不在 / 素テキスト / settings 登録 / 実態 3 本）。`bash scripts/check-session-start-matchers.test.sh`、`bash scripts/check-hook-doc-pointers.test.sh` ALL PASSED |
| 認証ファイル漏洩チェック | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| 依存監査（既知脆弱性） | ⬜ 未実施 | CI `dependency-audit` ジョブで実行 |
| ロックファイルの出所 | ⬜ 未実施 | CI `hooks-test` ジョブで実行 |
| docs 整合性 | ✅ 実施 (手動: パス) | `bash scripts/check-docs-integrity.test.sh` ALL PASSED。`bash scripts/check-claude-md-size.sh` 上限内 |
| hook 実機発火 | ✅ 実施 (手動: パス) | `claude -p --maintenance --debug --output-format json "OK とだけ返してください"` を実行し、`~/.claude/debug/<session>.txt` に `Hook Setup:maintenance (Setup) success` とダイジェスト本文を確認 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | derive は `docs/agents/actuator-inventory.md` のファイル名（`inventory`）で高リスク判定したが docs の 1 行追加のみ（既知の語衝突） |
| 生成型の鮮度 | ➖ 今回不要 | 同上。DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上。auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れていない |
| 同時実行 | ➖ 今回不要 | 同一行を複数ユーザーが更新する変更ではない |

- verify-claims: 未実施

## 05 何かあったらどうするか（観測・ロールバック）
- リリース後に見るログ/メトリクス: 期限超過時に `claude -p --maintenance` で ⚠ が出ること（`~/.claude/debug/` で hook の success を確認できる）
- 異常の判断基準: ダイジェストに「読み取れません」「見つかりません」が出たらランブックの書式・パスの問題
- ロールバック手順: revert

## 後任AIへの注意
- この実装で壊してはいけない前提: 3 ランブックの `## 次回実施予定日` 直下 `YYYY-MM-DD` 書式（テスト 7 が実態で検査）。全経路 exit 0
- 似ているが別物の用語: 「SessionStart の個別 staleness 警告」（たまたま始めたセッションで鳴る）と「Setup(maintenance) のダイジェスト」（明示的に呼ぶ）。両方残す
- 勝手にリファクタしない場所: `judge` の正規表現。3 本の staleness hook と同じ書式を共有している

🤖 Generated with [Claude Code](https://claude.com/claude-code)
