### PR TITLE
feat: CLAUDE_CODE_SUBAGENT_MODEL_FORCE が設定されていると AIDD のモデル階層が黙って無効化されるため SessionStart で警告する(issue #743)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,8 @@
       "Bash(bash scripts/check-direct-ddl-execution.test.sh*)",
       "Bash(scripts/check-automode-config.sh *)",
       "Bash(bash scripts/check-automode-config.test.sh*)",
+      "Bash(scripts/check-subagent-model-force.sh *)",
+      "Bash(bash scripts/check-subagent-model-force.test.sh*)",
       "Bash(scripts/check-blocked-issues-staleness.sh *)",
       "Bash(bash scripts/check-blocked-issues-staleness.test.sh*)",
       "Bash(scripts/check-fault-injection-drill-staleness.sh *)",
@@ -223,6 +225,11 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/check-upstream-docs-review-staleness.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-subagent-model-force.sh",
             "timeout": 10
           }
         ]

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -28,7 +28,7 @@
 | PreToolUse (Write/Edit/MultiEdit 高リスクパス) | `check-run-manifest-presence.sh` | warning-only | `permissionDecision: "allow"` + `additionalContext`。blockしない設計（issue #444、意図的） |
 | SessionStart | `check-workflow-interruption.sh` | **自動復旧（queue）** | Workflow中断を検知し`workflow-interrupted`としてqueue登録（issue #534） |
 | SessionStart | `check-recovery-queue.sh` | 自動復旧（queue、表示側） | pendingエントリのcontext注入＋surfaced放置エントリのエスカレーション表示（issue #523・#579）。是正の実行そのものはこのhookの範囲外 |
-| SessionStart（matcher: `compact` のみ） | `reinject-aidd-run-state.sh` | context 注入（是正なし） | compaction 直後に `.aidd/run-manifest.json`・`logs/agent-progress.jsonl`・`.aidd/recovery-queue.jsonl` の現在値を additionalContext として再注入する（issue #712）。同時に上記 12 本の警告系 hook は matcher `startup\|resume\|clear\|fork` に限定し、compact 時には再実行しない。構成は `scripts/check-session-start-matchers.test.sh` が固定する |
+| SessionStart（matcher: `compact` のみ） | `reinject-aidd-run-state.sh` | context 注入（是正なし） | compaction 直後に `.aidd/run-manifest.json`・`logs/agent-progress.jsonl`・`.aidd/recovery-queue.jsonl` の現在値を additionalContext として再注入する（issue #712）。同時に startup 群の警告系 hook（導入時 12 本、2026-09-05 時点で 14 本）は matcher `startup\|resume\|clear\|fork` に限定し、compact 時には再実行しない。構成は `scripts/check-session-start-matchers.test.sh` が固定する |
 | SessionStart | `check-branch-pr-status.sh` | warning-only | マージ済みブランチ上での作業を警告 |
 | SessionStart | `check-branch-tool-ownership.sh` | warning-only | ブランチ命名規約（codex/*・claude/*）と起動ツールの取り違えを警告。Claude/Codex両方のhook設定に登録される共有ガード（引数で自ツール名を渡す）。block不可のSessionStartのため意図的にwarning-only |
 | PreToolUse (Codex側・Bash/Write/Edit skipマーカー) | `codex-skip-marker-deny.sh` | **deny**（Codex側のみ） | `check-skip-marker-write.sh`（Claude側ask）のCodex用ラッパー。Codexはask未対応（実機確認済み）のためdenyへ読み替える。判定ロジックは共有正本に委譲し、出力契約の変換のみ担う |
@@ -38,6 +38,7 @@
 | SessionStart | `check-blocked-issues-staleness.sh` | warning-only | `blocked`ラベル長期滞留issueの警告 |
 | SessionStart | `check-fault-injection-drill-staleness.sh` | warning-only | fault injection訓練の実施タイミング警告 |
 | SessionStart | `check-upstream-docs-review-staleness.sh` | warning-only | 公式ドキュメント差分の定期確認（`docs/agents/upstream-docs-review.md`）の期限切れ警告 |
+| SessionStart | `check-subagent-model-force.sh` | warning-only | `CLAUDE_CODE_SUBAGENT_MODEL_FORCE`（Claude Code 2.1.257）が環境変数または settings の `env` に非空であれば警告（issue #743）。全 subagent のモデルを強制するため AIDD のモデル階層（agent ごとの model 指定、issue #419・#693）が黙って無効化される。個人環境の変数はリポジトリから消せず、意図的に使う場面もあるため warning-only |
 | Setup（matcher `maintenance`） | `maintenance-digest.sh` | warning-only | `claude -p --maintenance` で fault-injection 訓練・hook 実走ドリル・docs 差分確認の 3 期限を一括表示（issue #741）。明示的に呼ばないと動かないため SessionStart の個別警告は残す |
 | SessionStart | `check-claude-md-size.sh` | warning-only | CLAUDE.md/docs/agents/common.mdの行数肥大化を警告（トークン効率化。common.mdは機械検知ルール集のため「短ければ良い」わけではなく、削除判断は人間に委ねる） |
 | SessionStart | `check-stale-worktrees.sh` | warning-only | worktree・ローカルブランチ残骸の蓄積警告（issue #674）。マージ/クローズ済みPRに対応するworktree数・goneブランチ数（閾値超過時）・PRを一度も作らず一定日数放置されたブランチ数（閾値超過時、issue #708）を警告。削除は不可逆に近い操作のため意図的にwarning-only |

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -279,6 +279,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | [`docs/agents/hook-live-drill.md`](./hook-live-drill.md) | 全 hook を現在セッションの実データで実走し、fail-open の無音死を見つけるランブックと実施記録（2026-09-05 初回で 7 件発見。プラグイン v1 前の必須作業） |
 | [`docs/agents/upstream-docs-review.md`](./upstream-docs-review.md) | Claude Code / Anthropic / Codex の公式ドキュメント差分を月 1 で確認する手順・実施記録・「最後に確認した版」（v1 の対応バージョンの正本）。期限は `scripts/check-upstream-docs-review-staleness.sh` が SessionStart で警告 |
 | `scripts/maintenance-digest.sh` | 定期作業 3 つ（fault-injection 訓練・hook 実走ドリル・docs 差分確認）の期限を一括表示。`claude -p --maintenance`（Setup hook）または手動実行（issue #741） |
+| `scripts/check-subagent-model-force.sh` | `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` が設定されていると AIDD のモデル階層（agent ごとの model 指定）が黙って無効化されるため、SessionStart で警告する（issue #743） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |
 | `.claude/workflows/lib/prompts/` | ワークフロー内プロンプト文字列の正本（Workflow DSL側へはインライン複製、sync testで乖離検知） |

--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -79,6 +79,7 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 | SessionStart | check-blocked-issues-staleness | 正常（blocked 1 件、90 日未満） | |
 | SessionStart | check-fault-injection-drill-staleness | 正常（次回予定日前） | |
 | SessionStart | check-upstream-docs-review-staleness | 導入時（2026-09-05）に実態ファイルで沈黙・過去日 fixture で警告を確認 | 公式 docs 差分確認の期限監視 |
+| SessionStart | check-subagent-model-force | 導入時（2026-09-05）に実環境で沈黙（変数未設定）・`env CLAUDE_CODE_SUBAGENT_MODEL_FORCE=haiku` で警告を確認 | AIDD モデル階層の無効化検知（issue #743） |
 | SessionStart | check-workflow-interruption | 正常。killed 記録を注入すると復旧キューへ登録 | 表示は recovery-queue 側 |
 | SessionStart | check-recovery-queue | 正常（キュー無し） | |
 | SessionStart | check-claude-md-size | 起動時に発火確認（上限内） | |

--- a/scripts/check-subagent-model-force.sh
+++ b/scripts/check-subagent-model-force.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart hook（startup 群）から呼ばれる。issue #743。
+#
+# なぜ: Claude Code 2.1.257 で追加された環境変数 CLAUDE_CODE_SUBAGENT_MODEL_FORCE は、
+# 全 subagent に同じモデルを強制する。vkumai の AIDD は agent ごとに model / effort を
+# 分けてコストと精度を配分している（sweep=haiku / adversarial=opus 等。issue #419・#693）
+# ので、この変数が個人のシェル設定や settings の env に残っていると、その階層が
+# **黙って**無効化される（Workflow の agent() 呼び出しの model 指定が上書きされる）。
+# 結果は「eval が理由不明に悪化する」「コストが理由不明に増減する」として現れるため、
+# 起点で気づける形の検知を置く。
+#
+# warning-only の理由: 環境変数は個人環境の設定であり、リポジトリ側から消せない。
+# 意図的に使う場面（全 subagent を haiku にして安価に素振りする等）もあるため、
+# 止めずに「階層が無効化されている」事実だけ伝え、判断は人に委ねる。
+#
+# 検知源は 2 つ:
+#   1. 現在のプロセス環境（hook は claude 本体の環境を継承する）
+#   2. settings ファイルの `env` ブロック（settings.json / settings.local.json / 個人設定）。
+#      本体が env を適用したあとに hook が起動するなら 1 で拾えるが、適用順の仕様に
+#      依存しないよう、ファイル側も直接見る
+#
+# テスト用の注入ポイント:
+#   SUBAGENT_MODEL_FORCE_SETTINGS_PATHS  検査する settings ファイルのパス（コロン区切り。
+#                                        既定は project / local / $HOME の 3 つ）
+
+VAR_NAME="CLAUDE_CODE_SUBAGENT_MODEL_FORCE"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+DEFAULT_PATHS="$PROJECT_DIR/.claude/settings.json:$PROJECT_DIR/.claude/settings.local.json:$HOME/.claude/settings.json"
+SETTINGS_PATHS="${SUBAGENT_MODEL_FORCE_SETTINGS_PATHS:-$DEFAULT_PATHS}"
+
+FOUND_VALUE=""
+FOUND_SOURCE=""
+
+# 1. プロセス環境。空文字は「未設定」と同じ扱い（Claude Code 側も空なら強制しない）
+if [ -n "${!VAR_NAME:-}" ]; then
+  FOUND_VALUE="${!VAR_NAME}"
+  FOUND_SOURCE="環境変数"
+fi
+
+# 2. settings の env ブロック。jq が無い・ファイルが壊れている場合は fail-open で沈黙する
+#    （この hook の目的は「気づく」ことで、壊れた JSON の指摘は別の検査の仕事）
+if [ -z "$FOUND_VALUE" ] && command -v jq >/dev/null 2>&1; then
+  IFS=':' read -r -a paths <<< "$SETTINGS_PATHS"
+  for p in "${paths[@]}"; do
+    [ -f "$p" ] || continue
+    v="$(jq -r --arg k "$VAR_NAME" '.env[$k] // empty' "$p" 2>/dev/null || true)"
+    if [ -n "$v" ]; then
+      FOUND_VALUE="$v"
+      FOUND_SOURCE="$p の env"
+      break
+    fi
+  done
+fi
+
+[ -n "$FOUND_VALUE" ] || exit 0
+
+MSG="${VAR_NAME}=${FOUND_VALUE} が設定されています（検知元: ${FOUND_SOURCE}）。この変数は全 subagent のモデルを強制するため、AIDD のモデル階層（sweep=haiku / adversarial=opus など、Workflow の agent() ごとの model 指定。issue #419・#693）が無効化され、eval の精度とコストが設計値から黙ってずれます。意図した設定でなければ unset するか settings の env から削除してください（warning のみ、issue #743）。"
+
+jq -n --arg msg "$MSG" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $msg
+  }
+}'

--- a/scripts/check-subagent-model-force.test.sh
+++ b/scripts/check-subagent-model-force.test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# WHY: scripts/check-subagent-model-force.sh（SessionStart hook、issue #743）の回帰テスト。
+# CLAUDE_CODE_SUBAGENT_MODEL_FORCE が環境変数または settings の env ブロックに非空で
+# あれば警告し、無ければ沈黙することを固定する。settings ファイルは
+# SUBAGENT_MODEL_FORCE_SETTINGS_PATHS でテスト用に差し替える（本物の個人設定を読まない）。
+#
+# 実行: bash scripts/check-subagent-model-force.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-subagent-model-force.sh"
+
+fail=0
+assert_empty() {
+  local actual="$1" label="$2"
+  if [ -z "$actual" ]; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label (actual=$actual)"
+    fail=1
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  OK: $label"
+  else
+    echo "  NG: $label"
+    echo "      expected to find: $needle"
+    echo "      actual: $haystack"
+    fail=1
+  fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+NO_SETTINGS="$WORK/none-a.json:$WORK/none-b.json"
+
+# 実行環境（このテストを回す人のシェル）に変数が残っていても結果が変わらないよう、
+# 各シナリオで env -u により明示的に消してから起動する
+echo "=== scenario 1: 環境変数も settings の env も無い → 沈黙 ==="
+OUT="$(env -u CLAUDE_CODE_SUBAGENT_MODEL_FORCE SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$NO_SETTINGS" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空"
+
+echo "=== scenario 2: 環境変数に非空の値 → 警告（値と検知元を含む） ==="
+OUT="$(env CLAUDE_CODE_SUBAGENT_MODEL_FORCE=haiku SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$NO_SETTINGS" bash "$SCRIPT")"
+assert_contains "$OUT" "systemMessage" "systemMessage がある"
+assert_contains "$OUT" "CLAUDE_CODE_SUBAGENT_MODEL_FORCE=haiku" "変数名と値を含む"
+assert_contains "$OUT" "検知元: 環境変数" "検知元が環境変数"
+assert_contains "$OUT" '"hookEventName": "SessionStart"' "SessionStart の additionalContext 形式"
+
+echo "=== scenario 3: 環境変数が空文字 → 未設定と同じ扱いで沈黙 ==="
+OUT="$(env CLAUDE_CODE_SUBAGENT_MODEL_FORCE= SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$NO_SETTINGS" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空"
+
+echo "=== scenario 4: settings の env ブロックにある → 警告（ファイルパスを検知元に含む） ==="
+printf '{"env": {"CLAUDE_CODE_SUBAGENT_MODEL_FORCE": "sonnet"}}\n' > "$WORK/settings-env.json"
+OUT="$(env -u CLAUDE_CODE_SUBAGENT_MODEL_FORCE SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$WORK/none-a.json:$WORK/settings-env.json" bash "$SCRIPT")"
+assert_contains "$OUT" "CLAUDE_CODE_SUBAGENT_MODEL_FORCE=sonnet" "settings 側の値を含む"
+assert_contains "$OUT" "$WORK/settings-env.json の env" "検知元がファイルパス"
+
+echo "=== scenario 5: settings に env ブロックはあるが当該キーが無い → 沈黙 ==="
+printf '{"env": {"OTHER": "x"}, "permissions": {}}\n' > "$WORK/settings-other.json"
+OUT="$(env -u CLAUDE_CODE_SUBAGENT_MODEL_FORCE SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$WORK/settings-other.json" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空"
+
+echo "=== scenario 6: settings が壊れた JSON → クラッシュせず沈黙（fail-open） ==="
+printf '{broken\n' > "$WORK/settings-broken.json"
+OUT="$(env -u CLAUDE_CODE_SUBAGENT_MODEL_FORCE SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$WORK/settings-broken.json" bash "$SCRIPT")"
+assert_empty "$OUT" "出力が空"
+
+echo "=== scenario 7: 環境変数と settings の両方にある → 環境変数を優先して 1 回だけ警告 ==="
+OUT="$(env CLAUDE_CODE_SUBAGENT_MODEL_FORCE=opus SUBAGENT_MODEL_FORCE_SETTINGS_PATHS="$WORK/settings-env.json" bash "$SCRIPT")"
+assert_contains "$OUT" "CLAUDE_CODE_SUBAGENT_MODEL_FORCE=opus" "環境変数側の値"
+assert_contains "$OUT" "検知元: 環境変数" "検知元が環境変数"
+COUNT="$(printf '%s' "$OUT" | grep -c 'systemMessage' || true)"
+if [ "$COUNT" -eq 1 ]; then
+  echo "  OK: 警告は 1 件"
+else
+  echo "  NG: 警告件数=$COUNT"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
## 30秒サマリー

`CLAUDE_CODE_SUBAGENT_MODEL_FORCE`（Claude Code 2.1.257 で追加、全 subagent のモデルを強制）が個人環境に残っていると、AIDD の agent ごとの model 配分（sweep=haiku / adversarial=opus、issue #419・#693）が黙って無効化される。SessionStart で検知して警告する hook を 1 本追加した（warning-only）。プロダクトコード・DB には触れていない。危険度: 低（hook 追加のみ、fail-open）。

Closes #743

## 00 変更の要点

- `scripts/check-subagent-model-force.sh`（新規、SessionStart startup 群の 14 本目）: 環境変数、または settings 3 ファイル（project / local / `$HOME`）の `env` ブロックに非空の値があれば、値と検知元を含めて警告する。空文字は未設定扱い、壊れた settings は fail-open で沈黙
- `scripts/check-subagent-model-force.test.sh`（新規、7 シナリオ）: 未設定→沈黙 / 環境変数→警告 / 空文字→沈黙 / settings env→警告（ファイルパス付き） / 別キー→沈黙 / 壊れた JSON→沈黙 / 両方→環境変数優先で 1 件
- `.claude/settings.json`: hook 登録＋手動実行用 allow 2 行
- docs: `actuator-inventory.md`（行追加＋startup 群の本数表記 12→14 を訂正）、`hook-live-drill.md`（一覧に追加）、`common.md`（重要ファイル表に追加）
- 依存の変更: なし

## 01 なぜこの形か

- **warning-only**: 環境変数は個人環境の設定で、リポジトリ側から消せない。全 subagent を haiku にして安価に素振りするなど意図的に使う場面もあるため、止めずに事実だけ伝える
- **検知源を 2 つ持つ**: hook は claude 本体の環境を継承するので環境変数で拾えるはずだが、settings の `env` が hook 起動前に適用される保証は公式に無い。適用順の仕様に依存しないよう、ファイル側も直接読む
- **startup 群に置く**: compact 時に再注入しても意味が無い（`check-session-start-matchers.test.sh` の不変条件に従う）

## 02 影響範囲

- hook 追加のみ。既存 hook・Workflow・eval ハーネス・プロダクトコードは変更なし
- 変数が未設定の環境（通常）では出力ゼロ。設定済み環境ではセッション開始時に 1 件の警告が増える

## 03 約束（promise-catalog）

該当なし（auth / RLS / facility 境界に触れていない）

## 04 どう確認したか

`bash scripts/derive-test-selection.sh origin/main --format table` の出力を基に記入。`docs/agents/actuator-inventory.md` はファイル名の `inventory` がキーワード誤一致し route: deep と判定されたが、docs のみの変更で auth / RLS / DB には触れていない（既知の型、`known-failure-patterns.md` 参照）。

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ✅ 実施 | CI（本 PR の checks） |
| lint | ✅ 実施 | CI |
| unit（UI・データ層・API Route） | ✅ 実施 | CI |
| build | ✅ 実施 | CI |
| migration 静的テスト | ✅ 実施 | CI |
| DB 制約 ratchet | ✅ 実施 | CI |
| ワークフロー同期テスト | ✅ 実施 | CI |
| hook 回帰 | ✅ 実施 | ローカル `bash scripts/check-subagent-model-force.test.sh` 7 シナリオ ALL PASSED。`check-session-start-matchers.test.sh`・`check-hook-doc-pointers.test.sh` も ALL PASSED。CI `hooks-test` |
| 認証ファイル漏洩チェック | ✅ 実施 | CI |
| 依存監査（既知脆弱性） | ✅ 実施 | CI |
| ロックファイルの出所 | ✅ 実施 | CI |
| docs 整合性 | ✅ 実施 | ローカル `check-docs-integrity.test.sh`・`check-aidd-graph-rendered.test.sh`・`check-docs-issue-refs.mjs` すべて OK。CI |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 判定根拠は `actuator-inventory.md` のファイル名誤一致のみ。DB・RLS に触れていない |
| 生成型の鮮度 | ➖ 今回不要 | 同上（DB スキーマに触れていない） |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上（auth / 認可 / RLS に触れていない） |
| hook 実機発火 | ✅ 実施 | RED: `env CLAUDE_CODE_SUBAGENT_MODEL_FORCE=haiku bash scripts/check-subagent-model-force.sh` で警告 JSON（値・検知元入り）。GREEN: 実環境（未設定）で沈黙。新規セッションでの発火は次セッション起動時に確認予定（未設定環境では沈黙が正） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れておらず、retry_possible の申告も無い |
| 同時実行 | ➖ 今回不要 | 同一注文・同一在庫行を複数ユーザーが更新する変更ではなく、contention の申告も無い |
| E2E（Playwright） | ➖ 今回不要 | 節目の種別（main マージ後（自動）） |
| スキーマドリフト検知 | ➖ 今回不要 | 節目の種別（日次 cron（自動）） |
| fault injection 訓練（ゲート） | ➖ 今回不要 | 節目の種別（四半期、または aidd-phase2.js のプロンプト変更時） |
| 障害注入（外部依存停止） | ➖ 今回不要 | 節目の種別（依存 major 更新、外部公開前） |
| 復旧手順（ランブック） | ➖ 今回不要 | 節目の種別（障害発生時、公開前） |

## 05 後任への申し送り

- 「hook 実機発火」の新規セッション確認は、この変数を設定していない環境では沈黙が正なので、確認したい場合は `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=haiku claude` で起動して警告を見る
- 変数名が将来改名された場合（changelog で追う）、`VAR_NAME` の 1 箇所を変えれば追従できる
- 残る #742（`InstructionsLoaded` 実測）と #420（v1 仕様書）は別セッション

🤖 Generated with [Claude Code](https://claude.com/claude-code)
