### PR TITLE
feat: InstructionsLoaded hook で実際に読み込まれた CLAUDE.md / rules を記録し、常時ロード量の実測と rules 別ロード回数を月次サマリに出す(issue #742)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,6 +89,8 @@
       "Bash(bash scripts/check-automode-config.test.sh*)",
       "Bash(scripts/check-subagent-model-force.sh *)",
       "Bash(bash scripts/check-subagent-model-force.test.sh*)",
+      "Bash(bash scripts/summarize-instructions-loaded.sh*)",
+      "Bash(bash scripts/log-instructions-loaded.test.sh*)",
       "Bash(scripts/check-blocked-issues-staleness.sh *)",
       "Bash(bash scripts/check-blocked-issues-staleness.test.sh*)",
       "Bash(scripts/check-fault-injection-drill-staleness.sh *)",
@@ -288,6 +290,13 @@
       {
         "hooks": [
           { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/log-subagent-hook-skeleton.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/scripts/log-instructions-loaded.sh", "timeout": 5 }
         ]
       }
     ],

--- a/docs/agents/actuator-inventory.md
+++ b/docs/agents/actuator-inventory.md
@@ -56,8 +56,9 @@
 | （参考）`npm test`（CI含む） | `supabase/migrations/__tests__/constraint_coverage_ratchet.test.ts` | **block**（テスト失敗、ただしCI上の強制力はプラン依存） | issue #675。カーディナリティ未宣言の後付けFK列・統合テスト対応の無い制約migrationの**新規発生**を止める（既知分はbaselineに固定するratchet方式）。hookではなくテストなので、ローカル`npm test`とCIの両方で機械的に起動する。ただし本リポジトリはFreeプランでCI失敗がマージを阻止しないため、実効的な強制力はローカル実行時に限る |
 | （参考）per-edit | security-guidanceプラグイン（`possible_real_facility_name`等） | warning-only | issue #440。Claude Code公式プラグイン経由、上記`.claude/settings.json`のhooksとは別経路 |
 
-（`SubagentStart`/`SubagentStop`の`log-subagent-hook-skeleton.sh`は検知ではなく記録専用のため
-この表の対象外）
+（`SubagentStart`/`SubagentStop`の`log-subagent-hook-skeleton.sh`、および`InstructionsLoaded`の
+`log-instructions-loaded.sh`（issue #742。公式仕様で出力が全て無視されるため是正手段を持ちえない）は
+検知ではなく記録専用のためこの表の対象外）
 
 ## 集計と評価
 

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -279,6 +279,7 @@ AIDDフレームワークの相当部分がツール（Workflow DSL / `claude -p
 | [`docs/agents/hook-live-drill.md`](./hook-live-drill.md) | 全 hook を現在セッションの実データで実走し、fail-open の無音死を見つけるランブックと実施記録（2026-09-05 初回で 7 件発見。プラグイン v1 前の必須作業） |
 | [`docs/agents/upstream-docs-review.md`](./upstream-docs-review.md) | Claude Code / Anthropic / Codex の公式ドキュメント差分を月 1 で確認する手順・実施記録・「最後に確認した版」（v1 の対応バージョンの正本）。期限は `scripts/check-upstream-docs-review-staleness.sh` が SessionStart で警告 |
 | `scripts/maintenance-digest.sh` | 定期作業 3 つ（fault-injection 訓練・hook 実走ドリル・docs 差分確認）の期限を一括表示。`claude -p --maintenance`（Setup hook）または手動実行（issue #741） |
+| `scripts/log-instructions-loaded.sh` / `scripts/summarize-instructions-loaded.sh` | InstructionsLoaded hook で実際に context へ読み込まれた CLAUDE.md / rules をファイル単位で `logs/instructions-loaded.jsonl` に記録し、直近セッションの常時ロード量（文字数）と rules 別ロード回数を集計する（issue #742。`check-claude-md-size.sh` の自前計算との突き合わせ用。月次サマリにも載る） |
 | `scripts/check-subagent-model-force.sh` | `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` が設定されていると AIDD のモデル階層（agent ごとの model 指定）が黙って無効化されるため、SessionStart で警告する（issue #743） |
 | `scripts/aidd-fault-injection-setup.sh` / `scripts/aidd-fault-injection-teardown.sh` | fault injection訓練用の`.aidd/run-manifest.json`差し替え・復元（issue #395） |
 | `scripts/eval-workflow-prompts.sh` / `scripts/eval-fixtures/` | AIDDワークフロープロンプトのeval基盤（issue #391） |

--- a/docs/agents/hook-live-drill.md
+++ b/docs/agents/hook-live-drill.md
@@ -93,6 +93,7 @@ PreToolUse の deny / ask は、止めるべき入力の JSON（`tool_name` / `t
 | PreToolUse | check-direct-ddl-execution | RED: 素の `db push` / MCP execute_sql は deny、`--local` は通過 | |
 | PreToolUse | check-readonly-bash | 実機 deny 確認済み（#713） | |
 | SubagentStart/Stop | log-subagent-hook-skeleton | 記録あり。**app 内部の subagent（agentType 空）も記録される** | 集計側は wf_ パスで絞るため影響なし |
+| InstructionsLoaded | log-instructions-loaded | 導入時（2026-09-05、2.1.258）に `claude -p` で実発火を確認。3 件（個人 CLAUDE.md=session_start / CLAUDE.md=session_start / common.md=**include**）。project 配下 22,975 文字は `check-claude-md-size.sh` の自前計算と完全一致。**`memory_type` の実値は docs の `instructions` でなく `User` / `Project`**（docs 差分） | 記録専用（公式仕様で出力は全て無視される）。paths 付き rules は起動時に来ない（設計どおり） |
 | Stop | check-domain-decisions-suggest | 空 systemMessage | 害は未確認（下記） |
 | Stop | ai-check-suggest | 空 systemMessage | 同上 |
 | Stop | verify-claims | 観測ログが当日更新 → 生存 | 実走は課金のため省略 |

--- a/docs/agents/upstream-docs-review.md
+++ b/docs/agents/upstream-docs-review.md
@@ -56,7 +56,8 @@ SessionStart hook（`scripts/check-upstream-docs-review-staleness.sh`）が監�
 
 **取り込む価値あり（issue 化）**
 - `Setup` hook（`claude -p --maintenance`）を定期作業の入口にする → issue #741
-- `InstructionsLoaded` hook で常時ロード量を実測に置き換える → issue #742
+- `InstructionsLoaded` hook で常時ロード量を実測に置き換える → issue #742（同日実装。実測で docs との差を 1 件確認:
+  `memory_type` の実値は docs の `instructions` でなく `User` / `Project`（2.1.258）。次回の差分確認で docs 側が追従したか見る）
 - `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` が AIDD のモデル階層を無効化するため検知する → issue #743
 - `/skill-doctor`（2.1.261）で未使用スキルと context コストを 1 回測る（手動）
 - `subagentPromptCacheTtl` / frontmatter `experimental.cacheTtl`（1h）は `/cost` の cache miss 原因を見てから判断

--- a/scripts/check-claude-md-size.sh
+++ b/scripts/check-claude-md-size.sh
@@ -23,6 +23,11 @@ set -euo pipefail
 #      MEMORY.md（auto memory、先頭200行/25KB）と SessionStart hook の出力は、hook自身から
 #      安全に測れない（前者は $HOME 配下の個人ファイル、後者は自己再帰）ため対象外。
 #      それらを含めた実測値は issue #711 のコメントを参照。
+#      この自前計算が「実際に読まれたもの」と一致しているかは、InstructionsLoaded hook の記録
+#      （scripts/log-instructions-loaded.sh → logs/instructions-loaded.jsonl、issue #742）を
+#      scripts/summarize-instructions-loaded.sh で集計して突き合わせる。差があれば自前計算側の穴。
+#      判定自体をそちらへ移さないのは、InstructionsLoaded が SessionStart より後に来る上に
+#      出力が全て無視される（記録専用）ため、起動時の警告には使えないから。
 #
 # 閾値は環境変数で上書き可能:
 #   CLAUDE_MD_LINE_LIMIT（既定200）/ COMMON_MD_LINE_LIMIT（既定300）

--- a/scripts/gate-effectiveness-monthly-check.sh
+++ b/scripts/gate-effectiveness-monthly-check.sh
@@ -53,6 +53,9 @@ fi
 
 SUMMARY="$(bash scripts/summarize-loop-observability.sh --log-file "$LOG_FILE" 2>/dev/null || true)"
 PASSFAIL_SUMMARY="$(bash "$SCRIPT_DIR/summarize-gate-passfail.sh" 2>/dev/null || true)"
+# issue #742: InstructionsLoaded hook の記録から「どの rules がどの頻度で読まれたか」を同じ月次で出す
+# （読まれない paths 付き rules は削除候補）。記録が無ければ「記録なし」の 1 行になる。fail-open
+INSTRUCTIONS_SUMMARY="$(bash "$SCRIPT_DIR/summarize-instructions-loaded.sh" --days "$INTERVAL_DAYS" 2>/dev/null || true)"
 touch "$STATE_FILE"
 
 if [ -z "$SUMMARY" ] && [ -z "$PASSFAIL_SUMMARY" ]; then
@@ -66,6 +69,8 @@ MSG="品質ゲート月次サマリ（issue #412）:
 ${PASSFAIL_SUMMARY:-（取得できませんでした。npx/tsxが利用できない可能性があります）}
 
 ## feature別・コスト集計（loop-observability.jsonlベース＝自己申告。記録漏れによる欠落があり得るため、件数ゼロを「発火ゼロ」と読まないこと）
-${SUMMARY}"
+${SUMMARY}
+
+${INSTRUCTIONS_SUMMARY}"
 
 jq -n --arg msg "$MSG" '{systemMessage: $msg}'

--- a/scripts/lib/summarize-instructions-loaded.jq
+++ b/scripts/lib/summarize-instructions-loaded.jq
@@ -1,0 +1,48 @@
+# summarize-instructions-loaded.sh から `jq -r -s -f` で呼ばれる集計フィルタ（issue #742）。
+# 入力: instructions-loaded.jsonl 全行の配列（-s）。引数: $since（期間下限 ISO8601）、$days。
+# シェル側から分離した理由: `|` を含む jq フィルタは Bash ガードに誤検知されるため。
+
+def fmt_file_rows:
+  map("  - \(.filePath): \(.fileChars // "?")文字（\(.fileSizeBytes // "?")B）")
+  | join("\n");
+
+(map(select(.timestamp >= $since))) as $recent
+| ($recent | map(.sessionId) | unique | length) as $sessions
+| (
+    # 直近セッション = timestamp が最大の行の sessionId
+    if ($recent | length) == 0 then null
+    else ($recent | max_by(.timestamp) | .sessionId) end
+  ) as $latest
+# 起動時ロード = session_start（CLAUDE.md・paths 無し rules）+ include（@import 先）。
+# 2026-09-05 の実測で @import 先は load_reason "include" で来ると分かった（docs の記述どおり）。
+# path_glob_match（paths 付き rules の遅延ロード）と compact（再ロード）は起動時量に含めない
+| ($recent | map(select(.sessionId == $latest and (.loadReason == "session_start" or .loadReason == "include")))) as $start_rows
+| ($start_rows | map(.fileChars // 0) | add // 0) as $start_chars
+# project 配下（相対パス）だけの合計。check-claude-md-size.sh は個人の ~/.claude/CLAUDE.md を
+# 測れない（hook から $HOME 配下を安全に読めない）ため、突き合わせはこちらの値で行う
+| ($start_rows | map(select(.filePath | startswith("/") | not) | .fileChars // 0) | add // 0) as $start_chars_project
+| (
+    $recent
+    | group_by(.filePath)
+    | map({
+        filePath: .[0].filePath,
+        total: length,
+        byReason: (group_by(.loadReason) | map({key: .[0].loadReason, value: length}) | from_entries)
+      })
+    | sort_by(-.total)
+  ) as $per_file
+| [
+    "## InstructionsLoaded 実測（直近\($days)日、\($sessions)セッション、issue #742）",
+    "",
+    "### 直近セッション（\($latest // "なし")）の起動時ロード量（session_start + include）: 合計 \($start_chars) 文字（うち project 配下 \($start_chars_project) 文字）",
+    (if ($start_rows | length) == 0 then "  （起動時ロードの記録なし）" else ($start_rows | fmt_file_rows) end),
+    "",
+    "project 配下の値は check-claude-md-size.sh の自前計算（CLAUDE.md + @import + paths 無し rules）と同じ単位・同じ範囲。差があれば自前計算側の穴として扱う（個人の ~/.claude/CLAUDE.md は自前計算の対象外）。",
+    "",
+    "### ファイル別ロード回数（loadReason 別）",
+    (if ($per_file | length) == 0 then "  （記録なし）"
+     else ($per_file | map("  - \(.filePath): \(.total) 回 \(.byReason | tojson)") | join("\n")) end),
+    "",
+    "path_glob_match / include で一度も読まれない paths 付き rules は削除候補（読まれない規則は守られない）。"
+  ]
+| join("\n")

--- a/scripts/log-instructions-loaded.sh
+++ b/scripts/log-instructions-loaded.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# InstructionsLoaded hook（settings.json に登録）から呼ばれる。issue #742。
+#
+# なぜ: 常時ロードされる指示ファイルの量は、これまで check-claude-md-size.sh が
+# 「CLAUDE.md + @import 連鎖 + paths 無しの rules」を**自前で**再現して計算していた。
+# 公式の InstructionsLoaded イベントは、実際に context へ読み込まれたファイルごとに
+# 1 回発火し、file_path / load_reason（session_start / nested_traversal /
+# path_glob_match / include / compact）/ memory_type を渡す。これを記録すれば
+# 「実際に何が読まれたか」を推測ではなく事実で持てる。自前計算との差は、
+# 自前計算側の穴（読み方の仕様変更への追従漏れ）として検出できる。
+#
+# 記録専用の理由: 公式仕様では、このイベントの hook 出力（JSON・exit code）は
+# すべて無視され、ロードを止めることも内容を変えることもできない。
+# したがって文字数上限の判定は引き続き check-claude-md-size.sh（SessionStart）が担い、
+# ここは logs/instructions-loaded.jsonl への追記だけを行う。
+#
+# 記録する項目:
+#   - fileSizeBytes: ペイロードに file_size_bytes があればそれ、無ければ wc -c
+#     （docs の入力例にこのフィールドは無いが、issue #742 の想定として互換で受ける）
+#   - fileChars: 文字数（check-claude-md-size.sh の閾値は文字数なので突き合わせ用。
+#     バイト数は日本語 1 文字 3 バイトでトークンの指標にならない、issue #716）
+#   - memoryType: docs は "instructions" / "mcp_context" と書くが、2026-09-05 の実測
+#     （Claude Code 2.1.258）では "User"（~/.claude/CLAUDE.md）/ "Project" が来た。
+#     値の解釈はせず来たまま記録する（docs と実装の差自体が upstream-docs-review の材料）
+#   - filePath は CLAUDE_PROJECT_DIR 配下なら相対にする（worktree が違っても同じファイルを
+#     同じキーで集計するため。配下でなければ絶対パスのまま）
+#
+# fail-open: jq 不在・ペイロード不正・ファイル不在でも exit 0（記録が 1 件欠けるだけ。
+# hook の失敗でセッションを止めない。docs/agents/hook-live-drill.md の型どおり、
+# 無音死を疑うときは実データを流して bash -x で判定経路を見る）。
+#
+# テスト用の注入ポイント:
+#   INSTRUCTIONS_LOADED_LOG_FILE  追記先（既定 $(resolve_log_dir)/instructions-loaded.jsonl）
+#   CLAUDE_PROJECT_DIR            相対化の基準（既定 pwd）
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="${INSTRUCTIONS_LOADED_LOG_FILE:-$(resolve_log_dir)/instructions-loaded.jsonl}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+PAYLOAD="$(cat)"
+[ -n "$PAYLOAD" ] || exit 0
+
+HOOK_EVENT="$(printf '%s' "$PAYLOAD" | jq -r '.hook_event_name // empty' 2>/dev/null || true)"
+FILE_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.file_path // empty' 2>/dev/null || true)"
+if [ "$HOOK_EVENT" != "InstructionsLoaded" ] || [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty')"
+LOAD_REASON="$(printf '%s' "$PAYLOAD" | jq -r '.load_reason // empty')"
+MEMORY_TYPE="$(printf '%s' "$PAYLOAD" | jq -r '.memory_type // empty')"
+GLOB_PATTERN="$(printf '%s' "$PAYLOAD" | jq -r '.glob_pattern // empty')"
+SIZE_FROM_PAYLOAD="$(printf '%s' "$PAYLOAD" | jq -r '.file_size_bytes // empty')"
+
+FILE_SIZE_BYTES="$SIZE_FROM_PAYLOAD"
+FILE_CHARS=""
+if [ -f "$FILE_PATH" ]; then
+  if [ -z "$FILE_SIZE_BYTES" ]; then
+    FILE_SIZE_BYTES="$(wc -c < "$FILE_PATH" | tr -d ' ')"
+  fi
+  FILE_CHARS="$(jq -Rs 'length' "$FILE_PATH" 2>/dev/null || true)"
+fi
+
+REL_PATH="$FILE_PATH"
+case "$FILE_PATH" in
+  "$PROJECT_DIR"/*) REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}" ;;
+esac
+
+mkdir -p "$(dirname "$LOG_FILE")"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+jq -nc \
+  --arg timestamp "$TIMESTAMP" \
+  --arg sessionId "$SESSION_ID" \
+  --arg loadReason "$LOAD_REASON" \
+  --arg filePath "$REL_PATH" \
+  --arg memoryType "$MEMORY_TYPE" \
+  --arg globPattern "$GLOB_PATTERN" \
+  --arg fileSizeBytes "$FILE_SIZE_BYTES" \
+  --arg fileChars "$FILE_CHARS" \
+  '{
+    timestamp: $timestamp,
+    sessionId: $sessionId,
+    loadReason: $loadReason,
+    filePath: $filePath,
+    memoryType: $memoryType
+  }
+  + (if $globPattern != "" then {globPattern: $globPattern} else {} end)
+  + (if $fileSizeBytes != "" then {fileSizeBytes: ($fileSizeBytes | tonumber)} else {} end)
+  + (if $fileChars != "" then {fileChars: ($fileChars | tonumber)} else {} end)' \
+  >> "$LOG_FILE"
+
+exit 0

--- a/scripts/log-instructions-loaded.test.sh
+++ b/scripts/log-instructions-loaded.test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# WHY: scripts/log-instructions-loaded.sh（InstructionsLoaded hook、issue #742）と
+# scripts/summarize-instructions-loaded.sh の回帰テスト。公式 docs の入力例と同形の
+# ペイロードで 1 行追記されること、相対化・サイズ補完・不正入力の fail-open、
+# 集計の合計と回数を固定する。ログ先は INSTRUCTIONS_LOADED_LOG_FILE で sandbox に逃がす。
+#
+# 実行: bash scripts/log-instructions-loaded.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGGER="$SCRIPT_DIR/log-instructions-loaded.sh"
+SUMMARIZER="$SCRIPT_DIR/summarize-instructions-loaded.sh"
+
+fail=0
+ok() { echo "  OK: $1"; }
+ng() { echo "  NG: $1"; [ -n "${2:-}" ] && echo "      $2"; fail=1; }
+assert_contains() {
+  if printf '%s' "$1" | grep -qF -- "$2"; then ok "$3"; else ng "$3" "expected: $2 / actual: $1"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PROJ="$WORK/proj"
+mkdir -p "$PROJ/.claude/rules"
+LOG="$WORK/instructions-loaded.jsonl"
+
+# 日本語 5 文字 + 改行 = 6 文字 / 16 バイト（文字数とバイト数が違うことを検証に使う）
+printf 'あいうえお\n' > "$PROJ/CLAUDE.md"
+printf -- '---\npaths:\n  - "e2e/**"\n---\nrule\n' > "$PROJ/.claude/rules/e2e.md"
+
+run_logger() {
+  printf '%s' "$1" | env INSTRUCTIONS_LOADED_LOG_FILE="$LOG" CLAUDE_PROJECT_DIR="$PROJ" bash "$LOGGER"
+}
+
+echo "=== scenario 1: docs の入力例と同形（file_size_bytes 無し） → 相対パス・wc -c 補完・文字数付きで 1 行 ==="
+run_logger "{\"session_id\":\"s1\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"session_start\",\"file_path\":\"$PROJ/CLAUDE.md\",\"memory_type\":\"instructions\",\"cwd\":\"$PROJ\"}"
+LINES="$(wc -l < "$LOG" | tr -d ' ')"
+[ "$LINES" = "1" ] && ok "1 行追記" || ng "行数=$LINES"
+ROW="$(tail -n 1 "$LOG")"
+assert_contains "$ROW" '"filePath":"CLAUDE.md"' "PROJECT_DIR 配下は相対化"
+assert_contains "$ROW" '"fileSizeBytes":16' "バイト数を wc -c で補完"
+assert_contains "$ROW" '"fileChars":6' "文字数を記録"
+assert_contains "$ROW" '"loadReason":"session_start"' "loadReason を記録"
+if printf '%s' "$ROW" | grep -qF 'globPattern'; then ng "globPattern が無いのに出ている"; else ok "globPattern 無し"; fi
+
+echo "=== scenario 2: path_glob_match（glob_pattern・file_size_bytes あり） → ペイロードの値を優先 ==="
+run_logger "{\"session_id\":\"s1\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"path_glob_match\",\"file_path\":\"$PROJ/.claude/rules/e2e.md\",\"memory_type\":\"instructions\",\"glob_pattern\":\"e2e/**\",\"file_size_bytes\":999}"
+ROW="$(tail -n 1 "$LOG")"
+assert_contains "$ROW" '"globPattern":"e2e/**"' "globPattern を記録"
+assert_contains "$ROW" '"fileSizeBytes":999' "ペイロードの file_size_bytes を優先"
+assert_contains "$ROW" '"filePath":".claude/rules/e2e.md"' "rules も相対化"
+
+echo "=== scenario 3: PROJECT_DIR 外のファイル（個人 CLAUDE.md 相当） → 絶対パスのまま ==="
+printf 'x\n' > "$WORK/outside.md"
+run_logger "{\"session_id\":\"s1\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"session_start\",\"file_path\":\"$WORK/outside.md\",\"memory_type\":\"instructions\"}"
+assert_contains "$(tail -n 1 "$LOG")" "\"filePath\":\"$WORK/outside.md\"" "配下でなければ絶対パス"
+
+echo "=== scenario 4: 存在しないファイル → サイズ・文字数無しで記録は残す ==="
+run_logger "{\"session_id\":\"s1\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"compact\",\"file_path\":\"$PROJ/gone.md\",\"memory_type\":\"instructions\"}"
+ROW="$(tail -n 1 "$LOG")"
+assert_contains "$ROW" '"loadReason":"compact"' "記録は残る"
+if printf '%s' "$ROW" | grep -qF 'fileChars'; then ng "不在ファイルに fileChars が出ている"; else ok "fileChars 無し"; fi
+
+echo "=== scenario 5: 不正入力（別イベント / 空 / 壊れた JSON） → exit 0・追記なし ==="
+BEFORE="$(wc -l < "$LOG" | tr -d ' ')"
+run_logger '{"hook_event_name":"SessionStart","file_path":"/x"}'
+run_logger ''
+run_logger '{broken'
+AFTER="$(wc -l < "$LOG" | tr -d ' ')"
+[ "$BEFORE" = "$AFTER" ] && ok "追記なし（$BEFORE 行のまま）" || ng "追記された（$BEFORE → $AFTER）"
+
+echo "=== scenario 6: 集計 → 直近セッションの起動時ロード量（session_start + include、project 配下の内数）と loadReason 別回数 ==="
+# 別セッション s2 を足し、直近セッションが s2 に切り替わることを見る（timestamp は追記順で増える）。
+# 実測（2026-09-05）に合わせ、@import 先は include、個人 CLAUDE.md は絶対パスで session_start、
+# paths 付き rules は path_glob_match で来る。path_glob_match は起動時量に含めない
+mkdir -p "$PROJ/docs"
+printf 'ab\n' > "$PROJ/docs/common.md"   # 3 文字
+run_logger "{\"session_id\":\"s2\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"session_start\",\"file_path\":\"$WORK/outside.md\",\"memory_type\":\"User\"}"
+run_logger "{\"session_id\":\"s2\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"session_start\",\"file_path\":\"$PROJ/CLAUDE.md\",\"memory_type\":\"Project\"}"
+run_logger "{\"session_id\":\"s2\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"include\",\"file_path\":\"$PROJ/docs/common.md\",\"memory_type\":\"Project\"}"
+run_logger "{\"session_id\":\"s2\",\"hook_event_name\":\"InstructionsLoaded\",\"load_reason\":\"path_glob_match\",\"file_path\":\"$PROJ/.claude/rules/e2e.md\",\"memory_type\":\"Project\",\"glob_pattern\":\"e2e/**\"}"
+OUT="$(bash "$SUMMARIZER" --log-file "$LOG" --days 30)"
+# outside.md 2 文字 + CLAUDE.md 6 文字 + common.md 3 文字 = 11、うち project 配下 9
+assert_contains "$OUT" "直近セッション（s2）の起動時ロード量（session_start + include）: 合計 11 文字（うち project 配下 9 文字）" "起動時合計と project 内数"
+assert_contains "$OUT" "2セッション" "セッション数"
+assert_contains "$OUT" '.claude/rules/e2e.md: 2 回 {"path_glob_match":2}' "rules のロード回数"
+assert_contains "$OUT" 'CLAUDE.md: 2 回 {"session_start":2}' "CLAUDE.md のロード回数"
+assert_contains "$OUT" 'docs/common.md: 1 回 {"include":1}' "@import 先のロード回数"
+
+echo "=== scenario 7: 記録ファイルが無い → 集計は「記録なし」で exit 0 ==="
+OUT="$(bash "$SUMMARIZER" --log-file "$WORK/none.jsonl")"
+assert_contains "$OUT" "記録なし" "記録なしの案内"
+
+if [ "$fail" -ne 0 ]; then echo "FAILED"; exit 1; fi
+echo "ALL PASSED"

--- a/scripts/summarize-instructions-loaded.sh
+++ b/scripts/summarize-instructions-loaded.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# logs/instructions-loaded.jsonl（InstructionsLoaded hook の記録、issue #742）を集計する。
+#
+# 出力 2 節:
+#   1. 直近セッションの session_start ロード量（ファイル別の文字数と合計）。
+#      check-claude-md-size.sh の自前計算（CLAUDE.md + @import + paths 無し rules）と
+#      同じ単位（文字数）で出すので、両者の差＝自前計算側の穴として読める
+#   2. 期間内のファイル別ロード回数（loadReason 別）。path_glob_match / include で
+#      一度も読まれない rules は「削除候補」として月次で眺める材料にする
+#
+# 集計ロジックは jq に寄せ、シェル側は引数処理のみ。`|` を含む jq フィルタは
+# Bash ガードに誤検知されるため lib/summarize-instructions-loaded.jq に分離している。
+#
+# 使い方:
+#   bash scripts/summarize-instructions-loaded.sh [--log-file PATH] [--days N]
+#   --days の既定は 30（月次サマリの期間に合わせる）
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/resolve-log-dir.sh"
+
+LOG_FILE="$(resolve_log_dir)/instructions-loaded.jsonl"
+DAYS=30
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-file) LOG_FILE="$2"; shift 2 ;;
+    --days) DAYS="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "jq が必要です" >&2; exit 1; }
+if [ ! -f "$LOG_FILE" ]; then
+  echo "記録なし（$LOG_FILE が無い。InstructionsLoaded hook が一度も発火していないか、Claude Code の版が古い）"
+  exit 0
+fi
+
+# 期間の下限（UTC ISO8601）。BSD date と GNU date の両方で動く形にする
+if date -u -v-1d +%Y >/dev/null 2>&1; then
+  SINCE="$(date -u -v-"${DAYS}"d +"%Y-%m-%dT%H:%M:%SZ")"
+else
+  SINCE="$(date -u -d "-${DAYS} days" +"%Y-%m-%dT%H:%M:%SZ")"
+fi
+
+jq -r -s --arg since "$SINCE" --arg days "$DAYS" -f "$SCRIPT_DIR/lib/summarize-instructions-loaded.jq" "$LOG_FILE"


### PR DESCRIPTION
## 30秒サマリー

常時ロードされる指示ファイルの量を、これまでの自前計算（`check-claude-md-size.sh`）に加えて、公式の `InstructionsLoaded` hook の記録＝「実際に読まれたもの」で持てるようにした。実発火で project 配下 22,975 文字が自前計算と完全一致し、自前計算に穴が無いことを事実で確認した。副産物として docs と実装の差を 1 件発見（`memory_type` の実値）。プロダクトコード・DB には触れていない。危険度: 低（記録専用 hook の追加）。

Closes #742

## 00 変更の要点

- `scripts/log-instructions-loaded.sh`（新規、`InstructionsLoaded` hook）: ファイル 1 件ごとに `logs/instructions-loaded.jsonl` へ追記（sessionId / loadReason / filePath（project 配下は相対）/ memoryType / globPattern / fileSizeBytes（ペイロードに無ければ `wc -c`）/ fileChars）。不正入力・ファイル不在は fail-open
- `scripts/summarize-instructions-loaded.sh` + `scripts/lib/summarize-instructions-loaded.jq`（新規）: 直近セッションの起動時ロード量（`session_start` + `include`、project 配下の内数付き）と、期間内のファイル別・loadReason 別ロード回数
- `scripts/gate-effectiveness-monthly-check.sh`: 月次サマリの末尾に上記集計を追加（fail-open）
- `scripts/log-instructions-loaded.test.sh`（新規、7 シナリオ）
- `scripts/check-claude-md-size.sh`: コメントで突き合わせ先を明記（判定ロジックは変更なし。`InstructionsLoaded` は SessionStart より後に来て出力が無視されるため、起動時警告には使えない）
- `.claude/settings.json`: hook 登録＋allow 2 行
- docs: `actuator-inventory.md`（記録専用の注記）、`hook-live-drill.md`（実測結果）、`common.md`（重要ファイル表）、`upstream-docs-review.md`（docs 差分 1 件）
- 依存の変更: なし

## 01 なぜこの形か

- **判定を移さない**: 公式仕様でこのイベントの出力（JSON・exit code）は全て無視され、ロードを止められない。上限判定は引き続き `check-claude-md-size.sh`（SessionStart）が担い、ここは事実の記録と突き合わせに徹する
- **文字数を主に記録**: 自前計算の閾値が文字数なので同じ単位で比べる。バイト数は日本語 1 文字 3 バイトでトークンの指標にならない（issue #716 と同じ理由）
- **`include` を起動時量に含める**: 実発火で `@import` 先（common.md）は `load_reason: include` で来た。`path_glob_match`（paths 付き rules の遅延ロード）と `compact` は起動時量に含めない
- **project 配下だけの内数を出す**: 個人の `~/.claude/CLAUDE.md` も `session_start` で来るが、自前計算は `$HOME` 配下を測れない設計なので、突き合わせは project 配下の値で行う
- **jq フィルタをファイルに分離**: `|` を含む jq フィルタは Bash ガードに誤検知されるため（既存の `pr-numbers-from-transcript.jq` と同じ型）

## 02 影響範囲

- 新規 hook は記録のみ。セッション開始時にファイル数分（通常 3 回）起動し、各 1 行追記する。`logs/` は gitignore 対象
- 月次サマリの本文が 1 節増える（30 日に 1 回）

## 03 約束（promise-catalog）

該当なし

## 04 どう確認したか

`bash scripts/derive-test-selection.sh origin/main --format table` の出力を基に記入。`docs/agents/actuator-inventory.md` はファイル名の `inventory` がキーワード誤一致し route: deep と判定されたが、docs のみの変更で auth / RLS / DB には触れていない。derive が挙げた `summarize-instructions-loaded.test.sh` は存在せず、集計のテストは `log-instructions-loaded.test.sh` の scenario 6・7 に同居させている。

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ✅ 実施 | CI（本 PR の checks） |
| lint | ✅ 実施 | CI |
| unit（UI・データ層・API Route） | ✅ 実施 | CI |
| build | ✅ 実施 | CI |
| migration 静的テスト | ✅ 実施 | CI |
| DB 制約 ratchet | ✅ 実施 | CI |
| ワークフロー同期テスト | ✅ 実施 | CI |
| hook 回帰 | ✅ 実施 | ローカル `log-instructions-loaded.test.sh` 7 シナリオ、`check-claude-md-size.test.sh`、`gate-effectiveness-monthly-check.test.sh`、`check-session-start-matchers.test.sh`、`check-hook-doc-pointers.test.sh` すべて ALL PASSED。CI `hooks-test` |
| 認証ファイル漏洩チェック | ✅ 実施 | CI |
| 依存監査（既知脆弱性） | ✅ 実施 | CI |
| ロックファイルの出所 | ✅ 実施 | CI |
| docs 整合性 | ✅ 実施 | ローカル `check-docs-integrity.test.sh` OK。CI |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 判定根拠は `actuator-inventory.md` のファイル名誤一致のみ。DB・RLS に触れていない |
| 生成型の鮮度 | ➖ 今回不要 | 同上（DB スキーマに触れていない） |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上（auth / 認可 / RLS に触れていない） |
| hook 実機発火 | ✅ 実施 | `claude -p --output-format json "OK とだけ返してください"`（2.1.258、1 ターン $0.21）で 3 件記録: 個人 CLAUDE.md=session_start（3,597 文字）/ CLAUDE.md=session_start（3,694）/ common.md=include（19,281）。project 配下合計 22,975 文字 ＝ `STARTUP_CONTEXT_CHAR_LIMIT=1 bash scripts/check-claude-md-size.sh` の内訳合計 22,975 と一致。paths 付き rules 3 本は起動時に来ない（設計どおり） |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れておらず、retry_possible の申告も無い |
| 同時実行 | ➖ 今回不要 | 同一注文・同一在庫行を複数ユーザーが更新する変更ではなく、contention の申告も無い |
| E2E（Playwright） | ➖ 今回不要 | 節目の種別（main マージ後（自動）） |
| スキーマドリフト検知 | ➖ 今回不要 | 節目の種別（日次 cron（自動）） |
| fault injection 訓練（ゲート） | ➖ 今回不要 | 節目の種別（四半期、または aidd-phase2.js のプロンプト変更時） |
| 障害注入（外部依存停止） | ➖ 今回不要 | 節目の種別（依存 major 更新、外部公開前） |
| 復旧手順（ランブック） | ➖ 今回不要 | 節目の種別（障害発生時、公開前） |

## 05 後任への申し送り

- **docs との差**: `memory_type` は docs で `instructions` / `mcp_context` だが、実値は `User` / `Project`。hook は解釈せず来たまま記録している。次回の docs 差分確認（2026-10-05）で docs 側の追従を見る（`upstream-docs-review.md` に記載）
- `path_glob_match` の記録は、e2e/・supabase/migrations/・.claude/workflows/ 配下を触るセッションが走って初めて溜まる。月次サマリで「読まれない rules」を判断するのは記録が 1 か月分溜まってから
- MEMORY.md（auto memory）はこのイベントで来なかった（記録 3 件のみ）。常時ロード量の全体像には引き続き含まれない
- 集計は `bash scripts/summarize-instructions-loaded.sh [--days N]` で手動でも見られる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
