### PR TITLE
feat: TRI/RISK 判定の語彙を aidd.config.json（導入先アダプター）へ分離し、router-risk.js の既定値を汎用語のみにする(issue #420 v1 セット B1)

### DIFF
--- a/.claude/workflows/aidd-phase1-router.js
+++ b/.claude/workflows/aidd-phase1-router.js
@@ -7,12 +7,12 @@ export const meta = {
   ],
 }
 
-// args: { taskDescription?: string, maxRounds?: number, changedFiles?: string[] }
+// args: { taskDescription?: string, maxRounds?: number, changedFiles?: string[], riskConfig?: { keywords?, pathPrefixes?, domainKeywords?, metaPathPrefixes? } }
 // changedFiles: 変更対象ファイルパスの配列。Workflowスクリプト自体はgit diffを実行できない
 //   （filesystem/Node.js APIアクセス無し）ため、呼び出し側（Claude Code）が
 //   `git diff --name-only` や変更予定ファイルリストから取得して渡すこと。
 // 判定優先順位（issue #457で3段階に変更。common.md TRI/RISK機械判定基準の節を参照）:
-//   1. changedFilesが全てメタ改修パス（META_PATH_PREFIXES）配下 → 最優先でmetaルート
+//   1. changedFilesが全てメタ改修パス（metaPathPrefixes）配下 → 最優先でmetaルート
 //      （Sweep自体を起動しない。issue #457 症状2対策）
 //   2. 上記に該当しなければ、changedFilesが1件以上ある場合はパス一致（matchedPaths）のみで
 //      isHighRiskを判定する。taskDescriptionのキーワード一致は「〜には触れない」等の
@@ -26,65 +26,82 @@ export const meta = {
 // false positive（軽微なタスクが深掘りに回る＝時間コスト増）は許容し、
 // false negative（高リスク変更を軽量版で見逃す）は許容しない。
 
-const RISK_KEYWORDS = [
-  // パス由来
-  'migrations', 'migration', 'マイグレーション', 'スキーマ',
-  'src/lib/supabase', 'middleware.ts', 'proxy.ts', 'ミドルウェア',
-  // ドメイン由来（common.md TRI/RISK基準）
-  'auth', '認証', 'ログイン',
-  'facility', '施設',
-  'tenant', 'テナント',
-  'organization', '組織',
-  'inventory', '在庫',
-  'rls', 'policy', 'ポリシー',
-]
+// 汎用既定値。リポジトリ・スタック・ドメインに依存しない語だけを置く（共通プラグイン側の正本）。
+// 'migration' は path 判定（domainKeywords）にも入れる: 'supabase/migrations/' のような
+// 接頭辞はスタック固有なので既定にできないが、パスに migration を含む変更はどのスタックでも
+// スキーマ変更である可能性が高い。
+const DEFAULT_RISK_CONFIG = {
+  keywords: [
+    'migrations', 'migration', 'マイグレーション', 'スキーマ',
+    'middleware.ts', 'proxy.ts', 'ミドルウェア',
+    'auth', '認証', 'ログイン',
+    'rls', 'policy', 'ポリシー',
+  ],
+  pathPrefixes: [],
+  domainKeywords: ['auth', 'rls', 'policy', 'migration'],
+  // issue #457: パイプライン自体のメタ改修パス（AIDDワークフロー定義・エージェント定義・
+  // エージェント向けドキュメント）。プロダクトコードの判定とは別カテゴリであり、
+  // 意図的にこの3つのみに限定する（安全側に倒すため、対象を広げない）。
+  metaPathPrefixes: ['.claude/workflows/', '.claude/agents/', 'docs/agents/'],
+}
 
-// common.md記載のパスベース基準: supabase/migrations/ 配下、src/lib/supabase/ 配下
-const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
+// overrides（aidd.config.json の risk、または args.riskConfig）を base に「足す」。
+// 配列は和集合（base の順を先に保ち、重複は除く）。base を省略すると汎用既定値。
+// 既定値を消す手段は意図的に用意しない（迷ったら高リスク側）。
+function resolveRiskConfig(overrides, base) {
+  const b = base ?? DEFAULT_RISK_CONFIG
+  const o = overrides ?? {}
+  const union = (key) => {
+    const merged = [...(b[key] ?? [])]
+    for (const v of (Array.isArray(o[key]) ? o[key] : [])) {
+      if (typeof v === 'string' && v !== '' && !merged.includes(v)) merged.push(v)
+    }
+    return merged
+  }
+  return {
+    keywords: union('keywords'),
+    pathPrefixes: union('pathPrefixes'),
+    domainKeywords: union('domainKeywords'),
+    metaPathPrefixes: union('metaPathPrefixes'),
+  }
+}
 
-// common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
-const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
-
-function isHighRiskPath(filePath) {
+function isHighRiskPath(filePath, config) {
   const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
-  if (RISK_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))) return true
+  if (config.pathPrefixes.some(prefix => normalized.startsWith(prefix.toLowerCase()))) return true
   // middleware.ts / proxy.ts はプロジェクト内のすべてが対象（common.md）。
   // proxy.tsはNext.js 16でmiddleware.tsから改名された同一ファイル規約（issue #681）。
   // 移行前後どちらのブランチでも高リスク判定が抜け落ちないよう両方を判定する
   // （middleware.tsの削除は当issueのスコープ外・恒久的に併存させる方針）。
   if (normalized === 'middleware.ts' || normalized.endsWith('/middleware.ts')) return true
   if (normalized === 'proxy.ts' || normalized.endsWith('/proxy.ts')) return true
-  return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
+  return config.domainKeywords.some(kw => normalized.includes(kw.toLowerCase()))
 }
 
-function matchTaskKeywords(taskDescription) {
+function matchTaskKeywords(taskDescription, config) {
   const lower = String(taskDescription ?? '').toLowerCase()
-  return RISK_KEYWORDS.filter(kw => lower.includes(kw.toLowerCase()))
+  return config.keywords.filter(kw => lower.includes(kw.toLowerCase()))
 }
 
-// issue #457: パイプライン自体のメタ改修パス（AIDDワークフロー定義・エージェント定義・
-// エージェント向けドキュメント）。プロダクトコードのRISK_PATH_PREFIXES/RISK_DOMAIN_KEYWORDS
-// とは別カテゴリであり、意図的にこの3つのみに限定する（安全側に倒すため、対象を広げない）。
-const META_PATH_PREFIXES = ['.claude/workflows/', '.claude/agents/', 'docs/agents/']
-
-function isMetaPipelinePath(filePath) {
+function isMetaPipelinePath(filePath, config) {
   const normalized = String(filePath).toLowerCase().replace(/\\/g, '/').replace(/^\.\//, '')
-  return META_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))
+  return config.metaPathPrefixes.some(prefix => normalized.startsWith(prefix.toLowerCase()))
 }
 
-// changedFilesが1件以上あり、かつ全件がMETA_PATH_PREFIXES配下の場合のみtrue。
+// changedFilesが1件以上あり、かつ全件がmetaPathPrefixes配下の場合のみtrue。
 // changedFilesが空（未指定）の場合は「メタ改修と確認できない」としてfalseを返し、
 // 既存のtaskDescription/パスベース判定（isHighRiskPath・matchTaskKeywords）に委ねる。
-function isMetaPipelineOnlyChange(changedFiles) {
+function isMetaPipelineOnlyChange(changedFiles, config) {
   const files = changedFiles ?? []
   if (files.length === 0) return false
-  return files.every(isMetaPipelinePath)
+  return files.every(f => isMetaPipelinePath(f, config))
 }
 
 // taskDescription: 人間が書いた説明文（補助判定、後方互換のため残す）
 // changedFiles: 変更対象ファイルパスの配列（優先判定。Workflowスクリプト自体はgit diffを
 //               実行できない[filesystem/Node.js API access無し]ため、呼び出し側がgit diff等で
 //               取得して渡す）
+// riskConfig: 導入先の固有語彙（省略時は汎用既定値のみ。resolveRiskConfig で既定値に足す）
 // 戻り値: { isHighRisk, matchedKeywords, matchedPaths }
 //
 // changedFilesが1件以上渡されている場合はmatchedPaths（パスベース判定）のみでisHighRiskを
@@ -96,9 +113,10 @@ function isMetaPipelineOnlyChange(changedFiles) {
 // changedFilesが空（未指定含む）の場合は、パスベース判定ができないため、後方互換として
 // キーワード一致のみで判定する（issue #286時点の挙動を維持）。
 // matchedKeywordsはisHighRiskの判定に使われない場合でも、補助情報としてそのまま返す。
-function classifyRisk(taskDescription, changedFiles = []) {
-  const matchedKeywords = matchTaskKeywords(taskDescription)
-  const matchedPaths = (changedFiles ?? []).filter(isHighRiskPath)
+function classifyRisk(taskDescription, changedFiles = [], riskConfig) {
+  const config = resolveRiskConfig(riskConfig)
+  const matchedKeywords = matchTaskKeywords(taskDescription, config)
+  const matchedPaths = (changedFiles ?? []).filter(f => isHighRiskPath(f, config))
   const hasChangedFiles = (changedFiles ?? []).length > 0
   const isHighRisk = hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
   return { isHighRisk, matchedKeywords, matchedPaths }
@@ -120,11 +138,12 @@ function classifyRisk(taskDescription, changedFiles = []) {
 // 参照）。changedFilesが1件以上ある場合（パスベース判定が効く場合）はこの分岐を通らず、
 // 従来通りmatchedPathsのみでisHighRiskが決まる（issue #456の修正は変更しない）。
 // 戻り値: { route: 'meta'|'confirm'|'deep'|'light', isHighRisk, isMetaChange, matchedKeywords, matchedPaths }
-function classifyRoute(taskDescription, changedFiles = []) {
-  if (isMetaPipelineOnlyChange(changedFiles)) {
+function classifyRoute(taskDescription, changedFiles = [], riskConfig) {
+  const config = resolveRiskConfig(riskConfig)
+  if (isMetaPipelineOnlyChange(changedFiles, config)) {
     return { route: 'meta', isHighRisk: false, isMetaChange: true, matchedKeywords: [], matchedPaths: [] }
   }
-  const { isHighRisk, matchedKeywords, matchedPaths } = classifyRisk(taskDescription, changedFiles)
+  const { isHighRisk, matchedKeywords, matchedPaths } = classifyRisk(taskDescription, changedFiles, config)
   const hasChangedFiles = (changedFiles ?? []).length > 0
   if (!hasChangedFiles && matchedKeywords.length > 0) {
     return { route: 'confirm', isHighRisk, isMetaChange: false, matchedKeywords, matchedPaths }
@@ -144,7 +163,31 @@ const changedFiles = parsedArgs?.changedFiles ?? []
 
 phase('Route')
 
-const { route, isHighRisk, isMetaChange, matchedKeywords, matchedPaths } = classifyRoute(taskDescription, changedFiles)
+// @aidd-local-config:begin
+// このリポジトリ固有の TRI/RISK 語彙（導入先アダプター、issue #420 v1 セット B）。
+// Workflow DSL はファイルを読めないため aidd.config.json の risk をここにインラインで持つ。
+// 両者の一致は .claude/workflows/lib/__tests__/aidd-config.test.js が検証する。
+// プラグイン生成時はこのブロックを空（{}）に置き換え、導入先は args.riskConfig で渡す。
+const LOCAL_RISK_CONFIG = {
+  keywords: [
+    'migrations', 'migration', 'マイグレーション', 'スキーマ',
+    'src/lib/supabase', 'middleware.ts', 'proxy.ts', 'ミドルウェア',
+    'auth', '認証', 'ログイン',
+    'facility', '施設',
+    'tenant', 'テナント',
+    'organization', '組織',
+    'inventory', '在庫',
+    'rls', 'policy', 'ポリシー',
+  ],
+  pathPrefixes: ['supabase/migrations/', 'src/lib/supabase/'],
+  domainKeywords: ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy'],
+}
+// @aidd-local-config:end
+
+// 汎用既定値 ← LOCAL_RISK_CONFIG ← args.riskConfig の順に「足す」（消せない）。
+const riskConfig = resolveRiskConfig(parsedArgs?.riskConfig, resolveRiskConfig(LOCAL_RISK_CONFIG))
+
+const { route, isHighRisk, isMetaChange, matchedKeywords, matchedPaths } = classifyRoute(taskDescription, changedFiles, riskConfig)
 
 // issue #457: メタ改修（.claude/workflows/・.claude/agents/・docs/agents/配下のみの変更）は
 // TRI/RISK判定そのものを迂回し、4軸Sweep（aidd-phase1）も深掘り調査（aidd-1-1-deep-task）も

--- a/.claude/workflows/lib/__tests__/aidd-config.test.js
+++ b/.claude/workflows/lib/__tests__/aidd-config.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { extractDeclaration } from '../extract-declaration.js'
+import { DEFAULT_RISK_CONFIG, resolveRiskConfig, classifyRoute } from '../router-risk.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const CONFIG_FILE = path.join(REPO_ROOT, 'aidd.config.json')
+const SCHEMA_FILE = path.join(REPO_ROOT, 'scripts/lib/aidd-config.schema.json')
+const ROUTER_FILE = path.resolve(__dirname, '../../aidd-phase1-router.js')
+const LIB_FILE = path.resolve(__dirname, '../router-risk.js')
+
+// WHY: issue #420 v1 セット B。判定エンジン（router-risk.js）から vkumai 固有の語彙を
+// aidd.config.json（導入先アダプター）へ移した。壊れ方は 3 つ考えられる:
+//   1. aidd.config.json と aidd-phase1-router.js の LOCAL_RISK_CONFIG（Workflow DSL は
+//      ファイルを読めないためのインライン複製）がずれる → derive と router で判定が食い違う
+//   2. 共通側の既定値に vkumai / Supabase 固有の語が紛れ込む → プラグイン化で「vkumai 専用
+//      設定をそのまま汎用にしない」が破れる
+//   3. 設定が空・欠損のとき判定が緩む → 迷ったら高リスク側の原則が破れる
+// この 3 つを固定する。スキーマ検証は依存を増やさず（ajv 不採用）、必要な型・重複の検査だけ行う。
+
+const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+const schema = JSON.parse(readFileSync(SCHEMA_FILE, 'utf-8'))
+
+// LOCAL_RISK_CONFIG の宣言テキストから、キーごとの文字列配列を評価せずに取り出す
+// （ソースを実行しない。tri-risk-docs-sync.test.js の stringLiterals と同じ方針）
+function parseLocalRiskConfig() {
+  const decl = extractDeclaration(readFileSync(ROUTER_FILE, 'utf-8'), 'LOCAL_RISK_CONFIG')
+  const result = {}
+  for (const m of decl.matchAll(/(\w+):\s*\[([^\]]*)\]/g)) {
+    result[m[1]] = [...m[2].matchAll(/'([^']+)'/g)].map(x => x[1])
+  }
+  return result
+}
+
+describe('aidd.config.json（導入先アダプター、issue #420 v1 セット B）', () => {
+  it('スキーマに無いトップレベルキーを持たない（additionalProperties: false）', () => {
+    const allowed = Object.keys(schema.properties)
+    for (const key of Object.keys(config)) expect(allowed).toContain(key)
+  })
+
+  it('risk の各配列は空文字なし・重複なしの文字列配列', () => {
+    for (const key of ['keywords', 'pathPrefixes', 'domainKeywords']) {
+      const arr = config.risk[key]
+      expect(Array.isArray(arr)).toBe(true)
+      for (const v of arr) {
+        expect(typeof v).toBe('string')
+        expect(v.length).toBeGreaterThan(0)
+      }
+      expect(new Set(arr).size).toBe(arr.length)
+    }
+  })
+
+  it('aidd-phase1-router.js の LOCAL_RISK_CONFIG と aidd.config.json の risk が一致する（インライン複製の同期）', () => {
+    const local = parseLocalRiskConfig()
+    expect(local).toEqual(config.risk)
+  })
+
+  it('LOCAL_RISK_CONFIG は @aidd-local-config マーカーで囲まれている（プラグイン生成時の差し替え点）', () => {
+    const src = readFileSync(ROUTER_FILE, 'utf-8')
+    const begin = src.indexOf('// @aidd-local-config:begin')
+    const end = src.indexOf('// @aidd-local-config:end')
+    const decl = src.indexOf('const LOCAL_RISK_CONFIG')
+    expect(begin).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(decl)
+    expect(decl).toBeGreaterThan(begin)
+  })
+})
+
+describe('DEFAULT_RISK_CONFIG（共通側の汎用既定値）', () => {
+  const FORBIDDEN = ['vkumai', 'medical', 'facility', 'tenant', 'organization', 'inventory', 'supabase', 'npm', 'next']
+
+  it('vkumai / スタック固有の語を含まない（プラグイン化の禁止語）', () => {
+    const text = JSON.stringify(DEFAULT_RISK_CONFIG).toLowerCase()
+    for (const word of FORBIDDEN) expect(text).not.toContain(word)
+  })
+
+  it('router-risk.js のソース全体にも禁止語が無い（コメント込み。共通プラグインへそのままコピーするため）', () => {
+    // 'facility' は issue 経緯の説明として残す価値があるため、コメント中の 1 回だけ許容する
+    const src = readFileSync(LIB_FILE, 'utf-8').toLowerCase()
+    for (const word of ['vkumai', 'medical', 'supabase', 'npm ']) expect(src).not.toContain(word)
+  })
+
+  it('既定値だけでも auth / rls / policy / migration を含むパスは高リスク（設定が空でも緩まない）', () => {
+    for (const p of ['src/auth/login.ts', 'db/migrations/001.sql', 'lib/rls.ts', 'policy/x.ts']) {
+      expect(classifyRoute('', [p]).route).toBe('deep')
+      expect(classifyRoute('', [p], {}).route).toBe('deep')
+      expect(classifyRoute('', [p], { keywords: [], pathPrefixes: [], domainKeywords: [] }).route).toBe('deep')
+    }
+  })
+
+  it('既定値だけでは facility パスは高リスクにならず、vkumai の設定を足すと高リスクになる', () => {
+    const p = 'src/app/facility/page.tsx'
+    expect(classifyRoute('', [p]).route).toBe('light')
+    expect(classifyRoute('', [p], config.risk).route).toBe('deep')
+  })
+})
+
+describe('resolveRiskConfig', () => {
+  it('既定値に足すだけで、既定値の語は消せない', () => {
+    const r = resolveRiskConfig({ domainKeywords: ['facility'], keywords: [], pathPrefixes: [] })
+    for (const kw of DEFAULT_RISK_CONFIG.domainKeywords) expect(r.domainKeywords).toContain(kw)
+    expect(r.domainKeywords).toContain('facility')
+  })
+
+  it('重複・空文字・非文字列は捨てる', () => {
+    const r = resolveRiskConfig({ domainKeywords: ['auth', '', 42, 'auth', 'x'] })
+    expect(r.domainKeywords.filter(k => k === 'auth').length).toBe(1)
+    expect(r.domainKeywords).not.toContain('')
+    expect(r.domainKeywords).toContain('x')
+  })
+
+  it('undefined / null / 配列でない値でも壊れず既定値になる', () => {
+    expect(resolveRiskConfig(undefined)).toEqual(resolveRiskConfig({}))
+    expect(resolveRiskConfig(null)).toEqual(resolveRiskConfig({}))
+    expect(resolveRiskConfig({ keywords: 'auth' }).keywords).toEqual(DEFAULT_RISK_CONFIG.keywords)
+  })
+
+  it('base を渡すと二段階で足せる（router の 汎用 ← LOCAL ← args の順）', () => {
+    const local = resolveRiskConfig({ domainKeywords: ['facility'] })
+    const withArgs = resolveRiskConfig({ domainKeywords: ['corpus'] }, local)
+    expect(withArgs.domainKeywords).toContain('facility')
+    expect(withArgs.domainKeywords).toContain('corpus')
+    expect(withArgs.domainKeywords).toContain('auth')
+  })
+})

--- a/.claude/workflows/lib/__tests__/router-risk-sync.test.js
+++ b/.claude/workflows/lib/__tests__/router-risk-sync.test.js
@@ -14,13 +14,14 @@ const LIB_FILE = path.resolve(__dirname, '../router-risk.js')
 // issue #456で追加された簡易版sync test（CORE_LOGIC文字列の部分一致チェック）は、classifyRisk
 // を宣言単位で丸ごと比較するこちらのテストに統合した（classifyRiskをDECLARATIONSに含めており、
 // 部分一致よりも厳密にドリフトを検知できるため）。
+// issue #420 v1 セット B: 固有語彙（旧 RISK_KEYWORDS 等）は aidd.config.json と router 側の
+// LOCAL_RISK_CONFIG へ移り、ここで同期するのはエンジン（汎用既定値と判定関数）のみ。
+// LOCAL_RISK_CONFIG と aidd.config.json の同期は aidd-config.test.js が検証する。
 const DECLARATIONS = [
-  'RISK_KEYWORDS',
-  'RISK_PATH_PREFIXES',
-  'RISK_DOMAIN_KEYWORDS',
+  'DEFAULT_RISK_CONFIG',
+  'resolveRiskConfig',
   'isHighRiskPath',
   'matchTaskKeywords',
-  'META_PATH_PREFIXES',
   'isMetaPipelinePath',
   'isMetaPipelineOnlyChange',
   'classifyRisk',

--- a/.claude/workflows/lib/__tests__/router-risk.test.js
+++ b/.claude/workflows/lib/__tests__/router-risk.test.js
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { classifyRisk, classifyRoute } from '../router-risk.js'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import * as lib from '../router-risk.js'
+
+// issue #420 v1 セット B: エンジンの既定値は汎用語のみになり、facility / supabase 等の
+// vkumai 固有語は aidd.config.json から渡す。以下の既存テストは「vkumai の設定で従来と同じ
+// 判定になる」ことの回帰テストとして、設定を固定で渡すラッパー経由に置き換えた。
+// 汎用既定値のみでの挙動は aidd-config.test.js が検証する。
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const VKUMAI_RISK = JSON.parse(readFileSync(path.resolve(__dirname, '../../../../aidd.config.json'), 'utf-8')).risk
+const classifyRisk = (taskDescription, changedFiles) => lib.classifyRisk(taskDescription, changedFiles, VKUMAI_RISK)
+const classifyRoute = (taskDescription, changedFiles) => lib.classifyRoute(taskDescription, changedFiles, VKUMAI_RISK)
 
 describe('classifyRisk', () => {
   it('taskDescriptionにキーワードがあれば高リスク（後方互換）', () => {

--- a/.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js
+++ b/.claude/workflows/lib/__tests__/tri-risk-docs-sync.test.js
@@ -52,8 +52,16 @@ function stringLiterals(declSource) {
 
 describe('TRI/RISK 機械判定基準の AGENTS.md / common.md と router-risk.js の同期（issue #715）', () => {
   const libSource = readFileSync(LIB_FILE, 'utf-8')
-  const pathPrefixes = stringLiterals(extractDeclaration(libSource, 'RISK_PATH_PREFIXES'))
-  const domainKeywords = stringLiterals(extractDeclaration(libSource, 'RISK_DOMAIN_KEYWORDS'))
+  // issue #420 v1 セット B: 固有語彙は aidd.config.json（導入先アダプター）へ移った。docs に
+  // 書くべき基準は「汎用既定値（router-risk.js の DEFAULT_RISK_CONFIG）＋ vkumai の設定」の和。
+  // 'migration' は既定の domainKeywords にあるが docs の基準本文は `supabase/migrations/` 接頭辞で
+  // 表現しているため、docs 側の照合は設定ファイルの値で行い、既定値は存在確認のみにする
+  const riskConfig = JSON.parse(readFileSync(path.join(REPO_ROOT, 'aidd.config.json'), 'utf-8')).risk
+  const pathPrefixes = riskConfig.pathPrefixes
+  const domainKeywords = riskConfig.domainKeywords
+  const defaultDomainKeywords = stringLiterals(
+    extractDeclaration(libSource, 'DEFAULT_RISK_CONFIG').match(/domainKeywords:\s*\[[^\]]*\]/)[0]
+  )
   const fileNameRules = ['middleware.ts', 'proxy.ts']
 
   it('正本から接頭辞・ドメイン語を取り出せる（テスト自身の前提）', () => {
@@ -61,6 +69,12 @@ describe('TRI/RISK 機械判定基準の AGENTS.md / common.md と router-risk.j
     expect(domainKeywords.length).toBeGreaterThan(0)
     const isHighRiskPath = extractDeclaration(libSource, 'isHighRiskPath')
     for (const f of fileNameRules) expect(isHighRiskPath).toContain(f)
+  })
+
+  it('汎用既定値のドメイン語（migration を除く）は vkumai の設定にも含まれる（設定が既定値を狭めない）', () => {
+    for (const kw of defaultDomainKeywords.filter(k => k !== 'migration')) {
+      expect(domainKeywords).toContain(kw)
+    }
   })
 
   const sections = {}

--- a/.claude/workflows/lib/router-risk.js
+++ b/.claude/workflows/lib/router-risk.js
@@ -8,8 +8,17 @@
 // このファイルはvitestでの単体テスト用の正本。同期は
 // .claude/workflows/lib/__tests__/router-risk-sync.test.js が検証する（issue #457）。
 //
+// 【issue #420 v1 セット B】エンジン（判定ロジック）と語彙（リポジトリ固有の値）を分離した。
+// このファイルに残る既定値 DEFAULT_RISK_CONFIG は、どのリポジトリでも高リスクと言える汎用語
+// （auth / rls / policy / migration とファイル名規則）だけにし、リポジトリ固有の語
+// （施設・テナント等のドメイン語、DB クライアント配下のようなスタック固有パス）はリポジトリ直下の
+// aidd.config.json（導入先アダプター）へ移した。呼び出し側は classifyRoute の第3引数で
+// 設定を渡す（derive は aidd.config.json を読んで渡す。aidd-phase1-router.js は Workflow DSL
+// でファイルを読めないため、LOCAL_RISK_CONFIG をインラインで持ち、args.riskConfig で上書きできる）。
+// 設定は既定値に「足す」だけで、既定値を消すことはできない（迷ったら高リスク側）。
+//
 // 【issue #457】パイプライン自体のメタ改修（.claude/workflows/・.claude/agents/・
-// docs/agents/配下のみの変更）は、プロダクトコード向けのTRI/RISK基準（RISK_KEYWORDSの
+// docs/agents/配下のみの変更）は、プロダクトコード向けのTRI/RISK基準（keywords の
 // 単純文字列一致）にかけると2つの問題が起きていた:
 //   1. taskDescriptionに「DB/RLS/authには触れない」という否定文を書いても"auth"等の単語が
 //      キーワード一致し、changedFilesが実際は高リスク領域に一切該当しないのに深掘り調査へ
@@ -19,7 +28,7 @@
 //   2. 軽量Sweepの4軸（UI/データ/DB/型）はプロダクトコード向けの分類軸であり、
 //      ツール層の変更に対してはui/data/types軸が「対象コードが無いので当然指摘なし」を
 //      返すだけの無駄な実行になる（issue #456では未解決。issue #457のスコープ）
-// 対応: 「changedFilesが全てツール層(META_PATH_PREFIXES配下)のみ」という条件を、
+// 対応: 「changedFilesが全てツール層(metaPathPrefixes配下)のみ」という条件を、
 // classifyRisk（issue #456で改修済み）による判定より「先に」評価し、Sweep自体を一切
 // 起動しない専用ルートへ振り分ける。この条件を満たさない限り従来のisHighRiskPath/
 // matchTaskKeywords/classifyRisk判定には一切影響しない（プロダクトコード向けの
@@ -29,65 +38,82 @@
 // false positive（軽微なタスクが深掘りに回る＝時間コスト増）は許容し、
 // false negative（高リスク変更を軽量版で見逃す）は許容しない。
 
-const RISK_KEYWORDS = [
-  // パス由来
-  'migrations', 'migration', 'マイグレーション', 'スキーマ',
-  'src/lib/supabase', 'middleware.ts', 'proxy.ts', 'ミドルウェア',
-  // ドメイン由来（common.md TRI/RISK基準）
-  'auth', '認証', 'ログイン',
-  'facility', '施設',
-  'tenant', 'テナント',
-  'organization', '組織',
-  'inventory', '在庫',
-  'rls', 'policy', 'ポリシー',
-]
+// 汎用既定値。リポジトリ・スタック・ドメインに依存しない語だけを置く（共通プラグイン側の正本）。
+// 'migration' は path 判定（domainKeywords）にも入れる: '<db ツール名>/migrations/' のような
+// 接頭辞はスタック固有なので既定にできないが、パスに migration を含む変更はどのスタックでも
+// スキーマ変更である可能性が高い。
+const DEFAULT_RISK_CONFIG = {
+  keywords: [
+    'migrations', 'migration', 'マイグレーション', 'スキーマ',
+    'middleware.ts', 'proxy.ts', 'ミドルウェア',
+    'auth', '認証', 'ログイン',
+    'rls', 'policy', 'ポリシー',
+  ],
+  pathPrefixes: [],
+  domainKeywords: ['auth', 'rls', 'policy', 'migration'],
+  // issue #457: パイプライン自体のメタ改修パス（AIDDワークフロー定義・エージェント定義・
+  // エージェント向けドキュメント）。プロダクトコードの判定とは別カテゴリであり、
+  // 意図的にこの3つのみに限定する（安全側に倒すため、対象を広げない）。
+  metaPathPrefixes: ['.claude/workflows/', '.claude/agents/', 'docs/agents/'],
+}
 
-// common.md記載のパスベース基準: supabase/migrations/ 配下、src/lib/supabase/ 配下
-const RISK_PATH_PREFIXES = ['supabase/migrations/', 'src/lib/supabase/']
+// overrides（aidd.config.json の risk、または args.riskConfig）を base に「足す」。
+// 配列は和集合（base の順を先に保ち、重複は除く）。base を省略すると汎用既定値。
+// 既定値を消す手段は意図的に用意しない（迷ったら高リスク側）。
+function resolveRiskConfig(overrides, base) {
+  const b = base ?? DEFAULT_RISK_CONFIG
+  const o = overrides ?? {}
+  const union = (key) => {
+    const merged = [...(b[key] ?? [])]
+    for (const v of (Array.isArray(o[key]) ? o[key] : [])) {
+      if (typeof v === 'string' && v !== '' && !merged.includes(v)) merged.push(v)
+    }
+    return merged
+  }
+  return {
+    keywords: union('keywords'),
+    pathPrefixes: union('pathPrefixes'),
+    domainKeywords: union('domainKeywords'),
+    metaPathPrefixes: union('metaPathPrefixes'),
+  }
+}
 
-// common.md記載のドメインキーワード（ファイルパス・ファイル名に含まれるかで判定）
-const RISK_DOMAIN_KEYWORDS = ['auth', 'facility', 'tenant', 'organization', 'inventory', 'rls', 'policy']
-
-function isHighRiskPath(filePath) {
+function isHighRiskPath(filePath, config) {
   const normalized = String(filePath).toLowerCase().replace(/\\/g, '/')
-  if (RISK_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))) return true
+  if (config.pathPrefixes.some(prefix => normalized.startsWith(prefix.toLowerCase()))) return true
   // middleware.ts / proxy.ts はプロジェクト内のすべてが対象（common.md）。
   // proxy.tsはNext.js 16でmiddleware.tsから改名された同一ファイル規約（issue #681）。
   // 移行前後どちらのブランチでも高リスク判定が抜け落ちないよう両方を判定する
   // （middleware.tsの削除は当issueのスコープ外・恒久的に併存させる方針）。
   if (normalized === 'middleware.ts' || normalized.endsWith('/middleware.ts')) return true
   if (normalized === 'proxy.ts' || normalized.endsWith('/proxy.ts')) return true
-  return RISK_DOMAIN_KEYWORDS.some(kw => normalized.includes(kw))
+  return config.domainKeywords.some(kw => normalized.includes(kw.toLowerCase()))
 }
 
-function matchTaskKeywords(taskDescription) {
+function matchTaskKeywords(taskDescription, config) {
   const lower = String(taskDescription ?? '').toLowerCase()
-  return RISK_KEYWORDS.filter(kw => lower.includes(kw.toLowerCase()))
+  return config.keywords.filter(kw => lower.includes(kw.toLowerCase()))
 }
 
-// issue #457: パイプライン自体のメタ改修パス（AIDDワークフロー定義・エージェント定義・
-// エージェント向けドキュメント）。プロダクトコードのRISK_PATH_PREFIXES/RISK_DOMAIN_KEYWORDS
-// とは別カテゴリであり、意図的にこの3つのみに限定する（安全側に倒すため、対象を広げない）。
-const META_PATH_PREFIXES = ['.claude/workflows/', '.claude/agents/', 'docs/agents/']
-
-function isMetaPipelinePath(filePath) {
+function isMetaPipelinePath(filePath, config) {
   const normalized = String(filePath).toLowerCase().replace(/\\/g, '/').replace(/^\.\//, '')
-  return META_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix))
+  return config.metaPathPrefixes.some(prefix => normalized.startsWith(prefix.toLowerCase()))
 }
 
-// changedFilesが1件以上あり、かつ全件がMETA_PATH_PREFIXES配下の場合のみtrue。
+// changedFilesが1件以上あり、かつ全件がmetaPathPrefixes配下の場合のみtrue。
 // changedFilesが空（未指定）の場合は「メタ改修と確認できない」としてfalseを返し、
 // 既存のtaskDescription/パスベース判定（isHighRiskPath・matchTaskKeywords）に委ねる。
-function isMetaPipelineOnlyChange(changedFiles) {
+function isMetaPipelineOnlyChange(changedFiles, config) {
   const files = changedFiles ?? []
   if (files.length === 0) return false
-  return files.every(isMetaPipelinePath)
+  return files.every(f => isMetaPipelinePath(f, config))
 }
 
 // taskDescription: 人間が書いた説明文（補助判定、後方互換のため残す）
 // changedFiles: 変更対象ファイルパスの配列（優先判定。Workflowスクリプト自体はgit diffを
 //               実行できない[filesystem/Node.js API access無し]ため、呼び出し側がgit diff等で
 //               取得して渡す）
+// riskConfig: 導入先の固有語彙（省略時は汎用既定値のみ。resolveRiskConfig で既定値に足す）
 // 戻り値: { isHighRisk, matchedKeywords, matchedPaths }
 //
 // changedFilesが1件以上渡されている場合はmatchedPaths（パスベース判定）のみでisHighRiskを
@@ -99,9 +125,10 @@ function isMetaPipelineOnlyChange(changedFiles) {
 // changedFilesが空（未指定含む）の場合は、パスベース判定ができないため、後方互換として
 // キーワード一致のみで判定する（issue #286時点の挙動を維持）。
 // matchedKeywordsはisHighRiskの判定に使われない場合でも、補助情報としてそのまま返す。
-function classifyRisk(taskDescription, changedFiles = []) {
-  const matchedKeywords = matchTaskKeywords(taskDescription)
-  const matchedPaths = (changedFiles ?? []).filter(isHighRiskPath)
+function classifyRisk(taskDescription, changedFiles = [], riskConfig) {
+  const config = resolveRiskConfig(riskConfig)
+  const matchedKeywords = matchTaskKeywords(taskDescription, config)
+  const matchedPaths = (changedFiles ?? []).filter(f => isHighRiskPath(f, config))
   const hasChangedFiles = (changedFiles ?? []).length > 0
   const isHighRisk = hasChangedFiles ? matchedPaths.length > 0 : matchedKeywords.length > 0
   return { isHighRisk, matchedKeywords, matchedPaths }
@@ -123,11 +150,12 @@ function classifyRisk(taskDescription, changedFiles = []) {
 // 参照）。changedFilesが1件以上ある場合（パスベース判定が効く場合）はこの分岐を通らず、
 // 従来通りmatchedPathsのみでisHighRiskが決まる（issue #456の修正は変更しない）。
 // 戻り値: { route: 'meta'|'confirm'|'deep'|'light', isHighRisk, isMetaChange, matchedKeywords, matchedPaths }
-export function classifyRoute(taskDescription, changedFiles = []) {
-  if (isMetaPipelineOnlyChange(changedFiles)) {
+function classifyRoute(taskDescription, changedFiles = [], riskConfig) {
+  const config = resolveRiskConfig(riskConfig)
+  if (isMetaPipelineOnlyChange(changedFiles, config)) {
     return { route: 'meta', isHighRisk: false, isMetaChange: true, matchedKeywords: [], matchedPaths: [] }
   }
-  const { isHighRisk, matchedKeywords, matchedPaths } = classifyRisk(taskDescription, changedFiles)
+  const { isHighRisk, matchedKeywords, matchedPaths } = classifyRisk(taskDescription, changedFiles, config)
   const hasChangedFiles = (changedFiles ?? []).length > 0
   if (!hasChangedFiles && matchedKeywords.length > 0) {
     return { route: 'confirm', isHighRisk, isMetaChange: false, matchedKeywords, matchedPaths }
@@ -136,4 +164,7 @@ export function classifyRoute(taskDescription, changedFiles = []) {
 }
 
 // 後方互換用に従来のclassifyRiskもexportしたまま維持する（既存テスト・呼び出し元との互換性）。
-export { classifyRisk }
+// export は末尾でまとめる: 宣言本体を aidd-phase1-router.js のインライン複製と一字一句同じに
+// 保つため（同期テストは `export ` の有無だけを正規化する。宣言ごとに export を付けても
+// 動くが、末尾集約のほうが生成スクリプト（プラグイン化）での差し替えが単純になる）。
+export { DEFAULT_RISK_CONFIG, resolveRiskConfig, classifyRisk, classifyRoute }

--- a/aidd.config.json
+++ b/aidd.config.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "./scripts/lib/aidd-config.schema.json",
+  "_comment": "導入先アダプター（issue #420 v1 仕様 Part 2 セット B）。このリポジトリ固有の値だけを書く。判定エンジン（.claude/workflows/lib/router-risk.js）の汎用既定値（auth / rls / policy / migration）はここに書かなくても常に含まれる（安全側に倒すため、既定値は消せない・足すだけ）。risk の値は aidd-phase1-router.js の LOCAL_RISK_CONFIG と同期テストで突き合わせる。",
+  "risk": {
+    "keywords": [
+      "migrations", "migration", "マイグレーション", "スキーマ",
+      "src/lib/supabase", "middleware.ts", "proxy.ts", "ミドルウェア",
+      "auth", "認証", "ログイン",
+      "facility", "施設",
+      "tenant", "テナント",
+      "organization", "組織",
+      "inventory", "在庫",
+      "rls", "policy", "ポリシー"
+    ],
+    "pathPrefixes": ["supabase/migrations/", "src/lib/supabase/"],
+    "domainKeywords": ["auth", "facility", "tenant", "organization", "inventory", "rls", "policy"]
+  },
+  "readonlyAgentTypes": [
+    "sweep-ui", "sweep-data", "sweep-db", "sweep-types",
+    "reviewer", "completeness-critic", "adversarial-verify", "judge-panel"
+  ],
+  "commands": {
+    "check": "npm run ai:check",
+    "test": "npm test",
+    "lint": "npm run lint",
+    "typecheck": "npm run typecheck"
+  },
+  "docs": {
+    "domain": "docs/agents/domain.md",
+    "decisions": "docs/agents/decisions.md"
+  }
+}

--- a/docs/agents/common.md
+++ b/docs/agents/common.md
@@ -68,6 +68,13 @@ Write/Edit/MultiEdit時に`.aidd/run-manifest.json`が存在しなければ、Pr
 正本は`.claude/workflows/lib/router-risk.js`（`classifyRoute`）、`aidd-phase1-router.js`側の
 インライン複製との同期は`.claude/workflows/lib/__tests__/router-risk-sync.test.js`が検証する
 （`npm test`に含まれる。他のプロンプト同期テストと同型のガード）。
+判定エンジンと語彙は分離してある（issue #420 v1 セット B、2026-09-05）: エンジンの既定値は
+どのリポジトリでも高リスクと言える汎用語（auth / rls / policy / migration とファイル名規則）のみで、
+上記のリポジトリ固有の値（`supabase/migrations/`・`src/lib/supabase/`・facility / tenant /
+organization / inventory）はリポジトリ直下の`aidd.config.json`（導入先アダプター）にある。
+`aidd-phase1-router.js`は Workflow DSL でファイルを読めないため同じ値を`LOCAL_RISK_CONFIG`として
+インラインで持ち、両者の一致は`.claude/workflows/lib/__tests__/aidd-config.test.js`が検証する。
+設定は既定値に「足す」だけで、既定値を消す手段は無い（迷ったら高リスク側）。
 
 ## 依存関係の変更ルール（2026-09-04）
 

--- a/docs/agents/decisions.md
+++ b/docs/agents/decisions.md
@@ -382,3 +382,32 @@ transcript 形式の変化で無音死していた別件も見つかった。[`k
 `npm run eval:workflows <set>`（sweep 系は `scripts/eval-sweep-recall.sh <layer>`）を回して
 eval-runs.jsonl の追記をコミットに含める。eval が意味を持たない変更なら PR 本文に
 `eval-skip: <理由>` を書く。免除を多用し始めたら、それは fixture セットの不足の合図として扱う。
+
+## なぜ TRI/RISK 判定の語彙を router-risk.js から aidd.config.json へ移し、既定値は「足すだけで消せない」形にしたか（issue #420 v1 セット B、2026-09-05）
+
+プラグイン v1（[`docs/specs/plugin-v1/SPEC.md`](../specs/plugin-v1/SPEC.md)）の最重要原則は
+「vkumai 専用設定をそのまま汎用プラグインにしない」。判定エンジン `router-risk.js` は 7 月試作で
+そのままコピーされ、`facility` / `inventory` / `supabase/migrations/` といった語が共通側に残る形に
+なっていた。エンジン（4 分岐のロジック）と語彙（どの語を高リスクとみなすか）を分け、語彙を
+リポジトリ直下の `aidd.config.json`（導入先アダプター）へ移した。
+
+**既定値を汎用語だけに絞る代わりに、設定は既定値に「足す」だけにした理由:** 設定で既定値を上書き
+（置換）できる形にすると、導入先が `domainKeywords: ["corpus"]` と書いた瞬間に `auth` / `rls` /
+`policy` が消え、TRI/RISK の「迷ったら高リスク側」が設定ミス 1 つで破れる。和集合にしておけば、
+設定が空でも・壊れていても・キーを間違えても、判定は緩まない（緩む方向の失敗モードを構造的に
+無くす）。`migration` を既定の domainKeywords に入れたのは、`supabase/migrations/` のような接頭辞は
+スタック固有で既定にできない一方、パスに migration を含む変更はどのスタックでもスキーマ変更である
+可能性が高いため。
+
+**インライン複製を残した理由:** `aidd-phase1-router.js` は Workflow DSL でファイルを読めない
+（[`load-bearing-workarounds.md`](./load-bearing-workarounds.md)）。そのため同じ値を
+`LOCAL_RISK_CONFIG` としてインラインで持ち、`aidd.config.json` との一致を
+`aidd-config.test.js` が検証する。`@aidd-local-config:begin/end` マーカーで囲んであるのは、
+プラグイン生成時にその区間だけを空に置き換えるため（導入先は `args.riskConfig` で渡す）。
+
+**代替案（却下）:** 既定値に vkumai の値を残し、導入先が上書きする。共通側に固有語が残るため
+原則に反し、禁止語の構造テスト（`aidd-config.test.js`）で機械的に弾く形にした。
+
+**How to apply:** 高リスクの語・パスを足すときは `aidd.config.json` の `risk` と
+`aidd-phase1-router.js` の `LOCAL_RISK_CONFIG` の両方を直す（片方だけだとテストが RED）。
+汎用語を足すときだけ `router-risk.js` の `DEFAULT_RISK_CONFIG` を直す（禁止語に注意）。

--- a/docs/agents/portability-inventory.md
+++ b/docs/agents/portability-inventory.md
@@ -14,7 +14,8 @@ issue本文の進め方は変えていない。本ファイルはその判断材
 | 項目 | 所在 | 備考 |
 |---|---|---|
 | Phase骨格（調査→仕様→実装→統合→検証、停止①②） | ルート`CLAUDE.md`「フロー（骨格）」 | フェーズの区切り方・人間レビューを挟む位置という設計思想自体はドメイン非依存 |
-| TRI/RISK分類エンジンの構造（`classifyRoute`の4分岐: meta/confirm/deep/light、パスベース優先ロジック） | `.claude/workflows/lib/router-risk.js` | ロジック（changedFilesがあればパス優先、無ければキーワードフォールバック＋confirm、メタ改修は先に判定）は汎用。中身の`RISK_KEYWORDS`はドメイン固有（下記「判断が難しい部分」参照） |
+| TRI/RISK分類エンジンの構造（`classifyRoute`の4分岐: meta/confirm/deep/light、パスベース優先ロジック） | `.claude/workflows/lib/router-risk.js` | ロジック（changedFilesがあればパス優先、無ければキーワードフォールバック＋confirm、メタ改修は先に判定）は汎用。2026-09-05（issue #420 v1 セット B）に語彙を分離し、エンジンの既定値`DEFAULT_RISK_CONFIG`は汎用語（auth / rls / policy / migration）のみ。固有語は`aidd.config.json`へ（下表） |
+| 導入先アダプター設定の形（`aidd.config.json` と `scripts/lib/aidd-config.schema.json`。risk / readonlyAgentTypes / commands / docs の 4 キー、配列は既定値に足すだけで消せない） | `aidd.config.json`、`scripts/lib/aidd-config.schema.json`、`.claude/workflows/lib/__tests__/aidd-config.test.js` | issue #420 v1 セット B。形式・スキーマ・「既定値を狭めない」検査は汎用。値は固有（下表）。Workflow DSL はファイルを読めないため `aidd-phase1-router.js` は同じ値を `LOCAL_RISK_CONFIG` としてインラインで持ち、同期テストで突き合わせる |
 | gap check方式（before/expected件数の事前記録→事後突合というパターン） | `scripts/record-gap-check-state.sh`・`scripts/check-gap-check-state.sh` | 「記録漏れを期待値と実測値の突合で機械検知する」という方式自体は汎用 |
 | subagent役割分担パターン（sweep-* / reviewer / implementer / judge-panel / proposer / adversarial-verify / completeness-critic / contract-writer） | `.claude/agents/*.md` | 役割名・責務の切り方（発見/実装/レビュー/統合を分離する）は汎用。sweep-db/sweep-uiのような軸の中身はスタック依存 |
 | canonical eventのAdapterパターン（複数の自己申告ログを1つの正規化型へ変換して統合参照する設計） | `scripts/lib/canonical-event.ts`（issue #569） | 「書き込み側は無改修のまま読み取り側だけ統合する」という設計判断自体は汎用 |
@@ -41,7 +42,7 @@ issue本文の進め方は変えていない。本ファイルはその判断材
 |---|---|---|
 | `npm test` / `npm run lint`コマンド体系 | ルート`CLAUDE.md`「プロジェクト設定」 | Node/npmプロジェクト前提。他言語スタックでは丸ごと差し替えが必要 |
 | Supabase RLS/migration概念、`supabase db diff`等のCLI呼び出し | `supabase/migrations/`・`.claude/rules/db-schema.md` | DBがSupabase(PostgreSQL)であることに強く依存 |
-| facility/tenant/organization/inventory等のドメインキーワード | `.claude/workflows/lib/router-risk.js`の`RISK_KEYWORDS`一部 | 医療在庫管理ドメイン固有の語彙 |
+| facility/tenant/organization/inventory等のドメインキーワードと`supabase/migrations/`・`src/lib/supabase/`接頭辞 | `aidd.config.json`の`risk`（2026-09-05 に`router-risk.js`の`RISK_KEYWORDS`等から移動）、`aidd-phase1-router.js`の`LOCAL_RISK_CONFIG`（インライン複製） | 医療在庫管理ドメインと Supabase スタック固有の語彙。プラグイン生成時は`@aidd-local-config`マーカー区間を空にする |
 | GitHub issue/PR連携（`gh`コマンド依存） | `docs/agents/common.md`各所、`scripts/check-branch-pr-status.sh`等 | GitHub以外のissue tracker（Linear等）を使うリポジトリでは差し替えが必要 |
 | Next.js App Router固有の構造（`src/app/`・`proxy.ts`/旧`middleware.ts`） | ルート`CLAUDE.md`「プロジェクト設定」 | フレームワーク固有のディレクトリ規約 |
 | e2e/env-guard.ts・Playwright認証状態（`--isolated --storage-state`） | `e2e/`配下、`.claude/rules/e2e-test-hygiene.md` | Playwright前提。本番Supabase分離の実装もこのスタック向け |

--- a/scripts/lib/aidd-config.schema.json
+++ b/scripts/lib/aidd-config.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "aidd.config.schema.json",
+  "title": "AIDD 導入先アダプター設定（issue #420 v1）",
+  "description": "リポジトリ直下の aidd.config.json の形。共通プラグイン（判定エンジン・hook）が読む、リポジトリ固有の値だけを持つ。配列は共通側の汎用既定値に「足される」（既定値は消せない）。",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "_comment": { "type": "string" },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "TRI/RISK 判定（router-risk.js の classifyRoute）に足す固有語彙",
+      "properties": {
+        "keywords": { "$ref": "#/$defs/stringList", "description": "taskDescription（説明文）に含まれていれば高リスク候補とする語。changedFiles が空のときの補助判定にのみ使う" },
+        "pathPrefixes": { "$ref": "#/$defs/stringList", "description": "この接頭辞で始まる変更パスは高リスク（例: supabase/migrations/）" },
+        "domainKeywords": { "$ref": "#/$defs/stringList", "description": "変更パス・ファイル名に含まれていれば高リスクとする語（小文字比較）" },
+        "metaPathPrefixes": { "$ref": "#/$defs/stringList", "description": "全変更がこの接頭辞配下のみならメタ改修ルート。通常は既定値（.claude/workflows/ .claude/agents/ docs/agents/）のままでよい" }
+      }
+    },
+    "readonlyAgentTypes": { "$ref": "#/$defs/stringList", "description": "PreToolUse で書き込み系 Bash を deny する読み取り専用ロール名（check-readonly-bash.sh）。セット B2 で消費" },
+    "commands": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Stop hook の実行痕跡検知（ai-check-suggest.sh）と引き継ぎメモが参照するコマンド。セット B2 で消費",
+      "properties": {
+        "check": { "type": "string" },
+        "test": { "type": "string" },
+        "lint": { "type": "string" },
+        "typecheck": { "type": "string" }
+      }
+    },
+    "docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "高リスク変更時に追記を促すドキュメントの場所（check-domain-decisions-suggest.sh）。セット B2 で消費",
+      "properties": {
+        "domain": { "type": "string" },
+        "decisions": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  }
+}

--- a/scripts/lib/derive-test-selection.mjs
+++ b/scripts/lib/derive-test-selection.mjs
@@ -28,6 +28,18 @@ const { classifyRoute } = await import(
   pathToFileURL(path.join(REPO_ROOT, '.claude/workflows/lib/router-risk.js')).href
 )
 
+// issue #420 v1 セット B: 高リスク判定の固有語彙（facility / supabase 配下等）はリポジトリ直下の
+// aidd.config.json（導入先アダプター）にある。無ければ汎用既定値のみで判定する（緩むのではなく
+// 固有語が足されないだけ。既定の auth / rls / policy / migration は常に効く）。
+function loadRiskConfig() {
+  try {
+    return JSON.parse(readFileSync(path.join(REPO_ROOT, 'aidd.config.json'), 'utf8')).risk ?? {}
+  } catch {
+    return {}
+  }
+}
+const RISK_CONFIG = loadRiskConfig()
+
 function parseArgs(argv) {
   const opts = { format: 'json', risks: [], files: null, listKeys: false, listRules: false, listRisks: false }
   for (let i = 0; i < argv.length; i++) {
@@ -68,7 +80,7 @@ export function derive(files, risks = []) {
   if (unknownRisks.length > 0) throw new Error(`unknown risk key: ${unknownRisks.join(', ')}`)
 
   const normalized = [...new Set(files.map(normalize))]
-  const route = classifyRoute('', normalized)
+  const route = classifyRoute('', normalized, RISK_CONFIG)
   const ctx = { files: normalized, route, risks }
 
   const required = []

--- a/scripts/lib/derive-test-selection.rules.mjs
+++ b/scripts/lib/derive-test-selection.rules.mjs
@@ -218,4 +218,8 @@ export const CLASSIFIED_PATH_PATTERNS = [
   /^src\//, /^supabase\//, /^e2e\//, /^scripts\//, /^docs\//, /^\.claude\//, /^\.codex\//, /^\.agents\//,
   /^\.github\//, /^public\//, /^(package|package-lock|tsconfig[^/]*|vitest[^/]*|playwright[^/]*|eslint[^/]*|next[^/]*)\.(json|ts|js|mjs|cjs)$/,
   /^(CLAUDE|AGENTS|README)\.md$/, /^\.gitignore$/, /^\.env\.example$/,
+  // 導入先アダプター設定（issue #420 v1 セット B）。TRI/RISK 語彙・ロール名・コマンドを持つ。
+  // 変更時は「ワークフロー同期テスト」（aidd-config.test.js が LOCAL_RISK_CONFIG との一致を検査）が
+  // 毎回 required なので、専用の種別は設けない
+  /^aidd\.config\.json$/,
 ]


### PR DESCRIPTION
## 30秒サマリー

プラグイン v1（issue #420、仕様は `docs/specs/plugin-v1/SPEC.md`）のセット B1。TRI/RISK 判定エンジン `router-risk.js` から vkumai 固有の語彙（facility / tenant / organization / inventory、`supabase/migrations/`・`src/lib/supabase/`）を、リポジトリ直下の `aidd.config.json`（導入先アダプター）へ移した。エンジンの既定値は汎用語（auth / rls / policy / migration とファイル名規則）のみ。設定は既定値に「足す」だけで消せないので、設定が空でも判定は緩まない。vkumai の判定結果は従来と同一（既存テスト 30 件超を vkumai 設定経由で回帰固定）。プロダクトコード・DB には触れていない。危険度: 低〜中（判定ロジックの引数追加。誤ると Phase 1 の振り分けが変わる）。

Refs #420

eval-skip: 判定ロジックの語彙分離のみで、Workflow 内のプロンプト文字列（`lib/prompts/`・agent() の本文）には一切変更が無いため。ルーティング結果の同一性は vitest（router-risk.test.js を vkumai 設定経由で全件 green）で固定した

## 00 変更の要点

- `.claude/workflows/lib/router-risk.js`: `DEFAULT_RISK_CONFIG`（汎用既定値）と `resolveRiskConfig(overrides, base)`（和集合、既定値は消せない）を追加。`classifyRoute` / `classifyRisk` は第3引数 `riskConfig` を受ける。export は末尾集約
- `aidd.config.json`（新規、リポジトリ直下）: `risk` / `readonlyAgentTypes` / `commands` / `docs` の 4 キー。スキーマは `scripts/lib/aidd-config.schema.json`（draft 2020-12）。`readonlyAgentTypes` 以降を hook が読むのはセット B2
- `.claude/workflows/aidd-phase1-router.js`: インライン複製を正本から差し替え。Workflow DSL はファイルを読めないため `LOCAL_RISK_CONFIG`（`@aidd-local-config:begin/end` マーカー区間）を持ち、`args.riskConfig` でさらに足せる
- `scripts/lib/derive-test-selection.mjs`: `aidd.config.json` を読んで `classifyRoute` に渡す（無ければ汎用既定値）
- `scripts/lib/derive-test-selection.rules.mjs`: `aidd.config.json` を分類済みパスに追加
- テスト: 新規 `aidd-config.test.js`（12 件: LOCAL と config の同期、マーカーの存在、共通側の禁止語（vkumai / medical / supabase / npm 等）、設定が空でも auth / rls / policy / migration は deep、facility は設定を足すと deep）。`router-risk.test.js` は vkumai 設定を渡すラッパー経由に変更。`router-risk-sync.test.js`（同期対象を 8 宣言へ）・`tri-risk-docs-sync.test.js`（語彙を config から読む）を追従
- docs: `common.md`（正本の説明に分離の記述）、`decisions.md`（設計判断 1 節）、`portability-inventory.md`（共通 1 行追加・固有 1 行更新）
- 依存の変更: なし

## 01 なぜこの形か

- **足すだけで消せない和集合**: 上書き（置換）にすると導入先の設定ミス 1 つで `auth` が消え「迷ったら高リスク側」が破れる。和集合なら設定が空・壊れ・キー違いでも緩まない（`decisions.md` 参照）
- **`migration` を既定 domainKeywords に**: `supabase/migrations/` はスタック固有で既定にできないが、パスに migration を含む変更はどのスタックでもスキーマ変更の可能性が高い
- **インライン複製＋マーカー**: Workflow DSL はファイルを読めない（load-bearing workaround）。同期テストで一致を固定し、プラグイン生成時はマーカー区間だけ空にする
- **禁止語テストは自分にも効いた**: 最初のコミット前に自分のコメント（「vkumai 固有」「supabase/migrations/」）で RED になり、汎用表現へ直した

## 02 影響範囲

- `classifyRoute` の呼び出し元は 2 つ（`aidd-phase1-router.js`、`derive-test-selection.mjs`）で両方追従済み。第3引数省略時は汎用既定値になるため、**既存の外部呼び出しがもしあれば vkumai 語が効かなくなる**（リポジトリ内には無いことを grep で確認）
- Phase 1 ルーティングの結果は vkumai では従来と同じ（テストで固定）

## 03 約束（promise-catalog）

該当なし（auth / RLS / facility 境界の実装には触れていない。判定語彙の置き場所を変えただけ）

## 04 どう確認したか

`bash scripts/derive-test-selection.sh origin/main --format table` の出力（route: deep）を基に記入。deep の根拠は `docs/agents/portability-inventory.md` のファイル名 `inventory` の誤一致のみ。

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ✅ 実施 | ローカル `npm run typecheck` OK。CI |
| lint | ✅ 実施 | ローカル `npm run lint` OK。CI |
| unit（UI・データ層・API Route） | ✅ 実施 | ローカル `npm test` 195 files / 1562 tests 全 green。CI |
| build | ✅ 実施 | CI |
| migration 静的テスト | ✅ 実施 | `npm test` に含む |
| DB 制約 ratchet | ✅ 実施 | `npm test` に含む |
| ワークフロー同期テスト | ✅ 実施 | `router-risk-sync.test.js`（8 宣言一致）・`aidd-config.test.js`（LOCAL と config 一致）・`tri-risk-docs-sync.test.js` すべて green |
| hook 回帰 | ✅ 実施 | `derive-test-selection.test.sh` 13 シナリオ ALL PASSED。CI `hooks-test` |
| 認証ファイル漏洩チェック | ✅ 実施 | CI |
| 依存監査（既知脆弱性） | ✅ 実施 | CI |
| ロックファイルの出所 | ✅ 実施 | CI |
| docs 整合性 | ✅ 実施 | ローカル `check-docs-integrity.test.sh` OK。CI |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 判定根拠は `portability-inventory.md` のファイル名誤一致のみ。DB・RLS に触れていない |
| 生成型の鮮度 | ➖ 今回不要 | 同上（DB スキーマに触れていない） |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | 同上（auth / 認可 / RLS の実装に触れていない） |
| agents baseline 鮮度 | ✅ 実施 | `check-agent-baseline-freshness.sh origin/main HEAD` → model / effort の変更なし |
| ワークフロープロンプト eval | ➖ 今回不要 | プロンプト文字列に変更なし（本文冒頭の `eval-skip:` 参照）。ルーティングの同一性は vitest で固定 |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook スクリプト・settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れておらず、retry_possible の申告も無い |
| 同時実行 | ➖ 今回不要 | contention の申告も無い |
| E2E（Playwright） | ➖ 今回不要 | 節目の種別（main マージ後（自動）） |
| スキーマドリフト検知 | ➖ 今回不要 | 節目の種別（日次 cron（自動）） |
| fault injection 訓練（ゲート） | ➖ 今回不要 | 節目の種別（aidd-phase2.js のプロンプト変更なし） |
| 障害注入（外部依存停止） | ➖ 今回不要 | 節目の種別 |
| 復旧手順（ランブック） | ➖ 今回不要 | 節目の種別 |

## 05 後任への申し送り

- 高リスクの語・パスを足すときは `aidd.config.json` の `risk` と `aidd-phase1-router.js` の `LOCAL_RISK_CONFIG` の**両方**を直す（片方だけだと `aidd-config.test.js` が RED）
- セット B2（次 PR）: `check-readonly-bash.sh` / `check-run-manifest-presence.sh` / `ai-check-suggest.sh` / `check-domain-decisions-suggest.sh` が `aidd.config.json` の残り 3 キーを jq で読む（環境変数の注入ポイントは残す）
- `aidd-phase1-router.js` の `meta.whenToUse` にはまだ facility 等の語がある（Workflow の説明文）。プラグイン生成（セット C）の禁止語検査で扱う

🤖 Generated with [Claude Code](https://claude.com/claude-code)
