### PR TITLE
docs: プラグイン v1 の要検証 5 件を最小プラグインで実測し、結果を仕様書と docs 差分記録に書く(issue #420)

### DIFF
--- a/docs/agents/upstream-docs-review.md
+++ b/docs/agents/upstream-docs-review.md
@@ -58,6 +58,11 @@ SessionStart hook（`scripts/check-upstream-docs-review-staleness.sh`）が監�
 - `Setup` hook（`claude -p --maintenance`）を定期作業の入口にする → issue #741
 - `InstructionsLoaded` hook で常時ロード量を実測に置き換える → issue #742（同日実装。実測で docs との差を 1 件確認:
   `memory_type` の実値は docs の `instructions` でなく `User` / `Project`（2.1.258）。次回の差分確認で docs 側が追従したか見る）
+- プラグイン v1 の要検証 5 件を実機確認（`docs/specs/plugin-v1/SPEC.md` Part 2）。docs との差をもう 1 件確認:
+  plugins-reference は「`InstructionsLoaded` hook で `${CLAUDE_PLUGIN_ROOT}/instructions.md` を cat すれば
+  文脈に注入できる」例を載せているが、hooks docs の「このイベントの出力は全て無視される」が正しい
+  （2.1.258 実測: additionalContext / systemMessage とも文脈に現れない）。Workflow 名もプラグイン名で
+  修飾される（`plugin:workflow`）ことは docs に明記がなく実測で確定
 - `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` が AIDD のモデル階層を無効化するため検知する → issue #743
 - `/skill-doctor`（2.1.261）で未使用スキルと context コストを 1 回測る（手動）
 - `subagentPromptCacheTtl` / frontmatter `experimental.cacheTtl`（1h）は `/cost` の cache miss 原因を見てから判断

--- a/docs/specs/plugin-v1/SPEC.md
+++ b/docs/specs/plugin-v1/SPEC.md
@@ -138,17 +138,23 @@ v2 以降で「プラグインが正本、vkumai も消費者」へ反転する�
 - **D**: プラグインリポジトリの CI が vkumai の `hooks-test` と同じテストを生成物に対して回して green
 - **F**: RED 方向を必ず含める（名前空間を意図的に外した生成物で `agent type not found` が **エラーとして** 見えること。#521 の修正により `failedCount` に出る）
 
-### 要検証（実装前に実機で確かめる。docs に書いていない）
+### 要検証 → 実測結果（2026-09-05、Claude Code 2.1.258、scratchpad の最小プラグイン 2 つを
+`claude -p --plugin-dir` で読み込み、1 セッション $0.20 で確認）
 
-1. Workflow 名の名前空間（`workflow('aidd-core:aidd-phase1')` か `'aidd-phase1'` か）。7 月は
-   非修飾で「見つからない」にはならなかったが、agent と同じ規則かは未確認
-2. `${CLAUDE_PLUGIN_ROOT}` が hook の `command` で展開されること、および展開後のスクリプトから
-   `git rev-parse --git-common-dir` で導入先の `logs/` を解決できること
-3. プラグイン間依存（`aidd-vkumai` → `aidd-core`）で、依存側の hook・agent が両方ロードされる順序
-4. `--plugin-dir` で読んだプラグインの hook が `settings.json` の hook と**重複**して発火しないか
-   （vkumai 本体で両方入っている状態を作らない運用にするか、生成物側の hook を無効化する仕組みが要るか）
-5. plugins-reference の要約に「`InstructionsLoaded` でプラグインが文脈を注入できる」旨があるが、
-   hooks docs は「出力は全て無視」と書いており矛盾。実機で確かめ、結果を `upstream-docs-review.md` に記録
+1. **Workflow 名も名前空間付き**（`aidd-core-spike:spike-inner`）。DSL 内の `workflow('spike-inner')` も
+   メインエージェントの `Workflow({name: 'spike-flow'})` も、非修飾は「no workflow with that name」で失敗する
+   （エラー文に利用可能な修飾名一覧が出る）。agent も同様（7 月試作の再現。`agent type 'echo-agent' not found`）
+   → 生成スクリプトは agentType と workflow() の両方を書き換え、導入先 CLAUDE.md の呼び出し例も修飾名にする
+2. **`${CLAUDE_PLUGIN_ROOT}` は hook の command で展開される**（プラグインディレクトリの絶対パス）。
+   hook 内の `CLAUDE_PROJECT_DIR` と cwd は導入先で、`git rev-parse --git-common-dir` も導入先の `.git` を
+   返す → `resolve_log_dir` はそのまま導入先の `logs/` に解決する
+3. **別プラグインの agent / workflow を修飾名で呼べる**（adapter → core）。`dependencies` の解決順は
+   `--plugin-dir` 2 つ同時指定では検証できていない（両方明示ロードのため）。marketplace 経由の
+   インストールで再確認する
+4. 未検証（両方ロードすれば当然二重に発火する）。運用で「vkumai 本体では生成物を読まない」とし、
+   生成スクリプトの出力先を `dist/plugins/` に固定してリポジトリ内 `.claude/` と混ざらないようにする
+5. **InstructionsLoaded の出力は文脈に入らない**（hook は発火し stdin も来るが、additionalContext /
+   systemMessage とも無視）。hooks docs が正しく、plugins-reference の記述は誤り → `upstream-docs-review.md` に記録
 
 ### 型・データアクセス層の方針
 


### PR DESCRIPTION
## 30秒サマリー

プラグイン v1 仕様（issue #420）Part 2 の「要検証 5 件」を、scratchpad の最小プラグイン 2 つ（core / adapter）を `claude -p --plugin-dir` で読み込んで実測し（1 セッション $0.20、Claude Code 2.1.258）、結果を仕様書と公式 docs 差分記録に書いた。docs のみ。危険度: なし。

Refs #420

## 00 変更の要点

- `docs/specs/plugin-v1/SPEC.md`: 「要検証」節を「実測結果」に置換
  1. Workflow 名もプラグイン名で修飾される（非修飾は「no workflow with that name」。agent も同様）
  2. `${CLAUDE_PLUGIN_ROOT}` は hook の command で展開され、hook 内の cwd / `CLAUDE_PROJECT_DIR` / `git rev-parse` は導入先を指す（`resolve_log_dir` はそのまま使える）
  3. 別プラグインの agent / workflow を修飾名で呼べる（`dependencies` の解決順は marketplace 経由で再確認）
  4. 二重発火は未検証（運用で回避）
  5. `InstructionsLoaded` の出力は文脈に入らない（hooks docs が正しく、plugins-reference の例は誤り）
- `docs/agents/upstream-docs-review.md`: docs との差 1 件を追記
- 依存の変更: なし

## 01 なぜこの形か

実装（セット C の生成スクリプト）は名前空間の規則と hook の実行環境に依存するため、docs に書いていない挙動を先に実機で確定した。scratchpad の検証用プラグインはリポジトリに入れない（配布物ではない）。

## 02 影響範囲

docs のみ

## 03 約束（promise-catalog）

該当なし

## 04 どう確認したか

docs のみの変更（route: light）。

| 種別（test-matrix.md の行） | 状態 | 結果・証跡 |
| --- | --- | --- |
| 型検査 | ✅ 実施 | CI |
| lint | ✅ 実施 | CI |
| unit（UI・データ層・API Route） | ✅ 実施 | CI |
| build | ✅ 実施 | CI |
| migration 静的テスト | ✅ 実施 | CI |
| DB 制約 ratchet | ✅ 実施 | CI |
| ワークフロー同期テスト | ✅ 実施 | CI |
| hook 回帰 | ✅ 実施 | CI `hooks-test` |
| 認証ファイル漏洩チェック | ✅ 実施 | CI |
| 依存監査（既知脆弱性） | ✅ 実施 | CI |
| ロックファイルの出所 | ✅ 実施 | CI |
| docs 整合性 | ✅ 実施 | ローカル `check-docs-integrity.test.sh` OK。CI |
| 依存差分レビュー | ➖ 今回不要 | package.json / package-lock.json に触れていない |
| RLS/IDOR 統合（実 DB） | ➖ 今回不要 | 高リスクパスに触れていない |
| 生成型の鮮度 | ➖ 今回不要 | DB スキーマに触れていない |
| 直接攻撃の実測（テスト外） | ➖ 今回不要 | auth / 認可 / RLS に触れていない |
| agents baseline 鮮度 | ➖ 今回不要 | .claude/agents・.claude/workflows に触れていない |
| ワークフロープロンプト eval | ➖ 今回不要 | .claude/workflows に触れていない |
| hook 実機発火 | ➖ 今回不要 | hook スクリプト・settings に触れていない |
| 冪等性（再送・二重実行） | ➖ 今回不要 | 注文・返却系 RPC に触れておらず、retry_possible の申告も無い |
| 同時実行 | ➖ 今回不要 | contention の申告も無い |
| E2E（Playwright） | ➖ 今回不要 | 節目の種別 |
| スキーマドリフト検知 | ➖ 今回不要 | 節目の種別 |
| fault injection 訓練（ゲート） | ➖ 今回不要 | 節目の種別 |
| 障害注入（外部依存停止） | ➖ 今回不要 | 節目の種別 |
| 復旧手順（ランブック） | ➖ 今回不要 | 節目の種別 |

## 05 後任への申し送り

- 実測で分かった仕様の未達: 4 軸 Sweep（sweep-ui / data / db / types）と implementer 系 7 体はスタック固有語を含み、Workflow 5 本はそれらを名前で呼ぶ。名前空間はプラグイン単位なので、Workflow を共通側に置くと共通が固有側を参照する逆依存になる。v1.0 の層の切り方はユーザーに確認して決める（次の報告で提示）
- hook 33 本のうち 18 本は node / npx / python3 のいずれかを呼ぶ。導入先の前提として KNOWN-LIMITS に書く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
